### PR TITLE
Clarify reviewer resume-agent reuse rules

### DIFF
--- a/.agents/skills/harness-execute/references/review-orchestration.md
+++ b/.agents/skills/harness-execute/references/review-orchestration.md
@@ -111,18 +111,23 @@ round to use the same set.
 
 2. Spawn multiple reviewer subagents in parallel: one reviewer per returned
    slot or review dimension.
-   Use clean reviewer subagents for these slots. Do not inherit the
-   controller's long chat context into reviewer threads. Use only the fixed
-   reviewer prompt template for reviewer spawning.
+   For a slot's first pass in a tracked step or for one finalize review target
+   in one revision, or whenever reuse is not clearly safe, use clean reviewer
+   subagents. Moving to a different tracked step, moving from step review into
+   finalize review, or moving to a different revision always starts with fresh
+   reviewers. Do not inherit the controller's long chat context into reviewer
+   threads. Use only the fixed reviewer prompt template for reviewer spawning.
 3. Use a fixed reviewer prompt template so model or runtime changes do not
    silently change the reviewer contract.
 4. Keep track of every spawned reviewer agent ID.
 5. Wait for all reviewer subagents to finish before aggregation.
 6. Verify each reviewer actually submitted a valid result for its slot.
 7. Close the finished reviewer agent after verification, even when its
-   submission was missing or invalid.
-8. If a reviewer finished without a valid submission, respawn a reviewer for
-   that slot immediately.
+   submission was missing or invalid. Closed is the default steady state
+   between rounds; do not leave reviewer agents hanging open just in case they
+   might be useful later.
+8. If a reviewer finished without a valid submission, respawn a clean reviewer
+   for that slot immediately.
 9. Only after every expected reviewer slot has a valid submission and every
    reviewer agent is closed, run:
 
@@ -145,9 +150,42 @@ You are the reviewer for one harness review slot.
 Use the harness-reviewer skill and follow it exactly.
 
 Round ID: <round-id>
+Target: <review-target>
+Revision: <candidate-revision-or-none>
 Slot: <slot>
 Assigned dimension: <dimension-name>
 Instructions: <dimension-instructions>
