### PR TITLE
Add harness --version diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Verify the command is available:
 ```bash
 command -v harness
 harness --help
+harness --version
 ```
 
 After changing Go CLI code, rerun `scripts/install-dev-harness` so the direct
@@ -72,6 +73,10 @@ chosen install directory earlier in `PATH`.
 - `harness reopen --mode <finalize-fix|new-step>`
 - `harness land --pr <url> [--commit <sha>]`
 - `harness land complete`
+
+The root CLI also exposes `harness --version` as a plain-text debug flag for
+identifying the running binary. Unlike the stateful workflow commands above,
+it is not a JSON-first command surface.
 
 `harness ui` is deferred.
 

--- a/docs/plans/archived/2026-03-23-harness-version-command.md
+++ b/docs/plans/archived/2026-03-23-harness-version-command.md
@@ -1,0 +1,314 @@
+---
+template_version: 0.2.0
+created_at: "2026-03-23T00:20:00+08:00"
+source_type: direct_request
+source_refs: []
+---
+
+# Add harness --version command
+
+## Goal
+
+Add a top-level `harness --version` diagnostic entrypoint so operators can tell
+which `harness` binary is actually running without digging through wrapper
+paths or local build state by hand.
+
+This slice should keep the existing agent-facing workflow commands JSON-first
+while treating `--version` as a human-oriented debug surface. The command
+should report the running binary's build commit, identify whether the binary is
+running in dev or release mode, and print the binary path only for dev mode.
+
+## Scope
+
+### In Scope
+
+- Add root-level `harness --version` handling distinct from `harness --help`
+  and the workflow subcommand surface.
+- Report the running binary's build commit as the primary commit identity for
+  the command.
+- Distinguish dev vs release mode and print the resolved binary path in dev
+  mode only.
+- Update root help and tracked docs where the command surface or output
+  contract changes.
+- Add unit and smoke coverage for the new flag and its output contract.
+
+### Out of Scope
+
+- Adding a `harness version` subcommand alongside the root `--version` flag.
+- Making `harness --version` return JSON by default in this slice.
+- Reworking workflow subcommands away from their current JSON-first behavior.
+- Broader installer-policy changes beyond any metadata plumbing needed to make
+  dev-mode version reporting work correctly.
+
+## Acceptance Criteria
+
+- [x] `harness --version` exits zero and prints concise human-readable debug
+      output rather than a JSON envelope.
+- [x] The output includes the running binary's build commit and an explicit
+      mode indicator, and includes the resolved binary path only when the
+      binary is in dev mode.
+- [x] Root help and tracked docs describe `--version` as a debug-oriented
+      exception to the JSON-first workflow commands without absorbing it into
+      `--help` itself.
+- [x] Automated coverage proves the new root flag works without regressing
+      existing help or subcommand parsing behavior.
+
+## Deferred Items
+
+- Add an opt-in JSON form such as `harness --version --json` if a later slice
+  needs machine-readable version output.
+- Expand version output with richer build metadata such as dirty state, build
+  time, Go version, or wrapper/install provenance if those become useful.
+- Revisit installer default-directory discovery separately if the current
+  allowlist policy for user-local wrapper dirs still feels too rigid after more
+  dogfooding.
+
+## Work Breakdown
+
+### Step 1: Capture discovery decisions for the version command
+
+- Done: [x]
+
+#### Objective
+
+Record the command shape, output model, and adjacent installer-policy decisions
+already settled in discovery so execution does not depend on chat memory.
+
+#### Details
+
+Discovery converged on a root `harness --version` flag rather than a
+`harness version` subcommand or a `--help` expansion. The command is treated as
+a debug-oriented diagnostic surface, so plain text output is intentional even
+though stateful workflow commands remain JSON-first. The current working
+assumption is that `commit` means the running binary's build commit because
+that remains meaningful even when the binary is invoked outside a
+`superharness` worktree. Discovery also converged on keeping the wrapper
+installer's default directory policy conservative: prefer allowlisted
+user-local wrapper dirs such as `~/.local/bin` and `~/bin`, not arbitrary
+writable `PATH` entries.
+
+#### Expected Files
+
+- `docs/plans/active/2026-03-23-harness-version-command.md`
+
+#### Validation
+
+- The tracked plan captures the accepted `--version` direction, non-goals, and
+  the current build-commit assumption without relying on hidden chat context.
+
+#### Execution Notes
+
+Discovery completed before planning. The accepted direction is:
+`harness --version`, plain text output, build-commit identity, and dev-mode
+path reporting only. The installer-policy discussion is included here as
+adjacent context, not as committed execution scope for this slice.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: discovery-only closeout recorded directly in the plan.
+
+### Step 2: Implement the root --version flag and metadata plumbing
+
+- Done: [x]
+
+#### Objective
+
+Add root-level `--version` handling and wire enough build/runtime metadata into
+the binary to report commit, mode, and dev path correctly.
+
+#### Details
+
+Keep the new flag outside the workflow subcommand tree so it behaves like a
+binary-identity probe rather than a stateful command. Prefer metadata that
+describes the running binary itself, not the caller's current working tree.
+Use Go build information when it is sufficient and deterministic; if that
+cannot cleanly express build commit or dev-mode detection across installed dev
+binaries and tests, add explicit build variables or a small internal package
+that centralizes version data instead of scattering logic through the CLI.
+
+#### Expected Files
+
+- `cmd/harness/main.go`
+- `internal/cli/app.go`
+- `internal/cli/app_test.go`
+- `scripts/install-dev-harness`
+- optional new internal package if version/build metadata needs a dedicated home
+
+#### Validation
+
+- Root-flag unit tests cover `--version`, `--help`, and ordinary subcommand
+  parsing without ambiguity.
+- Tests pin the expected labeled fields in the version output without relying
+  on an unstable exact local path or commit string fixture.
+- Dev installs still produce a binary whose version output can identify itself
+  correctly when run from the worktree or through the installed wrapper.
+
+#### Execution Notes
+
+Added a small `internal/version` package to centralize build commit, mode, and
+dev-path reporting, then wired root-level `harness --version` handling through
+`internal/cli/app.go` as plain-text debug output rather than the shared JSON
+envelope. Dev installs now build with explicit version metadata so the command
+can report `mode: dev`, while ordinary binary builds continue to default to
+`release`. Step-closeout review then exposed that the repo-built release binary
+and the dev installer smoke path could still degrade to `commit: unknown`
+without failing coverage, so the slice was tightened by explicitly injecting
+`BuildCommit` into the repo-level test binary helper and by pinning smoke
+expectations to the current `HEAD` commit for release builds plus a
+deterministic fake-git commit for dev installs. Validated the implementation
+with `go test ./internal/version ./internal/cli -count=1`,
+`go test ./tests/smoke -count=1`, `go test ./... -count=1`,
+`bash -n scripts/install-dev-harness`, `scripts/install-dev-harness`, and a
+direct `PATH="$HOME/.local/bin:$PATH" harness --version` run that reported the
+current worktree binary path.
+
+#### Review Notes
+
+Step-closeout review `review-001-delta` requested changes because the initial
+smoke coverage only asserted that `commit:` labels existed and did not fail
+when the version output degraded to `commit: unknown`. After the test binary
+builder and smoke assertions were tightened, step-closeout review
+`review-002-delta` passed. One non-blocking follow-up remains tracked in
+`#33`: add dedicated smoke coverage for the installer's PATH-verified branch.
+
+### Step 3: Document the contract and add repo-level validation
+
+- Done: [x]
+
+#### Objective
+
+Document the new command surface clearly and add high-signal validation that
+protects the debug contract from regressions.
+
+#### Details
+
+Update the command-surface docs and any CLI contract wording needed to explain
+why `--version` stays plain text while workflow commands remain JSON-first.
+Extend the smoke suite so the built binary covers the new root flag alongside
+existing top-level help behavior. Keep the docs explicit that `--version` is a
+debug surface and not a stateful workflow command.
+
+#### Expected Files
+
+- `README.md`
+- `docs/specs/cli-contract.md`
+- `tests/smoke/smoke_test.go`
+- any other docs/help locations that list the root command surface
+
+#### Validation
+
+- Smoke coverage proves the built binary responds to `harness --version`
+  successfully.
+- Updated docs and help text stay consistent about where JSON is required and
+  where plain text is intentional.
+- Full Go test coverage still passes after the new flag and docs land.
+
+#### Execution Notes
+
+Updated README and the CLI contract to document `harness --version` as a
+plain-text debug exception outside the JSON-first workflow commands. Extended
+repo-level smoke coverage for root help, plain-text release-mode `--version`
+output, dev-mode `--version` through the installed wrapper, managed-wrapper
+refresh, and legacy-wrapper replacement without `--force`. Validated this
+slice with `go test ./tests/smoke -count=1`, `go test ./...`, and
+`bash -n scripts/install-dev-harness`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 step-closeout review covers the tightly coupled
+docs and smoke-test follow-up for this slice.
+
+## Validation Strategy
+
+- Run `harness plan lint docs/plans/active/2026-03-23-harness-version-command.md`
+  before execution starts and whenever the plan wording changes materially.
+- During implementation, keep `go test ./internal/cli -count=1` and
+  `go test ./tests/smoke -count=1` green as the fastest contract checks for the
+  new root flag.
+- Before archive, run `go test ./...` so the new flag, metadata plumbing, and
+  smoke coverage do not regress the wider CLI surface.
+
+## Risks
+
+- Risk: The reported commit could be misread as the current worktree's `HEAD`
+  rather than the running binary's build identity.
+  - Mitigation: Make the plan and docs explicit that `--version` reports the
+    running binary's build commit, and pair it with a mode label plus dev path
+    when relevant.
+- Risk: Dev-mode path reporting and build metadata may be awkward to test if
+  the output bakes in local absolute paths or environment-specific VCS data.
+  - Mitigation: Assert labeled fields and presence/absence rules in unit and
+    smoke tests instead of snapshotting the entire output verbatim.
+- Risk: Root flag parsing could accidentally interfere with existing `--help`
+  behavior or unknown-command handling.
+  - Mitigation: Add root-level parser coverage that exercises `--version`,
+    `--help`, and ordinary subcommands side by side.
+
+## Validation Summary
+
+- `harness plan lint docs/plans/active/2026-03-23-harness-version-command.md`
+- `go test ./internal/version ./internal/cli -count=1`
+- `go test ./tests/smoke -count=1`
+- `go test ./... -count=1`
+- `bash -n scripts/install-dev-harness`
+- `scripts/install-dev-harness`
+- `PATH="$HOME/.local/bin:$PATH" harness --version`
+
+## Review Summary
+
+- `review-001-delta` requested changes because the first smoke pass only
+  checked for `commit:` labels and allowed release or dev outputs to degrade
+  to `commit: unknown`.
+- `review-002-delta` passed after explicit build-commit injection was added to
+  the repo-level test binary helper and the smoke suite pinned release/dev
+  commit expectations. It left one non-blocking installer-coverage note that
+  is now tracked in `#33`.
+- `review-003-full` passed as the `pre_archive` gate. Correctness and
+  docs-consistency reviews were clean; the same non-blocking installer PATH
+  verification coverage gap remains deferred to `#33`.
+
+## Archive Summary
+
+- Archived At: 2026-03-23T01:30:58+08:00
+- Revision: 1
+- PR: not created yet; publish evidence will record the PR URL after archive.
+- Ready: `review-003-full` passed as the structural `pre_archive` gate, all
+  acceptance criteria are satisfied, and the remaining work is the archive move
+  plus publish/CI/sync evidence.
+- Merge Handoff: After archive, commit and push the archived plan move plus the
+  tracked code/doc changes, open the PR, record publish/CI/sync evidence, and
+  carry deferred follow-up scope in `#31`, `#32`, and `#33`.
+
+## Outcome Summary
+
+### Delivered
+
+- Added a root-level `harness --version` flag that prints plain-text debug
+  output for the running binary instead of the JSON envelope used by workflow
+  commands.
+- Added centralized version/build metadata handling in `internal/version`,
+  including explicit dev-mode path reporting and build-commit resolution for
+  both installed dev binaries and repo-built validation binaries.
+- Updated root help, README, and the CLI contract to document `--version` as a
+  debug-oriented exception to the JSON-first workflow surface.
+- Added unit and smoke coverage that pins release-mode commit reporting to the
+  current repository `HEAD`, pins dev-mode commit reporting through a
+  deterministic fake-git installer path, and protects the wrapper refresh and
+  legacy-wrapper replacement behavior already touched by this slice.
+
+### Not Delivered
+
+- An opt-in machine-readable form such as `harness --version --json`.
+- Richer version/build metadata such as dirty state, build time, Go version,
+  or wrapper/install provenance.
+- Broader installer default-directory discovery beyond the current
+  `~/.local/bin` / `~/bin` allowlist.
+- Dedicated smoke coverage for the installer's on-PATH verification branch.
+
+### Follow-Up Issues
+
+- `#32` Extend `harness --version` with optional JSON and richer build
+  metadata.
+- `#31` Revisit installer default wrapper-directory discovery.
+- `#33` Cover the PATH-verified install branch in `install-dev-harness` smoke
+  tests.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -28,6 +28,11 @@ The current command surface is:
 - `harness land --pr <url> [--commit <sha>]`
 - `harness land complete`
 
