### PR TITLE
Improve archive handoff status and execute guidance

### DIFF
--- a/.agents/skills/harness-execute/SKILL.md
+++ b/.agents/skills/harness-execute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-execute
-description: Use when a tracked harness plan has been approved and the controller agent should drive implementation, review, CI, sync, closeout, and archive work until the plan reaches awaiting_merge_approval. This is the main controller skill for day-to-day execution after approval.
+description: Use when a tracked harness plan has been approved and the controller agent should drive implementation, review, CI, sync, publish handoff, closeout, and archive work until the archived candidate is genuinely ready to wait for merge approval. This is the main controller skill for day-to-day execution after approval.
 ---
 
 # Harness Execute
@@ -10,6 +10,12 @@ description: Use when a tracked harness plan has been approved and the controlle
 Use this skill after plan approval to drive the repository from active work to
 an archived, merge-ready candidate.
 
+ALWAYS use `harness-execute` whenever `harness status` resolves a current
+approved tracked plan and the lifecycle does not clearly call for a different
+skill. That includes fresh sessions, resumed sessions after compaction, and
+pick-up work where the safest next move is to follow the current plan instead
+of improvising a new workflow.
+
 The controller agent stays in `harness-execute` for the whole execution loop,
 including review orchestration. Do not switch the controller into
 `harness-reviewer`; that skill is only for spawned reviewer subagents assigned
@@ -18,10 +24,16 @@ to specific review slots.
 Keep exactly one active review round at a time. The detailed review rules live
 in [review-orchestration.md](references/review-orchestration.md).
 
+For behavior-changing work, default to Red/Green/Refactor TDD. Only skip TDD
+when it is genuinely impractical, and record the reason in the step's
+`Execution Notes`.
+
 ## Start Here
 
 1. Run `harness status`.
-2. Open the current tracked plan from `plan_path`.
+2. If `harness status` points to a current tracked plan that is already
+   approved for execution, stay in `harness-execute` and open that plan from
+   `plan_path`.
 3. Identify the active or next plan step.
 4. Use the status output to answer four questions:
    - which tracked plan is current
@@ -42,7 +54,9 @@ in [review-orchestration.md](references/review-orchestration.md).
 - `blocked`
   - resolve the blocker or get human input
 - `awaiting_merge_approval`
-  - wait for merge approval or switch to `harness-land` only when asked
+  - read `handoff_state` from `harness status`; finish publish or CI handoff
+    first, and only wait for merge approval once the archived candidate is
+    actually ready
 
 ## Reference Guide
 
@@ -61,6 +75,8 @@ Execute is done when:
 
 - the plan is archived
 - lifecycle is `awaiting_merge_approval`
+- `harness status` no longer reports archived handoff follow-up such as
+  `pending_publish`, `waiting_post_archive_ci`, or `followup_required`
 - durable closeout summaries are written into the tracked plan
 
 ## Do Not
@@ -68,6 +84,8 @@ Execute is done when:
 - Do not ask the human to micromanage routine execution once the plan is
   approved.
 - Do not bypass lifecycle gates just because the next action feels obvious.
+- Do not skip TDD for behavior changes without documenting why the usual
+  Red/Green/Refactor loop was not practical.
 - Do not rely on chat memory when `harness status`, the tracked plan, or local
   artifacts can tell you the truth more directly.
 - Do not archive based on memory alone; use the current plan plus `.local`

--- a/.agents/skills/harness-execute/references/closeout-and-archive.md
+++ b/.agents/skills/harness-execute/references/closeout-and-archive.md
@@ -5,6 +5,8 @@ Archive is a freeze-and-summarize step, not just a file move.
 ## Before Archive
 
 1. Run `harness status` and confirm the plan is actually archive-ready.
+   - If `status` returns `blockers`, fix those first instead of learning them
+     from a failing `harness archive`.
 2. Make sure acceptance criteria are checked and steps are completed.
 3. Read the latest review, CI, sync, and publish artifacts under `.local`.
 4. Update the tracked plan's durable summaries from those artifacts:
@@ -12,7 +14,9 @@ Archive is a freeze-and-summarize step, not just a file move.
    - `Review Summary`
    - `Archive Summary`
    - `Outcome Summary`
