### PR TITLE
Add repo-level smoke and review workflow tests

### DIFF
--- a/docs/plans/archived/2026-03-22-repo-level-smoke-and-review-workflow-tests.md
+++ b/docs/plans/archived/2026-03-22-repo-level-smoke-and-review-workflow-tests.md
@@ -1,0 +1,335 @@
+---
+template_version: 0.2.0
+created_at: "2026-03-22T00:00:00+08:00"
+source_type: issue
+source_refs:
+    - '#6'
+---
+
+# Add repo-level smoke and review workflow tests
+
+## Goal
+
+Introduce the first repo-level Go test structure under `tests/` so
+`superharness` can exercise the real built `harness` binary in smoke and
+multi-command workflow scenarios without relying on whichever binary happens to
+be on `PATH`.
+
+This slice should prove the proposal in
+`docs/specs/proposals/testing-structure.md` is workable without expanding into
+a full testing-architecture refactor. The new support helpers should stay
+scoped to repo-level suites only, while the first golden end-to-end scenario
+covers the review workflow from plan creation through review aggregation.
+
+## Scope
+
+### In Scope
+
+- Add a repo-level `tests/support/` package for binary build, temporary
+  workspace setup, command execution, and stable assertion helpers used by
+  top-level suites only.
+- Add `tests/smoke/` coverage that runs the built `harness` binary for
+  `harness --help`, `harness status`, and a minimal
+  `plan template -> plan lint` roundtrip.
+- Add `tests/e2e/` coverage for the first golden workflow:
+  `plan template -> execute start -> review start -> review submit -> review aggregate`.
+- Keep the built binary under test aligned with the working tree by compiling
+  `./cmd/harness` into a temporary path instead of resolving `harness` from
+  `PATH`.
+- Record the deferred follow-up coverage that remains intentionally out of
+  scope for this first repo-level slice.
+
+### Out of Scope
+
+- Refactoring existing `internal/*` package-local tests to reuse
+  `tests/support/` or otherwise changing their helper structure in this slice.
+- Adding `tests/resilience/` or broader repo-level suites beyond the first
+  smoke package and one review-workflow E2E path.
+- Covering lifecycle-heavy flows such as
+  `archive -> status -> reopen -> status` or landed-state reporting.
+- Adding fuzz tests, wrapper scripts, build tags, or CI wiring changes beyond
+  what is needed to run the new Go test packages locally.
+- Changing the production CLI contract except for behavior-preserving
+  testability adjustments that are strictly required by the new repo-level
+  suites.
+
+## Acceptance Criteria
+
+- [x] `tests/support/` exists as a repo-level helper package, is used by the
+      new top-level suites, and keeps binary building plus workspace/command
+      setup out of the smoke and E2E test bodies.
+- [x] `go test ./tests/smoke -count=1` passes with real-binary coverage for
+      `harness --help`, `harness status`, and a minimal
+      `plan template -> plan lint` roundtrip without depending on `PATH`.
+- [x] `go test ./tests/e2e -count=1` passes with one golden review-workflow
+      scenario that asserts the key command outputs plus durable review/state
+      artifacts after start, submit, and aggregate.
+- [x] Existing package-local suites continue to pass without being migrated to
+      the new support package, and the plan records explicit deferred follow-up
+      coverage for lifecycle, resilience, and fuzzing work.
+
+## Deferred Items
+
+- Add more repo-level E2E coverage for lifecycle-heavy flows such as
+  `archive -> status -> reopen -> status` and landed-state reporting after
+  `harness land --pr ...` plus `harness land complete`.
+- Add `tests/resilience/` with deterministic failure-injection cases such as
+  corrupted `.local/harness/current-plan.json`, missing review artifacts, and
+  archive rollback failures.
+- Evaluate fuzz coverage for parsing-heavy paths such as plan linting and
+  review artifact parsing once the repo-level baseline is stable.
+- Revisit whether repo-level suites should stay as opt-in package paths or
+  join the default `go test ./...` developer path with explicit expectations
+  for runtime and caching.
+- Revisit package-local helper deduplication separately if `internal/*` test
+  repetition becomes expensive enough to justify a dedicated test utility
+  layer.
+
+## Work Breakdown
+
+### Step 1: Add repo-level test support helpers
+
+- Done: [x]
+
+#### Objective
+
+Create the first `tests/support/` helpers so repo-level suites can build the
+working-tree `harness` binary, create temporary harness workspaces, run
+commands, and assert stable results without duplicating shell/process setup in
+every test.
+
+#### Details
+
+Keep the support surface intentionally narrow and repo-level in meaning. The
+helpers should work for `tests/smoke` and `tests/e2e`, but they should not
+become a dumping ground for package-local unit-test helpers or production
+dependencies. Prefer generated temporary workspaces over large checked-in
+snapshots for this first slice, and make the binary under test come from the
+current working tree rather than `PATH`.
+
+#### Expected Files
+
+- `tests/support/binary.go`
+- `tests/support/repo.go`
+- `tests/support/run.go`
+- `tests/support/assert.go`
+- `tests/support/plan.go`
+
+#### Validation
+
+- `tests/smoke` and `tests/e2e` can share one helper package without hiding
+  important assertions behind opaque abstractions.
+- The helper package can build `./cmd/harness`, execute commands against a
+  temporary repository, and return stdout, stderr, and exit status in a form
+  the suite tests can assert on directly.
+
+#### Execution Notes
+
+Added `tests/support/` as a narrow repo-level helper package for top-level
+binary-driven suites only. `binary.go` builds the working-tree `./cmd/harness`
+binary into a temporary path, `repo.go` creates temporary workspaces and JSON
+fixtures, `run.go` executes commands and captures stdout/stderr/exit status,
+`assert.go` provides JSON/file/assertion helpers, and `plan.go` rewrites
+generated tracked plans into deterministic repo-level fixtures for workflow
+coverage. Validated the helpers by running
+`go test ./tests/smoke ./tests/e2e -count=1` and `go test ./...`.
+
+#### Review Notes
+
+`review-011-delta` caught a documentation-only contradiction in the prior step
+note, and `review-012-delta` then passed clean for this helper slice. Step 1
+now has recorded step-closeout review history that matches the repo-level
+workflow contract before archive.
+
+### Step 2: Add real-binary smoke coverage
+
+- Done: [x]
+
+#### Objective
+
+Add a small smoke suite that proves the built `harness` binary starts, reports
+help text, handles status in a temporary repo, and can complete a minimal plan
+template/lint roundtrip.
+
+#### Details
+
+Keep the smoke suite intentionally small and fast. It should assert stable,
+user-visible behavior that is worth guarding at the repository level without
+duplicating the package-local CLI tests. The goal is to establish the repo
+test structure and binary-execution harness, not to rebuild exhaustive CLI
+coverage at a slower layer.
+
+#### Expected Files
+
+- `tests/smoke/smoke_test.go`
+- `tests/support/binary.go`
+- `tests/support/repo.go`
+- `tests/support/run.go`
+- `tests/support/assert.go`
+
+#### Validation
+
+- `go test ./tests/smoke -count=1` passes and each smoke case runs the real
+  built binary instead of calling internal Go entrypoints directly.
+- Smoke cases cover `harness --help`, `harness status`, and
+  `plan template -> plan lint` with assertions on stable outputs and exit
+  status.
+
+#### Execution Notes
+
+Added `tests/smoke/smoke_test.go` with real-binary coverage for top-level help
+output, idle `harness status` behavior in a temporary workspace, and a minimal
+`plan template -> plan lint` roundtrip. The smoke cases use `tests/support/`
+instead of package-local CLI entrypoints, assert stable command behavior, and
+avoid rebuilding a second assertion layer in shell scripts.
+
+#### Review Notes
+
+`review-013-delta` found that the idle `harness status` smoke case did not pin
+the stable handoff summary/guidance contract, and `review-014-delta` then found
+that root help coverage still under-specified the command surface. After
+tightening both smoke assertions, `review-015-delta` confirmed one more root
+help command-surface gap. `review-016-delta` then passed clean, so this smoke
+slice now has recorded step-closeout review history that matches its repo-level
+coverage claims before archive.
+
+### Step 3: Add the first golden review-workflow E2E
+
+- Done: [x]
+
+#### Objective
+
+Prove the repo-level structure can drive one realistic multi-command workflow
+by covering `plan template -> execute start -> review start -> review submit -> review aggregate`.
+
+#### Details
+
+Use the simplest valid review scenario that still exercises the command-owned
+artifacts and state transitions: generate a plan in a temporary repo, start
+execution, start a review round with a minimal valid spec, submit the required
+review slot payload, and aggregate the round. Assert the durable artifacts that
+matter for future refactors, such as review manifests, submissions, aggregate
+results, and state pointers, while avoiding overexpansion into archive/reopen
+or resilience behavior in this same slice.
+
+#### Expected Files
+
+- `tests/e2e/review_workflow_test.go`
+- `tests/support/binary.go`
+- `tests/support/repo.go`
+- `tests/support/run.go`
+- `tests/support/assert.go`
+
+#### Validation
+
+- `go test ./tests/e2e -count=1` passes with one golden review-workflow test
+  that uses the real built binary for every command in the flow.
+- The E2E assertions cover the generated plan path, execution start behavior,
+  review round creation, review submission persistence, aggregate output, and
+  the local artifacts/state that prove the workflow actually completed.
+
+#### Execution Notes
+
+Added `tests/e2e/review_workflow_test.go` to drive the first golden workflow
+through the real built binary:
+`plan template -> execute start -> review start -> review submit -> review aggregate`.
+The test generates a temporary plan, writes JSON inputs for review start and
+submit, uses `tests/support/plan.go` to shape deterministic tracked-plan
+fixtures, and asserts the resulting manifest, ledger, submission, aggregate,
+and local `state.json` artifacts so future workflow refactors keep the durable
+review contract intact.
+
+#### Review Notes
+
+Finalize full reviews previously forced more faithful step-review closeout,
+multi-slot aggregate gating assertions, deterministic fixture shaping, and
+finalize-review state persistence checks for this E2E slice. `review-017-delta`
+then exposed two more state-machine gaps around stale step-review metadata and
+failed finalize-aggregate persistence. After fixing those behaviors and
+assertions, `review-018-delta` passed clean, so this E2E slice now has recorded
+step-closeout review history that matches its workflow contract before archive.
+
+## Validation Strategy
+
+- Run `harness plan lint` on this tracked plan before execution starts and
+  whenever scope wording changes.
+- During implementation, keep the repo-level suites individually runnable with
+  `go test ./tests/smoke -count=1` and `go test ./tests/e2e -count=1`.
+- Before archive, run `go test ./...` to confirm the new top-level packages do
+  not regress the existing package-local test suite.
+
+## Risks
+
+- Risk: The new repo-level helpers could grow into a second general-purpose
+  test framework or start overlapping with package-local test utilities.
+  - Mitigation: Keep `tests/support/` narrowly focused on real-binary repo
+    suites and leave `internal/*` helper deduplication deferred to separate
+    follow-up work.
+- Risk: Repo-level tests could become slow or flaky if they over-assert help
+  text formatting or rebuild the binary unnecessarily for every command.
+  - Mitigation: Keep smoke coverage intentionally small, centralize binary
+    build/caching logic in support helpers, and assert durable contract fields
+    or artifacts rather than incidental formatting.
+
+## Validation Summary
+
+- `go test ./tests/smoke -count=1`
+- `go test ./tests/e2e -count=1`
+- `go test ./internal/status -count=1`
+- `go test ./...`
+
+## Review Summary
+
+- Step 1 helper slice: `review-011-delta` caught a stale closeout note, and
+  `review-012-delta` passed after the step history was corrected.
+- Step 2 smoke slice: `review-013-delta`, `review-014-delta`, and
+  `review-015-delta` progressively tightened idle-status and root-help
+  coverage; `review-016-delta` passed clean.
+- Step 3 E2E slice: repeated finalize full reviews exposed workflow-state
+  gaps, `review-017-delta` isolated the stale step-review/finalize persistence
+  issues, and `review-018-delta` passed after those fixes landed.
+- Full-candidate review: repeated full rounds through `review-020-full` drove
+  the remaining archive-candidate assertion fixes, and `review-021-full`
+  passed as the structural `pre_archive` gate with one non-blocking handoff
+  note about documenting `tests/support/plan.go` more explicitly.
+
+## Archive Summary
+
+- Archived At: 2026-03-22T13:24:54+08:00
+- Revision: 1
+- PR: not created yet; publish evidence will record the PR URL after archive.
+- Ready: structural `pre_archive` review passed clean; remaining work is the
+  archive move plus publish/CI/sync evidence for merge readiness.
+- Merge Handoff: after archive, open the PR, record publish/CI/sync evidence,
+  and keep deferred testing scope linked through `#6` and `#22`.
+
+## Outcome Summary
+
+### Delivered
+
+- Added repo-level `tests/support/` helpers that build the working-tree
+  `harness` binary, create temporary workspaces, run commands, and provide
+  reusable assertion helpers for top-level suites.
+- Added `tests/smoke/` coverage for root help, idle `harness status`, default
+  stdout `plan template`, and `plan template --output -> plan lint`.
+- Added a golden `tests/e2e/` review-workflow test that exercises step-level
+  delta review, multi-slot finalize review, missing-submission aggregate
+  failure, manifest/submission/ledger persistence, and finalize-review status
+  behavior with the real built binary.
+- Fixed `harness status` so stale step-closeout review metadata no longer leaks
+  into finalize nodes after a clean step review.
+
+### Not Delivered
+
+- Additional repo-level lifecycle E2E coverage such as
+  `archive -> status -> reopen -> status` or land-state flows.
+- `tests/resilience/` deterministic failure-injection coverage.
+- Fuzz coverage for parsing-heavy plan/review paths.
+- Any refactor of existing `internal/*` package-local test helpers.
+
+### Follow-Up Issues
+
+- `#6` Track the remaining repo-level testing expansion, including lifecycle,
+  resilience, fuzzing, and other broader integration coverage.
+- `#22` Clarify automatic review progression and closeout expectations in
+  `AGENTS.md` and the harness execute skill.