+The root CLI also exposes one debug-oriented flag outside that stateful
+workflow surface:
+
+- `harness --version`
+
 ## Design Principles
 
 ### Agent-Friendly by Default
@@ -52,6 +57,9 @@ explicit verbose or debug mode.
 
 Commands that primarily render content, such as `harness plan template`, may
 default to markdown or plain text instead of the JSON envelope.
+
+`harness --version` is also a plain-text exception because it is a binary
+identity/debug probe rather than a workflow-state command.
 
 ### Help Must Be Actionable
 
@@ -614,6 +622,20 @@ Contract:
 - leave tracked plans untouched; this is local-state cleanup only
 - return next actions that guide the worktree back to idle or on to the next
   slice
+
+### `harness --version`
+
+Purpose:
+
+- print concise debug information for the running harness binary
+
+Contract:
+
+- remain a root-level flag rather than a workflow subcommand
+- print plain text rather than the shared JSON envelope
+- report the running binary's build commit
+- report whether the binary is running in `dev` or `release` mode
+- print the resolved binary path only in `dev` mode
 
 ## Review Runtime Boundary
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -16,23 +16,26 @@ import (
 	"github.com/yzhang1918/superharness/internal/plan"
 	"github.com/yzhang1918/superharness/internal/review"
 	"github.com/yzhang1918/superharness/internal/status"
+	versioninfo "github.com/yzhang1918/superharness/internal/version"
 )
 
 type App struct {
-	Stdout io.Writer
-	Stderr io.Writer
-	Stdin  io.Reader
-	Now    func() time.Time
-	Getwd  func() (string, error)
+	Stdout  io.Writer
+	Stderr  io.Writer
+	Stdin   io.Reader
+	Now     func() time.Time
+	Getwd   func() (string, error)
+	Version func() versioninfo.Info
 }
 
 func New(stdout, stderr io.Writer) *App {
 	return &App{
-		Stdout: stdout,
-		Stderr: stderr,
-		Stdin:  os.Stdin,
-		Now:    time.Now,
-		Getwd:  os.Getwd,
+		Stdout:  stdout,
+		Stderr:  stderr,
+		Stdin:   os.Stdin,
+		Now:     time.Now,
+		Getwd:   os.Getwd,
+		Version: versioninfo.Current,
 	}
 }
 