-5. Make sure deferred items that still matter have follow-up GitHub issues.
+5. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
+   with durable handoff details before archive. Issue links are fine, but the
+   main rule is that it must not stay `NONE`.
 6. Run:
 
    ```bash
@@ -31,9 +35,12 @@ Archive changes tracked files, so it still needs the normal git flow:
 
 1. Commit the archive move and summary updates.
 2. Push the branch.
-3. Run `harness status` again so the next agent sees `awaiting_merge_approval`.
-4. Let CI re-run if the repository requires it.
-5. Wait for human merge approval or switch to `harness-land` only when asked.
+3. Open or update the PR.
+4. Run `harness status` again to confirm the archived candidate now reports the
+   expected `handoff_state` for this worktree.
+5. Let CI re-run if the repository requires it.
+6. Wait for human merge approval or switch to `harness-land` only when asked
+   once status says the archived candidate is truly ready.
 
 If new feedback or remote changes invalidate the archived candidate, use:
 

--- a/.agents/skills/harness-execute/references/publish-ci-sync.md
+++ b/.agents/skills/harness-execute/references/publish-ci-sync.md
@@ -12,6 +12,14 @@ current step.
 5. fix failures
 6. decide whether the repair needs delta review or full review
 
+For archived candidates, use the same sequence as post-archive handoff work:
+
+1. commit the archive move
+2. push the branch
+3. open or update the PR
+4. wait for post-archive CI
+5. only then treat the candidate as ready to wait for merge approval
+
 ## Remote Freshness
 
 Refresh remote state before archive-sensitive or merge-sensitive work.
@@ -23,4 +31,3 @@ If remote changes introduce real conflict work:
 - run delta or full review depending on how broad the repair was
 
 Do not create a new review round while an earlier one is still active.
-

--- a/.agents/skills/harness-execute/references/review-orchestration.md
+++ b/.agents/skills/harness-execute/references/review-orchestration.md
@@ -94,6 +94,9 @@ round to use the same set.
 
 2. Spawn multiple reviewer subagents in parallel: one reviewer per returned
    slot or review dimension.
+   Use clean reviewer subagents for these slots. Do not inherit the
+   controller's long chat context into reviewer threads. Use only the fixed
+   reviewer prompt template for reviewer spawning.
 3. Use a fixed reviewer prompt template so model or runtime changes do not
    silently change the reviewer contract.
 4. Keep track of every spawned reviewer agent ID.
@@ -139,6 +142,11 @@ Codex reviewer subagents are asynchronous.
   of them automatically.
 - A completed reviewer agent may still remain open in the background until you
   close it.
+- Use `spawn_agent(..., fork_context=false)` for reviewer slots so the reviewer
+  starts from a clean context and sees only the fixed reviewer prompt.
+- Do not append extra controller reasoning, artifact tours, or side
+  instructions to the fixed reviewer prompt when spawning Codex reviewer
+  subagents.
 
 Use this pattern:
 

--- a/.agents/skills/harness-execute/references/step-inner-loop.md
+++ b/.agents/skills/harness-execute/references/step-inner-loop.md
@@ -5,8 +5,12 @@ The inner loop is how you finish one plan step cleanly.
 ## Inner Loop
 
 1. Confirm the current step from `harness status` and the tracked plan.
-2. Implement the smallest reviewable slice that advances that step.
-3. Add or update tests for behavior changes.
+2. For behavior changes, run Red/Green/Refactor:
+   - Red: write or update a test that fails for the intended behavior.
+   - Green: implement the smallest change that makes the test pass.
+   - Refactor: improve structure without changing the behavior you just proved.
+3. If TDD is genuinely impractical for this slice, record the reason in
+   `Execution Notes` before continuing.
 4. Run focused validation for the slice.
 5. Update the step's `Execution Notes` with a concise summary.
 6. If the slice is green and meaningfully reviewable, make a small commit.

--- a/.agents/skills/harness-land/SKILL.md
+++ b/.agents/skills/harness-land/SKILL.md
@@ -24,12 +24,22 @@ merge.
 6. Add any final PR comment or remote update that belongs on the permanent
    record.
 7. Close or update linked issues when the merge resolves them.
-8. Sync local `main`, delete the feature branch if appropriate, and leave the
+8. Run:
+
+   ```bash
+   harness land record
+   ```
+
+   This clears the current candidate pointer and records the last landed
+   archived plan so `harness status` reports an idle-after-land worktree.
+9. Sync local `main`, delete the feature branch if appropriate, and leave the
    worktree clean.
 
 ## Do Not
 
 - Do not merge without explicit human approval.
 - Do not edit the archived plan after merge just to record merge metadata.
+- Do not leave the worktree pointing at the archived candidate after land; run
+  `harness land record` so status stops reporting `awaiting_merge_approval`.
 - Do not keep using `land` if the candidate is no longer valid; switch back to
   `harness-execute` via `harness reopen`.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ chosen install directory earlier in `PATH`.
 - `harness review start`
 - `harness review submit`
 - `harness review aggregate`
+- `harness land record`
 - `harness archive`
 - `harness reopen`
 
@@ -74,13 +75,16 @@ The repository currently uses this lifecycle:
 1. Discovery
 2. Plan
 3. Execute
-4. Archive / await merge approval
+4. Archive / publish handoff / await merge approval
 5. Land
 
 For medium or large work, create or update a tracked plan under
 `docs/plans/active/`, execute against that plan, archive it under
 `docs/plans/archived/` once the candidate is ready for merge, and only then
-land or wait for a human merge.
+finish commit/push/PR handoff plus any post-archive CI before treating it as
+truly waiting for merge approval. After land, the worktree should move back to
+an idle local state instead of continuing to present the archived candidate as
+the current plan.
 
 High-level guidance lives in [AGENTS.md](./AGENTS.md). The durable contracts
 for plans and CLI behavior live in [docs/specs/index.md](./docs/specs/index.md).
@@ -93,7 +97,8 @@ Execution detail for agents lives in `.agents/skills/`.
 - `docs/plans/`: tracked plans
 - `docs/specs/`: durable repo contracts
 - `.agents/skills/`: repo-local workflow skills
-- `.local/harness/`: disposable runtime state, review artifacts, and trajectory
+- `.local/harness/`: disposable runtime state, current-plan/last-landed
+  markers, review artifacts, and trajectory
 
 ## Current Constraints
 

--- a/docs/plans/archived/2026-03-20-archive-readiness-landed-status-and-execute-tdd.md
+++ b/docs/plans/archived/2026-03-20-archive-readiness-landed-status-and-execute-tdd.md
@@ -1,0 +1,421 @@
+---
+status: archived
+lifecycle: awaiting_merge_approval
+revision: 3
+template_version: 0.1.0
+created_at: "2026-03-20T00:00:00+08:00"
+updated_at: "2026-03-20T23:30:31+08:00"
+source_type: issue
+source_refs:
+    - '#13'
+---
+
+# Surface archive blockers, archive handoff, landed status, and execute TDD discipline
+
+## Goal
+
+Expose archive-readiness problems before the final `harness archive` write so
+the controller can fix closeout gaps from `harness status` instead of only at
+the freeze step. `harness archive` should run the same readiness evaluation as
+a dry run before it mutates tracked files or local pointers.
+
+This slice also tightens three workflow edges discovered during discovery:
+after archive, `harness status` should stop presenting a merely local archived
+candidate as if it were already waiting for merge approval; after land,
+`harness status` should stop presenting the archived candidate as still
+current; and the execute skill should explicitly require Red/Green/Refactor
+TDD discipline for behavior changes.
+
+## Scope
+
+### In Scope
+
+- Define which archive blockers should be surfaced before archive and expose
+  them through `harness status`.
+- Reuse the same readiness evaluation inside `harness archive` before any
+  tracked file or local-state write happens.
+- Keep the deferred-follow-up contract simple: when `## Deferred Items`
+  contains real items at archive time, `## Outcome Summary > Follow-Up Issues`
+  must not remain `NONE`.
+- Clarify the time-based split between archive-known deferred work and
+  retrospective follow-up discovered only after land.
+- Distinguish coarse tracked lifecycle from local post-archive handoff state so
+  `harness status` can tell whether the archived candidate still needs publish
+  work, is waiting on post-archive CI, or is truly ready to wait for merge
+  approval.
+- Add disposable landed-worktree state so `harness status` can report an idle
+  post-land worktree instead of an outdated `awaiting_merge_approval`
+  candidate.
+- Update execute guidance so behavior-changing work follows
+  Red/Green/Refactor TDD by default, with documented exceptions only when TDD
+  is genuinely impractical.
+
+### Out of Scope
+
+- First-class remote PR, branch publication, mergeability, or CI modeling from
+  issue `#12`.
+- Adding a standalone `harness preflight` command.
+- Redesigning the tracked plan lifecycle beyond the local `harness land record`
+  marker, such as adding a new persisted `landed` frontmatter state.
+- Building first-class publish/PR/CI capture commands in the CLI before issue
+  `#12`; this slice only consumes existing local publish and CI state when it
+  is present.
+- Verifying specific follow-up reference formats beyond the rule that
+  `Follow-Up Issues` must not stay `NONE` when deferred items remain.
+
+## Acceptance Criteria
+
+- [x] `harness status` reports concrete archive blockers before archive,
+      including deferred-item follow-up gaps and missing archive-summary
+      content, with fix-oriented next actions.
+- [x] `harness archive` runs the shared archive-readiness evaluation before any
+      tracked or local-state writes, and a failing preflight leaves the current
+      plan and `.local` pointers untouched.
+- [x] After archive, `harness status` distinguishes a local archived candidate
+      that still needs commit/push/PR handoff from one that is truly ready to
+      wait for merge approval, without introducing new tracked lifecycle
+      values.
+- [x] After post-merge land cleanup records a landed local marker, `harness
+      status` no longer reports the archived candidate as waiting for merge
+      approval and instead surfaces an idle/no-current-plan worktree with
+      last-landed context.
+- [x] `harness-execute` and its step-inner-loop reference explicitly require
+      Red/Green/Refactor TDD for behavior changes, and the docs say skipped
+      TDD must be justified.
+
+## Deferred Items
+
+- First-class remote PR/CI/publish state remains deferred to `#12`.
+
+## Work Breakdown
+
+### Step 1: Align archive, land, and execute contracts
+
+- Status: completed
+
+#### Objective
+
+Update the durable specs and repo-local skills so archive blockers, landed
+cleanup, and execute-time TDD rules all describe the same workflow.
+
+#### Details
+
+Capture the intended split explicitly: deferred items known before archive must
+be closed out through the archived plan, while retrospective follow-up
+discovered after land belongs in issues or PR comments instead of retroactive
+plan edits. Define landed-worktree behavior as disposable local state rather
+than a new tracked-plan lifecycle. Borrow the Red/Green/Refactor wording from
+`missless` for behavior-changing work and document when skipping TDD is
+allowed.
+
+#### Expected Files
+
+- `docs/specs/cli-contract.md`
+- `docs/specs/plan-schema.md`
+- `README.md`
+- `.agents/skills/harness-execute/SKILL.md`
+- `.agents/skills/harness-execute/references/closeout-and-archive.md`
+- `.agents/skills/harness-execute/references/step-inner-loop.md`
+- `.agents/skills/harness-land/SKILL.md`
+
+#### Validation
+
+- The specs, README, and skill docs agree on archive-readiness, landed cleanup,
+  and TDD expectations without contradicting each other.
+- `harness plan lint` still passes for the tracked plan after any scope notes
+  or examples are updated.
+
+#### Execution Notes
+
+Updated the durable docs and repo-local skills to agree on the new behavior:
+`harness status` may now report structured archive blockers, `Follow-Up
+Issues` only needs to stop being `NONE` when deferred items remain, land
+cleanup should leave the worktree in an idle-after-land local state, and
+behavior-changing execute work now defaults to Red/Green/Refactor TDD. The
+closeout reference now tells agents to fix `status.blockers` before trying
+`harness archive`.
+
+#### Review Notes
+
+Doc and skill changes were checked against the new CLI behavior implemented in
+this slice, then validated by `harness plan lint`, `go test ./internal/plan
+./internal/status ./internal/lifecycle`, `go test ./...`, and a direct
+`harness status` run after reinstalling the dev binary.
+
+### Step 2: Share archive-readiness evaluation between status and archive
+
+- Status: completed
+
+#### Objective
+
+Implement a single archive-readiness evaluation that `harness status` can
+surface early and `harness archive` can enforce before any write happens.
+
+#### Details
+
+Factor the current late archive checks into reusable logic that covers
+acceptance completion, step completion, archive placeholders, completed-step
+placeholders, required archive-summary lines, deferred-item follow-up
+non-`NONE`, and archive-sensitive local state such as review, CI, and sync.
+`harness status` should report the blockers with repair-first guidance, while
+`harness archive` should reuse the same evaluation before writing the archived
+plan or updating `.local` pointers.
+
+#### Expected Files
+
+- `internal/lifecycle/service.go`
+- `internal/lifecycle/service_test.go`
+- `internal/status/service.go`
+- `internal/status/service_test.go`
+- `internal/plan/document.go`
+
+#### Validation
+
+- Targeted tests prove `harness status` surfaces concrete blocker messages for
+  incomplete closeout state instead of generic archive guidance.
+- Targeted tests prove `harness archive` returns preflight failures without
+  mutating tracked files or local-state pointers.
+
+#### Execution Notes
+
+Extracted plan-local archive checks into `Document.ArchiveReadinessIssues()` and
+added `lifecycle.EvaluateArchiveReadiness()` so both `harness status` and
+`harness archive` read from the same blocker list. `harness archive` now
+preflights before any tracked-file or `.local` write, while `harness status`
+surfaces the blockers through a dedicated `blockers` field, blocker-aware
+summary text, and fix-first next actions once the work breakdown is complete.
+
+#### Review Notes
+
+Added regression tests that prove status reports missing archive-summary fields
+and deferred-item follow-up gaps before archive, and that a failing archive
+preflight leaves the active plan and current pointers untouched. `go test
+./internal/plan ./internal/status ./internal/lifecycle` and `go test ./...`
+both passed.
+
+### Step 3: Represent landed worktrees as idle local state
+
+- Status: completed
+
+#### Objective
+
+Teach status to represent a post-land worktree as idle state with last-landed
+context instead of reusing the archived candidate as if merge approval were
+still pending.
+
+#### Details
+
+Keep landed information in `.local` and avoid editing archived plans after
+merge. Remove ambiguous archived-plan fallback from current-plan detection,
+persist enough disposable local state to remember the most recently landed
+plan, and make status prefer active plans when they exist while surfacing an
+idle-after-land summary when only landed context remains. Update the land skill
+so its cleanup step writes the expected local marker and clears the old current
+candidate pointer.
+
+#### Expected Files
+
+- `internal/plan/current.go`
+- `internal/plan/current_test.go`
+- `internal/runstate/state.go`
+- `internal/status/service.go`
+- `internal/status/service_test.go`
+- `.agents/skills/harness-land/SKILL.md`
+
+#### Validation
+
+- Tests cover archive-created archived pointers, land cleanup that clears the
+  current candidate, and status output for both active-plan and idle-after-land
+  worktrees.
+- Manual or scripted dogfood proves a landed worktree no longer reports the
+  old archived candidate as awaiting merge approval.
+
+#### Execution Notes
+
+Removed the implicit archived-plan fallback from current-plan detection,
+extended `.local/harness/current-plan.json` to store `last_landed_plan_path`
+plus `last_landed_at`, and taught `harness status` to return
+`worktree_state: idle_after_land` when that marker exists without a current
+plan. The land skill now explicitly tells the controller to rewrite the local
+marker after merge so status stops claiming the archived candidate is still
+awaiting merge approval.
+
+#### Review Notes
+
+Added regression coverage for no-pointer archived plans and idle-after-land
+status output, then validated the end-to-end status behavior with `go test
+./internal/plan ./internal/status ./internal/lifecycle`, `go test ./...`, and
+the direct post-install `harness status` smoke check.
+
+### Step 4: Differentiate archived handoff from true merge-waiting state
+
+- Status: completed
+
+#### Objective
+
+Teach `harness status` to treat `awaiting_merge_approval` as a coarse tracked
+phase and surface a separate local handoff state that says whether the archived
+candidate still needs publish work, is waiting on post-archive CI, or is ready
+for actual merge approval.
+
+#### Details
+
+Reuse the existing `.local` publish and CI fields instead of inventing a new
+tracked lifecycle. Update the CLI contract, README, and execute guidance so
+archive is no longer described as the end of execution by itself. Status
+output should become conservative by default: without local publish evidence,
+an archived plan should be described as locally archived and still pending
+publish handoff rather than already waiting for merge approval.
+
+#### Expected Files
+
+- `internal/status/service.go`
+- `internal/status/service_test.go`
+- `docs/specs/cli-contract.md`
+- `docs/specs/plan-schema.md`
+- `README.md`
+- `.agents/skills/harness-execute/SKILL.md`
+- `.agents/skills/harness-execute/references/closeout-and-archive.md`
+- `.agents/skills/harness-execute/references/publish-ci-sync.md`
+- `.agents/skills/harness-execute/references/review-orchestration.md`
+
+#### Validation
+
+- Tests cover archived status output for at least pending-publish and
+  ready-for-merge-approval local handoff states.
+- Durable docs and skills no longer imply that local archive alone means the
+  controller can stop before commit/push/PR handoff.
+
+#### Execution Notes
+
+Added archived-plan `handoff_state` inference to `harness status` so the CLI
+now distinguishes `pending_publish`, `waiting_post_archive_ci`, and
+`ready_for_merge_approval` instead of treating every archived candidate as
+already waiting for merge approval. Reused the existing local publish and CI
+fields, surfaced PR URLs in status artifacts, and updated specs, README, and
+execute guidance so archive is no longer described as the natural end of
+execution by itself. After review follow-up, tightened the handoff logic so
+fresh sync evidence is also required before merge-ready status, added missing
+CI/sync regressions, and documented that reviewer subagents should use clean
+Codex contexts instead of inheriting the controller transcript. Revision 3 then
+tightened the execute-skill wording so resumed agents are told to ALWAYS use
+`harness-execute` when `harness status` resolves an approved current plan,
+clarified that post-archive `harness status` is rerun to confirm the local
+handoff state for the same worktree, and made the reviewer-spawn guidance stick
+to the fixed clean prompt only.
+
+#### Review Notes
+
+`review-004-delta` caught two legitimate gaps in the first handoff-state pass:
+published candidates without CI evidence were still marked merge-ready, and
+the `followup_required` branch lacked a regression test. `review-005-delta`
+then caught the remaining correctness gap that missing sync evidence also had
+to block merge-ready status. After tightening the state machine and coverage,
+`review-006-delta` passed cleanly across correctness, tests, and
+docs-consistency. The final reviewer rerun also used clean Codex reviewer
+subagents without inherited controller context. The revision-3 docs follow-up
+for resume guidance and fixed clean reviewer prompts then passed in
+`review-007-delta` across docs-consistency and agent-ux.
+
+## Validation Strategy
+
+- Run `harness plan lint` while evolving the tracked plan and doc wording.
+- Run targeted package tests for `./internal/status`, `./internal/lifecycle`,
+  `./internal/plan`, and `./internal/runstate` while implementing the shared
+  readiness, archived-handoff, and landed-state behavior.
+- Run `go test ./...` before closeout.
+- Dogfood the workflow with local-state fixtures or a temp worktree to verify
+  archive preflight guidance and landed-worktree status behavior end to end.
+
+## Risks
+
+- Risk: Removing implicit archived-plan fallback could make some cold-start
+  resume flows less convenient.
+  - Mitigation: Preserve explicit archived pointers after `harness archive`,
+    add regression tests for active-plan preference and idle-after-land flows,
+    and document land cleanup clearly in the skill.
+- Risk: A non-`NONE` follow-up rule may allow vague handoff text.
+  - Mitigation: Keep the docs explicit that the section must contain actionable
+    follow-up information for archive-known deferred items, and make status
+    prompt the controller to fill that section before archive.
+- Risk: TDD guidance could be over-applied to pure docs or mechanical
+  refactors.
+  - Mitigation: Limit the requirement to behavior-changing work and require a
+    brief documented reason when TDD is skipped.
+- Risk: Archived handoff state could look more authoritative than the local
+  publish and CI evidence actually available in v0.1.
+  - Mitigation: Keep the new handoff state conservative by default and fall
+    back to pending-publish guidance when local publish evidence is absent.
+
+## Validation Summary
+
+- `harness plan lint docs/plans/active/2026-03-20-archive-readiness-landed-status-and-execute-tdd.md`
+  passed after the revision-3 execute-skill wording updates.
+- `go test ./...` passed after the comment-driven docs follow-up.
+- `harness status` was rerun after reopen to confirm the revision-3 candidate
+  was back in active execution and again before archive to confirm closeout was
+  complete.
+
+## Review Summary
+
+- `review-001-full` requested changes for archive/reopen rollback safety,
+  landed-state coverage, stale issue-ref wording in the plan schema, and the
+  missing land-cleanup CLI path; those issues were fixed before the next round.
+- `review-002-full` requested changes for the missing negative-path
+  `land record` regression and stale active-plan workflow wording; both were
+  fixed before rerunning review.
+- `review-003-full` passed with zero blocking or non-blocking findings for the
+  initial archive-readiness slice.
+- After reopen, `review-004-delta` and `review-005-delta` caught archived
+  handoff-state correctness and coverage gaps around missing CI and sync
+  evidence before merge approval.
+- `review-006-delta` passed with zero blocking or non-blocking findings after
+  those archived-handoff fixes.
+- `review-007-delta` passed with zero blocking or non-blocking findings after
+  the execute-skill wording follow-up for ALWAYS resume guidance and fixed
+  clean reviewer prompts.
+
+## Archive Summary
+
+- Archived At: 2026-03-20T23:30:31+08:00
+- Revision: 3
+- PR: NONE
+- Ready: Acceptance criteria are satisfied, archive blockers still surface
+  early, archived candidates distinguish local publish handoff from true
+  merge-ready waiting, and the latest comment-driven execute-skill follow-up
+  closed cleanly in `review-007-delta`.
+- Merge Handoff: Commit the archive move, push the branch, open or update the
+  PR, and only treat the candidate as truly waiting for merge approval once
+  post-archive handoff evidence is complete.
+
+## Outcome Summary
+
+### Delivered
+
+- Added shared archive-readiness evaluation so `harness status` surfaces
+  closeout blockers early and `harness archive` refuses to write partial
+  archive state.
+- Added landed local-state recording with `harness land record`, explicit
+  `idle_after_land` status output, and rollback-safe archive/reopen state
+  transitions.
+- Added archived-plan `handoff_state` output so `harness status` distinguishes
+  `pending_publish`, `waiting_post_archive_ci`, `followup_required`, and true
+  merge-ready waiting from the same coarse archived lifecycle.
+- Updated the durable specs, README, and repo-local execute skills so archive
+  is no longer described as the end of execution by itself, `harness-execute`
+  now explicitly says to ALWAYS resume there when an approved current plan is
+  present, and reviewer orchestration now documents fixed clean Codex reviewer
+  prompts with `fork_context=false`.
+- Updated execute guidance to require Red/Green/Refactor TDD by default for
+  behavior-changing work, with documented exceptions only when TDD is
+  genuinely impractical.
+
+### Not Delivered
+
+- First-class remote PR, publish, and CI capture commands from `#12`.
+- A richer tracked `landed` lifecycle or stricter follow-up reference parsing
+  beyond the local marker plus non-`NONE` contract shipped here.
+
+### Follow-Up Issues
+
+- `#12` tracks first-class remote PR, publish, and CI modeling.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -18,6 +18,7 @@ The initial v0.1 command surface is:
 - `harness review start`
 - `harness review submit`
 - `harness review aggregate`