--- a/docs/postmortems/2026-03-22-review-discipline-postmortem.md
+++ b/docs/postmortems/2026-03-22-review-discipline-postmortem.md
@@ -1,0 +1,128 @@
+# Review Discipline Postmortem
+
+## Scope
+
+This note analyzes why the controller agent skipped step-level review discipline
+for the `2026-03-22-repo-level-smoke-and-review-workflow-tests` plan and then
+stopped after implementation instead of autonomously continuing through
+finalize review and archive closeout.
+
+The question is whether the failure was primarily:
+
+- instruction ambiguity
+- skill gap
+- tooling or permission mismatch
+- controller judgment
+
+## Summary
+
+The primary cause was controller judgment. The controller had enough
+information to continue the execution loop, but it chose to stop and ask the
+human whether it should run review orchestration instead of proceeding
+autonomously.
+
+There was also some instruction ambiguity, but it was secondary. The repo docs
+and harness skills describe review orchestration clearly enough to proceed once
+the work becomes reviewable, yet they do not spell out a single hard trigger for
+when step-level review must start versus when finalize review must start. That
+left a seam the controller used as a reason to pause.
+
+This was not a tooling or permission problem. `harness` was available, the plan
+was active, `harness status` worked, and there was no command failure that
+blocked review or archive progression.
+
+## Evidence
+
+The repo agreement already says agents should execute approved scope and avoid
+making humans micromanage routine execution. See [AGENTS.md](/Users/yaozhang/.codex/worktrees/f978/superharness/AGENTS.md#L12-L18)
+and [AGENTS.md](/Users/yaozhang/.codex/worktrees/f978/superharness/AGENTS.md#L52-L71).
+
+The harness execute skill says the controller should stay in `harness-execute`
+through the whole execution loop, keep going until the plan is archived and the
+worktree reaches `execution/finalize/await_merge`, and not skip routine
+execution by asking the human to micromanage. See [harness-execute/SKILL.md](/Users/yaozhang/.codex/worktrees/f978/superharness/.agents/skills/harness-execute/SKILL.md#L13-L30)
+and [harness-execute/SKILL.md](/Users/yaozhang/.codex/worktrees/f978/superharness/.agents/skills/harness-execute/SKILL.md#L80-L99).
+
+The review orchestration guide says that once review is in flight, the controller
+should create the round, spawn reviewer subagents, wait for them, verify their
+submissions, and only then aggregate. See [review-orchestration.md](/Users/yaozhang/.codex/worktrees/f978/superharness/.agents/skills/harness-execute/references/review-orchestration.md#L3-L18)
+and [review-orchestration.md](/Users/yaozhang/.codex/worktrees/f978/superharness/.agents/skills/harness-execute/references/review-orchestration.md#L87-L113).
+
+The step inner loop also says a finished slice that is ready for review should
+run a delta review, and that the step should only be marked complete once the
+objective and validation are genuinely satisfied. See [step-inner-loop.md](/Users/yaozhang/.codex/worktrees/f978/superharness/.agents/skills/harness-execute/references/step-inner-loop.md#L7-L22).
+
+The tracked plan for this slice had already been advanced into
+`execution/finalize/review` when the controller paused. From that node, the
+correct next action was still to continue into finalize review instead of
+asking the human to choose whether routine review orchestration should happen.
+That evidence is about the controller's stop-and-wait mistake only; it does not
+endorse skipping step-level review discipline earlier in the branch. See
+[2026-03-22-repo-level-smoke-and-review-workflow-tests.md](/Users/yaozhang/.codex/worktrees/f978/superharness/docs/plans/active/2026-03-22-repo-level-smoke-and-review-workflow-tests.md#L239-L246).
+
+## Root Cause Analysis
+
+### Primary cause: controller judgment
+
+The controller had enough evidence to continue but chose to pause and ask the
+human whether it should run finalize review. That is a workflow judgment error,
+not a missing capability.
+
+The controller should have treated these as automatic continuation signals:
+
+- the tracked plan had already been approved
+- the tracked plan had already been advanced into finalize review
+- `harness status` had already moved the worktree into `execution/finalize/review`
+- the skills explicitly say the controller should stay in `harness-execute`
+  through review orchestration and archive closeout
+
+Instead, the controller treated the final review step like a human-choice gate.
+That contradicts the working agreement and the execute skill.
+
+Separately, this postmortem should not be read as approving the earlier lack of
+step-scoped delta review. That is a different workflow defect, and the tracked
+tests/docs need to model the state-model review rules more faithfully.
+
+### Secondary cause: instruction ambiguity
+
+The docs describe the review flow well, but they do not state one explicit
+sentence that says, "when the last tracked step is complete, automatically start
+finalize review before asking for anything else." The controller could therefore
+misread the system as allowing a pause after implementation.
+
+The seam is narrow, but it is real:
+
+- `step-inner-loop.md` says to run delta review "if the slice is ready for review"
+- `review-orchestration.md` explains how to run review once it is active
+- `harness-execute/SKILL.md` says to keep moving until archive and await merge
+
+What is missing is a crisp rule tying those together into a single automatic
+transition.
+
+### Not a tooling or permission mismatch
+
+There was no evidence of a blocked command path or a missing binary. The
+controller had working `harness` access, could inspect status, and could have
+continued into review orchestration and archive work.
+
+## What Should Change
+
+The repo instructions should make two things explicit:
+
+1. Routine review and archive progression is controller-owned and automatic once
+   the plan is approved.
+2. Human confirmation is only needed for scope changes, blockers, or actual
+   merge approval, not for routine step closeout.
+
+Recommended edits:
+
+- Tighten [AGENTS.md](/Users/yaozhang/.codex/worktrees/f978/superharness/AGENTS.md) so the review section says the controller must autonomously start step or finalize review when a slice becomes reviewable.
+- Tighten [harness-execute/SKILL.md](/Users/yaozhang/.codex/worktrees/f978/superharness/.agents/skills/harness-execute/SKILL.md) so `execution/finalize/review` is treated as a mandatory continuation state, not just a descriptive hint.
+- Tighten [step-inner-loop.md](/Users/yaozhang/.codex/worktrees/f978/superharness/.agents/skills/harness-execute/references/step-inner-loop.md) so "ready for review" explicitly means "run the review round now, before closing the step."
+- Add one short rule to [review-orchestration.md](/Users/yaozhang/.codex/worktrees/f978/superharness/.agents/skills/harness-execute/references/review-orchestration.md) that the controller should not ask the human whether to start routine finalize review once the plan reaches closeout.
+
+## Follow-Up Issue
+
+See [GitHub issue #22](https://github.com/yzhang1918/superharness/issues/22)
+for the concrete instruction changes to make this failure less likely in future
+runs.

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -238,6 +238,9 @@ func (s Service) Read() Result {
 	}
 
 	result.Blockers = blockers
+	if strings.HasPrefix(result.State.CurrentNode, "execution/finalize/") && reviewCtx != nil && reviewCtx.Trigger == "step_closeout" {
+		clearStepCloseoutReviewMetadata(facts, result.Artifacts)
+	}
 	result.Summary = buildSummary(result.State.CurrentNode, facts, reviewCtx, blockers, currentPlan)
 	result.NextAction = buildNextActions(result.State.CurrentNode, facts, reviewCtx, blockers)
 	if facts.empty() {
@@ -263,6 +266,18 @@ func (s Service) Read() Result {
 	}
 
 	return result
+}
+
+func clearStepCloseoutReviewMetadata(facts *Facts, artifacts *Artifacts) {
+	if facts != nil {
+		facts.ReviewKind = ""
+		facts.ReviewTrigger = ""
+		facts.ReviewTarget = ""
+		facts.ReviewStatus = ""
+	}
+	if artifacts != nil {
+		artifacts.ReviewRoundID = ""
+	}
 }
 
 func resolveStepNode(doc *plan.Document, reviewCtx *reviewContext) (int, string) {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -401,6 +401,38 @@ func TestStatusFinalizeReviewNode(t *testing.T) {
 	}
 }
 
+func TestStatusFinalizeReviewClearsPriorStepReviewFacts(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
+		return completeAllSteps(content, false)
+	})
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"execution_started_at": "2026-03-18T10:05:00+08:00",
+		"active_review_round": map[string]any{
+			"round_id":   "review-003-delta",
+			"kind":       "delta",
+			"trigger":    "step_closeout",
+			"aggregated": true,
+			"decision":   "pass",
+		},
+	})
+	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-003-delta", map[string]any{
+		"target":  stepTwoTitle,
+		"trigger": "step_closeout",
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if result.State.CurrentNode != "execution/finalize/review" {
+		t.Fatalf("unexpected node: %#v", result.State)
+	}
+	if result.Facts != nil && (result.Facts.ReviewStatus != "" || result.Facts.ReviewTarget != "" || result.Facts.ReviewTrigger != "" || result.Facts.ReviewKind != "") {
+		t.Fatalf("expected prior step-review facts to be cleared at finalize review, got %#v", result.Facts)
+	}
+	if result.Artifacts != nil && result.Artifacts.ReviewRoundID != "" {
+		t.Fatalf("expected prior step-review artifact pointer to be cleared at finalize review, got %#v", result.Artifacts)
+	}
+}
+
 func TestStatusFinalizeReviewInFlightIncludesReviewFacts(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {

--- a/tests/e2e/review_workflow_test.go
+++ b/tests/e2e/review_workflow_test.go
@@ -1,0 +1,729 @@
+package e2e_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/yzhang1918/superharness/tests/support"
+)
+
+const (
+	reviewWorkflowTitle = "Review Workflow Plan"
+	stepOneTitle        = "Build repo-level test support"
+	stepTwoTitle        = "Validate multi-slot review workflow"
+)
+
+type commandError struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+type reviewSlot struct {
+	Name           string `json:"name"`
+	Slot           string `json:"slot"`
+	Instructions   string `json:"instructions,omitempty"`
+	SubmissionPath string `json:"submission_path"`
+}
+
+type reviewDimension struct {
+	Name         string `json:"name"`
+	Slot         string `json:"slot"`
+	Instructions string `json:"instructions"`
+}
+
+type executeStartResult struct {
+	OK        bool   `json:"ok"`
+	Command   string `json:"command"`
+	Artifacts struct {
+		LocalStatePath string `json:"local_state_path"`
+	} `json:"artifacts"`
+}
+
+type reviewStartResult struct {
+	OK        bool   `json:"ok"`
+	Command   string `json:"command"`
+	Artifacts struct {
+		RoundID       string       `json:"round_id"`
+		ManifestPath  string       `json:"manifest_path"`
+		LedgerPath    string       `json:"ledger_path"`
+		AggregatePath string       `json:"aggregate_path"`
+		Slots         []reviewSlot `json:"slots"`
+	} `json:"artifacts"`
+	NextAction []struct {
+		Command     *string `json:"command"`
+		Description string  `json:"description"`
+	} `json:"next_actions"`
+}
+
+type submitResult struct {
+	OK        bool   `json:"ok"`
+	Command   string `json:"command"`
+	Artifacts struct {
+		Slot           string `json:"slot"`
+		SubmissionPath string `json:"submission_path"`
+		LedgerPath     string `json:"ledger_path"`
+	} `json:"artifacts"`
+}
+
+type aggregateResult struct {
+	OK        bool           `json:"ok"`
+	Command   string         `json:"command"`
+	Summary   string         `json:"summary"`
+	Errors    []commandError `json:"errors"`
+	Artifacts struct {
+		AggregatePath  string `json:"aggregate_path"`
+		LocalStatePath string `json:"local_state_path"`
+	} `json:"artifacts"`
+	Review struct {
+		Decision            string `json:"decision"`
+		NonBlockingFindings []struct {
+			Severity string `json:"severity"`
+			Title    string `json:"title"`
+			Details  string `json:"details"`
+		} `json:"non_blocking_findings"`
+	} `json:"review"`
+	NextAction []struct {
+		Command     *string `json:"command"`
+		Description string  `json:"description"`
+	} `json:"next_actions"`
+}
+
+type aggregateArtifact struct {
+	RoundID             string `json:"round_id"`
+	Kind                string `json:"kind"`
+	Target              string `json:"target"`
+	Decision            string `json:"decision"`
+	AggregatedAt        string `json:"aggregated_at"`
+	NonBlockingFindings []struct {
+		Severity string `json:"severity"`
+		Title    string `json:"title"`
+		Details  string `json:"details"`
+	} `json:"non_blocking_findings"`
+}
+
+type reviewManifest struct {
+	RoundID    string            `json:"round_id"`
+	PlanPath   string            `json:"plan_path"`
+	Dimensions []reviewDimension `json:"dimensions"`
+}
+
+type reviewLedger struct {
+	Slots []struct {
+		Slot   string `json:"slot"`
+		Status string `json:"status"`
+	} `json:"slots"`
+}
+
+type reviewSubmission struct {
+	RoundID   string `json:"round_id"`
+	Slot      string `json:"slot"`
+	Dimension string `json:"dimension"`
+	Summary   string `json:"summary"`
+	Findings  []struct {
+		Severity string `json:"severity"`
+		Title    string `json:"title"`
+		Details  string `json:"details"`
+	} `json:"findings"`
+}
+
+type currentPlan struct {
+	PlanPath string `json:"plan_path"`
+}
+
+type statusResult struct {
+	OK      bool   `json:"ok"`
+	Command string `json:"command"`
+	Summary string `json:"summary"`
+	State   struct {
+		CurrentNode string `json:"current_node"`
+	} `json:"state"`
+	Facts struct {
+		CurrentStep  string `json:"current_step"`
+		ReviewStatus string `json:"review_status"`
+		ReviewTarget string `json:"review_target"`
+	} `json:"facts"`
+	Artifacts struct {
+		ReviewRoundID string `json:"review_round_id"`
+	} `json:"artifacts"`
+	NextAction []struct {
+		Command     *string `json:"command"`
+		Description string  `json:"description"`
+	} `json:"next_actions"`
+}
+
+type runState struct {
+	ExecutionStartedAt string `json:"execution_started_at"`
+	PlanPath           string `json:"plan_path"`
+	ActiveReviewRound  struct {
+		RoundID    string `json:"round_id"`
+		Aggregated bool   `json:"aggregated"`
+		Decision   string `json:"decision"`
+	} `json:"active_review_round"`
+}
+
+func TestReviewWorkflowWithBuiltBinary(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	planRelPath := "docs/plans/active/2026-03-22-review-workflow.md"
+	planPath := workspace.Path(planRelPath)
+
+	template := support.Run(
+		t,
+		workspace.Root,
+		"plan", "template",
+		"--title", reviewWorkflowTitle,
+		"--timestamp", "2026-03-22T00:00:00Z",
+		"--source-type", "issue",
+		"--source-ref", "#6",
+		"--output", planRelPath,
+	)
+	support.RequireSuccess(t, template)
+	support.RequireNoStderr(t, template)
+	support.RequireFileExists(t, planPath)
+
+	// Smoke covers the default template body. This E2E rewrites the generated
+	// file into a deterministic fixture so workflow assertions follow the
+	// state-model contract instead of incidental template copy.
+	support.RewritePlanPreservingFrontmatter(t, planPath, reviewWorkflowTitle, reviewWorkflowPlanBody())
+	lint := support.Run(t, workspace.Root, "plan", "lint", planRelPath)
+	support.RequireSuccess(t, lint)
+	support.RequireNoStderr(t, lint)
+
+	execute := support.Run(t, workspace.Root, "execute", "start")
+	support.RequireSuccess(t, execute)
+	support.RequireNoStderr(t, execute)
+	executePayload := support.RequireJSONResult[executeStartResult](t, execute)
+	if !executePayload.OK || executePayload.Command != "execute start" {
+		t.Fatalf("unexpected execute-start payload: %#v", executePayload)
+	}
+	support.RequireFileExists(t, executePayload.Artifacts.LocalStatePath)
+
+	currentPlanPath := workspace.Path(".local/harness/current-plan.json")
+	support.RequireFileExists(t, currentPlanPath)
+	current := support.ReadJSONFile[currentPlan](t, currentPlanPath)
+	if current.PlanPath != planRelPath {
+		t.Fatalf("expected current plan pointer %q, got %#v", planRelPath, current)
+	}
+
+	initialStatus := runStatus(t, workspace.Root)
+	assertNode(t, initialStatus, "execution/step-1/implement")
+	if initialStatus.Facts.CurrentStep != trackedStepTitle(1, stepOneTitle) {
+		t.Fatalf("expected current step %q after execute start, got %#v", trackedStepTitle(1, stepOneTitle), initialStatus)
+	}
+
+	stepOneRound := runPassingDeltaReview(t, workspace, stepOneTitle, 1)
+	postStepOneReview := runStatus(t, workspace.Root)
+	assertNode(t, postStepOneReview, "execution/step-1/implement")
+	if postStepOneReview.Facts.ReviewStatus != "pass" || postStepOneReview.Facts.ReviewTarget != trackedStepTitle(1, stepOneTitle) {
+		t.Fatalf("expected clean step-one review facts after aggregate, got %#v", postStepOneReview)
+	}
+	support.CompleteStep(
+		t,
+		planPath,
+		1,
+		"Built the repo-level binary/workspace/assertion helpers used by smoke and E2E coverage.",
+		fmt.Sprintf("Clean delta review %s passed for %q before advancing to step 2.", stepOneRound, stepOneTitle),
+	)
+
+	secondStepStatus := runStatus(t, workspace.Root)
+	assertNode(t, secondStepStatus, "execution/step-2/implement")
+	if secondStepStatus.Facts.CurrentStep != trackedStepTitle(2, stepTwoTitle) {
+		t.Fatalf("expected current step %q after step-one closeout, got %#v", trackedStepTitle(2, stepTwoTitle), secondStepStatus)
+	}
+
+	stepTwoRound := runPassingDeltaReview(t, workspace, stepTwoTitle, 2)
+	postStepTwoReview := runStatus(t, workspace.Root)
+	assertNode(t, postStepTwoReview, "execution/step-2/implement")
+	if postStepTwoReview.Facts.ReviewStatus != "pass" || postStepTwoReview.Facts.ReviewTarget != trackedStepTitle(2, stepTwoTitle) {
+		t.Fatalf("expected clean step-two review facts after aggregate, got %#v", postStepTwoReview)
+	}
+
+	support.CheckAllAcceptanceCriteria(t, planPath)
+	support.CompleteStep(
+		t,
+		planPath,
+		2,
+		"Exercised finalize review orchestration, submission persistence, and aggregate gating across multiple slots.",
+		fmt.Sprintf("Clean delta review %s passed for %q before entering finalize review.", stepTwoRound, stepTwoTitle),
+	)
+
+	preReviewStatus := runStatus(t, workspace.Root)
+	assertNode(t, preReviewStatus, "execution/finalize/review")
+	if preReviewStatus.Summary != "Plan has finished its tracked steps and needs finalize review before archive." {
+		t.Fatalf("expected finalize-review preflight summary, got %#v", preReviewStatus)
+	}
+	if preReviewStatus.Facts.ReviewStatus != "" || preReviewStatus.Facts.ReviewTarget != "" {
+		t.Fatalf("expected finalize preflight to clear prior step-review facts, got %#v", preReviewStatus)
+	}
+	if preReviewStatus.Artifacts.ReviewRoundID != "" {
+		t.Fatalf("expected finalize preflight to clear prior step-review artifacts, got %#v", preReviewStatus)
+	}
+	if len(preReviewStatus.NextAction) == 0 || preReviewStatus.NextAction[0].Command == nil || *preReviewStatus.NextAction[0].Command != "harness review start --spec <path>" {
+		t.Fatalf("expected finalize-review next action guidance, got %#v", preReviewStatus)
+	}
+
+	specPath := workspace.WriteJSON(t, "tmp/review-spec.json", map[string]any{
+		"kind":    "full",
+		"target":  "Full branch candidate before archive",
+		"trigger": "pre_archive",
+		"dimensions": []map[string]any{
+			{
+				"name":         "correctness",
+				"instructions": "Check that the repo-level binary workflow is wired correctly.",
+			},
+			{
+				"name":         "tests",
+				"instructions": "Check that aggregate waits for every expected reviewer submission.",
+			},
+		},
+	})
+
+	start := support.Run(t, workspace.Root, "review", "start", "--spec", specPath)
+	support.RequireSuccess(t, start)
+	support.RequireNoStderr(t, start)
+	startPayload := support.RequireJSONResult[reviewStartResult](t, start)
+	if !startPayload.OK || startPayload.Command != "review start" {
+		t.Fatalf("unexpected review-start payload: %#v", startPayload)
+	}
+	if !strings.HasPrefix(startPayload.Artifacts.RoundID, "review-") || !strings.HasSuffix(startPayload.Artifacts.RoundID, "-full") {
+		t.Fatalf("expected full review round id shape, got %#v", startPayload)
+	}
+	if len(startPayload.Artifacts.Slots) != 2 {
+		t.Fatalf("expected two review slots for finalize review, got %#v", startPayload)
+	}
+	support.RequireFileExists(t, startPayload.Artifacts.ManifestPath)
+	support.RequireFileExists(t, startPayload.Artifacts.LedgerPath)
+	if len(startPayload.NextAction) < 2 || startPayload.NextAction[1].Command == nil || *startPayload.NextAction[1].Command != "harness review aggregate --round "+startPayload.Artifacts.RoundID {
+		t.Fatalf("expected review-start next actions to point at aggregate, got %#v", startPayload)
+	}
+
+	inReviewStatus := runStatus(t, workspace.Root)
+	assertNode(t, inReviewStatus, "execution/finalize/review")
+	if inReviewStatus.Summary != "Plan is in finalize review and waiting for the active review round to be aggregated." {
+		t.Fatalf("expected finalize-review summary to reflect active round, got %#v", inReviewStatus)
+	}
+	if inReviewStatus.Facts.ReviewStatus != "in_progress" {
+		t.Fatalf("expected active finalize review status, got %#v", inReviewStatus)
+	}
+	if inReviewStatus.Artifacts.ReviewRoundID != startPayload.Artifacts.RoundID {
+		t.Fatalf("expected active review round %q in status artifacts, got %#v", startPayload.Artifacts.RoundID, inReviewStatus)
+	}
+	if len(inReviewStatus.NextAction) == 0 || inReviewStatus.NextAction[0].Command == nil || *inReviewStatus.NextAction[0].Command != "harness review aggregate --round "+startPayload.Artifacts.RoundID {
+		t.Fatalf("expected status guidance to point at aggregate for the active round, got %#v", inReviewStatus)
+	}
+
+	slots := slotMap(startPayload.Artifacts.Slots)
+	correctnessSlot, ok := slots["correctness"]
+	if !ok {
+		t.Fatalf("missing correctness slot in %#v", startPayload.Artifacts.Slots)
+	}
+	if correctnessSlot.Instructions != "Check that the repo-level binary workflow is wired correctly." {
+		t.Fatalf("expected correctness instructions in review-start receipt, got %#v", correctnessSlot)
+	}
+	testsSlot, ok := slots["tests"]
+	if !ok {
+		t.Fatalf("missing tests slot in %#v", startPayload.Artifacts.Slots)
+	}
+	if testsSlot.Instructions != "Check that aggregate waits for every expected reviewer submission." {
+		t.Fatalf("expected tests instructions in review-start receipt, got %#v", testsSlot)
+	}
+
+	preSubmitLedger := support.ReadJSONFile[reviewLedger](t, startPayload.Artifacts.LedgerPath)
+	assertLedgerStatuses(t, preSubmitLedger, map[string]string{
+		correctnessSlot.Slot: "pending",
+		testsSlot.Slot:       "pending",
+	})
+
+	submitReviewSlot(t, workspace, startPayload.Artifacts.RoundID, correctnessSlot, "Core workflow artifacts look correct.", nil)
+
+	postFirstSubmitLedger := support.ReadJSONFile[reviewLedger](t, startPayload.Artifacts.LedgerPath)
+	assertLedgerStatuses(t, postFirstSubmitLedger, map[string]string{
+		correctnessSlot.Slot: "submitted",
+		testsSlot.Slot:       "pending",
+	})
+
+	blockedAggregate := support.Run(t, workspace.Root, "review", "aggregate", "--round", startPayload.Artifacts.RoundID)
+	support.RequireExitCode(t, blockedAggregate, 1)
+	support.RequireNoStderr(t, blockedAggregate)
+	blockedAggregatePayload := support.RequireJSONResult[aggregateResult](t, blockedAggregate)
+	if blockedAggregatePayload.OK || blockedAggregatePayload.Command != "review aggregate" {
+		t.Fatalf("expected failed aggregate payload, got %#v", blockedAggregatePayload)
+	}
+	if blockedAggregatePayload.Summary != "Review round is missing required submissions." {
+		t.Fatalf("expected missing-submission summary, got %#v", blockedAggregatePayload)
+	}
+	if len(blockedAggregatePayload.Errors) != 1 || blockedAggregatePayload.Errors[0].Path != "submissions" || !strings.Contains(blockedAggregatePayload.Errors[0].Message, testsSlot.Slot) {
+		t.Fatalf("expected missing tests-slot error, got %#v", blockedAggregatePayload.Errors)
+	}
+	support.RequireFileMissing(t, startPayload.Artifacts.AggregatePath)
+
+	stillInReviewStatus := runStatus(t, workspace.Root)
+	assertNode(t, stillInReviewStatus, "execution/finalize/review")
+	if stillInReviewStatus.Summary != "Plan is in finalize review and waiting for the active review round to be aggregated." {
+		t.Fatalf("expected failed aggregate to preserve active finalize-review summary, got %#v", stillInReviewStatus)
+	}
+	if stillInReviewStatus.Facts.ReviewStatus != "in_progress" {
+		t.Fatalf("expected failed aggregate to preserve active review status, got %#v", stillInReviewStatus)
+	}
+	if stillInReviewStatus.Artifacts.ReviewRoundID != startPayload.Artifacts.RoundID {
+		t.Fatalf("expected failed aggregate to preserve active review round %q, got %#v", startPayload.Artifacts.RoundID, stillInReviewStatus)
+	}
+	if len(stillInReviewStatus.NextAction) == 0 || stillInReviewStatus.NextAction[0].Command == nil || *stillInReviewStatus.NextAction[0].Command != "harness review aggregate --round "+startPayload.Artifacts.RoundID {
+		t.Fatalf("expected failed aggregate to keep aggregate guidance for the active round, got %#v", stillInReviewStatus)
+	}
+
+	submitReviewSlot(t, workspace, startPayload.Artifacts.RoundID, testsSlot, "Aggregate gating waited for every reviewer slot.", []map[string]any{
+		{
+			"severity": "minor",
+			"title":    "Review path exercised across multiple slots",
+			"details":  "This E2E intentionally records one non-blocking finding so the full aggregate preserves reviewer output while still passing.",
+		},
+	})
+
+	postSubmitLedger := support.ReadJSONFile[reviewLedger](t, startPayload.Artifacts.LedgerPath)
+	assertLedgerStatuses(t, postSubmitLedger, map[string]string{
+		correctnessSlot.Slot: "submitted",
+		testsSlot.Slot:       "submitted",
+	})
+
+	aggregate := support.Run(t, workspace.Root, "review", "aggregate", "--round", startPayload.Artifacts.RoundID)
+	support.RequireSuccess(t, aggregate)
+	support.RequireNoStderr(t, aggregate)
+	aggregatePayload := support.RequireJSONResult[aggregateResult](t, aggregate)
+	if !aggregatePayload.OK || aggregatePayload.Command != "review aggregate" {
+		t.Fatalf("unexpected review-aggregate payload: %#v", aggregatePayload)
+	}
+	if aggregatePayload.Review.Decision != "pass" {
+		t.Fatalf("expected passing aggregate decision, got %#v", aggregatePayload)
+	}
+	if len(aggregatePayload.Review.NonBlockingFindings) != 1 || aggregatePayload.Review.NonBlockingFindings[0].Severity != "minor" {
+		t.Fatalf("expected one non-blocking finding in aggregate result, got %#v", aggregatePayload.Review)
+	}
+	support.RequireFileExists(t, aggregatePayload.Artifacts.AggregatePath)
+	if aggregatePayload.Artifacts.AggregatePath != startPayload.Artifacts.AggregatePath {
+		t.Fatalf("expected aggregate to reuse review-start aggregate path, got start=%q aggregate=%q", startPayload.Artifacts.AggregatePath, aggregatePayload.Artifacts.AggregatePath)
+	}
+
+	manifest := support.ReadJSONFile[reviewManifest](t, startPayload.Artifacts.ManifestPath)
+	if manifest.RoundID != startPayload.Artifacts.RoundID || manifest.PlanPath != planRelPath {
+		t.Fatalf("unexpected manifest: %#v", manifest)
+	}
+	if len(manifest.Dimensions) != 2 {
+		t.Fatalf("expected two persisted dimensions, got %#v", manifest)
+	}
+	manifestInstructions := map[string]string{}
+	for _, dimension := range manifest.Dimensions {
+		manifestInstructions[dimension.Name] = dimension.Instructions
+	}
+	if manifestInstructions["correctness"] != "Check that the repo-level binary workflow is wired correctly." ||
+		manifestInstructions["tests"] != "Check that aggregate waits for every expected reviewer submission." {
+		t.Fatalf("expected persisted manifest instructions, got %#v", manifest)
+	}
+
+	correctnessSubmission := support.ReadJSONFile[reviewSubmission](t, correctnessSlot.SubmissionPath)
+	if correctnessSubmission.RoundID != startPayload.Artifacts.RoundID || correctnessSubmission.Slot != correctnessSlot.Slot || correctnessSubmission.Dimension != correctnessSlot.Name {
+		t.Fatalf("unexpected correctness submission: %#v", correctnessSubmission)
+	}
+	if correctnessSubmission.Summary != "Core workflow artifacts look correct." {
+		t.Fatalf("expected persisted correctness summary, got %#v", correctnessSubmission)
+	}
+	if len(correctnessSubmission.Findings) != 0 {
+		t.Fatalf("expected correctness submission without findings, got %#v", correctnessSubmission)
+	}
+
+	testsSubmission := support.ReadJSONFile[reviewSubmission](t, testsSlot.SubmissionPath)
+	if testsSubmission.RoundID != startPayload.Artifacts.RoundID || testsSubmission.Slot != testsSlot.Slot || testsSubmission.Dimension != testsSlot.Name {
+		t.Fatalf("unexpected tests submission: %#v", testsSubmission)
+	}
+	if testsSubmission.Summary != "Aggregate gating waited for every reviewer slot." {
+		t.Fatalf("expected persisted tests summary, got %#v", testsSubmission)
+	}
+	if len(testsSubmission.Findings) != 1 || testsSubmission.Findings[0].Title != "Review path exercised across multiple slots" {
+		t.Fatalf("expected persisted multi-slot finding in tests submission, got %#v", testsSubmission)
+	}
+
+	aggregateArtifact := support.ReadJSONFile[aggregateArtifact](t, aggregatePayload.Artifacts.AggregatePath)
+	if aggregateArtifact.RoundID != startPayload.Artifacts.RoundID || aggregateArtifact.Kind != "full" {
+		t.Fatalf("unexpected aggregate artifact: %#v", aggregateArtifact)
+	}
+	if aggregateArtifact.Target != "Full branch candidate before archive" || aggregateArtifact.Decision != "pass" || aggregateArtifact.AggregatedAt == "" {
+		t.Fatalf("unexpected aggregate artifact contents: %#v", aggregateArtifact)
+	}
+	if len(aggregateArtifact.NonBlockingFindings) != 1 || aggregateArtifact.NonBlockingFindings[0].Title != "Review path exercised across multiple slots" {
+		t.Fatalf("expected persisted non-blocking finding in aggregate artifact, got %#v", aggregateArtifact)
+	}
+
+	postAggregateLedger := support.ReadJSONFile[reviewLedger](t, startPayload.Artifacts.LedgerPath)
+	assertLedgerStatuses(t, postAggregateLedger, map[string]string{
+		correctnessSlot.Slot: "submitted",
+		testsSlot.Slot:       "submitted",
+	})
+
+	state := support.ReadJSONFile[runState](t, aggregatePayload.Artifacts.LocalStatePath)
+	if state.ExecutionStartedAt == "" || state.PlanPath != planRelPath {
+		t.Fatalf("unexpected runstate: %#v", state)
+	}
+	if state.ActiveReviewRound.RoundID != startPayload.Artifacts.RoundID {
+		t.Fatalf("expected active review round %q, got %#v", startPayload.Artifacts.RoundID, state)
+	}
+	if !state.ActiveReviewRound.Aggregated || state.ActiveReviewRound.Decision != "pass" {
+		t.Fatalf("unexpected aggregated review state: %#v", state)
+	}
+
+	postAggregateStatus := runStatus(t, workspace.Root)
+	assertNode(t, postAggregateStatus, "execution/finalize/archive")
+	if len(postAggregateStatus.NextAction) == 0 || postAggregateStatus.NextAction[0].Description == "" {
+		t.Fatalf("expected archive-stage resume guidance after clean review, got %#v", postAggregateStatus)
+	}
+}
+
+func reviewWorkflowPlanBody() string {
+	return strings.TrimSpace(fmt.Sprintf(`
+## Goal
+
+Exercise repo-level review orchestration with deterministic tracked-plan
+content so the workflow assertions follow the state-model contract rather than
+the packaged template copy.
+
+## Scope
+
+### In Scope
+
+- Drive the built harness binary through step review and finalize review.
+- Assert durable review artifacts, state transitions, and aggregate gating.
+
+### Out of Scope
+
+- Archive, publish, and land follow-up.
+
+## Acceptance Criteria
+
+- [ ] Step review passes before the tracked plan advances to the next step.
+- [ ] Finalize review waits for every expected reviewer submission before it can pass.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: %s
+
+- Done: [ ]
+
+#### Objective
+
+Prepare repo-level helper coverage so the workflow can use the real built
+binary in a temporary workspace.
+
+#### Details
+
+Keep the fixture deterministic and scoped to repo-level test support.
+
+#### Expected Files
+
+- tests/support/*
+
+#### Validation
+
+- Run a delta review before advancing beyond step 1.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: %s
+
+- Done: [ ]
+
+#### Objective
+
+Exercise a multi-slot finalize review that proves aggregate gating and durable
+artifacts.
+
+#### Details
+
+Use structured tracked-plan updates and review artifacts rather than brittle
+template-string rewrites.
+
+#### Expected Files
+
+- tests/e2e/review_workflow_test.go
+
+#### Validation
+
+- Run a delta review before entering finalize review.
+- Prove a full review refuses to aggregate while a slot is still missing.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run repo-level smoke and E2E coverage with the built binary.
+
+## Risks
+
+- Risk: Workflow assertions could accidentally depend on incidental template wording.
+  - Mitigation: Rewrite the generated file into a deterministic fixture before driving the workflow.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE
+`, stepOneTitle, stepTwoTitle))
+}
+
+func runPassingDeltaReview(t *testing.T, workspace *support.Workspace, stepTitle string, stepNumber int) string {
+	t.Helper()
+
+	target := trackedStepTitle(stepNumber, stepTitle)
+	specPath := workspace.WriteJSON(t, fmt.Sprintf("tmp/step-%d-review-spec.json", stepNumber), map[string]any{
+		"kind":    "delta",
+		"target":  target,
+		"trigger": "step_closeout",
+		"dimensions": []map[string]any{
+			{
+				"name":         "correctness",
+				"instructions": "Check that the tracked step is ready to close out cleanly.",
+			},
+		},
+	})
+
+	start := support.Run(t, workspace.Root, "review", "start", "--spec", specPath)
+	support.RequireSuccess(t, start)
+	support.RequireNoStderr(t, start)
+	startPayload := support.RequireJSONResult[reviewStartResult](t, start)
+	if !startPayload.OK || startPayload.Command != "review start" {
+		t.Fatalf("unexpected delta review-start payload: %#v", startPayload)
+	}
+	if !strings.HasSuffix(startPayload.Artifacts.RoundID, "-delta") {
+		t.Fatalf("expected delta round id shape, got %#v", startPayload)
+	}
+	if len(startPayload.Artifacts.Slots) != 1 {
+		t.Fatalf("expected one delta review slot, got %#v", startPayload)
+	}
+
+	reviewStatus := runStatus(t, workspace.Root)
+	assertNode(t, reviewStatus, fmt.Sprintf("execution/step-%d/review", stepNumber))
+	if reviewStatus.Facts.CurrentStep != target || reviewStatus.Facts.ReviewStatus != "in_progress" || reviewStatus.Facts.ReviewTarget != target {
+		t.Fatalf("expected active step-review facts for %q, got %#v", target, reviewStatus)
+	}
+
+	slot := startPayload.Artifacts.Slots[0]
+	submitReviewSlot(t, workspace, startPayload.Artifacts.RoundID, slot, fmt.Sprintf("Step %d is ready to close out.", stepNumber), nil)
+
+	aggregate := support.Run(t, workspace.Root, "review", "aggregate", "--round", startPayload.Artifacts.RoundID)
+	support.RequireSuccess(t, aggregate)
+	support.RequireNoStderr(t, aggregate)
+	aggregatePayload := support.RequireJSONResult[aggregateResult](t, aggregate)
+	if !aggregatePayload.OK || aggregatePayload.Review.Decision != "pass" {
+		t.Fatalf("expected clean delta aggregate for %q, got %#v", stepTitle, aggregatePayload)
+	}
+
+	return startPayload.Artifacts.RoundID
+}
+
+func runStatus(t *testing.T, workdir string) statusResult {
+	t.Helper()
+
+	status := support.Run(t, workdir, "status")
+	support.RequireSuccess(t, status)
+	support.RequireNoStderr(t, status)
+	return support.RequireJSONResult[statusResult](t, status)
+}
+
+func assertNode(t *testing.T, status statusResult, want string) {
+	t.Helper()
+	if status.State.CurrentNode != want {
+		t.Fatalf("expected current node %q, got %#v", want, status)
+	}
+}
+
+func submitReviewSlot(t *testing.T, workspace *support.Workspace, roundID string, slot reviewSlot, summary string, findings []map[string]any) {
+	t.Helper()
+
+	submissionPath := workspace.WriteJSON(t, fmt.Sprintf("tmp/%s-%s.json", roundID, slot.Slot), map[string]any{
+		"summary":  summary,
+		"findings": findings,
+	})
+
+	submit := support.Run(
+		t,
+		workspace.Root,
+		"review", "submit",
+		"--round", roundID,
+		"--slot", slot.Slot,
+		"--input", submissionPath,
+	)
+	support.RequireSuccess(t, submit)
+	support.RequireNoStderr(t, submit)
+	submitPayload := support.RequireJSONResult[submitResult](t, submit)
+	if !submitPayload.OK || submitPayload.Command != "review submit" {
+		t.Fatalf("unexpected review-submit payload: %#v", submitPayload)
+	}
+	if submitPayload.Artifacts.Slot != slot.Slot || submitPayload.Artifacts.SubmissionPath != slot.SubmissionPath {
+		t.Fatalf("unexpected submit artifacts for slot %#v: %#v", slot, submitPayload)
+	}
+	support.RequireFileExists(t, submitPayload.Artifacts.SubmissionPath)
+}
+
+func slotMap(slots []reviewSlot) map[string]reviewSlot {
+	byName := make(map[string]reviewSlot, len(slots))
+	for _, slot := range slots {
+		byName[slot.Name] = slot
+	}
+	return byName
+}
+
+func assertLedgerStatuses(t *testing.T, ledger reviewLedger, want map[string]string) {
+	t.Helper()
+
+	got := make(map[string]string, len(ledger.Slots))
+	for _, slot := range ledger.Slots {
+		got[slot.Slot] = slot.Status
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d ledger slots, got %#v", len(want), ledger)
+	}
+	for slot, status := range want {
+		if got[slot] != status {
+			t.Fatalf("expected ledger slot %q to be %q, got %#v", slot, status, ledger)
+		}
+	}
+}
+
+func trackedStepTitle(stepNumber int, stepTitle string) string {
+	return fmt.Sprintf("Step %d: %s", stepNumber, stepTitle)
+}

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -1,0 +1,180 @@
+package smoke_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/yzhang1918/superharness/tests/support"
+)
+
+type statusResult struct {
+	OK      bool   `json:"ok"`
+	Command string `json:"command"`
+	Summary string `json:"summary"`
+	State   struct {
+		CurrentNode string `json:"current_node"`
+	} `json:"state"`
+	NextAction []struct {
+		Command     *string `json:"command"`
+		Description string  `json:"description"`
+	} `json:"next_actions"`
+}
+
+type lintResult struct {
+	OK        bool   `json:"ok"`
+	Command   string `json:"command"`
+	Summary   string `json:"summary"`
+	Artifacts struct {
+		PlanPath string `json:"plan_path"`
+	} `json:"artifacts"`
+}
+
+func TestHelpShowsTopLevelUsage(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	result := support.Run(t, workspace.Root, "--help")
+	support.RequireSuccess(t, result)
+	support.RequireContains(t, result.CombinedOutput(), "Usage: harness <command> [subcommand] [flags]")
+	support.RequireContains(t, result.CombinedOutput(), "plan template   Render the packaged plan template")
+	support.RequireContains(t, result.CombinedOutput(), "plan lint       Validate a tracked plan")
+	support.RequireContains(t, result.CombinedOutput(), "execute start   Record the execution-start milestone")
+	support.RequireContains(t, result.CombinedOutput(), "evidence submit Record append-only CI, publish, or sync evidence")
+	support.RequireContains(t, result.CombinedOutput(), "review start    Create a deterministic review round")
+	support.RequireContains(t, result.CombinedOutput(), "review submit   Record one reviewer submission")
+	support.RequireContains(t, result.CombinedOutput(), "review aggregate Aggregate reviewer submissions")
+	support.RequireContains(t, result.CombinedOutput(), "land            Record merge confirmation for the archived candidate")
+	support.RequireContains(t, result.CombinedOutput(), "land complete   Record post-merge cleanup completion")
+	support.RequireContains(t, result.CombinedOutput(), "archive         Freeze the current active plan")
+	support.RequireContains(t, result.CombinedOutput(), "reopen          Restore the current archived plan")
+	support.RequireContains(t, result.CombinedOutput(), "status          Summarize the current plan and local execution state")
+}
+
+func TestStatusReportsIdleWorkspace(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	result := support.Run(t, workspace.Root, "status")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[statusResult](t, result)
+	if !payload.OK {
+		t.Fatalf("expected ok status payload, got %#v", payload)
+	}
+	if payload.Command != "status" {
+		t.Fatalf("expected status command, got %#v", payload)
+	}
+	if payload.State.CurrentNode != "idle" {
+		t.Fatalf("expected idle state, got %#v", payload)
+	}
+	if payload.Summary != "No current plan is active in this worktree." {
+		t.Fatalf("expected idle summary, got %#v", payload)
+	}
+	if len(payload.NextAction) == 0 {
+		t.Fatalf("expected idle status to include next-action guidance, got %#v", payload)
+	}
+	if payload.NextAction[0].Command != nil {
+		t.Fatalf("expected idle next action to be descriptive only, got %#v", payload)
+	}
+	if payload.NextAction[0].Description != "Start discovery or create a new tracked plan when the next slice is ready." {
+		t.Fatalf("expected idle handoff guidance, got %#v", payload)
+	}
+}
+
+func TestPlanTemplatePrintsToStdoutByDefault(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	result := support.Run(
+		t,
+		workspace.Root,
+		"plan", "template",
+		"--title", "Stdout Plan",
+		"--timestamp", "2026-03-22T00:00:00Z",
+		"--source-type", "issue",
+		"--source-ref", "#6",
+	)
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+	support.RequireContains(t, result.Stdout, "# Stdout Plan")
+	support.RequireContains(t, result.Stdout, "created_at: 2026-03-22T00:00:00Z")
+	support.RequireContains(t, result.Stdout, "source_type: issue")
+	support.RequireContains(t, result.Stdout, "source_refs: [\"#6\"]")
+}
+
+func TestSupportRunUsesBuiltBinaryInsteadOfPATH(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	poisonDir := workspace.Path("tmp/poison-bin")
+	if err := os.MkdirAll(poisonDir, 0o755); err != nil {
+		t.Fatalf("mkdir poison dir: %v", err)
+	}
+
+	name := "harness"
+	script := "#!/bin/sh\necho poisoned harness\nexit 97\n"
+	mode := os.FileMode(0o755)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+		script = "@echo poisoned harness\r\nexit /b 97\r\n"
+		mode = 0o644
+	}
+	poisonPath := filepath.Join(poisonDir, name)
+	if err := os.WriteFile(poisonPath, []byte(script), mode); err != nil {
+		t.Fatalf("write poison harness: %v", err)
+	}
+
+	// Build once before poisoning PATH so the runner can only succeed by using
+	// the cached absolute binary path instead of resolving `harness` from PATH.
+	support.BuildBinary(t)
+	t.Setenv("PATH", poisonDir)
+
+	result := support.Run(t, workspace.Root, "--help")
+	support.RequireSuccess(t, result)
+	support.RequireContains(t, result.CombinedOutput(), "Usage: harness <command> [subcommand] [flags]")
+	if result.CombinedOutput() == "poisoned harness\n" || result.CombinedOutput() == "poisoned harness\r\n" {
+		t.Fatalf("expected support runner to bypass PATH and invoke the built binary, got %q", result.CombinedOutput())
+	}
+}
+
+func TestPlanTemplateAndLintRoundTrip(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	planRelPath := "docs/plans/active/2026-03-22-smoke-plan.md"
+
+	template := support.Run(
+		t,
+		workspace.Root,
+		"plan", "template",
+		"--title", "Smoke Plan",
+		"--timestamp", "2026-03-22T00:00:00Z",
+		"--source-type", "issue",
+		"--source-ref", "#6",
+		"--output", planRelPath,
+	)
+	support.RequireSuccess(t, template)
+	support.RequireNoStderr(t, template)
+
+	planPath := workspace.Path(planRelPath)
+	support.RequireFileExists(t, planPath)
+	data, err := os.ReadFile(planPath)
+	if err != nil {
+		t.Fatalf("read rendered plan: %v", err)
+	}
+	support.RequireContains(t, string(data), "# Smoke Plan")
+	support.RequireContains(t, string(data), "created_at: 2026-03-22T00:00:00Z")
+	support.RequireContains(t, string(data), "source_type: issue")
+	support.RequireContains(t, string(data), "source_refs: [\"#6\"]")
+
+	lint := support.Run(t, workspace.Root, "plan", "lint", planRelPath)
+	support.RequireSuccess(t, lint)
+	support.RequireNoStderr(t, lint)
+
+	payload := support.RequireJSONResult[lintResult](t, lint)
+	if !payload.OK {
+		t.Fatalf("expected lint success, got %#v", payload)
+	}
+	if payload.Command != "plan lint" {
+		t.Fatalf("expected lint command, got %#v", payload)
+	}
+	if payload.Artifacts.PlanPath != planRelPath {
+		t.Fatalf("expected lint plan path %q, got %#v", planRelPath, payload)
+	}
+}

--- a/tests/support/assert.go
+++ b/tests/support/assert.go
@@ -1,0 +1,72 @@
+package support
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func RequireExitCode(t *testing.T, result Result, want int) {
+	t.Helper()
+	if result.ExitCode != want {
+		t.Fatalf("expected exit code %d, got %d\nstdout:\n%s\nstderr:\n%s", want, result.ExitCode, result.Stdout, result.Stderr)
+	}
+}
+
+func RequireSuccess(t *testing.T, result Result) {
+	t.Helper()
+	RequireExitCode(t, result, 0)
+}
+
+func RequireContains(t *testing.T, actual, fragment string) {
+	t.Helper()
+	if !strings.Contains(actual, fragment) {
+		t.Fatalf("expected %q to contain %q", actual, fragment)
+	}
+}
+
+func RequireNoStderr(t *testing.T, result Result) {
+	t.Helper()
+	if strings.TrimSpace(result.Stderr) != "" {
+		t.Fatalf("expected empty stderr, got:\n%s", result.Stderr)
+	}
+}
+
+func RequireFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+}
+
+func RequireFileMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("expected %s to be absent", path)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+}
+
+func RequireJSONResult[T any](t *testing.T, result Result) T {
+	t.Helper()
+	var value T
+	if err := json.Unmarshal([]byte(result.Stdout), &value); err != nil {
+		t.Fatalf("decode json stdout: %v\nstdout:\n%s\nstderr:\n%s", err, result.Stdout, result.Stderr)
+	}
+	return value
+}
+
+func ReadJSONFile[T any](t *testing.T, path string) T {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var value T
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	return value
+}

--- a/tests/support/binary.go
+++ b/tests/support/binary.go
@@ -1,0 +1,60 @@
+package support
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+var (
+	buildOnce sync.Once
+	buildPath string
+	buildErr  error
+)
+
+func RepoRoot(t *testing.T) string {
+	t.Helper()
+	return repoRoot()
+}
+
+func BuildBinary(t *testing.T) string {
+	t.Helper()
+
+	buildOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "superharness-harness-*")
+		if err != nil {
+			buildErr = fmt.Errorf("create temporary binary directory: %w", err)
+			return
+		}
+
+		name := "harness"
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		buildPath = filepath.Join(dir, name)
+
+		cmd := exec.Command("go", "build", "-o", buildPath, "./cmd/harness")
+		cmd.Dir = repoRoot()
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			buildErr = fmt.Errorf("build harness binary: %w\n%s", err, output)
+		}
+	})
+
+	if buildErr != nil {
+		t.Fatalf("build harness binary: %v", buildErr)
+	}
+	return buildPath
+}
+
+func repoRoot() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("resolve tests/support source path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}

--- a/tests/support/plan.go
+++ b/tests/support/plan.go
@@ -1,0 +1,148 @@
+package support
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func RewritePlanPreservingFrontmatter(t *testing.T, path, title, body string) {
+	t.Helper()
+
+	content := readPlanFile(t, path)
+	frontmatter := extractFrontmatter(t, content)
+	rewritten := frontmatter + "\n\n# " + strings.TrimSpace(title) + "\n\n" + strings.TrimSpace(body) + "\n"
+	writePlanFile(t, path, rewritten)
+}
+
+func CheckAllAcceptanceCriteria(t *testing.T, path string) {
+	t.Helper()
+
+	content := readPlanFile(t, path)
+	updated, replaced := rewriteSection(content, "## Acceptance Criteria", func(section string) string {
+		lines := strings.Split(section, "\n")
+		count := 0
+		for i, line := range lines {
+			if strings.HasPrefix(line, "- [ ] ") {
+				lines[i] = strings.Replace(line, "- [ ] ", "- [x] ", 1)
+				count++
+			}
+		}
+		if count == 0 {
+			t.Fatalf("expected unchecked acceptance criteria in %s", path)
+		}
+		return strings.Join(lines, "\n")
+	})
+	if !replaced {
+		t.Fatalf("acceptance criteria section not found in %s", path)
+	}
+	writePlanFile(t, path, updated)
+}
+
+func CompleteStep(t *testing.T, path string, stepNumber int, executionNotes, reviewNotes string) {
+	t.Helper()
+
+	content := readPlanFile(t, path)
+	heading := fmt.Sprintf("### Step %d:", stepNumber)
+	stepStart := strings.Index(content, heading)
+	if stepStart < 0 {
+		t.Fatalf("step heading %q not found in %s", heading, path)
+	}
+
+	stepEnd := len(content)
+	for _, marker := range []string{"\n### Step ", "\n## Validation Strategy"} {
+		if idx := strings.Index(content[stepStart+1:], marker); idx >= 0 {
+			candidate := stepStart + 1 + idx
+			if candidate < stepEnd {
+				stepEnd = candidate
+			}
+		}
+	}
+
+	block := content[stepStart:stepEnd]
+	if strings.Contains(block, "- Done: [ ]") {
+		block = strings.Replace(block, "- Done: [ ]", "- Done: [x]", 1)
+	} else if !strings.Contains(block, "- Done: [x]") {
+		t.Fatalf("done marker not found in step %d for %s", stepNumber, path)
+	}
+
+	block = replaceSubsectionBody(t, path, block, "#### Execution Notes", executionNotes)
+	block = replaceSubsectionBody(t, path, block, "#### Review Notes", reviewNotes)
+	writePlanFile(t, path, content[:stepStart]+block+content[stepEnd:])
+}
+
+func readPlanFile(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read plan %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func writePlanFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write plan %s: %v", path, err)
+	}
+}
+
+func extractFrontmatter(t *testing.T, content string) string {
+	t.Helper()
+
+	if !strings.HasPrefix(content, "---\n") {
+		t.Fatalf("expected frontmatter block at start of plan")
+	}
+	rest := strings.TrimPrefix(content, "---\n")
+	end := strings.Index(rest, "\n---\n")
+	if end < 0 {
+		t.Fatalf("expected closing frontmatter delimiter")
+	}
+	return "---\n" + rest[:end] + "\n---"
+}
+
+func rewriteSection(content, heading string, rewrite func(section string) string) (string, bool) {
+	start := strings.Index(content, heading)
+	if start < 0 {
+		return content, false
+	}
+
+	bodyStart := start + len(heading)
+	end := len(content)
+	if idx := strings.Index(content[bodyStart:], "\n## "); idx >= 0 {
+		end = bodyStart + idx
+	}
+
+	section := content[bodyStart:end]
+	return content[:bodyStart] + rewrite(section) + content[end:], true
+}
+
+func replaceSubsectionBody(t *testing.T, path, block, heading, body string) string {
+	t.Helper()
+
+	start := strings.Index(block, heading)
+	if start < 0 {
+		t.Fatalf("subsection %q not found in %s", heading, path)
+	}
+
+	bodyStart := start + len(heading)
+	if !strings.HasPrefix(block[bodyStart:], "\n") {
+		t.Fatalf("expected newline after %q in %s", heading, path)
+	}
+	bodyStart++
+
+	bodyEnd := len(block)
+	for _, marker := range []string{"\n#### ", "\n### ", "\n## "} {
+		if idx := strings.Index(block[bodyStart:], marker); idx >= 0 {
+			candidate := bodyStart + idx
+			if candidate < bodyEnd {
+				bodyEnd = candidate
+			}
+		}
+	}
+
+	return block[:bodyStart] + strings.TrimSpace(body) + "\n" + block[bodyEnd:]
+}