+```
+
+## Fixed Reviewer Resume Prompt Template
+
+Use resume only for a narrow same-slot follow-up after the controller has
+already verified and closed that reviewer's earlier successful submission.
+Do not resume across tracked steps, or from a step review into finalize
+review. Those boundaries always start with fresh reviewers.
+Resume is only valid while the review target itself is still the same:
+
+- for step review, the same tracked step title
+- for finalize review, the same finalize candidate target for the same revision
+
+If reopen, a new tracked step, a new revision, or a new finalize target
+changes that target, start with fresh reviewers.
+
+Use this controller prompt shape when resuming a previously closed reviewer:
+
+```text
+You are resuming the same harness review slot you handled earlier.
+
+Use the harness-reviewer skill and follow it exactly.
+
+New round ID: <new-round-id>
+Target: <review-target>
+Revision: <candidate-revision-or-none>
+Slot: <slot>
+Assigned dimension: <dimension-name>
+Instructions: <dimension-instructions>
+Follow-up scope: Verify only the bounded changes since your last submission.
+Change summary since your last submission: <bounded-change-summary>
 ```
 
 ## Codex-Specific Subagent Rules
@@ -161,9 +199,41 @@ Codex reviewer subagents are asynchronous.
   close it.
 - Use `spawn_agent(..., fork_context=false)` for reviewer slots so the reviewer
   starts from a clean context and sees only the fixed reviewer prompt.
+- After a reviewer is cleanly closed, `resume_agent` may reopen that same
+  reviewer later, but only for a narrow same-slot follow-up where continuity is
+  genuinely helpful.
 - Do not append extra controller reasoning, artifact tours, or side
   instructions to the fixed reviewer prompt when spawning Codex reviewer
   subagents.
+
+Prefer `resume_agent` only when all of these are true:
+
+- the earlier reviewer submission for that agent was valid and already verified
+  by the controller
+- the new round is still narrow enough for `delta` review
+- the new round stays within the same tracked step review boundary, or within
+  the same finalize review target for the same revision
+- the new round keeps the same review target as the earlier submission
+- the reviewer keeps the same slot and materially the same dimension
+  instructions
+- the controller can give a bounded change summary that is directly tied to the
+  earlier findings
+
+Treat the closed reviewer as retired for this follow-up and spawn a fresh clean
+reviewer instead when any of these are true:
+
+- the earlier submission was missing, invalid, or never verified
+- the controller is moving to a different tracked step, or from a step review
+  into finalize review
+- the review target changed because of reopen, a new tracked step, a new
+  revision, or a later finalize pass against a different candidate
+- the follow-up broadened into `full` review or otherwise changed target
+  materially
+- the slot or instructions changed enough that the old reviewer context would
+  mislead more than help
+- the repair batch includes unrelated changes, remote-sync churn, or other
+  broad context that deserves a clean reread
+- you want an unbiased second look more than continuity
 
 Use this pattern:
 
@@ -177,4 +247,12 @@ Use this pattern:
 7. repeat until the pending set is empty and every expected slot is filled
 8. aggregate only after all reviewer agents are both finished and closed
 
-This is required to avoid premature aggregation and dangling background agents.
+After a later repair round starts, you may either spawn fresh reviewers again
+or reopen an eligible closed reviewer with `resume_agent` only for the same
+tracked step, or for the same finalize review target in the same revision,
+then deliver only the fixed resume prompt for the new round. Even when you
+reuse a reviewer this way, close it again immediately after the new submission
+is verified.
+
+This is required to avoid premature aggregation, dangling background agents,
+and stale-context leakage.

--- a/.agents/skills/harness-reviewer/SKILL.md
+++ b/.agents/skills/harness-reviewer/SKILL.md
@@ -7,7 +7,9 @@ description: Use when acting as a dedicated reviewer subagent for one assigned h
 
 ## Purpose
 
-Use this skill only in reviewer subagents.
+Use this skill only in reviewer subagents, including a reviewer subagent that
+the controller later resumes for the same slot within the same tracked step
+review boundary or for the same finalize review target in the same revision.
 
 The reviewer agent owns exactly one review slot in an existing review round. It
 does not start rounds, aggregate rounds, orchestrate other reviewers, or infer
@@ -64,7 +66,8 @@ deferral stale.
 
 ## Workflow
 
-1. Read the controller's round ID, slot, and assigned instructions.
+1. Read the controller's round ID, target, revision context when present, slot,
+   and assigned instructions.
 2. If the controller did not give enough information to submit cleanly, report
    the missing input back to the controller instead of improvising.
 3. Inspect the relevant diff, plan context, and local artifacts needed for that
@@ -74,9 +77,19 @@ deferral stale.
 6. Report the submission receipt back to the controller agent.
 7. Stop once the receipt is reported. The controller agent is responsible for
    closing reviewer subagents after verifying the successful submission.
+8. If the controller later resumes you for the same slot within the same
+   tracked step review boundary or for the same finalize review target in the
+   same revision, treat the newest round ID, target, revision context, slot,
+   and instructions as authoritative for that new assignment. Reuse your prior
+   context only to understand the bounded follow-up the controller asked you to
+   verify.
 
 ## Do Not
 
 - Do not call any harness command other than `harness review submit`.
 - Do not edit tracked files.
 - Do not keep exploring after a successful submission.
+- Do not assume an older round ID, revision context, or instructions still
+  apply after a resume.
+- Do not assume a resume carries across tracked steps or from step review into
+  finalize review.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -423,7 +423,11 @@ Contract:
 Recommended next action:
 
 - on success, report the receipt to the controller agent and end the reviewer
-  thread unless asked to keep working
+  thread; a runtime may later reopen the same reviewer for a narrow same-slot
+  follow-up for the same tracked step or the same finalize review target in
+  the same revision, but only after the earlier submission was verified and
+  only when the slot instructions still materially match; immediate closeout
+  is the safe default
 - on validation failure, fix the reviewer artifact and resubmit
 
 ### `harness review aggregate`
@@ -623,6 +627,17 @@ The controller agent decides how to launch reviewer subagents. In Codex, that
 means using `spawn_agent` rather than trying to do reviewer work in the main
 agent thread. The reviewer skill or reviewer prompt should own the details of
 calling `harness review submit`.
+
+Codex should still default to closing reviewer agents after each verified
+submission. If a later narrow follow-up round keeps the same slot and
+materially the same instructions for the same tracked step or the same
+finalize review target in the same revision, the controller may reopen that
+previously closed reviewer with `resume_agent` instead of spawning fresh.
+Moving to a different tracked step, moving from step review to finalize
+review, changing the review target because of reopen or a new revision, broad
+follow-up, changed slot ownership, invalid earlier submissions, or any
+situation where a clean reread is safer should stay on fresh `spawn_agent`
+reviewer threads.
 
 The CLI only owns deterministic local contracts:
 

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -427,7 +427,7 @@ func (s Service) Submit(roundID, slot string, inputBytes []byte) SubmitResult {
 		NextAction: []NextAction{
 			{
 				Command:     nil,
-				Description: "Report the submission receipt to the controller agent and end the reviewer thread unless asked to keep working.",
+				Description: "Report the submission receipt to the controller agent and end the reviewer thread. If the same slot later needs a narrow follow-up for the same tracked step or the same finalize review target in the same revision, the controller may reopen this reviewer through the runtime's native resume mechanism only after this submission is verified and only while the slot instructions still materially match.",
 			},
 		},
 	}

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -214,6 +214,9 @@ func TestSubmitStoresSubmissionAndUpdatesLedger(t *testing.T) {
 	if _, err := os.Stat(result.Artifacts.SubmissionPath); err != nil {
 		t.Fatalf("submission missing: %v", err)
 	}
+	if len(result.NextAction) != 1 || result.NextAction[0].Description != "Report the submission receipt to the controller agent and end the reviewer thread. If the same slot later needs a narrow follow-up for the same tracked step or the same finalize review target in the same revision, the controller may reopen this reviewer through the runtime's native resume mechanism only after this submission is verified and only while the slot instructions still materially match." {
+		t.Fatalf("unexpected submit next action: %#v", result.NextAction)
+	}
 }
 
 func TestSubmitRejectsUnknownSlot(t *testing.T) {


### PR DESCRIPTION
## Summary
- clarify when the controller may reuse a closed reviewer with `resume_agent`
- require fresh reviewers across tracked steps, step-to-finalize transitions, and revision or target changes
- align the reviewer prompt templates, reviewer skill, CLI contract, and `review submit` receipt text around the same reuse rules

## Testing
- `go test ./internal/review/...`
- `go test ./tests/e2e/... -run TestReviewWorkflowWithBuiltBinary`