+- `harness land record`
 - `harness archive`
 - `harness reopen`
 
@@ -105,6 +106,7 @@ Stateful commands should return an envelope shaped like:
 ### Common Optional Fields
 
 - `artifacts`
+- `blockers`
 - `warnings`
 - `errors`
 
@@ -123,7 +125,7 @@ The CLI should use a small, consistent state vocabulary:
 
 - `plan_status`
   - mirrors tracked plan placement and mutability
-  - expected values: `active`, `archived`
+  - expected values when a current plan exists: `active`, `archived`
 - `lifecycle`
   - the coarse human-steer workflow stage from the tracked plan
 - `step`
@@ -132,6 +134,14 @@ The CLI should use a small, consistent state vocabulary:
   - the current operating mode for the current step inside `executing`
   - derived from current plan content plus local artifacts rather than tracked
     directly in markdown
+- `handoff_state`
+  - optional archived-plan hint when `lifecycle: awaiting_merge_approval`
+  - derived from local publish, CI, and sync artifacts rather than tracked in
+    plan frontmatter
+- `worktree_state`
+  - optional worktree-level state when no current tracked plan is active
+  - v0.1 adds `idle_after_land` for worktrees that have completed land cleanup
+    and only retain last-landed context in `.local`
 
 Most humans and agents should read these together as one sentence, for example:
 
@@ -143,6 +153,13 @@ Most humans and agents should read these together as one sentence, for example:
 In plain language, that means: "the active plan is in the executing lifecycle,
 currently focused on Step 3, and the agent is implementing rather than waiting
 on review or CI."
+
+When `worktree_state: idle_after_land` is present, `plan_status` and
+`lifecycle` may be empty because the worktree is intentionally between plans.
+
+When `handoff_state` is present, `lifecycle: awaiting_merge_approval` should be
+read as a coarse archived phase, not as proof that publish handoff and CI are
+already done.
 
 ### Step Inference
 
@@ -180,8 +197,8 @@ v0.1 should keep `step_state` deliberately small:
 - `resolving_conflicts`
   - local state explicitly says the branch is mid-conflict-resolution
 - `ready_for_archive`
-  - all steps are completed, all acceptance criteria are checked, and archive
-    summary sections are no longer placeholders
+  - all steps are completed, all acceptance criteria are checked, and the
+    shared archive-readiness evaluation finds no remaining blockers
 - `implementing`
   - the default executing mode when nothing stronger applies
 
@@ -273,13 +290,22 @@ Contract:
 - infer `step` from plan step status
 - infer a minimal `step_state` from local review/CI/publish/sync state when
   `lifecycle: executing`
+- infer a minimal archived `handoff_state` from local publish/CI/sync state
+  when `lifecycle: awaiting_merge_approval` so local archive, publish handoff,
+  and true merge-ready waiting are not collapsed into one message
 - surface aggregated review failures as a concrete repair signal rather than
   falling back to a generic "implementing" state
 - if legacy aggregated review outcome cannot be recovered, degrade
   conservatively to review-follow-up guidance instead of closeout or archive
   guidance
+- once all steps and acceptance criteria are complete, surface archive blockers
+  early through a structured `blockers` list plus repair-first next actions
+  instead of making the controller learn them only from `harness archive`
 - surface stale or unknown remote freshness as warnings and next actions rather
   than as a long-lived `step_state`
+- if no current plan is active but `.local/harness/current-plan.json` records a
+  landed candidate, return an `idle_after_land` worktree status instead of
+  pretending the archived candidate is still waiting for merge approval
 - return recommended next actions for both "continue work" and "wait/observe"
   situations
 
@@ -293,6 +319,8 @@ Recommended next action examples:
 - refresh remote state if the latest sync evidence is stale or missing
 - wait for CI
 - archive the plan
+- commit, push, and update the PR after archive before waiting for merge
+  approval
 
 ### `harness review start`
 
@@ -472,10 +500,14 @@ Purpose:
 Contract:
 
 - validate that the plan is active and archive-ready
+- run the shared archive-readiness evaluation before any tracked-file or local
+  state write happens so a failing archive attempt leaves the current candidate
+  untouched
 - assume the plan's durable summary sections have already been written from the
   current plan plus local artifacts, not reconstructed from agent memory
-- if the plan still contains `## Deferred Items`, require concrete follow-up
-  issue references before allowing archive to succeed
+- if the plan still contains `## Deferred Items`, require
+  `## Outcome Summary > Follow-Up Issues` to be something other than `NONE`
+  before allowing archive to succeed
 - reject archive when plan-local state still shows unresolved review, CI, or
   sync work for the current candidate
 - require plan-local review state to retain the latest review decision, or
@@ -498,21 +530,22 @@ Important note:
 - `harness archive` changes tracked files locally
 - the controller agent should commit and push the archive move before treating
   the plan as truly waiting for merge approval
+- until local publish evidence exists, `harness status` should describe the
+  archived candidate as pending publish handoff rather than already waiting for
+  merge approval
 - PR checks may rerun on that archive commit; if new feedback or check failures
   appear, use `harness reopen`
 - merge actor, merge timestamp, and other land-only notes should go to PR
   comments or remote history rather than back into the archived plan
-- if deferred items exist, the controller agent should ensure their
-  corresponding
-  follow-up issues are created and referenced in the archived plan before
-  archive completes
+- if deferred items exist, the controller agent should replace `NONE` in
+  `Follow-Up Issues` with durable handoff details before archive completes
 
 Recommended next action:
 
-- create or verify follow-up issues for deferred work
+- create or verify durable follow-up notes for deferred work
 - commit and push the archived plan
 - update the PR if needed
-- wait for human merge approval
+- wait for post-archive CI or human merge approval once publish handoff is done
 - reopen if the archived candidate no longer looks merge-ready
 
 ### `harness reopen`
@@ -540,6 +573,22 @@ Recommended next action:
 - update plan content if scope or acceptance criteria changed
 - continue the inferred current step, or set `awaiting_plan_approval` if the
   plan contract itself needs fresh approval
+
+### `harness land record`
+
+Purpose:
+
+- record post-merge local cleanup for the current archived candidate
+
+Contract:
+
+- require the current tracked plan to still be the archived
+  `awaiting_merge_approval` candidate that just landed
+- rewrite `.local/harness/current-plan.json` so `plan_path` is cleared
+- record `last_landed_plan_path` and `last_landed_at` for worktree handoff
+- leave tracked plans untouched; this is local-state cleanup only
+- return next actions that guide the worktree back to idle or on to the next
+  slice
 
 ## Review Runtime Boundary
 

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -207,11 +207,15 @@ The tracked plan stores only the coarse lifecycle:
 - `blocked`
   - Work cannot proceed without human input or an external dependency.
 - `awaiting_merge_approval`
-  - The plan is archived and frozen; merge approval happens outside the plan.
+  - The plan is archived and frozen; merge approval happens outside the plan,
+    and CLI output may add a separate local handoff hint before the candidate
+    is truly ready to wait for approval.
 
 Step state such as "testing", "waiting for CI", or "resolving conflicts" must
 be inferred from step context plus `.local` review/CI/publish/sync artifacts
 and shown in CLI output rather than hand-maintained in the tracked markdown.
+The same rule applies to archived-plan handoff details such as "pending
+publish" or "waiting on post-archive CI".
 
 ## Required Sections
 
@@ -233,7 +237,7 @@ Every plan must contain these sections in order:
 `## Deferred Items` is the single place for consciously deferred slice items,
 whether they look more like postponed tasks or accepted-but-tracked risks.
 It is different from `Outcome Summary > Follow-Up Issues`, which records the
-actual tracker entries created to own those deferred items after archive.
+durable handoff note recorded at archive time for those deferred items.
 
 ### Scope Structure
 
@@ -349,14 +353,19 @@ Use these two surfaces deliberately:
 - `## Deferred Items`
   - work or risk deliberately deferred from the current slice
 - `## Outcome Summary > Follow-Up Issues`
-  - actual tracker items created to own deferred items or post-archive follow-up
+  - the durable handoff note recorded at archive time for deferred items that
+    are still intentionally left out of the current slice
 
 Archive readiness should enforce this distinction:
 
 - if `## Deferred Items` contains real items at archive time, the archived plan
   must not leave `### Follow-Up Issues` as `NONE`
-- archived follow-up entries should include concrete tracker references such as
-  issue numbers or URLs
+- archived follow-up entries should contain enough durable detail for the next
+  human or agent to continue the work; concrete issue or PR-comment references
+  are recommended but not required
+- follow-up discovered only after land belongs in issues, PR comments, or the
+  next plan's intake metadata rather than retroactive edits to the archived
+  plan
 - if there are no deferred items and no post-archive follow-up, `### Follow-Up
   Issues` may remain `NONE`
 
@@ -450,7 +459,7 @@ implementation.
 - active plans stored under `archived/` or archived plans stored under
   `active/`
 - archived plans with unchecked step-local acceptance criteria
-- archived plans with deferred items but no follow-up issue references
+- archived plans with deferred items but `Follow-Up Issues: NONE`
 - archived plans with completed steps that still contain
   `PENDING_STEP_EXECUTION` or `PENDING_STEP_REVIEW`
 - archived plans that still contain `PENDING_UNTIL_ARCHIVE`

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -46,6 +46,8 @@ func (a *App) Run(args []string) int {
 		return a.runPlan(args[1:])
 	case "review":
 		return a.runReview(args[1:])
+	case "land":
+		return a.runLand(args[1:])
 	case "archive":
 		return a.runArchive(args[1:])
 	case "reopen":
@@ -100,6 +102,24 @@ func (a *App) runPlan(args []string) int {
 	default:
 		fmt.Fprintf(a.Stderr, "unknown plan subcommand %q\n\n", args[0])
 		a.printPlanUsage()
+		return 2
+	}
+}
+
+func (a *App) runLand(args []string) int {
+	if len(args) == 0 {
+		a.printLandUsage()
+		return 2
+	}
+	switch args[0] {
+	case "record":
+		return a.runLandRecord(args[1:])
+	case "-h", "--help", "help":
+		a.printLandUsage()
+		return 0
+	default:
+		fmt.Fprintf(a.Stderr, "unknown land subcommand %q\n\n", args[0])
+		a.printLandUsage()
 		return 2
 	}
 }