--- a/tests/support/repo.go
+++ b/tests/support/repo.go
@@ -1,0 +1,42 @@
+package support
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type Workspace struct {
+	Root string
+}
+
+func NewWorkspace(t *testing.T) *Workspace {
+	t.Helper()
+	return &Workspace{Root: t.TempDir()}
+}
+
+func (w *Workspace) Path(rel string) string {
+	if rel == "" {
+		return w.Root
+	}
+	return filepath.Join(w.Root, filepath.FromSlash(rel))
+}
+
+func (w *Workspace) WriteJSON(t *testing.T, rel string, value any) string {
+	t.Helper()
+
+	path := w.Path(rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}

--- a/tests/support/run.go
+++ b/tests/support/run.go
@@ -1,0 +1,67 @@
+package support
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+type RunOptions struct {
+	Workdir string
+	Args    []string
+	Stdin   string
+	Env     []string
+}
+
+type Result struct {
+	Args     []string
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+func (r Result) CombinedOutput() string {
+	return r.Stdout + r.Stderr
+}
+
+func Run(t *testing.T, workdir string, args ...string) Result {
+	t.Helper()
+	return RunWithOptions(t, RunOptions{
+		Workdir: workdir,
+		Args:    args,
+	})
+}
+
+func RunWithOptions(t *testing.T, opts RunOptions) Result {
+	t.Helper()
+
+	cmd := exec.Command(BuildBinary(t), opts.Args...)
+	cmd.Dir = opts.Workdir
+	cmd.Env = append(os.Environ(), opts.Env...)
+	cmd.Stdin = strings.NewReader(opts.Stdin)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	result := Result{
+		Args:   append([]string(nil), opts.Args...),
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+	if err == nil {
+		return result
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("run harness %v: %v", opts.Args, err)
+	}
+	result.ExitCode = exitErr.ExitCode()
+	return result
+}


### PR DESCRIPTION
## Summary
- add `tests/support`, `tests/smoke`, and a golden review-workflow E2E that exercise the built `harness` binary
- tighten `harness status` finalize behavior so stale step-review metadata does not leak into finalize nodes
- archive the approved plan and include a postmortem plus follow-up issue for the missed execute/review discipline

## Validation
- `go test ./tests/smoke -count=1`
- `go test ./tests/e2e -count=1`
- `go test ./internal/status -count=1`
- `go test ./...`
- `harness plan lint docs/plans/active/2026-03-22-repo-level-smoke-and-review-workflow-tests.md`

## Follow-up
- Refs #6
- Refs #22