@@ -43,6 +46,8 @@ func (a *App) Run(args []string) int {
 	}
 
 	switch args[0] {
+	case "--version":
+		return a.runVersion(args[1:])
 	case "plan":
 		return a.runPlan(args[1:])
 	case "execute":
@@ -67,6 +72,35 @@ func (a *App) Run(args []string) int {
 		a.printRootUsage()
 		return 2
 	}
+}
+
+func (a *App) runVersion(args []string) int {
+	fs := flag.NewFlagSet("harness --version", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(a.Stderr, "Usage: harness --version")
+		fmt.Fprintln(a.Stderr)
+		fmt.Fprintln(a.Stderr, "Print concise debug information for the running harness binary.")
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+	if a.Version == nil {
+		a.Version = versioninfo.Current
+	}
+	_, err := io.WriteString(a.Stdout, a.Version().String())
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "write version output: %v\n", err)
+		return 1
+	}
+	return 0
 }
 
 func (a *App) runReview(args []string) int {
@@ -595,6 +629,9 @@ func (a *App) resolveTimestamp(timestampValue, dateValue string) (time.Time, err
 
 func (a *App) printRootUsage() {
 	fmt.Fprintln(a.Stderr, "Usage: harness <command> [subcommand] [flags]")
+	fmt.Fprintln(a.Stderr)
+	fmt.Fprintln(a.Stderr, "Flags:")
+	fmt.Fprintln(a.Stderr, "  --version       Print concise debug information for the running harness binary")
 	fmt.Fprintln(a.Stderr)
 	fmt.Fprintln(a.Stderr, "Commands:")
 	fmt.Fprintln(a.Stderr, "  plan template   Render the packaged plan template")

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/yzhang1918/superharness/internal/plan"
 	"github.com/yzhang1918/superharness/internal/runstate"
 	"github.com/yzhang1918/superharness/internal/status"
+	version "github.com/yzhang1918/superharness/internal/version"
 )
 
 func TestPlanTemplateWritesOutputFile(t *testing.T) {
@@ -43,6 +44,76 @@ func TestPlanTemplateWritesOutputFile(t *testing.T) {
 	}
 	if !bytes.Contains(data, []byte("# CLI Generated Plan")) {
 		t.Fatalf("generated file missing title:\n%s", data)
+	}
+}
+
+func TestVersionFlagPrintsHumanReadableDebugInfo(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	app.Version = func() version.Info {
+		return version.Info{
+			Commit: "abc123",
+			Mode:   "dev",
+			Path:   "/tmp/harness",
+		}
+	}
+
+	exitCode := app.Run([]string{"--version"})
+	if exitCode != 0 {
+		t.Fatalf("expected version exit code 0, got %d: %s", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr for version output, got %q", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "{") {
+		t.Fatalf("expected non-JSON version output, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "mode: dev") {
+		t.Fatalf("expected mode in version output, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "commit: abc123") {
+		t.Fatalf("expected commit in version output, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "path: /tmp/harness") {
+		t.Fatalf("expected dev path in version output, got %q", stdout.String())
+	}
+}
+
+func TestVersionFlagOmitsPathOutsideDevMode(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	app.Version = func() version.Info {
+		return version.Info{
+			Commit: "abc123",
+			Mode:   "release",
+		}
+	}
+
+	exitCode := app.Run([]string{"--version"})
+	if exitCode != 0 {
+		t.Fatalf("expected version exit code 0, got %d: %s", exitCode, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "path:") {
+		t.Fatalf("expected release version output to omit path, got %q", stdout.String())
+	}
+}
+
+func TestVersionHelpExitsZero(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"--version", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected version help exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "Usage: harness --version") {
+		t.Fatalf("expected version help text, got %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout for version help, got %q", stdout.String())
 	}
 }
 
@@ -91,6 +162,23 @@ func TestPlanTemplateHelpExitsZero(t *testing.T) {
 	}
 	if !bytes.Contains(stderr.Bytes(), []byte("Usage: harness plan template")) {
 		t.Fatalf("expected help text, got %s", stderr.String())
+	}
+}
+
+func TestRootHelpMentionsVersionFlag(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected root help exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "Usage: harness <command> [subcommand] [flags]") {
+		t.Fatalf("expected root help usage, got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--version       Print concise debug information for the running harness binary") {
+		t.Fatalf("expected root help to mention --version, got %q", stderr.String())
 	}
 }
 

--- a/internal/version/info.go
+++ b/internal/version/info.go
@@ -1,0 +1,71 @@
+package version
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strings"
+)
+
+var (
+	BuildCommit = ""
+	BuildMode   = ""
+)
+
+type Info struct {
+	Commit string
+	Mode   string
+	Path   string
+}
+
+func (i Info) String() string {
+	var lines []string
+	lines = append(lines, fmt.Sprintf("mode: %s", i.Mode))
+	lines = append(lines, fmt.Sprintf("commit: %s", i.Commit))
+	if i.Mode == "dev" && strings.TrimSpace(i.Path) != "" {
+		lines = append(lines, fmt.Sprintf("path: %s", i.Path))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func Current() Info {
+	return current(debug.ReadBuildInfo, os.Executable)
+}
+
+func current(readBuildInfo func() (*debug.BuildInfo, bool), executablePath func() (string, error)) Info {
+	info := Info{
+		Commit: resolveCommit(readBuildInfo),
+		Mode:   resolveMode(),
+	}
+	if info.Mode == "dev" {
+		if path, err := executablePath(); err == nil {
+			info.Path = strings.TrimSpace(path)
+		}
+	}
+	return info
+}
+
+func resolveCommit(readBuildInfo func() (*debug.BuildInfo, bool)) string {
+	if commit := strings.TrimSpace(BuildCommit); commit != "" {
+		return commit
+	}
+	if readBuildInfo != nil {
+		if buildInfo, ok := readBuildInfo(); ok {
+			for _, setting := range buildInfo.Settings {
+				if setting.Key == "vcs.revision" {
+					if commit := strings.TrimSpace(setting.Value); commit != "" {
+						return commit
+					}
+				}
+			}
+		}
+	}
+	return "unknown"
+}
+
+func resolveMode() string {
+	if mode := strings.TrimSpace(BuildMode); mode != "" {
+		return mode
+	}
+	return "release"
+}

--- a/internal/version/info_test.go
+++ b/internal/version/info_test.go
@@ -1,0 +1,90 @@
+package version
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+func TestCurrentUsesBuildInfoCommitInReleaseMode(t *testing.T) {
+	t.Cleanup(func() {
+		BuildCommit = ""
+		BuildMode = ""
+	})
+
+	info := current(
+		func() (*debug.BuildInfo, bool) {
+			return &debug.BuildInfo{
+				Settings: []debug.BuildSetting{
+					{Key: "vcs.revision", Value: "abc123"},
+				},
+			}, true
+		},
+		func() (string, error) {
+			t.Fatal("release mode should not need executable path")
+			return "", nil
+		},
+	)
+
+	if info.Commit != "abc123" {
+		t.Fatalf("expected build-info commit, got %#v", info)
+	}
+	if info.Mode != "release" {
+		t.Fatalf("expected release mode by default, got %#v", info)
+	}
+	if info.Path != "" {
+		t.Fatalf("expected release mode to omit path, got %#v", info)
+	}
+}
+
+func TestCurrentUsesExplicitDevMetadata(t *testing.T) {
+	t.Cleanup(func() {
+		BuildCommit = ""
+		BuildMode = ""
+	})
+
+	BuildCommit = "deadbeef"
+	BuildMode = "dev"
+
+	info := current(
+		func() (*debug.BuildInfo, bool) {
+			return nil, false
+		},
+		func() (string, error) {
+			return "/tmp/dev-harness", nil
+		},
+	)
+
+	if info.Commit != "deadbeef" {
+		t.Fatalf("expected explicit build commit, got %#v", info)
+	}
+	if info.Mode != "dev" {
+		t.Fatalf("expected dev mode, got %#v", info)
+	}
+	if info.Path != "/tmp/dev-harness" {
+		t.Fatalf("expected dev path, got %#v", info)
+	}
+	if !strings.Contains(info.String(), "path: /tmp/dev-harness") {
+		t.Fatalf("expected formatted version output to include dev path, got %q", info.String())
+	}
+}
+
+func TestCurrentFallsBackToUnknownCommit(t *testing.T) {
+	t.Cleanup(func() {
+		BuildCommit = ""
+		BuildMode = ""
+	})
+
+	info := current(
+		func() (*debug.BuildInfo, bool) {
+			return nil, false
+		},
+		func() (string, error) {
+			return "", nil
+		},
+	)
+
+	if info.Commit != "unknown" {
+		t.Fatalf("expected unknown commit fallback, got %#v", info)
+	}
+}

--- a/scripts/install-dev-harness
+++ b/scripts/install-dev-harness
@@ -48,6 +48,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 binary_dir="${repo_root}/.local/bin"
 binary_path="${binary_dir}/harness"
 repo_module_line="module github.com/yzhang1918/superharness"
+version_package="github.com/yzhang1918/superharness/internal/version"
 
 is_superharness_root() {
   local dir="$1"
@@ -228,13 +229,27 @@ managed_superharness_wrapper() {
 
   grep -Fq 'fallback_binary_path=' "${path}" &&
     grep -Fq 'find_repo_root()' "${path}" &&
-    grep -Fq 'cmd/harness/main.go' "${path}"
+    grep -Fq 'cmd/harness/main.go' "${path}" &&
+    return 0
+
+  grep -Fq 'find_repo_root()' "${path}" &&
+    grep -Fq 'cmd/harness/main.go' "${path}" &&
+    grep -Fq 'binary_path="${repo_root}/.local/bin/harness"' "${path}"
 }
 
 mkdir -p "${binary_dir}"
+build_commit=""
+if command -v git >/dev/null 2>&1; then
+  build_commit="$(git -C "${repo_root}" rev-parse HEAD 2>/dev/null || true)"
+fi
+build_ldflags=("-X" "${version_package}.BuildMode=dev")
+if [[ -n "${build_commit}" ]]; then
+  build_ldflags+=("-X" "${version_package}.BuildCommit=${build_commit}")
+fi
+build_args=("-o" "${binary_path}" "-ldflags" "${build_ldflags[*]}" "./cmd/harness")
 (
   cd "${repo_root}"
-  go build -o "${binary_path}" ./cmd/harness
+  go build "${build_args[@]}"
 )
 "${binary_path}" --help >/dev/null
 

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -3,6 +3,7 @@ package smoke_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -151,6 +152,63 @@ func TestInstallDevHarnessWrapperFallsBackOutsideWorktree(t *testing.T) {
 	support.RequireContains(t, wrapperResult.CombinedOutput(), "Usage: harness <command> [subcommand] [flags]")
 }
 
+func TestInstallDevHarnessVersionReportsDevModeAndPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	installDir := filepath.Join(t.TempDir(), "global-bin")
+	expectedCommit := "0123456789abcdef0123456789abcdef01234567"
+	fakeGitDir := fakeGitDirForHeadCommit(t, repoRoot, expectedCommit)
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": t.TempDir(),
+			"PATH": installerPath(t, fakeGitDir),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--install-dir", installDir,
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	wrapperPath := filepath.Join(installDir, "harness")
+	support.RequireFileExists(t, wrapperPath)
+
+	otherProject := t.TempDir()
+	versionResult := runCommand(
+		t,
+		otherProject,
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t, fakeGitDir),
+		}),
+		wrapperPath,
+		"--version",
+	)
+	if versionResult.ExitCode != 0 {
+		t.Fatalf("wrapper version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
+	}
+
+	if mode := requireVersionField(t, versionResult.Stdout, "mode"); mode != "dev" {
+		t.Fatalf("expected dev mode, got %q\noutput:\n%s", mode, versionResult.Stdout)
+	}
+	if commit := requireVersionField(t, versionResult.Stdout, "commit"); commit != expectedCommit {
+		t.Fatalf("expected injected dev commit %q, got %q\noutput:\n%s", expectedCommit, commit, versionResult.Stdout)
+	}
+	expectedPath := filepath.Join(repoRoot, ".local", "bin", "harness")
+	if path := requireVersionField(t, versionResult.Stdout, "path"); path != expectedPath {
+		t.Fatalf("expected dev path %q, got %q\noutput:\n%s", expectedPath, path, versionResult.Stdout)
+	}
+	if strings.HasPrefix(strings.TrimSpace(versionResult.Stdout), "{") {
+		t.Fatalf("expected plain-text version output, got %q", versionResult.Stdout)
+	}
+}
+
 func TestInstallDevHarnessRefreshesManagedWrapperWithoutForce(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
@@ -205,6 +263,85 @@ func TestInstallDevHarnessRefreshesManagedWrapperWithoutForce(t *testing.T) {
 	if strings.Contains(string(after), filepath.Join(repoOne, ".local", "bin", "harness")) {
 		t.Fatalf("expected refreshed wrapper to stop pointing at first worktree fallback\nwrapper:\n%s", string(after))
 	}
+}
+
+func TestInstallDevHarnessReplacesLegacyManagedWrapperWithoutForce(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	installDir := filepath.Join(t.TempDir(), "global-bin")
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		t.Fatalf("mkdir install dir: %v", err)
+	}
+
+	wrapperPath := filepath.Join(installDir, "harness")
+	legacyWrapper := `#!/usr/bin/env bash
+set -euo pipefail
+
+find_repo_root() {
+  local root=""
+  if command -v git >/dev/null 2>&1; then
+    root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    if [[ -n "${root}" && -f "${root}/scripts/install-dev-harness" && -f "${root}/cmd/harness/main.go" ]]; then
+      printf '%s\n' "${root}"
+      return 0
+    fi
+  fi
+
+  local dir="${PWD}"
+  while :; do
+    if [[ -f "${dir}/scripts/install-dev-harness" && -f "${dir}/cmd/harness/main.go" ]]; then
+      printf '%s\n' "${dir}"
+      return 0
+    fi
+    if [[ "${dir}" == "/" ]]; then
+      break
+    fi
+    dir="$(dirname "${dir}")"
+  done
+
+  return 1
+}
+
+if ! repo_root="$(find_repo_root)"; then
+  echo "Could not find a superharness worktree from ${PWD}." >&2
+  echo "Run harness from inside a superharness checkout, or call a repo-local binary directly." >&2
+  exit 1
+fi
+
+binary_path="${repo_root}/.local/bin/harness"
+if [[ ! -x "${binary_path}" ]]; then
+  echo "No repo-local harness binary found at ${binary_path}." >&2
+  echo "Run scripts/install-dev-harness from this worktree first." >&2
+  exit 1
+fi
+
+exec "${binary_path}" "$@"
+`
+	writeFixtureFile(t, wrapperPath, legacyWrapper, 0o755)
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": t.TempDir(),
+			"PATH": installerPath(t),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--install-dir", installDir,
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	refreshed, err := os.ReadFile(wrapperPath)
+	if err != nil {
+		t.Fatalf("read refreshed wrapper: %v", err)
+	}
+	support.RequireContains(t, string(refreshed), "# superharness-install-dev-wrapper")
 }
 
 func copyInstallerFixture(t *testing.T) string {
@@ -370,6 +507,33 @@ func installerPath(t *testing.T, extraDirs ...string) string {
 	addDir("/sbin")
 
 	return strings.Join(dirs, string(os.PathListSeparator))
+}
+
+func fakeGitDirForHeadCommit(t *testing.T, repoRoot, commit string) string {
+	t.Helper()
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find git on PATH: %v", err)
+	}
+
+	dir := t.TempDir()
+	script := fmt.Sprintf(`#!/bin/sh
+set -eu
+
+repo_root=%q
+fake_commit=%q
+real_git=%q
+
+if [ "$#" -ge 4 ] && [ "$1" = "-C" ] && [ "$2" = "$repo_root" ] && [ "$3" = "rev-parse" ] && [ "$4" = "HEAD" ]; then
+  printf '%%s\n' "$fake_commit"
+  exit 0
+fi
+
+exec "$real_git" "$@"
+`, repoRoot, commit, realGit)
+	writeFixtureFile(t, filepath.Join(dir, "git"), script, 0o755)
+	return dir
 }
 
 func runCommand(t *testing.T, workdir string, env []string, argv ...string) commandResult {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -2,8 +2,10 @@ package smoke_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/yzhang1918/superharness/tests/support"
@@ -37,6 +39,7 @@ func TestHelpShowsTopLevelUsage(t *testing.T) {
 	result := support.Run(t, workspace.Root, "--help")
 	support.RequireSuccess(t, result)
 	support.RequireContains(t, result.CombinedOutput(), "Usage: harness <command> [subcommand] [flags]")
+	support.RequireContains(t, result.CombinedOutput(), "--version       Print concise debug information for the running harness binary")
 	support.RequireContains(t, result.CombinedOutput(), "plan template   Render the packaged plan template")
 	support.RequireContains(t, result.CombinedOutput(), "plan lint       Validate a tracked plan")
 	support.RequireContains(t, result.CombinedOutput(), "execute start   Record the execution-start milestone")
@@ -49,6 +52,27 @@ func TestHelpShowsTopLevelUsage(t *testing.T) {
 	support.RequireContains(t, result.CombinedOutput(), "archive         Freeze the current active plan")
 	support.RequireContains(t, result.CombinedOutput(), "reopen          Restore the current archived plan")
 	support.RequireContains(t, result.CombinedOutput(), "status          Summarize the current plan and local execution state")
+}
+
+func TestVersionPrintsHumanReadableBuildInfo(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	result := support.Run(t, workspace.Root, "--version")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+	if mode := requireVersionField(t, result.Stdout, "mode"); mode != "release" {
+		t.Fatalf("expected release mode, got %q\noutput:\n%s", mode, result.Stdout)
+	}
+	expectedCommit := gitHeadCommit(t, support.RepoRoot(t))
+	if commit := requireVersionField(t, result.Stdout, "commit"); commit != expectedCommit {
+		t.Fatalf("expected release version commit %q, got %q\noutput:\n%s", expectedCommit, commit, result.Stdout)
+	}
+	if strings.Contains(result.Stdout, "path: ") {
+		t.Fatalf("expected release build version output to omit path, got %q", result.Stdout)
+	}
+	if strings.HasPrefix(strings.TrimSpace(result.Stdout), "{") {
+		t.Fatalf("expected plain-text version output, got %q", result.Stdout)
+	}
 }
 
 func TestStatusReportsIdleWorkspace(t *testing.T) {
@@ -177,4 +201,38 @@ func TestPlanTemplateAndLintRoundTrip(t *testing.T) {
 	if payload.Artifacts.PlanPath != planRelPath {
 		t.Fatalf("expected lint plan path %q, got %#v", planRelPath, payload)
 	}
+}
+
+func requireVersionField(t *testing.T, output, field string) string {
+	t.Helper()
+
+	prefix := field + ": "
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			value := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+			if value == "" {
+				t.Fatalf("expected version field %q to be non-empty\noutput:\n%s", field, output)
+			}
+			return value
+		}
+	}
+
+	t.Fatalf("expected version field %q in output:\n%s", field, output)
+	return ""
+}
+
+func gitHeadCommit(t *testing.T, repoRoot string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "HEAD")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v\n%s", err, output)
+	}
+
+	commit := strings.TrimSpace(string(output))
+	if commit == "" {
+		t.Fatalf("expected git HEAD commit for %s", repoRoot)
+	}
+	return commit
 }

--- a/tests/support/binary.go
+++ b/tests/support/binary.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -15,6 +16,8 @@ var (
 	buildPath string
 	buildErr  error
 )
+
+const versionPackage = "github.com/yzhang1918/superharness/internal/version"
 
 func RepoRoot(t *testing.T) string {
 	t.Helper()
@@ -37,7 +40,14 @@ func BuildBinary(t *testing.T) string {
 		}
 		buildPath = filepath.Join(dir, name)
 
-		cmd := exec.Command("go", "build", "-o", buildPath, "./cmd/harness")
+		commit, err := repoHeadCommit(repoRoot())
+		if err != nil {
+			buildErr = fmt.Errorf("resolve harness build commit: %w", err)
+			return
+		}
+
+		ldflags := fmt.Sprintf("-X %s.BuildCommit=%s", versionPackage, commit)
+		cmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", buildPath, "./cmd/harness")
 		cmd.Dir = repoRoot()
 		output, err := cmd.CombinedOutput()
 		if err != nil {
@@ -57,4 +67,17 @@ func repoRoot() string {
 		panic("resolve tests/support source path")
 	}
 	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func repoHeadCommit(root string) (string, error) {
+	output, err := exec.Command("git", "-C", root, "rev-parse", "HEAD").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse HEAD: %w\n%s", err, output)
+	}
+
+	commit := strings.TrimSpace(string(output))
+	if commit == "" {
+		return "", fmt.Errorf("git rev-parse HEAD returned an empty commit")
+	}
+	return commit, nil
 }


### PR DESCRIPTION
## Summary

- add a root `harness --version` debug flag with plain-text mode / commit output and dev-only path reporting
- centralize version metadata resolution in `internal/version` and inject build commits for dev installs plus repo-built validation binaries
- document the contract, archive the tracked plan, and harden smoke coverage around release/dev commit identity

## Validation

- `harness plan lint docs/plans/active/2026-03-23-harness-version-command.md`
- `go test ./internal/version ./internal/cli -count=1`
- `go test ./tests/smoke -count=1`
- `go test ./... -count=1`
- `bash -n scripts/install-dev-harness`
- `scripts/install-dev-harness`
- `PATH="$HOME/.local/bin:$PATH" harness --version`

## Follow-up

- #31
- #32
- #33