@@ -334,6 +354,33 @@ func (a *App) runReviewAggregate(args []string) int {
 	return a.writeJSONResult(result)
 }
 
+func (a *App) runLandRecord(args []string) int {
+	fs := flag.NewFlagSet("harness land record", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(a.Stderr, "Usage: harness land record")
+		fmt.Fprintln(a.Stderr)
+		fmt.Fprintln(a.Stderr, "Record post-merge landed local state for the current archived plan.")
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+	workdir, err := a.Getwd()
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
+		return 1
+	}
+	result := lifecycle.Service{Workdir: workdir, Now: a.Now}.RecordLanded()
+	return a.writeJSONResult(result)
+}
+
 func (a *App) runArchive(args []string) int {
 	fs := flag.NewFlagSet("harness archive", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
@@ -415,6 +462,7 @@ func (a *App) printRootUsage() {
 	fmt.Fprintln(a.Stderr, "  review start    Create a deterministic review round")
 	fmt.Fprintln(a.Stderr, "  review submit   Record one reviewer submission")
 	fmt.Fprintln(a.Stderr, "  review aggregate Aggregate reviewer submissions")
+	fmt.Fprintln(a.Stderr, "  land record     Record post-merge landed local state")
 	fmt.Fprintln(a.Stderr, "  archive         Freeze the current active plan")
 	fmt.Fprintln(a.Stderr, "  reopen          Restore the current archived plan")
 	fmt.Fprintln(a.Stderr, "  status          Summarize the current plan and local execution state")
@@ -435,6 +483,13 @@ func (a *App) printReviewUsage() {
 	fmt.Fprintln(a.Stderr, "  start      Create a deterministic review round")
 	fmt.Fprintln(a.Stderr, "  submit     Record one reviewer submission")
 	fmt.Fprintln(a.Stderr, "  aggregate  Aggregate reviewer submissions")
+}
+
+func (a *App) printLandUsage() {
+	fmt.Fprintln(a.Stderr, "Usage: harness land <subcommand> [flags]")
+	fmt.Fprintln(a.Stderr)
+	fmt.Fprintln(a.Stderr, "Subcommands:")
+	fmt.Fprintln(a.Stderr, "  record    Record post-merge landed local state")
 }
 
 type stringListFlag []string

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/yzhang1918/superharness/internal/cli"
+	"github.com/yzhang1918/superharness/internal/plan"
+	"github.com/yzhang1918/superharness/internal/runstate"
+	"github.com/yzhang1918/superharness/internal/status"
 )
 
 func TestPlanTemplateWritesOutputFile(t *testing.T) {
@@ -136,4 +139,137 @@ func TestStatusCommandReturnsJSON(t *testing.T) {
 	if payload["command"] != "status" {
 		t.Fatalf("unexpected payload: %#v", payload)
 	}
+}
+
+func TestLandRecordCommandReturnsJSON(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 6, 0, 0, 0, time.UTC)
+	}
+
+	writeArchivedPlanForCLI(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	exitCode := app.Run([]string{"land", "record"})
+	if exitCode != 0 {
+		t.Fatalf("land record command failed with %d: %s", exitCode, stderr.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON land record output: %v\n%s", err, stdout.String())
+	}
+	if payload["command"] != "land record" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+}
+
+func TestLandRecordCommandRejectsActivePlanWithoutWritingLandedMarker(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 6, 0, 0, 0, time.UTC)
+	}
+
+	outputPath := filepath.Join(root, "docs/plans/active/2026-03-18-active-plan.md")
+	if exitCode := app.Run([]string{
+		"plan", "template",
+		"--title", "CLI Active Plan",
+		"--output", outputPath,
+	}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/active/2026-03-18-active-plan.md"); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+
+	exitCode := app.Run([]string{"land", "record"})
+	if exitCode != 1 {
+		t.Fatalf("expected land record failure exit code, got %d", exitCode)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON land record output: %v\n%s", err, stdout.String())
+	}
+	if payload["command"] != "land record" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	if ok, _ := payload["ok"].(bool); ok {
+		t.Fatalf("expected ok=false, got %#v", payload)
+	}
+
+	current, err := runstate.LoadCurrentPlan(root)
+	if err != nil {
+		t.Fatalf("load current plan: %v", err)
+	}
+	if current == nil || current.PlanPath != "docs/plans/active/2026-03-18-active-plan.md" {
+		t.Fatalf("expected active current plan to remain, got %#v", current)
+	}
+	if current.LastLandedPlanPath != "" || current.LastLandedAt != "" {
+		t.Fatalf("expected no landed marker on failed command, got %#v", current)
+	}
+
+	statusResult := status.Service{Workdir: root}.Read()
+	if !statusResult.OK {
+		t.Fatalf("expected active-plan status after failed land record, got %#v", statusResult)
+	}
+	if statusResult.State.WorktreeState == "idle_after_land" {
+		t.Fatalf("failed land record should not switch status to idle_after_land: %#v", statusResult)
+	}
+}
+
+func writeArchivedPlanForCLI(t *testing.T, root, relPath string) string {
+	t.Helper()
+	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title:      "CLI Landed Plan",
+		Timestamp:  time.Date(2026, 3, 18, 2, 0, 0, 0, time.UTC),
+		SourceType: "direct_request",
+	})
+	if err != nil {
+		t.Fatalf("RenderTemplate: %v", err)
+	}
+	content := rendered
+	content = bytes.NewBufferString(content).String()
+	content = replaceCLI(content, "status: active", "status: archived")
+	content = replaceCLI(content, "lifecycle: awaiting_plan_approval", "lifecycle: awaiting_merge_approval")
+	content = replaceCLIAll(content, "- Status: pending", "- Status: completed")
+	content = replaceCLIAll(content, "- [ ]", "- [x]")
+	content = replaceCLIAll(content, "PENDING_STEP_EXECUTION", "Done.")
+	content = replaceCLIAll(content, "PENDING_STEP_REVIEW", "Reviewed.")
+	content = replaceCLI(content, "## Validation Summary\n\nPENDING_UNTIL_ARCHIVE", "## Validation Summary\n\nValidated the slice.")
+	content = replaceCLI(content, "## Review Summary\n\nPENDING_UNTIL_ARCHIVE", "## Review Summary\n\nFull review passed.")
+	content = replaceCLI(content, "## Archive Summary\n\nPENDING_UNTIL_ARCHIVE", "## Archive Summary\n\n- Archived At: 2026-03-18T02:00:00Z\n- Revision: 1\n- PR: NONE\n- Ready: Ready for merge approval.\n- Merge Handoff: Commit and push before merge approval.")
+	content = replaceCLI(content, "### Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Delivered\n\nDelivered the slice.")
+	content = replaceCLI(content, "### Not Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Not Delivered\n\nNONE.")
+	path := filepath.Join(root, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write archived plan: %v", err)
+	}
+	return path
+}
+
+func replaceCLI(content, old, new string) string {
+	tuned := bytes.Replace([]byte(content), []byte(old), []byte(new), 1)
+	return string(tuned)
+}
+
+func replaceCLIAll(content, old, new string) string {
+	tuned := bytes.ReplaceAll([]byte(content), []byte(old), []byte(new))
+	return string(tuned)
 }

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -68,31 +68,11 @@ func (s Service) Archive() Result {
 			Message: fmt.Sprintf("archive requires status=active and lifecycle=executing, got status=%q lifecycle=%q", doc.Frontmatter.Status, doc.Frontmatter.Lifecycle),
 		}})
 	}
-	if !doc.AllAcceptanceChecked() {
-		return errorResult("archive", "Current plan is not archive-ready.", []CommandError{{Path: "section.Acceptance Criteria", Message: "all acceptance criteria must be checked before archive"}})
-	}
-	if !doc.AllStepsCompleted() {
-		return errorResult("archive", "Current plan is not archive-ready.", []CommandError{{Path: "section.Work Breakdown", Message: "all steps must be completed before archive"}})
-	}
-	if doc.HasPendingArchivePlaceholders() {
-		return errorResult("archive", "Current plan still contains archive placeholders.", []CommandError{{Path: "sections", Message: "replace every PENDING_UNTIL_ARCHIVE token before archive"}})
-	}
-	if doc.CompletedStepsHavePendingPlaceholders() {
-		return errorResult("archive", "Current plan still contains completed-step placeholders.", []CommandError{{Path: "steps", Message: "replace every PENDING_STEP_EXECUTION and PENDING_STEP_REVIEW token before archive"}})
-	}
-	if issues := archiveStateIssues(s.Workdir, planStem, doc.Frontmatter.Revision, state); len(issues) > 0 {
+	if issues := EvaluateArchiveReadiness(s.Workdir, planStem, doc, state); len(issues) > 0 {
 		return errorResult("archive", "Current plan is not archive-ready.", issues)
 	}
 
 	archiveSummary := doc.SectionText("Archive Summary")
-	missingLabels := missingArchiveSummaryLabels(archiveSummary, []string{"PR", "Ready", "Merge Handoff"})
-	if len(missingLabels) > 0 {
-		return errorResult("archive", "Archive Summary is missing required fields.", []CommandError{{
-			Path:    "section.Archive Summary",
-			Message: fmt.Sprintf("add archive summary lines for: %s", strings.Join(missingLabels, ", ")),
-		}})
-	}
-
 	archiveSummary = stripArchiveSummaryLines(archiveSummary, []string{"Archived At", "Revision"})
 	archiveSummary = strings.TrimSpace(strings.Join([]string{
 		fmt.Sprintf("- Archived At: %s", now.Format(time.RFC3339)),
@@ -128,28 +108,39 @@ func (s Service) Archive() Result {
 		_ = os.Remove(targetPath)
 		return errorResult("archive", "Archived plan did not pass validation.", lintErrorsToCommandErrors(lint.Errors))
 	}
-	if err := os.Remove(currentPath); err != nil {
-		_ = os.Remove(targetPath)
-		return errorResult("archive", "Unable to remove the active plan after archiving.", []CommandError{{Path: "path", Message: err.Error()}})
-	}
 
 	relTargetPath, err := filepath.Rel(s.Workdir, targetPath)
 	if err != nil {
+		_ = os.Remove(targetPath)
 		return errorResult("archive", "Unable to relativize archived plan path.", []CommandError{{Path: "path", Message: err.Error()}})
 	}
 	relTargetPath = filepath.ToSlash(relTargetPath)
 
-	currentPlanPath, err := runstate.SaveCurrentPlan(s.Workdir, relTargetPath)
-	if err != nil {
-		return errorResult("archive", "Unable to update current-plan pointer.", []CommandError{{Path: "state", Message: err.Error()}})
-	}
-	if state != nil {
-		state.PlanPath = relTargetPath
-		state.PlanStem = planStem
-		statePath, err = runstate.SaveState(s.Workdir, planStem, state)
+	originalState := cloneState(state)
+	nextState := cloneState(state)
+	if nextState != nil {
+		nextState.PlanPath = relTargetPath
+		nextState.PlanStem = planStem
+		statePath, err = runstate.SaveState(s.Workdir, planStem, nextState)
 		if err != nil {
+			_ = os.Remove(targetPath)
 			return errorResult("archive", "Unable to update local state after archiving.", []CommandError{{Path: "state", Message: err.Error()}})
 		}
+	}
+
+	currentPlanPath, err := runstate.SaveCurrentPlan(s.Workdir, relTargetPath)
+	if err != nil {
+		if originalState != nil {
+			_, _ = runstate.SaveState(s.Workdir, planStem, originalState)
+		}
+		_ = os.Remove(targetPath)
+		return errorResult("archive", "Unable to update current-plan pointer.", []CommandError{{Path: "state", Message: err.Error()}})
+	}
+
+	if err := os.Remove(currentPath); err != nil {
+		rollbackErrors := rollbackTransition(s.Workdir, relCurrentPath, planStem, originalState, targetPath)
+		rollbackErrors = append([]CommandError{{Path: "path", Message: err.Error()}}, rollbackErrors...)
+		return errorResult("archive", "Unable to remove the active plan after archiving.", rollbackErrors)
 	}
 
 	return Result{
@@ -242,31 +233,42 @@ func (s Service) Reopen() Result {
 		_ = os.Remove(targetPath)
 		return errorResult("reopen", "Reopened plan did not pass validation.", lintErrorsToCommandErrors(lint.Errors))
 	}
-	if err := os.Remove(currentPath); err != nil {
-		_ = os.Remove(targetPath)
-		return errorResult("reopen", "Unable to remove the archived plan after reopening.", []CommandError{{Path: "path", Message: err.Error()}})
-	}
 
 	relTargetPath, err := filepath.Rel(s.Workdir, targetPath)
 	if err != nil {
+		_ = os.Remove(targetPath)
 		return errorResult("reopen", "Unable to relativize active plan path.", []CommandError{{Path: "path", Message: err.Error()}})
 	}
 	relTargetPath = filepath.ToSlash(relTargetPath)
 
-	currentPlanPath, err := runstate.SaveCurrentPlan(s.Workdir, relTargetPath)
-	if err != nil {
-		return errorResult("reopen", "Unable to update current-plan pointer.", []CommandError{{Path: "state", Message: err.Error()}})
-	}
-	if state != nil {
-		state.PlanPath = relTargetPath
-		state.PlanStem = planStem
-		state.ActiveReviewRound = nil
-		state.LatestCI = nil
-		state.Sync = nil
-		statePath, err = runstate.SaveState(s.Workdir, planStem, state)
+	originalState := cloneState(state)
+	nextState := cloneState(state)
+	if nextState != nil {
+		nextState.PlanPath = relTargetPath
+		nextState.PlanStem = planStem
+		nextState.ActiveReviewRound = nil
+		nextState.LatestCI = nil
+		nextState.Sync = nil
+		statePath, err = runstate.SaveState(s.Workdir, planStem, nextState)
 		if err != nil {
+			_ = os.Remove(targetPath)
 			return errorResult("reopen", "Unable to update local state after reopen.", []CommandError{{Path: "state", Message: err.Error()}})
 		}
+	}
+
+	currentPlanPath, err := runstate.SaveCurrentPlan(s.Workdir, relTargetPath)
+	if err != nil {
+		if originalState != nil {
+			_, _ = runstate.SaveState(s.Workdir, planStem, originalState)
+		}
+		_ = os.Remove(targetPath)
+		return errorResult("reopen", "Unable to update current-plan pointer.", []CommandError{{Path: "state", Message: err.Error()}})
+	}
+
+	if err := os.Remove(currentPath); err != nil {
+		rollbackErrors := rollbackTransition(s.Workdir, relCurrentPath, planStem, originalState, targetPath)
+		rollbackErrors = append([]CommandError{{Path: "path", Message: err.Error()}}, rollbackErrors...)
+		return errorResult("reopen", "Unable to remove the archived plan after reopening.", rollbackErrors)
 	}
 
 	return Result{
@@ -288,6 +290,40 @@ func (s Service) Reopen() Result {
 			{Command: nil, Description: "Review the feedback or remote change that caused reopen."},
 			{Command: nil, Description: "Update the plan content if scope or acceptance criteria changed."},
 			{Command: nil, Description: "Continue the inferred current step, or set awaiting_plan_approval if the plan contract needs fresh approval."},
+		},
+	}
+}
+
+func (s Service) RecordLanded() Result {
+	now := s.now()
+	currentPath, doc, _, _, relCurrentPath, _, _, result := s.loadCurrentPlan()
+	if result != nil {
+		result.Command = "land record"
+		return *result
+	}
+	if doc.Frontmatter.Status != "archived" || doc.Frontmatter.Lifecycle != "awaiting_merge_approval" {
+		return errorResult("land record", "Current plan is not archived.", []CommandError{{
+			Path:    "plan.lifecycle",
+			Message: fmt.Sprintf("land record requires status=archived and lifecycle=awaiting_merge_approval, got status=%q lifecycle=%q", doc.Frontmatter.Status, doc.Frontmatter.Lifecycle),
+		}})
+	}
+
+	currentPlanPath, err := runstate.SaveLandedPlan(s.Workdir, relCurrentPath, now.Format(time.RFC3339))
+	if err != nil {
+		return errorResult("land record", "Unable to record landed local state.", []CommandError{{Path: "state", Message: err.Error()}})
+	}
+
+	return Result{
+		OK:      true,
+		Command: "land record",
+		Summary: fmt.Sprintf("Recorded landed local state for %s.", filepath.Base(currentPath)),
+		Artifacts: &Artifacts{
+			FromPlanPath:    relCurrentPath,
+			CurrentPlanPath: currentPlanPath,
+		},
+		NextAction: []NextAction{
+			{Command: nil, Description: "Run harness status to confirm the worktree now reports idle-after-land state."},
+			{Command: nil, Description: "Start discovery or create a new plan when the next slice is ready."},
 		},
 	}
 }
@@ -447,6 +483,55 @@ func (s Service) now() time.Time {
 
 func strPtr(value string) *string {
 	return &value
+}
+
+func cloneState(state *runstate.State) *runstate.State {
+	if state == nil {
+		return nil
+	}
+	cloned := *state
+	if state.ActiveReviewRound != nil {
+		round := *state.ActiveReviewRound
+		cloned.ActiveReviewRound = &round
+	}
+	if state.LatestCI != nil {
+		ci := *state.LatestCI
+		cloned.LatestCI = &ci
+	}
+	if state.Sync != nil {
+		sync := *state.Sync
+		cloned.Sync = &sync
+	}
+	if state.LatestPublish != nil {
+		publish := *state.LatestPublish
+		cloned.LatestPublish = &publish
+	}
+	return &cloned
+}
+
+func rollbackTransition(workdir, relCurrentPath, planStem string, originalState *runstate.State, targetPath string) []CommandError {
+	issues := make([]CommandError, 0)
+	if _, err := runstate.SaveCurrentPlan(workdir, relCurrentPath); err != nil {
+		issues = append(issues, CommandError{Path: "state", Message: fmt.Sprintf("rollback current-plan pointer: %v", err)})
+	}
+	if originalState != nil {
+		if _, err := runstate.SaveState(workdir, planStem, originalState); err != nil {
+			issues = append(issues, CommandError{Path: "state", Message: fmt.Sprintf("rollback local state: %v", err)})
+		}
+	}
+	if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+		issues = append(issues, CommandError{Path: "path", Message: fmt.Sprintf("rollback target path: %v", err)})
+	}
+	return issues
+}
+
+func EvaluateArchiveReadiness(workdir, planStem string, doc *plan.Document, state *runstate.State) []CommandError {
+	issues := make([]CommandError, 0)
+	for _, issue := range doc.ArchiveReadinessIssues() {
+		issues = append(issues, CommandError{Path: issue.Path, Message: issue.Message})
+	}
+	issues = append(issues, archiveStateIssues(workdir, planStem, doc.Frontmatter.Revision, state)...)
+	return issues
 }
 
 func archiveStateIssues(workdir, planStem string, revision int, state *runstate.State) []CommandError {

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yzhang1918/superharness/internal/lifecycle"
 	"github.com/yzhang1918/superharness/internal/plan"
 	"github.com/yzhang1918/superharness/internal/runstate"
+	"github.com/yzhang1918/superharness/internal/status"
 )
 
 func TestArchiveMovesPlanAndUpdatesPointers(t *testing.T) {
@@ -92,6 +93,99 @@ func TestArchiveRejectsMissingArchiveSummaryFields(t *testing.T) {
 		t.Fatalf("expected archive failure, got %#v", result)
 	}
 	assertErrorPath(t, result.Errors, "section.Archive Summary")
+}
+
+func TestArchivePreflightFailureLeavesPlanAndPointersUntouched(t *testing.T) {
+	root := t.TempDir()
+	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
+	activePath := filepath.Join(root, activeRelPath)
+	content := buildActiveArchiveCandidate(t)
+	content = strings.Replace(content, "## Deferred Items\n\n- None.\n", "## Deferred Items\n\n- Deferred follow-up still needs to be written down.\n", 1)
+	content = strings.Replace(content, "- PR: NONE\n", "", 1)
+	writeFile(t, activePath, content)
+	if _, err := runstate.SaveCurrentPlan(root, activeRelPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
+		PlanPath: activeRelPath,
+		PlanStem: "2026-03-18-archive-smoke",
+		ActiveReviewRound: &runstate.ReviewRound{
+			RoundID:    "review-001-full",
+			Kind:       "full",
+			Aggregated: true,
+			Decision:   "pass",
+		},
+	}); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	result := lifecycle.Service{Workdir: root}.Archive()
+	if result.OK {
+		t.Fatalf("expected archive failure, got %#v", result)
+	}
+	assertErrorPath(t, result.Errors, "section.Archive Summary")
+	assertErrorPath(t, result.Errors, "section.Outcome Summary.Follow-Up Issues")
+
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("expected active plan to remain after failed archive, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs/plans/archived/2026-03-18-archive-smoke.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected no archived plan to be written, got %v", err)
+	}
+	current, err := runstate.LoadCurrentPlan(root)
+	if err != nil {
+		t.Fatalf("load current plan: %v", err)
+	}
+	if current == nil || current.PlanPath != activeRelPath {
+		t.Fatalf("expected current plan pointer to remain on active plan, got %#v", current)
+	}
+	state, _, err := runstate.LoadState(root, "2026-03-18-archive-smoke")
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if state == nil || state.PlanPath != activeRelPath {
+		t.Fatalf("expected state pointer to remain on active plan, got %#v", state)
+	}
+}
+
+func TestArchiveRollsBackWhenCurrentPlanWriteFails(t *testing.T) {
+	root := t.TempDir()
+	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
+	activePath := writeActiveArchiveCandidate(t, root, activeRelPath)
+	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
+		PlanPath: activeRelPath,
+		PlanStem: "2026-03-18-archive-smoke",
+		ActiveReviewRound: &runstate.ReviewRound{
+			RoundID:    "review-001-full",
+			Kind:       "full",
+			Aggregated: true,
+			Decision:   "pass",
+		},
+	}); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	currentPlanAsDir := filepath.Join(root, ".local", "harness", "current-plan.json")
+	if err := os.MkdirAll(currentPlanAsDir, 0o755); err != nil {
+		t.Fatalf("mkdir current-plan dir: %v", err)
+	}
+
+	result := lifecycle.Service{Workdir: root}.Archive()
+	if result.OK {
+		t.Fatalf("expected archive failure, got %#v", result)
+	}
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("expected active plan to remain after rollback, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs/plans/archived/2026-03-18-archive-smoke.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected archived target to be removed on rollback, got %v", err)
+	}
+	state, _, err := runstate.LoadState(root, "2026-03-18-archive-smoke")
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if state == nil || state.PlanPath != activeRelPath {
+		t.Fatalf("expected state to roll back to active path, got %#v", state)
+	}
 }
 
 func TestArchiveRejectsUnresolvedLocalState(t *testing.T) {
@@ -405,10 +499,70 @@ func TestReopenClearsStaleCIAndSyncSignals(t *testing.T) {
 	}
 }
 
+func TestRecordLandedWritesIdleMarkerForStatus(t *testing.T) {
+	root := t.TempDir()
+	writeArchivedLandedPlan(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	result := lifecycle.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 6, 0, 0, 0, time.UTC)
+		},
+	}.RecordLanded()
+	if !result.OK {
+		t.Fatalf("expected landed record success, got %#v", result)
+	}
+
+	current, err := runstate.LoadCurrentPlan(root)
+	if err != nil {
+		t.Fatalf("load current plan: %v", err)
+	}
+	if current == nil || current.PlanPath != "" || current.LastLandedPlanPath != "docs/plans/archived/2026-03-18-landed-plan.md" {
+		t.Fatalf("unexpected current plan marker: %#v", current)
+	}
+
+	statusResult := status.Service{Workdir: root}.Read()
+	if !statusResult.OK {
+		t.Fatalf("expected idle-after-land status, got %#v", statusResult)
+	}
+	if statusResult.State.WorktreeState != "idle_after_land" {
+		t.Fatalf("unexpected worktree state: %#v", statusResult.State)
+	}
+}
+
 func writeActiveArchiveCandidate(t *testing.T, root, relPath string) string {
 	t.Helper()
 	path := filepath.Join(root, relPath)
 	writeFile(t, path, buildActiveArchiveCandidate(t))
+	return path
+}
+
+func writeArchivedLandedPlan(t *testing.T, root, relPath string) string {
+	t.Helper()
+	path := filepath.Join(root, relPath)
+	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title:      "Landed Plan",
+		Timestamp:  time.Date(2026, 3, 18, 2, 0, 0, 0, time.UTC),
+		SourceType: "direct_request",
+	})
+	if err != nil {
+		t.Fatalf("render template: %v", err)
+	}
+	rendered = strings.Replace(rendered, "status: active", "status: archived", 1)
+	rendered = strings.Replace(rendered, "lifecycle: awaiting_plan_approval", "lifecycle: awaiting_merge_approval", 1)
+	rendered = strings.ReplaceAll(rendered, "- Status: pending", "- Status: completed")
+	rendered = strings.ReplaceAll(rendered, "- [ ]", "- [x]")
+	rendered = strings.ReplaceAll(rendered, "PENDING_STEP_EXECUTION", "Done.")
+	rendered = strings.ReplaceAll(rendered, "PENDING_STEP_REVIEW", "Reviewed.")
+	rendered = strings.Replace(rendered, "## Validation Summary\n\nPENDING_UNTIL_ARCHIVE", "## Validation Summary\n\nValidated the slice.", 1)
+	rendered = strings.Replace(rendered, "## Review Summary\n\nPENDING_UNTIL_ARCHIVE", "## Review Summary\n\nFull review passed.", 1)
+	rendered = strings.Replace(rendered, "## Archive Summary\n\nPENDING_UNTIL_ARCHIVE", "## Archive Summary\n\n- Archived At: 2026-03-18T02:00:00Z\n- Revision: 1\n- PR: NONE\n- Ready: Ready for merge approval.\n- Merge Handoff: Commit and push before merge approval.", 1)
+	rendered = strings.Replace(rendered, "### Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Delivered\n\nDelivered the slice.", 1)
+	rendered = strings.Replace(rendered, "### Not Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Not Delivered\n\nNONE.", 1)
+	writeFile(t, path, rendered)
 	return path
 }
 

--- a/internal/plan/current.go
+++ b/internal/plan/current.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 
 	"github.com/yzhang1918/superharness/internal/runstate"
 )
+
+var ErrNoCurrentPlan = errors.New("no current plan found")
 
 func DetectCurrentPath(workdir string) (string, error) {
 	activeMatches, err := filepath.Glob(filepath.Join(workdir, "docs", "plans", "active", "*.md"))
@@ -50,16 +53,7 @@ func DetectCurrentPath(workdir string) (string, error) {
 		return "", fmt.Errorf("multiple active plans found; add .local/harness/current-plan.json to disambiguate")
 	}
 
-	archivedMatches, err := filepath.Glob(filepath.Join(workdir, "docs", "plans", "archived", "*.md"))
-	if err != nil {
-		return "", err
-	}
-	sort.Strings(archivedMatches)
-	if len(archivedMatches) == 1 {
-		return archivedMatches[0], nil
-	}
-
-	return "", fmt.Errorf("no current plan found")
+	return "", ErrNoCurrentPlan
 }
 
 func containsPath(paths []string, target string) bool {

--- a/internal/plan/current_test.go
+++ b/internal/plan/current_test.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,6 +61,16 @@ func TestDetectCurrentPathErrorsWhenArchivedPointerCannotDisambiguateMultipleAct
 
 	if _, err := DetectCurrentPath(root); err == nil {
 		t.Fatal("expected error when archived pointer cannot disambiguate multiple active plans")
+	}
+}
+
+func TestDetectCurrentPathDoesNotFallBackToArchivedPlanWithoutPointer(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "docs", "plans", "archived", "2026-03-17-old-work.md"))
+
+	_, err := DetectCurrentPath(root)
+	if !errors.Is(err, ErrNoCurrentPlan) {
+		t.Fatalf("expected ErrNoCurrentPlan, got %v", err)
 	}
 }
 

--- a/internal/plan/document.go
+++ b/internal/plan/document.go
@@ -31,6 +31,11 @@ type DocumentCheckbox struct {
 	Checked bool
 }
 
+type DocumentIssue struct {
+	Path    string
+	Message string
+}
+
 func LoadFile(path string) (*Document, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
@@ -160,10 +165,86 @@ func (d *Document) CompletedStepsHavePendingPlaceholders() bool {
 	return false
 }
 
+func (d *Document) ArchiveReadinessIssues() []DocumentIssue {
+	issues := make([]DocumentIssue, 0)
+	if !d.AllAcceptanceChecked() {
+		issues = append(issues, DocumentIssue{
+			Path:    "section.Acceptance Criteria",
+			Message: "all acceptance criteria must be checked before archive",
+		})
+	}
+	if !d.AllStepsCompleted() {
+		issues = append(issues, DocumentIssue{
+			Path:    "section.Work Breakdown",
+			Message: "all steps must be completed before archive",
+		})
+	}
+
+	for _, sectionName := range []string{"Validation Summary", "Review Summary", "Archive Summary", "Outcome Summary"} {
+		section := d.Sections[sectionName]
+		if section != nil && strings.Contains(strings.Join(section.lines, "\n"), "PENDING_UNTIL_ARCHIVE") {
+			issues = append(issues, DocumentIssue{
+				Path:    "section." + sectionName,
+				Message: "replace PENDING_UNTIL_ARCHIVE before archive",
+			})
+		}
+	}
+
+	for _, step := range d.Steps {
+		if step.Status != "completed" {
+			continue
+		}
+		if step.Sections["Execution Notes"] == "PENDING_STEP_EXECUTION" {
+			issues = append(issues, DocumentIssue{
+				Path:    "step." + step.Title + ".Execution Notes",
+				Message: "replace PENDING_STEP_EXECUTION before archive",
+			})
+		}
+		if step.Sections["Review Notes"] == "PENDING_STEP_REVIEW" {
+			issues = append(issues, DocumentIssue{
+				Path:    "step." + step.Title + ".Review Notes",
+				Message: "replace PENDING_STEP_REVIEW before archive",
+			})
+		}
+	}
+
+	archiveSummary := d.SectionText("Archive Summary")
+	for _, label := range []string{"PR", "Ready", "Merge Handoff"} {
+		if !strings.Contains(archiveSummary, "- "+label+":") {
+			issues = append(issues, DocumentIssue{
+				Path:    "section.Archive Summary",
+				Message: fmt.Sprintf("add archive summary line for: %s", label),
+			})
+		}
+	}
+
+	if d.DeferredItems && d.followUpIssuesUnset() {
+		issues = append(issues, DocumentIssue{
+			Path:    "section.Outcome Summary.Follow-Up Issues",
+			Message: "replace NONE with follow-up information before archive when deferred items remain",
+		})
+	}
+
+	return issues
+}
+
 func (d *Document) SectionText(name string) string {
 	section := d.Sections[name]
 	if section == nil {
 		return ""
 	}
 	return strings.TrimSpace(strings.Join(section.lines, "\n"))
+}
+
+func (d *Document) followUpIssuesUnset() bool {
+	section := d.Sections["Outcome Summary"]
+	if section == nil {
+		return true
+	}
+	subsections, _ := parseLevelThreeSections(section.lines)
+	followUp := subsections["Follow-Up Issues"]
+	if followUp == nil {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(strings.Join(followUp.lines, "\n")), "NONE")
 }

--- a/internal/runstate/state.go
+++ b/internal/runstate/state.go
@@ -9,7 +9,9 @@ import (
 )
 
 type CurrentPlan struct {
-	PlanPath string `json:"plan_path"`
+	PlanPath           string `json:"plan_path,omitempty"`
+	LastLandedPlanPath string `json:"last_landed_plan_path,omitempty"`
+	LastLandedAt       string `json:"last_landed_at,omitempty"`
 }
 
 type State struct {
@@ -64,11 +66,22 @@ func LoadCurrentPlan(workdir string) (*CurrentPlan, error) {
 }
 
 func SaveCurrentPlan(workdir, planPath string) (string, error) {
+	return saveCurrentPlan(workdir, CurrentPlan{PlanPath: planPath})
+}
+
+func SaveLandedPlan(workdir, planPath, landedAt string) (string, error) {
+	return saveCurrentPlan(workdir, CurrentPlan{
+		LastLandedPlanPath: planPath,
+		LastLandedAt:       landedAt,
+	})
+}
+
+func saveCurrentPlan(workdir string, current CurrentPlan) (string, error) {
 	path := filepath.Join(workdir, ".local", "harness", "current-plan.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
 	}
-	data, err := json.MarshalIndent(CurrentPlan{PlanPath: planPath}, "", "  ")
+	data, err := json.MarshalIndent(current, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("marshal current-plan.json: %w", err)
 	}

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -1,10 +1,12 @@
 package status
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 
+	"github.com/yzhang1918/superharness/internal/lifecycle"
 	"github.com/yzhang1918/superharness/internal/plan"
 	"github.com/yzhang1918/superharness/internal/runstate"
 )
@@ -20,22 +22,28 @@ type Result struct {
 	State      State         `json:"state"`
 	Artifacts  *Artifacts    `json:"artifacts,omitempty"`
 	NextAction []NextAction  `json:"next_actions"`
+	Blockers   []StatusError `json:"blockers,omitempty"`
 	Warnings   []string      `json:"warnings,omitempty"`
 	Errors     []StatusError `json:"errors,omitempty"`
 }
 
 type State struct {
-	PlanStatus string `json:"plan_status"`
-	Lifecycle  string `json:"lifecycle"`
-	Step       string `json:"step,omitempty"`
-	StepState  string `json:"step_state,omitempty"`
+	PlanStatus    string `json:"plan_status"`
+	Lifecycle     string `json:"lifecycle"`
+	Step          string `json:"step,omitempty"`
+	StepState     string `json:"step_state,omitempty"`
+	HandoffState  string `json:"handoff_state,omitempty"`
+	WorktreeState string `json:"worktree_state,omitempty"`
 }
 
 type Artifacts struct {
-	PlanPath       string `json:"plan_path"`
-	LocalStatePath string `json:"local_state_path,omitempty"`
-	ReviewRoundID  string `json:"review_round_id,omitempty"`
-	CISnapshotID   string `json:"ci_snapshot_id,omitempty"`
+	PlanPath           string `json:"plan_path,omitempty"`
+	LocalStatePath     string `json:"local_state_path,omitempty"`
+	ReviewRoundID      string `json:"review_round_id,omitempty"`
+	CISnapshotID       string `json:"ci_snapshot_id,omitempty"`
+	PRURL              string `json:"pr_url,omitempty"`
+	LastLandedPlanPath string `json:"last_landed_plan_path,omitempty"`
+	LastLandedAt       string `json:"last_landed_at,omitempty"`
 }
 
 type NextAction struct {
@@ -49,8 +57,21 @@ type StatusError struct {
 }
 
 func (s Service) Read() Result {
+	currentPlan, err := runstate.LoadCurrentPlan(s.Workdir)
+	if err != nil {
+		return Result{
+			OK:      false,
+			Command: "status",
+			Summary: "Unable to read current worktree state.",
+			Errors:  []StatusError{{Path: "state", Message: err.Error()}},
+		}
+	}
+
 	planPath, err := plan.DetectCurrentPath(s.Workdir)
 	if err != nil {
+		if errors.Is(err, plan.ErrNoCurrentPlan) && currentPlan != nil && strings.TrimSpace(currentPlan.LastLandedPlanPath) != "" {
+			return idleAfterLandResult(currentPlan)
+		}
 		return Result{
 			OK:      false,
 			Command: "status",
@@ -114,11 +135,22 @@ func (s Service) Read() Result {
 		}
 	}
 
+	archiveBlockers := make([]lifecycle.CommandError, 0)
+	if doc.Frontmatter.Lifecycle == "executing" && doc.AllStepsCompleted() && doc.AllAcceptanceChecked() {
+		archiveBlockers = lifecycle.EvaluateArchiveReadiness(s.Workdir, planStem, doc, state)
+		for _, blocker := range archiveBlockers {
+			result.Blockers = append(result.Blockers, StatusError{Path: blocker.Path, Message: blocker.Message})
+		}
+	}
+	if doc.Frontmatter.Lifecycle == "awaiting_merge_approval" {
+		result.State.HandoffState = inferHandoffState(state)
+	}
+
 	if current := doc.CurrentStep(); current != nil {
 		result.State.Step = current.Title
 	}
 	if doc.Frontmatter.Lifecycle == "executing" {
-		result.State.StepState = inferStepState(doc, state, reviewDecisionKnown, reviewDecision)
+		result.State.StepState = inferStepState(doc, state, reviewDecisionKnown, reviewDecision, archiveBlockers)
 	}
 	if state != nil {
 		if state.ActiveReviewRound != nil {
@@ -127,16 +159,19 @@ func (s Service) Read() Result {
 		if state.LatestCI != nil {
 			result.Artifacts.CISnapshotID = state.LatestCI.SnapshotID
 		}
+		if state.LatestPublish != nil {
+			result.Artifacts.PRURL = state.LatestPublish.PRURL
+		}
 	}
 
 	result.Warnings = append(result.Warnings, buildWarnings(state)...)
-	result.NextAction = buildNextActions(doc, state, result.State.StepState, reviewDecisionKnown)
-	result.Summary = buildSummary(doc, state, result.State.StepState, reviewDecisionKnown)
+	result.NextAction = buildNextActions(doc, state, result.State.StepState, result.State.HandoffState, reviewDecisionKnown, result.Blockers)
+	result.Summary = buildSummary(doc, state, result.State.StepState, result.State.HandoffState, reviewDecisionKnown, result.Blockers)
 
 	return result
 }
 
-func inferStepState(doc *plan.Document, state *runstate.State, reviewDecisionKnown bool, reviewDecision string) string {
+func inferStepState(doc *plan.Document, state *runstate.State, reviewDecisionKnown bool, reviewDecision string, archiveBlockers []lifecycle.CommandError) string {
 	if state != nil {
 		if state.Sync != nil && state.Sync.Conflicts {
 			return "resolving_conflicts"
@@ -151,7 +186,7 @@ func inferStepState(doc *plan.Document, state *runstate.State, reviewDecisionKno
 			return "waiting_ci"
 		}
 	}
-	if doc.AllStepsCompleted() && doc.AllAcceptanceChecked() && !doc.HasPendingArchivePlaceholders() && !doc.CompletedStepsHavePendingPlaceholders() {
+	if doc.AllStepsCompleted() && doc.AllAcceptanceChecked() && len(archiveBlockers) == 0 {
 		return "ready_for_archive"
 	}
 	return "implementing"
@@ -171,7 +206,35 @@ func buildWarnings(state *runstate.State) []string {
 	}
 }
 
-func buildNextActions(doc *plan.Document, state *runstate.State, stepState string, reviewDecisionKnown bool) []NextAction {
+func inferHandoffState(state *runstate.State) string {
+	if state == nil || state.LatestPublish == nil || strings.TrimSpace(state.LatestPublish.PRURL) == "" {
+		return "pending_publish"
+	}
+	if state.Sync == nil {
+		return "followup_required"
+	}
+	if state.Sync.Conflicts {
+		return "followup_required"
+	}
+	switch strings.ToLower(strings.TrimSpace(state.Sync.Freshness)) {
+	case "fresh":
+	default:
+		return "followup_required"
+	}
+	if state.LatestCI != nil {
+		switch strings.ToLower(strings.TrimSpace(state.LatestCI.Status)) {
+		case "pending":
+			return "waiting_post_archive_ci"
+		case "success", "passed", "green", "succeeded":
+			return "ready_for_merge_approval"
+		default:
+			return "followup_required"
+		}
+	}
+	return "waiting_post_archive_ci"
+}
+
+func buildNextActions(doc *plan.Document, state *runstate.State, stepState string, handoffState string, reviewDecisionKnown bool, blockers []StatusError) []NextAction {
 	next := make([]NextAction, 0)
 	if state != nil && state.Sync != nil && (state.Sync.Freshness == "stale" || state.Sync.Freshness == "unknown") {
 		next = append(next, NextAction{
@@ -186,10 +249,17 @@ func buildNextActions(doc *plan.Document, state *runstate.State, stepState strin
 	case "blocked":
 		next = append(next, NextAction{Command: nil, Description: "Resolve the blocking dependency or get human input before continuing."})
 	case "awaiting_merge_approval":
-		next = append(next,
-			NextAction{Command: nil, Description: "Wait for merge approval or merge manually from the PR once checks are green."},
-			NextAction{Command: strPtr("harness reopen"), Description: "Reopen the plan if new feedback or remote changes mean the archived candidate is no longer ready."},
-		)
+		switch handoffState {
+		case "pending_publish":
+			next = append(next, NextAction{Command: nil, Description: "Commit the archive move, push the branch, and open or update the PR before treating this candidate as ready for merge approval."})
+		case "waiting_post_archive_ci":
+			next = append(next, NextAction{Command: nil, Description: "Wait for required post-archive CI to finish, then address any failures before merge approval."})
+		case "followup_required":
+			next = append(next, NextAction{Command: nil, Description: "Refresh or repair the archived candidate's publish, CI, or sync handoff before merge approval."})
+		default:
+			next = append(next, NextAction{Command: nil, Description: "Wait for merge approval or merge manually from the PR once checks are green."})
+		}
+		next = append(next, NextAction{Command: strPtr("harness reopen"), Description: "Reopen the plan if new feedback or remote changes mean the archived candidate is no longer ready."})
 	default:
 		if stepState == "fix_required" {
 			description := "Address the findings from the latest aggregated review, update step-local notes, rerun focused validation, and start a fresh review round once the slice is ready."
@@ -212,10 +282,17 @@ func buildNextActions(doc *plan.Document, state *runstate.State, stepState strin
 			)
 			break
 		}
+		if doc.CurrentStep() == nil && doc.AllStepsCompleted() && doc.AllAcceptanceChecked() && len(blockers) > 0 {
+			next = append(next, NextAction{
+				Command:     nil,
+				Description: "Fix the archive blockers surfaced below, update the durable summaries or local state, and rerun harness status before archive.",
+			})
+			break
+		}
 		if doc.CurrentStep() == nil && doc.AllStepsCompleted() && doc.AllAcceptanceChecked() {
 			next = append(next, NextAction{
 				Command:     nil,
-				Description: "Write the final Validation, Review, Archive, and Outcome summaries, then verify deferred items have follow-up issue references before archive.",
+				Description: "Write the final Validation, Review, Archive, and Outcome summaries, then verify deferred items have follow-up details before archive.",
 			})
 			break
 		}
@@ -234,14 +311,23 @@ func buildNextActions(doc *plan.Document, state *runstate.State, stepState strin
 	return next
 }
 
-func buildSummary(doc *plan.Document, state *runstate.State, stepState string, reviewDecisionKnown bool) string {
+func buildSummary(doc *plan.Document, state *runstate.State, stepState string, handoffState string, reviewDecisionKnown bool, blockers []StatusError) string {
 	switch doc.Frontmatter.Lifecycle {
 	case "awaiting_plan_approval":
 		return "Plan is awaiting approval before execution begins."
 	case "blocked":
 		return "Plan is currently blocked and needs external input before continuing."
 	case "awaiting_merge_approval":
-		return "Plan is archived and waiting for merge approval."
+		switch handoffState {
+		case "pending_publish":
+			return "Plan is archived locally but still needs publish handoff before merge approval."
+		case "waiting_post_archive_ci":
+			return "Plan is archived and published, and post-archive CI is still in flight before merge approval."
+		case "followup_required":
+			return "Plan is archived, but local handoff evidence still needs follow-up before merge approval."
+		default:
+			return "Plan is archived, published, and ready to wait for merge approval."
+		}
 	}
 
 	if stepState == "ready_for_archive" {
@@ -257,8 +343,8 @@ func buildSummary(doc *plan.Document, state *runstate.State, stepState string, r
 		return fmt.Sprintf("Plan still needs follow-up because the latest aggregated review (%s) requested changes.", state.ActiveReviewRound.RoundID)
 	}
 
-	if doc.CurrentStep() == nil && doc.AllStepsCompleted() && doc.AllAcceptanceChecked() {
-		return "Plan has completed all tracked steps and now needs archive-ready summaries before it can be archived."
+	if doc.CurrentStep() == nil && doc.AllStepsCompleted() && doc.AllAcceptanceChecked() && len(blockers) > 0 {
+		return fmt.Sprintf("Plan has completed all tracked steps but still has %d archive blocker(s) to fix before archive.", len(blockers))
 	}
 
 	if step := doc.CurrentStep(); step != nil {
@@ -268,6 +354,25 @@ func buildSummary(doc *plan.Document, state *runstate.State, stepState string, r
 		return fmt.Sprintf("Plan is %s %s.", doc.Frontmatter.Lifecycle, step.Title)
 	}
 	return fmt.Sprintf("Plan is %s.", doc.Frontmatter.Lifecycle)
+}
+
+func idleAfterLandResult(currentPlan *runstate.CurrentPlan) Result {
+	return Result{
+		OK:      true,
+		Command: "status",
+		Summary: "No current plan is active in this worktree. The most recent landed candidate is recorded for handoff context.",
+		State: State{
+			WorktreeState: "idle_after_land",
+		},
+		Artifacts: &Artifacts{
+			LastLandedPlanPath: currentPlan.LastLandedPlanPath,
+			LastLandedAt:       currentPlan.LastLandedAt,
+		},
+		NextAction: []NextAction{
+			{Command: nil, Description: "Start discovery or create a new plan for the next slice when new work is ready."},
+			{Command: nil, Description: "Record any post-land retrospective follow-up in issues or PR comments instead of editing the archived plan."},
+		},
+	}
 }
 
 func strPtr(value string) *string {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -245,8 +245,20 @@ func TestStatusReadyForArchive(t *testing.T) {
 		content = stringsReplaceAll(content, "- [ ]", "- [x]")
 		content = stringsReplaceAll(content, "PENDING_STEP_EXECUTION", "Done.")
 		content = stringsReplaceAll(content, "PENDING_STEP_REVIEW", "Reviewed.")
-		content = stringsReplaceAll(content, "PENDING_UNTIL_ARCHIVE", "Ready.")
+		content = stringsReplaceAll(content, "## Validation Summary\n\nPENDING_UNTIL_ARCHIVE", "## Validation Summary\n\nValidated the implementation.")
+		content = stringsReplaceAll(content, "## Review Summary\n\nPENDING_UNTIL_ARCHIVE", "## Review Summary\n\nNo blocking review findings remain.")
+		content = stringsReplaceAll(content, "## Archive Summary\n\nPENDING_UNTIL_ARCHIVE", "## Archive Summary\n\n- PR: NONE\n- Ready: The candidate satisfies the acceptance criteria and is ready for merge approval.\n- Merge Handoff: Commit and push the archive move before treating this candidate as awaiting merge approval.")
+		content = stringsReplaceAll(content, "### Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Delivered\n\nDelivered the planned slice.")
+		content = stringsReplaceAll(content, "### Not Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Not Delivered\n\nNONE.")
 		return content
+	})
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"active_review_round": map[string]any{
+			"round_id":   "review-001-full",
+			"kind":       "full",
+			"aggregated": true,
+			"decision":   "pass",
+		},
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -279,15 +291,18 @@ func TestStatusCloseoutBeforeArchive(t *testing.T) {
 	if result.State.Step != "" {
 		t.Fatalf("expected no current step, got %#v", result.State)
 	}
-	if len(result.NextAction) == 0 || !strings.Contains(result.NextAction[0].Description, "Validation, Review, Archive, and Outcome summaries") {
+	if len(result.Blockers) == 0 {
+		t.Fatalf("expected archive blockers, got %#v", result)
+	}
+	if len(result.NextAction) == 0 || !strings.Contains(result.NextAction[0].Description, "Fix the archive blockers") {
 		t.Fatalf("unexpected next actions: %#v", result.NextAction)
 	}
-	if !strings.Contains(result.Summary, "archive-ready summaries") {
+	if !strings.Contains(result.Summary, "archive blocker") {
 		t.Fatalf("unexpected summary: %q", result.Summary)
 	}
 }
 
-func TestStatusArchivedPlan(t *testing.T) {
+func TestStatusArchivedPlanNeedsPublishHandoff(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
 		content = replaceOnce(t, content, "status: active", "status: archived")
@@ -299,6 +314,7 @@ func TestStatusArchivedPlan(t *testing.T) {
 		content = stringsReplaceAll(content, "PENDING_UNTIL_ARCHIVE", "Ready.")
 		return content
 	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
 
 	result := status.Service{Workdir: root}.Read()
 	if !result.OK || result.State.PlanStatus != "archived" || result.State.Lifecycle != "awaiting_merge_approval" {
@@ -306,6 +322,277 @@ func TestStatusArchivedPlan(t *testing.T) {
 	}
 	if result.State.StepState != "" {
 		t.Fatalf("expected no step_state for archived plan, got %#v", result.State)
+	}
+	if result.State.HandoffState != "pending_publish" {
+		t.Fatalf("expected pending_publish handoff state, got %#v", result.State)
+	}
+	if !strings.Contains(result.Summary, "archived locally") {
+		t.Fatalf("unexpected summary: %q", result.Summary)
+	}
+	if len(result.NextAction) == 0 || !strings.Contains(result.NextAction[0].Description, "open or update the PR") {
+		t.Fatalf("unexpected next actions: %#v", result.NextAction)
+	}
+}
+
+func TestStatusArchivedPlanWaitingForPostArchiveCI(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		content = replaceOnce(t, content, "status: active", "status: archived")
+		content = replaceOnce(t, content, "lifecycle: awaiting_plan_approval", "lifecycle: awaiting_merge_approval")
+		content = stringsReplaceAll(content, "- Status: pending", "- Status: completed")
+		content = stringsReplaceAll(content, "- [ ]", "- [x]")
+		content = stringsReplaceAll(content, "PENDING_STEP_EXECUTION", "Done.")
+		content = stringsReplaceAll(content, "PENDING_STEP_REVIEW", "Reviewed.")
+		content = stringsReplaceAll(content, "PENDING_UNTIL_ARCHIVE", "Ready.")
+		return content
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"latest_publish": map[string]any{
+			"attempt_id": "publish-001",
+			"pr_url":     "https://github.com/yzhang1918/superharness/pull/13",
+		},
+		"latest_ci": map[string]any{
+			"snapshot_id": "ci-001",
+			"status":      "pending",
+		},
+		"sync": map[string]any{
+			"freshness": "fresh",
+			"conflicts": false,
+		},
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if result.State.HandoffState != "waiting_post_archive_ci" {
+		t.Fatalf("expected waiting_post_archive_ci handoff state, got %#v", result.State)
+	}
+	if !strings.Contains(result.Summary, "post-archive CI") {
+		t.Fatalf("unexpected summary: %q", result.Summary)
+	}
+	if result.Artifacts == nil || result.Artifacts.PRURL != "https://github.com/yzhang1918/superharness/pull/13" {
+		t.Fatalf("unexpected artifacts: %#v", result.Artifacts)
+	}
+}
+
+func TestStatusArchivedPlanNeedsCIEvidenceBeforeMergeApproval(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		content = replaceOnce(t, content, "status: active", "status: archived")
+		content = replaceOnce(t, content, "lifecycle: awaiting_plan_approval", "lifecycle: awaiting_merge_approval")
+		content = stringsReplaceAll(content, "- Status: pending", "- Status: completed")
+		content = stringsReplaceAll(content, "- [ ]", "- [x]")
+		content = stringsReplaceAll(content, "PENDING_STEP_EXECUTION", "Done.")
+		content = stringsReplaceAll(content, "PENDING_STEP_REVIEW", "Reviewed.")
+		content = stringsReplaceAll(content, "PENDING_UNTIL_ARCHIVE", "Ready.")
+		return content
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"latest_publish": map[string]any{
+			"attempt_id": "publish-001",
+			"pr_url":     "https://github.com/yzhang1918/superharness/pull/13",
+		},
+		"sync": map[string]any{
+			"freshness": "fresh",
+			"conflicts": false,
+		},
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if result.State.HandoffState != "waiting_post_archive_ci" {
+		t.Fatalf("expected waiting_post_archive_ci without CI evidence, got %#v", result.State)
+	}
+	if !strings.Contains(result.Summary, "post-archive CI") {
+		t.Fatalf("unexpected summary: %q", result.Summary)
+	}
+}
+
+func TestStatusArchivedPlanReadyForMergeApproval(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		content = replaceOnce(t, content, "status: active", "status: archived")
+		content = replaceOnce(t, content, "lifecycle: awaiting_plan_approval", "lifecycle: awaiting_merge_approval")
+		content = stringsReplaceAll(content, "- Status: pending", "- Status: completed")
+		content = stringsReplaceAll(content, "- [ ]", "- [x]")
+		content = stringsReplaceAll(content, "PENDING_STEP_EXECUTION", "Done.")
+		content = stringsReplaceAll(content, "PENDING_STEP_REVIEW", "Reviewed.")
+		content = stringsReplaceAll(content, "PENDING_UNTIL_ARCHIVE", "Ready.")
+		return content
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"latest_publish": map[string]any{
+			"attempt_id": "publish-001",
+			"pr_url":     "https://github.com/yzhang1918/superharness/pull/13",
+		},
+		"latest_ci": map[string]any{
+			"snapshot_id": "ci-001",
+			"status":      "success",
+		},
+		"sync": map[string]any{
+			"freshness": "fresh",
+			"conflicts": false,
+		},
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if result.State.HandoffState != "ready_for_merge_approval" {
+		t.Fatalf("expected ready_for_merge_approval handoff state, got %#v", result.State)
+	}
+	if !strings.Contains(result.Summary, "ready to wait for merge approval") {
+		t.Fatalf("unexpected summary: %q", result.Summary)
+	}
+	if len(result.NextAction) == 0 || !strings.Contains(result.NextAction[0].Description, "Wait for merge approval") {
+		t.Fatalf("unexpected next actions: %#v", result.NextAction)
+	}
+}
+
+func TestStatusArchivedPlanRequiresSyncEvidenceBeforeMergeApproval(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		content = replaceOnce(t, content, "status: active", "status: archived")
+		content = replaceOnce(t, content, "lifecycle: awaiting_plan_approval", "lifecycle: awaiting_merge_approval")
+		content = stringsReplaceAll(content, "- Status: pending", "- Status: completed")
+		content = stringsReplaceAll(content, "- [ ]", "- [x]")
+		content = stringsReplaceAll(content, "PENDING_STEP_EXECUTION", "Done.")
+		content = stringsReplaceAll(content, "PENDING_STEP_REVIEW", "Reviewed.")
+		content = stringsReplaceAll(content, "PENDING_UNTIL_ARCHIVE", "Ready.")
+		return content
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"latest_publish": map[string]any{
+			"attempt_id": "publish-001",
+			"pr_url":     "https://github.com/yzhang1918/superharness/pull/13",
+		},
+		"latest_ci": map[string]any{
+			"snapshot_id": "ci-001",
+			"status":      "success",
+		},
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if result.State.HandoffState != "followup_required" {
+		t.Fatalf("expected followup_required without sync evidence, got %#v", result.State)
+	}
+	if !strings.Contains(result.Summary, "needs follow-up") {
+		t.Fatalf("unexpected summary: %q", result.Summary)
+	}
+}
+
+func TestStatusArchivedPlanRequiresFollowupWhenSyncIsNotClean(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		content = replaceOnce(t, content, "status: active", "status: archived")
+		content = replaceOnce(t, content, "lifecycle: awaiting_plan_approval", "lifecycle: awaiting_merge_approval")
+		content = stringsReplaceAll(content, "- Status: pending", "- Status: completed")
+		content = stringsReplaceAll(content, "- [ ]", "- [x]")
+		content = stringsReplaceAll(content, "PENDING_STEP_EXECUTION", "Done.")
+		content = stringsReplaceAll(content, "PENDING_STEP_REVIEW", "Reviewed.")
+		content = stringsReplaceAll(content, "PENDING_UNTIL_ARCHIVE", "Ready.")
+		return content
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"latest_publish": map[string]any{
+			"attempt_id": "publish-001",
+			"pr_url":     "https://github.com/yzhang1918/superharness/pull/13",
+		},
+		"latest_ci": map[string]any{
+			"snapshot_id": "ci-001",
+			"status":      "success",
+		},
+		"sync": map[string]any{
+			"freshness": "stale",
+			"conflicts": false,
+		},
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if result.State.HandoffState != "followup_required" {
+		t.Fatalf("expected followup_required handoff state, got %#v", result.State)
+	}
+	if !strings.Contains(result.Summary, "needs follow-up") {
+		t.Fatalf("unexpected summary: %q", result.Summary)
+	}
+	if len(result.NextAction) == 0 || !strings.Contains(result.NextAction[0].Description, "Refresh remote state") {
+		t.Fatalf("expected remote follow-up guidance, got %#v", result.NextAction)
+	}
+}
+
+func TestStatusSurfacesArchiveBlockersBeforeArchive(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
+		content = replaceOnce(t, content, "lifecycle: awaiting_plan_approval", "lifecycle: executing")
+		content = stringsReplaceAll(content, "- Status: pending", "- Status: completed")
+		content = stringsReplaceAll(content, "- [ ]", "- [x]")
+		content = stringsReplaceAll(content, "PENDING_STEP_EXECUTION", "Done.")
+		content = stringsReplaceAll(content, "PENDING_STEP_REVIEW", "Reviewed.")
+		content = stringsReplaceAll(content, "## Deferred Items\n\n- None.\n", "## Deferred Items\n\n- Deferred cleanup still needs a durable handoff.\n")
+		content = stringsReplaceAll(content, "## Validation Summary\n\nPENDING_UNTIL_ARCHIVE", "## Validation Summary\n\nValidated the implementation.")
+		content = stringsReplaceAll(content, "## Review Summary\n\nPENDING_UNTIL_ARCHIVE", "## Review Summary\n\nNo blocking review findings remain.")
+		content = stringsReplaceAll(content, "## Archive Summary\n\nPENDING_UNTIL_ARCHIVE", "## Archive Summary\n\n- Ready: Closeout is nearly done.\n- Merge Handoff: Commit and push the archive move before merge approval.")
+		content = stringsReplaceAll(content, "### Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Delivered\n\nDelivered the planned slice.")
+		content = stringsReplaceAll(content, "### Not Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Not Delivered\n\nDeferred cleanup remains.")
+		return content
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if !result.OK {
+		t.Fatalf("expected OK status result, got %#v", result)
+	}
+	if result.State.StepState == "ready_for_archive" {
+		t.Fatalf("expected blockers to prevent ready_for_archive, got %#v", result.State)
+	}
+	if len(result.Blockers) < 2 {
+		t.Fatalf("expected multiple archive blockers, got %#v", result.Blockers)
+	}
+	if !hasBlockerPath(result.Blockers, "section.Archive Summary") {
+		t.Fatalf("expected Archive Summary blocker, got %#v", result.Blockers)
+	}
+	if !hasBlockerPath(result.Blockers, "section.Outcome Summary.Follow-Up Issues") {
+		t.Fatalf("expected follow-up blocker, got %#v", result.Blockers)
+	}
+	if !strings.Contains(result.Summary, "archive blocker") {
+		t.Fatalf("unexpected summary: %q", result.Summary)
+	}
+	if len(result.NextAction) == 0 || !strings.Contains(result.NextAction[0].Description, "Fix the archive blockers") {
+		t.Fatalf("unexpected next actions: %#v", result.NextAction)
+	}
+}
+
+func TestStatusReportsIdleAfterLandMarker(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		content = replaceOnce(t, content, "status: active", "status: archived")
+		content = replaceOnce(t, content, "lifecycle: awaiting_plan_approval", "lifecycle: awaiting_merge_approval")
+		content = stringsReplaceAll(content, "- Status: pending", "- Status: completed")
+		content = stringsReplaceAll(content, "- [ ]", "- [x]")
+		content = stringsReplaceAll(content, "PENDING_STEP_EXECUTION", "Done.")
+		content = stringsReplaceAll(content, "PENDING_STEP_REVIEW", "Reviewed.")
+		content = stringsReplaceAll(content, "PENDING_UNTIL_ARCHIVE", "Ready.")
+		return content
+	})
+	writeCurrentPlanPayload(t, root, map[string]any{
+		"last_landed_plan_path": "docs/plans/archived/2026-03-18-status-plan.md",
+		"last_landed_at":        "2026-03-19T12:00:00Z",
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if !result.OK {
+		t.Fatalf("expected OK idle-after-land result, got %#v", result)
+	}
+	if result.State.WorktreeState != "idle_after_land" {
+		t.Fatalf("unexpected worktree state: %#v", result.State)
+	}
+	if result.State.PlanStatus != "" || result.State.Lifecycle != "" {
+		t.Fatalf("expected no active current plan state, got %#v", result.State)
+	}
+	if result.Artifacts == nil || result.Artifacts.LastLandedPlanPath != "docs/plans/archived/2026-03-18-status-plan.md" {
+		t.Fatalf("unexpected artifacts: %#v", result.Artifacts)
+	}
+	if !strings.Contains(result.Summary, "most recent landed candidate") {
+		t.Fatalf("unexpected summary: %q", result.Summary)
 	}
 }
 
@@ -332,11 +619,16 @@ func writePlan(t *testing.T, root, relPath string, mutate func(string) string) s
 
 func writeCurrentPlan(t *testing.T, root, relPath string) {
 	t.Helper()
+	writeCurrentPlanPayload(t, root, map[string]any{"plan_path": relPath})
+}
+
+func writeCurrentPlanPayload(t *testing.T, root string, payloadMap map[string]any) {
+	t.Helper()
 	dir := filepath.Join(root, ".local", "harness")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir current-plan dir: %v", err)
 	}
-	payload, err := json.Marshal(map[string]any{"plan_path": relPath})
+	payload, err := json.Marshal(payloadMap)
 	if err != nil {
 		t.Fatalf("marshal current-plan: %v", err)
 	}
@@ -390,4 +682,13 @@ func stringsReplaceOnce(content, old, new string) string {
 
 func stringsReplaceAll(content, old, new string) string {
 	return strings.ReplaceAll(content, old, new)
+}
+
+func hasBlockerPath(blockers []status.StatusError, path string) bool {
+	for _, blocker := range blockers {
+		if blocker.Path == path {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- surface archive blockers early in `harness status` and share archive preflight checks with `harness archive`
- add landed local state plus archived `handoff_state` so status distinguishes local archive, post-archive CI, and true merge-ready waiting
- tighten `harness-execute` guidance for resume flow, TDD discipline, and clean reviewer subagents

## Validation
- `go test ./...`
- `harness plan lint docs/plans/archived/2026-03-20-archive-readiness-landed-status-and-execute-tdd.md`
- `harness status`
