### PR TITLE
Simplify inferred review metadata

### DIFF
--- a/.agents/skills/harness-execute/references/review-orchestration.md
+++ b/.agents/skills/harness-execute/references/review-orchestration.md
@@ -25,11 +25,11 @@ the next action, start that review without asking the human for permission.
 
 ## Routine Start Rules
 
-- After a completed step becomes reviewable, start `step_closeout` review
-  before treating the step as durably done, unless the step will instead record
+- After a completed step becomes reviewable, start a step-bound review before
+  treating the step as durably done, unless the step will instead record
   `NO_STEP_REVIEW_NEEDED: <reason>` in `Review Notes`.
 - Once all tracked steps are complete and no warning-driven repair remains,
-  start `pre_archive` review for the full candidate before archive closeout.
+  start finalize review for the full candidate before archive closeout.
 - If `harness status` surfaces an earlier completed step that still lacks
   review closeout, resolve that warning before trusting later-step or finalize
   progression.
@@ -47,8 +47,7 @@ Use a compact JSON shape like:
 ```json
 {
   "kind": "delta",
-  "target": "Step 3: Make skill contracts more distributable",
-  "trigger": "step_closeout",
+  "summary": "Check the completed step for contract mistakes and handoff clarity.",
   "dimensions": [
     {
       "name": "correctness",
@@ -68,22 +67,19 @@ Field rules:
   - enum: `delta` or `full`
   - `delta` is for a completed step or narrow follow-up change
   - `full` is for an archive candidate or another broad branch-level pass
-- `target`
-  - free-form description of what this round is reviewing
-- `trigger`
-  - free-form tag describing why the round exists
-  - it is not a CLI enum today
-  - useful common values include:
-    - `step_closeout`
-    - `review_feedback`
-    - `review_fix`
-    - `pre_archive`
-    - `human_feedback`
-    - `ci_repair`
-    - `conflict_repair`
+- `summary`
+  - optional human-readable note for the controller and reviewers
+- `step`
+  - optional 1-based tracked step number
+  - usually omit it and let `harness` bind the round automatically
+  - only include it when you need to point review at a specific tracked step explicitly
 - `dimensions`
   - one reviewer slot per dimension after normalization
   - each dimension should have a short name and a concrete instruction
+
+The controller agent should not invent workflow metadata like `trigger` or
+`target`. `harness review start` infers whether the round is step-bound or
+finalize-bound from the current node and persists that structure itself.
 
 Suggested dimensions:
 
@@ -111,7 +107,7 @@ round to use the same set.
 
 2. Spawn multiple reviewer subagents in parallel: one reviewer per returned
    slot or review dimension.
-   For a slot's first pass in a tracked step or for one finalize review target
+   For a slot's first pass in a tracked step or for one finalize review scope
    in one revision, or whenever reuse is not clearly safe, use clean reviewer
    subagents. Moving to a different tracked step, moving from step review into
    finalize review, or moving to a different revision always starts with fresh
@@ -163,13 +159,13 @@ Use resume only for a narrow same-slot follow-up after the controller has
 already verified and closed that reviewer's earlier successful submission.
 Do not resume across tracked steps, or from a step review into finalize
 review. Those boundaries always start with fresh reviewers.
-Resume is only valid while the review target itself is still the same:
+Resume is only valid while the review scope itself is still the same:
 
 - for step review, the same tracked step title
-- for finalize review, the same finalize candidate target for the same revision
+- for finalize review, the same candidate summary for the same revision
 
-If reopen, a new tracked step, a new revision, or a new finalize target
-changes that target, start with fresh reviewers.
+If reopen, a new tracked step, a new revision, or a new finalize candidate
+changes that scope, start with fresh reviewers.
 
 Use this controller prompt shape when resuming a previously closed reviewer:
 
@@ -212,8 +208,8 @@ Prefer `resume_agent` only when all of these are true:
   by the controller
 - the new round is still narrow enough for `delta` review
 - the new round stays within the same tracked step review boundary, or within
-  the same finalize review target for the same revision
-- the new round keeps the same review target as the earlier submission
+  the same finalize review scope for the same revision
+- the new round keeps the same review scope as the earlier submission
 - the reviewer keeps the same slot and materially the same dimension
   instructions
 - the controller can give a bounded change summary that is directly tied to the
@@ -225,9 +221,9 @@ reviewer instead when any of these are true:
 - the earlier submission was missing, invalid, or never verified
 - the controller is moving to a different tracked step, or from a step review
   into finalize review
-- the review target changed because of reopen, a new tracked step, a new
+- the review scope changed because of reopen, a new tracked step, a new
   revision, or a later finalize pass against a different candidate
-- the follow-up broadened into `full` review or otherwise changed target
+- the follow-up broadened into `full` review or otherwise changed scope
   materially
 - the slot or instructions changed enough that the old reviewer context would
   mislead more than help
@@ -249,7 +245,7 @@ Use this pattern:
 
 After a later repair round starts, you may either spawn fresh reviewers again
 or reopen an eligible closed reviewer with `resume_agent` only for the same
-tracked step, or for the same finalize review target in the same revision,
+tracked step, or for the same finalize review scope in the same revision,
 then deliver only the fixed resume prompt for the new round. Even when you
 reuse a reviewer this way, close it again immediately after the new submission
 is verified.

--- a/docs/plans/archived/2026-03-26-simplify-review-metadata-and-inference.md
+++ b/docs/plans/archived/2026-03-26-simplify-review-metadata-and-inference.md
@@ -1,0 +1,301 @@
+---
+template_version: 0.2.0
+created_at: "2026-03-26T18:21:04+08:00"
+source_type: direct_request
+source_refs:
+    - '#50'
+---
+
+# Simplify review metadata and infer structural closeout context
+
+## Goal
+
+Reduce the review-spec burden on controller agents by removing agent-authored
+structural metadata that harness can already infer from workflow state.
+
+Keep the two important guidance surfaces stable after that reduction:
+`harness status` must still warn when a completed step lacks durable
+step-closeout coverage, and archive readiness must still require a qualifying
+finalize review for the current revision. The new model should also eliminate
+the current mismatch where repaired step reviews or finalize reviews can pass
+but fail to satisfy closeout because the agent chose a different free-form
+`trigger`.
+
+## Scope
+
+### In Scope
+
+- Simplify the review-start contract so controller agents no longer need to
+  hand-author structural `trigger`/`target` metadata for ordinary step and
+  finalize review.
+- Persist internal review structure from workflow state at review-start time,
+  including whether the round is step-scoped or finalize-scoped, which step it
+  belongs to when applicable, and which revision it belongs to.
+- Rework status/archive review satisfaction logic to rely on inferred durable
+  review structure instead of free-form structural triggers.
+- Remove the legacy agent-authored `trigger`/`target` contract instead of
+  carrying compatibility shims for prerelease behavior that we no longer want.
+- Add regression coverage for repaired step review, repaired finalize review,
+  revision-sensitive finalize requirements, and reopen flows.
+- Update CLI/spec/skill guidance so future agents know the reduced review spec
+  shape and the new inference rules.
+
+### Out of Scope
+
+- Redesigning reviewer dimensions, reviewer submission payloads, or round ID
+  allocation.
+- Changing the existing reopen modes or archive/publish/land lifecycle shape.
+- Designing a separate advanced review-authoring escape hatch beyond the
+  minimal routine contract.
+
+## Acceptance Criteria
+
+- [x] `harness review start` accepts a reduced agent-authored review spec for
+      ordinary execution, with structural review identity inferred from the
+      current workflow node rather than supplied as free-form `trigger` and
+      `target` text.
+- [x] Harness persists enough internal review metadata to determine, for every
+      round, whether it is step-closeout or finalize review, which step it is
+      bound to when applicable, and which revision it belongs to.
+- [x] A repaired step review that reruns from the same step still counts as the
+      latest step-closeout evidence for that step after it passes; status no
+      longer demands an extra closeout round only because the repair round used
+      different human-facing labeling.
+- [x] Archive readiness and `harness status` both require a passing finalize
+      review bound to the current revision, with `revision 1` still requiring
+      `full` and later revisions allowing `delta` for narrow finalize-fix
+      repairs.
+- [x] `harness status` continues to surface the two important guidance layers:
+      missing step-closeout debt before later-step/finalize/archive progression,
+      and missing or insufficient finalize review before archive.
+- [x] Reopen flows stay coherent: both reopen modes advance revision, `new-step`
+      still waits for the first new unfinished step, and `finalize-fix`
+      continues to require a fresh qualifying finalize review for the new
+      revision.
+- [x] Focused tests cover the reduced input contract, repaired step review,
+      repaired finalize review, and reopen-sensitive review guidance without
+      preserving old trigger/target fallback behavior.
+
+## Deferred Items
+
+- Consider whether a later follow-up should rename the remaining human-facing
+  review note field from `target` to `summary` after the structural inference
+  cutover is stable.
+- Consider whether the CLI should eventually expose an explicit advanced escape
+  hatch for non-routine review creation outside normal step/finalize nodes.
+
+## Work Breakdown
+
+### Step 1: Shrink the review-start contract
+
+- Done: [x]
+
+#### Objective
+
+Define the reduced review-spec shape and document how harness infers review
+structure from workflow state.
+
+#### Details
+
+Update the normative docs, CLI help text, and relevant skills so a future
+controller agent only needs to choose review breadth (`delta` or `full`), the
+review dimensions, and an optional human-readable summary. Fold the discovery
+decisions into tracked docs: structural meaning now comes from current node and
+revision, not from a free-form trigger string supplied by the agent.
+
+#### Expected Files
+
+- `docs/specs/cli-contract.md`
+- `docs/specs/state-model.md`
+- `.agents/skills/harness-execute/references/review-orchestration.md`
+- `internal/cli/app.go`
+
+#### Validation
+
+- The docs and help text make the reduced spec shape unambiguous to a cold
+  reader.
+- The documented rules still explain how routine step-closeout versus finalize
+  review is distinguished after trigger removal from agent input.
+
+#### Execution Notes
+
+Updated the CLI help, specs, and review-orchestration guidance so routine
+review input is now `kind + dimensions + optional summary/step`. The docs now
+say explicitly that harness infers step-bound versus finalize-bound review from
+workflow state instead of accepting agent-authored `trigger`/`target`.
+
+#### Review Notes
+
+`review-001-delta` passed with one minor wording finding about legacy
+pre-archive language in CLI help. Updated `internal/cli/app.go`, then reran a
+narrow `agent_ux` check in `review-002-delta`, which passed cleanly with no
+findings.
+
+### Step 2: Persist inferred review structure and reuse it for closeout
+
+- Done: [x]
+
+#### Objective
+
+Teach review start/status/archive to use inferred structural metadata instead
+of free-form structural triggers.
+
+#### Details
+
+Bind each round to internal structural facts at creation time: current
+revision, finalize versus step scope, and step index when step-scoped. Update
+the step-closeout reminder scan, active review context loading, finalize review
+satisfaction checks, and archive readiness checks to rely on these inferred
+facts rather than `trigger == "step_closeout"` or `trigger == "pre_archive"`.
+
+#### Expected Files
+
+- `internal/review/service.go`
+- `internal/runstate/state.go`
+- `internal/status/service.go`
+- `internal/lifecycle/service.go`
+
+#### Validation
+
+- A repaired step review pass satisfies step-closeout debt without requiring an
+  extra controller-authored closeout round.
+- A repaired finalize review after reopen satisfies archive readiness for the
+  new revision when its kind is sufficient for that revision.
+
+#### Execution Notes
+
+Simplified `review.Spec` and persisted review metadata to use inferred
+`step`/`revision` bindings plus a human-readable `summary`. `status` and
+`archive` now key off those durable bindings, which fixes the repaired
+step-review case and the revision-aware finalize case without asking agents to
+choose structural tags.
+
+#### Review Notes
+
+`review-003-delta` checked the inferred `step`/`revision` binding, active
+review recovery, and archive-readiness gating. Both `correctness` and
+`risk_scan` slots passed cleanly with no findings.
+
+### Step 3: Lock in guidance with regressions
+
+- Done: [x]
+
+#### Objective
+
+Cover the reduced metadata model with focused tests for warning stability and
+revision-aware review satisfaction.
+
+#### Details
+
+Add regression tests for: step review fails then repair review passes; finalize
+review fails then finalize-fix repair review passes on a later revision; `new-step`
+reopen consumes its pending new-step requirement once the first new unfinished
+step exists. Remove the old trigger/target compatibility expectations from the
+test suite so prerelease coverage matches the reduced contract.
+
+#### Expected Files
+
+- `internal/status/service_test.go`
+- `internal/lifecycle/service_test.go`
+- `internal/review/service_test.go`
+
+#### Validation
+
+- The new regressions fail against the old trigger-driven behavior and pass
+  with the inferred-structure implementation.
+- The warning and next-action text remains specific enough for a future agent
+  to recover without discovery chat.
+
+#### Execution Notes
+
+Updated unit tests and e2e helpers to use the reduced review spec, added
+coverage for inferred structure in review/lifecycle/status, and removed the
+old missing-trigger/target fallback expectations that no longer reflect the
+desired prerelease behavior.
+
+#### Review Notes
+
+`review-004-delta` found that shared status fixtures still relied on legacy
+`trigger`/`target` shims. `review-005-delta` then found the helper layer was
+still backfilling `step`/`revision`. Removed both shim layers, updated the
+fixtures to express structural metadata directly, reran focused review/lifecycle/status/e2e
+validation, and closed the step with `review-006-delta`, which passed cleanly
+with no findings.
+
+## Validation Strategy
+
+- Lint the tracked plan with `harness plan lint`.
+- Run focused Go tests for review start, status, and lifecycle archive/reopen
+  behavior.
+- Manually inspect representative `harness status` outputs for:
+  - missing earlier step closeout
+  - repaired step review that now counts
+  - revision 1 finalize requiring `full`
+  - revision >1 finalize-fix allowing `delta`
+
+## Risks
+
+- Risk: Over-simplifying the internal model could lose the distinction between
+  step review and finalize review during reopen or multi-round repair flows.
+  - Mitigation: Persist explicit internal step binding plus revision at review
+    creation time and cover reopen/fix flows with regression tests.
+
+## Validation Summary
+
+- `harness plan lint docs/plans/active/2026-03-26-simplify-review-metadata-and-inference.md`
+  passed after closeout updates.
+- `go test ./...` passed before step-closeout orchestration, and the final
+  focused regression sweep passed with
+  `go test ./internal/review ./internal/lifecycle ./internal/status ./tests/e2e`.
+- Manual `harness status` checks confirmed the intended guidance transitions:
+  step closeout debt, finalize-review gating, archive blockers, and
+  revision-aware finalize readiness.
+
+## Review Summary
+
+- Step closeout review passed for Step 1 after one minor wording cleanup in
+  `internal/cli/app.go` (`review-002-delta` was the final clean rerun).
+- Step 2 closeout passed cleanly in `review-003-delta`.
+- Step 3 closeout required two repair loops to remove the remaining fixture
+  compatibility shims, then passed cleanly in `review-006-delta`.
+- Finalize review passed cleanly in `review-007-full` across `correctness`,
+  `tests`, and `docs_consistency`.
+
+## Archive Summary
+
+- Archived At: 2026-03-26T19:20:28+08:00
+- Revision: 1
+- PR: NONE
+- Ready: The candidate has a passing full finalize review for revision 1, all
+  tracked steps are complete, and the remaining work is archive/publish
+  handoff.
+- Merge Handoff: Archive this plan, commit the tracked changes, push
+  `codex/review-metadata-inference`, open or update the PR, then record
+  publish/CI/sync evidence before waiting for merge approval.
+
+## Outcome Summary
+
+### Delivered
+
+- Removed agent-authored structural `target`/`trigger` inputs from routine
+  review start and replaced them with harness-inferred step/finalize bindings.
+- Persisted durable review structure as `step` plus `revision`, then rewired
+  status and archive gating to use that structure instead of free-form tags.
+- Updated CLI/spec/skill guidance and rewrote regression fixtures so the
+  reduced review metadata contract is exercised directly in tests and e2e
+  helpers.
+
+### Not Delivered
+
+- A follow-up rename of the remaining human-facing review summary field was
+  intentionally deferred.
+- An explicit advanced review-start escape hatch outside routine step/finalize
+  nodes was intentionally deferred.
+
+### Follow-Up Issues
+
+- #52 Rename remaining review summary field consistently across local artifacts
+  (`https://github.com/catu-ai/microharness/issues/52`)
+- #53 Design an explicit advanced review-start escape hatch outside routine
+  step/finalize nodes
+  (`https://github.com/catu-ai/microharness/issues/53`)

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -155,7 +155,9 @@ help explain the node:
 - `reopen_mode`
 - `review_kind`
 - `review_trigger`
+  - optional derived label such as `step_closeout` or `pre_archive`
 - `review_target`
+  - optional derived human-readable review summary
 - `review_status`
 - `archive_blocker_count`
 - `publish_status`
@@ -351,8 +353,7 @@ Canonical input shape:
 ```json
 {
   "kind": "delta",
-  "target": "Step 3: Implement local state and harness status",
-  "trigger": "step_closeout",
+  "summary": "Check the completed step for state-machine mistakes and handoff clarity.",
   "dimensions": [
     {
       "name": "correctness",
@@ -379,15 +380,27 @@ harness review start --spec /tmp/review-spec.json
 The command returns JSON describing the created round, persisted manifest path,
 owned artifact paths, and next actions for the controller agent.
 
-For review-spec semantics:
+Review-spec semantics:
 
-- `trigger: step_closeout`
-  - the review is closing out one tracked step
-  - `target` should use the tracked step title so status can match the review to
-    the intended step deterministically
-- `trigger: pre_archive`
-  - the review is a branch-level finalize review
-  - `target` should describe the full candidate rather than a single step
+- `kind`
+  - required
+  - enum: `delta` or `full`
+- `dimensions`
+  - required
+  - one reviewer slot per normalized dimension
+- `summary`
+  - optional
+  - human-readable note shown back to the controller and reviewers
+- `step`
+  - optional 1-based tracked step number
+  - usually omitted
+  - when omitted, `harness review start` infers the binding from workflow state:
+    - during `execution/step-<n>/implement`, the round binds to the current step
+    - during `execution/finalize/review` or `execution/finalize/fix`, the round binds to finalize review
+
+Agents should not supply structural workflow tags such as `step_closeout` or
+`pre_archive`. The CLI owns that inference and persists the bound step or
+finalize scope in the round manifest and local state.
 
 Round identifiers should be short and plan-local:
 
@@ -396,11 +409,11 @@ Round identifiers should be short and plan-local:
 - keep precise timestamps in the manifest and aggregate artifacts rather than
   embedding them in the round ID
 
-`target` should be free-form and human-readable. Examples:
+If `summary` is omitted, the CLI fills one in:
 
-- delta after a step: `Step 3: Implement local state and harness status`
-- full pre-archive review: `Full branch candidate before archive`
-- follow-up after human feedback: `Changes addressing human comments on archive summary`
+- step-bound review defaults to the tracked step title
+- finalize `full` review defaults to `Full branch candidate before archive`
+- finalize `delta` review defaults to `Branch candidate before archive`
 
 Dimension-specific reviewer instructions belong in the input review spec.
 Generic reviewer behavior, such as "inspect the current diff and submit results
@@ -434,7 +447,7 @@ Recommended next action:
 
 - on success, report the receipt to the controller agent and end the reviewer
   thread; a runtime may later reopen the same reviewer for a narrow same-slot
-  follow-up for the same tracked step or the same finalize review target in
+  follow-up for the same tracked step or the same finalize review scope in
   the same revision, but only after the earlier submission was verified and
   only when the slot instructions still materially match; immediate closeout
   is the safe default
@@ -476,7 +489,7 @@ Recommended next action:
 The CLI contract should assume this review cadence:
 
 - use `delta` review after a completed plan step or after a narrow follow-up fix
-- allow a `full` review to satisfy `step_closeout` when a narrower review would
+- allow a `full` review to satisfy step closeout when a narrower review would
   be misleading for that completed step
 - use `full` review once all planned work appears complete and the branch looks
   like an archive candidate
@@ -658,10 +671,10 @@ calling `harness review submit`.
 Codex should still default to closing reviewer agents after each verified
 submission. If a later narrow follow-up round keeps the same slot and
 materially the same instructions for the same tracked step or the same
-finalize review target in the same revision, the controller may reopen that
+finalize review scope in the same revision, the controller may reopen that
 previously closed reviewer with `resume_agent` instead of spawning fresh.
 Moving to a different tracked step, moving from step review to finalize
-review, changing the review target because of reopen or a new revision, broad
+review, changing the review scope because of reopen or a new revision, broad
 follow-up, changed slot ownership, invalid earlier submissions, or any
 situation where a clean reread is safer should stay on fresh `spawn_agent`
 reviewer threads.

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -211,9 +211,9 @@ Merge is confirmed and post-merge cleanup is in progress. Cleanup remains in
   review notes, and relevant review loop are complete, or the step records why
   no review was needed.
 - A completed step is review-complete when either:
-  - the latest known `step_closeout` review for that step is clean
+  - the latest known step-bound review for that step is clean
   - or `Review Notes` records `NO_STEP_REVIEW_NEEDED: <reason>` and no later
-    in-flight or non-clean `step_closeout` review exists for that step
+    in-flight or non-clean step-bound review exists for that step
 - Step-closeout review should default to `delta`, but a `full` review may
   satisfy step closeout when a narrower pass would be misleading or the slice
   needs a broader risk scan.

--- a/docs/specs/state-transitions.md
+++ b/docs/specs/state-transitions.md
@@ -27,7 +27,7 @@ the normative transition matrix.
 
 | From | To | Driver | Required inputs | Notes |
 | --- | --- | --- | --- | --- |
-| `execution/step-<n>/implement` | `execution/step-<n>/review` | `harness review start` | Review round targets the current step | Review nodes require real review artifacts. |
+| `execution/step-<n>/implement` | `execution/step-<n>/review` | `harness review start` | The command binds the new round to the current step | Review nodes require real review artifacts. |
 | `execution/step-<n>/implement` | `execution/step-<m>/implement` | Derived from tracked plan edits | Step `<n>` becomes durably complete, any required step review is clean, and another unfinished step exists | A failed step review must be repaired and rerun before this transition is allowed. |
 | `execution/step-<n>/implement` | `execution/finalize/review` | Derived from tracked plan edits | Step `<n>` becomes durably complete, any required step review is clean, and no unfinished steps remain | Finalize review stays distinct from step review. |
 | `execution/step-<n>/review` | `execution/step-<n>/implement` | `harness review aggregate` | Latest aggregate is clean | Review is no longer in flight; the controller may continue implementation or mark the step done. |

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -411,7 +411,9 @@ func (a *App) runReviewStart(args []string) int {
 	fs.Usage = func() {
 		fmt.Fprintln(a.Stderr, "Usage: harness review start [--spec <path>]")
 		fmt.Fprintln(a.Stderr)
-		fmt.Fprintln(a.Stderr, "Create a deterministic review round from an agent-supplied spec.")
+		fmt.Fprintln(a.Stderr, "Create a deterministic review round from a minimal review spec.")
+		fmt.Fprintln(a.Stderr, "The spec must include `kind` and `dimensions`, and may include optional `summary` or `step`.")
+		fmt.Fprintln(a.Stderr, "Harness infers whether the round is step-bound or finalize-bound from the current workflow state.")
 	}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -900,7 +900,7 @@ func archiveStateIssues(workdir, planStem string, revision int, state *runstate.
 			Message: "latest review decision is unknown; rerun or re-aggregate the latest review before archive",
 		})
 	}
-	trigger, triggerKnown, err := runstate.EffectiveReviewTrigger(workdir, planStem, state.ActiveReviewRound)
+	reviewRevision, reviewRevisionKnown, err := runstate.EffectiveReviewRevision(workdir, planStem, state.ActiveReviewRound)
 	if err != nil {
 		issues = append(issues, CommandError{
 			Path:    "state.active_review_round",
@@ -908,10 +908,24 @@ func archiveStateIssues(workdir, planStem string, revision int, state *runstate.
 		})
 		return issues
 	}
-	if !triggerKnown || trigger != "pre_archive" {
+	if !reviewRevisionKnown || reviewRevision != revision {
 		issues = append(issues, CommandError{
 			Path:    "state.active_review_round",
 			Message: requiredReviewMessage(revision),
+		})
+	}
+	stepNumber, stepKnown, err := runstate.EffectiveReviewStep(workdir, planStem, state.ActiveReviewRound)
+	if err != nil {
+		issues = append(issues, CommandError{
+			Path:    "state.active_review_round",
+			Message: fmt.Sprintf("unable to read the latest manifest artifact for %s: %v", state.ActiveReviewRound.RoundID, err),
+		})
+		return issues
+	}
+	if stepKnown {
+		issues = append(issues, CommandError{
+			Path:    "state.active_review_round",
+			Message: fmt.Sprintf("latest review is still bound to step %d; archive requires a finalize review for revision %d", stepNumber, revision),
 		})
 	}
 	if known && decision != "pass" {

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -26,7 +26,7 @@ func TestArchiveMovesPlanAndUpdatesPointers(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -228,7 +228,7 @@ func TestArchiveRejectsMissingArchiveSummaryFields(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -262,7 +262,7 @@ func TestArchivePreflightFailureLeavesPlanAndPointersUntouched(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -310,7 +310,7 @@ func TestArchiveRollsBackWhenCurrentPlanWriteFails(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -370,7 +370,7 @@ func TestArchiveRejectsUnresolvedLocalState(t *testing.T) {
 				tc.state.ActiveReviewRound = &runstate.ReviewRound{
 					RoundID:    "review-001-full",
 					Kind:       "full",
-					Trigger:    "pre_archive",
+					Revision:   1,
 					Aggregated: true,
 					Decision:   "pass",
 				}
@@ -406,7 +406,7 @@ func TestArchiveRequiresPassingReviewForRevisionOne(t *testing.T) {
 				ActiveReviewRound: &runstate.ReviewRound{
 					RoundID:    "review-001-delta",
 					Kind:       "delta",
-					Trigger:    "pre_archive",
+					Revision:   1,
 					Aggregated: true,
 					Decision:   "pass",
 				},
@@ -419,7 +419,7 @@ func TestArchiveRequiresPassingReviewForRevisionOne(t *testing.T) {
 				ActiveReviewRound: &runstate.ReviewRound{
 					RoundID:    "review-001-full",
 					Kind:       "full",
-					Trigger:    "pre_archive",
+					Revision:   1,
 					Aggregated: true,
 					Decision:   "changes_requested",
 				},
@@ -463,7 +463,7 @@ func TestArchiveAllowsPassingDeltaReviewForReopenedRevision(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-002-delta",
 			Kind:       "delta",
-			Trigger:    "pre_archive",
+			Revision:   2,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -494,7 +494,7 @@ func TestArchiveIgnoresCIPublishSyncSignalsOnceFinalizeReviewPasses(t *testing.T
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -526,7 +526,7 @@ func TestArchiveUsesAggregateArtifactForLegacyReviewDecision(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 		},
 	}); err != nil {
@@ -557,7 +557,7 @@ func TestReopenMovesArchivedPlanBackToActiveAndResetsSummaries(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -628,7 +628,7 @@ func TestReopenNewStepRecordsModeAndStatusCue(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -692,7 +692,7 @@ func TestReopenMarkersMustBeClearedBeforeRearchive(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -728,7 +728,7 @@ func TestReopenMarkersMustBeClearedBeforeRearchive(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-002-delta",
 			Kind:       "delta",
-			Trigger:    "pre_archive",
+			Revision:   2,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -773,7 +773,7 @@ func TestReopenClearsStaleCIAndSyncSignals(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},
@@ -800,7 +800,7 @@ func TestReopenClearsStaleCIAndSyncSignals(t *testing.T) {
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
-			Trigger:    "pre_archive",
+			Revision:   1,
 			Aggregated: true,
 			Decision:   "pass",
 		},

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -26,9 +26,9 @@ type Service struct {
 }
 
 type Spec struct {
+	Step       *int        `json:"step,omitempty"`
 	Kind       string      `json:"kind"`
-	Target     string      `json:"target"`
-	Trigger    string      `json:"trigger"`
+	Summary    string      `json:"summary,omitempty"`
 	Dimensions []Dimension `json:"dimensions"`
 }
 
@@ -40,8 +40,9 @@ type Dimension struct {
 type Manifest struct {
 	RoundID     string         `json:"round_id"`
 	Kind        string         `json:"kind"`
-	Target      string         `json:"target"`
-	Trigger     string         `json:"trigger"`
+	Step        *int           `json:"step,omitempty"`
+	Revision    int            `json:"revision"`
+	Summary     string         `json:"summary,omitempty"`
 	PlanPath    string         `json:"plan_path"`
 	PlanStem    string         `json:"plan_stem"`
 	CreatedAt   string         `json:"created_at"`
@@ -96,7 +97,9 @@ type Finding struct {
 type Aggregate struct {
 	RoundID             string             `json:"round_id"`
 	Kind                string             `json:"kind"`
-	Target              string             `json:"target"`
+	Step                *int               `json:"step,omitempty"`
+	Revision            int                `json:"revision"`
+	Summary             string             `json:"summary,omitempty"`
 	Decision            string             `json:"decision"`
 	BlockingFindings    []AggregateFinding `json:"blocking_findings"`
 	NonBlockingFindings []AggregateFinding `json:"non_blocking_findings"`
@@ -208,6 +211,15 @@ func (s Service) Start(specBytes []byte) StartResult {
 			Errors:  issues,
 		}
 	}
+	inferredStep, revision, summary, err := inferReviewBinding(doc, state, spec)
+	if err != nil {
+		return StartResult{
+			OK:      false,
+			Command: "review start",
+			Summary: "Review spec does not match the current workflow state.",
+			Errors:  []CommandError{{Path: "spec", Message: err.Error()}},
+		}
+	}
 
 	roundID, err := nextRoundID(s.Workdir, planStem, spec.Kind)
 	if err != nil {
@@ -259,8 +271,9 @@ func (s Service) Start(specBytes []byte) StartResult {
 	manifest := Manifest{
 		RoundID:     roundID,
 		Kind:        spec.Kind,
-		Target:      spec.Target,
-		Trigger:     spec.Trigger,
+		Step:        inferredStep,
+		Revision:    revision,
+		Summary:     summary,
 		PlanPath:    relPlanPath,
 		PlanStem:    planStem,
 		CreatedAt:   now.Format(time.RFC3339),
@@ -294,7 +307,8 @@ func (s Service) Start(specBytes []byte) StartResult {
 	state.ActiveReviewRound = &runstate.ReviewRound{
 		RoundID:    roundID,
 		Kind:       spec.Kind,
-		Trigger:    spec.Trigger,
+		Step:       inferredStep,
+		Revision:   revision,
 		Aggregated: false,
 		Decision:   "",
 	}
@@ -533,7 +547,9 @@ func (s Service) Aggregate(roundID string) AggregateResult {
 	aggregate := Aggregate{
 		RoundID:             roundID,
 		Kind:                manifest.Kind,
-		Target:              manifest.Target,
+		Step:                manifest.Step,
+		Revision:            manifest.Revision,
+		Summary:             manifest.Summary,
 		Decision:            decision,
 		BlockingFindings:    blocking,
 		NonBlockingFindings: nonBlocking,
@@ -568,7 +584,8 @@ func (s Service) Aggregate(roundID string) AggregateResult {
 	state.ActiveReviewRound = &runstate.ReviewRound{
 		RoundID:    manifest.RoundID,
 		Kind:       manifest.Kind,
-		Trigger:    manifest.Trigger,
+		Step:       manifest.Step,
+		Revision:   manifest.Revision,
 		Aggregated: true,
 		Decision:   decision,
 	}
@@ -709,11 +726,8 @@ func validateSpec(spec Spec) []CommandError {
 	if !slices.Contains([]string{"delta", "full"}, spec.Kind) {
 		issues = append(issues, CommandError{Path: "spec.kind", Message: "must be delta or full"})
 	}
-	if strings.TrimSpace(spec.Target) == "" {
-		issues = append(issues, CommandError{Path: "spec.target", Message: "must not be empty"})
-	}
-	if strings.TrimSpace(spec.Trigger) == "" {
-		issues = append(issues, CommandError{Path: "spec.trigger", Message: "must not be empty"})
+	if spec.Step != nil && *spec.Step <= 0 {
+		issues = append(issues, CommandError{Path: "spec.step", Message: "must be a positive 1-based step number"})
 	}
 	if len(spec.Dimensions) == 0 {
 		issues = append(issues, CommandError{Path: "spec.dimensions", Message: "must contain at least one dimension"})
@@ -807,6 +821,77 @@ func nextRoundSequence(workdir, planStem string) (int, error) {
 
 func formatRoundID(sequence int, kind string) string {
 	return fmt.Sprintf("review-%03d-%s", sequence, kind)
+}
+
+func inferReviewBinding(doc *plan.Document, state *runstate.State, spec Spec) (*int, int, string, error) {
+	revision := runstate.CurrentRevision(state)
+	if stepIndex, ok, err := inferReviewStepIndex(doc, state, spec); err != nil {
+		return nil, 0, "", err
+	} else if ok {
+		summary := strings.TrimSpace(spec.Summary)
+		if summary == "" {
+			summary = doc.Steps[stepIndex].Title
+		}
+		stepNumber := stepIndex + 1
+		return &stepNumber, revision, summary, nil
+	}
+
+	if pendingNewStepReopen(doc, state) {
+		return nil, 0, "", fmt.Errorf("reopen mode new-step still requires a new unfinished step before review can start")
+	}
+	if !doc.AllStepsCompleted() {
+		return nil, 0, "", fmt.Errorf("no reviewable tracked step could be inferred; set spec.step to select a tracked step explicitly")
+	}
+
+	summary := strings.TrimSpace(spec.Summary)
+	if summary == "" {
+		if spec.Kind == "full" {
+			summary = "Full branch candidate before archive"
+		} else {
+			summary = "Branch candidate before archive"
+		}
+	}
+	return nil, revision, summary, nil
+}
+
+func inferReviewStepIndex(doc *plan.Document, state *runstate.State, spec Spec) (int, bool, error) {
+	if doc == nil {
+		return 0, false, fmt.Errorf("current plan is unavailable")
+	}
+	if spec.Step != nil {
+		index := *spec.Step - 1
+		if index < 0 || index >= len(doc.Steps) {
+			return 0, false, fmt.Errorf("spec.step=%d does not match a tracked step", *spec.Step)
+		}
+		return index, true, nil
+	}
+	if current := currentStepIndex(doc); current >= 0 {
+		return current, true, nil
+	}
+	return 0, false, nil
+}
+
+func currentStepIndex(doc *plan.Document) int {
+	if doc == nil {
+		return -1
+	}
+	for index, step := range doc.Steps {
+		if !step.Done {
+			return index
+		}
+	}
+	return -1
+}
+
+func pendingNewStepReopen(doc *plan.Document, state *runstate.State) bool {
+	return state != nil &&
+		state.Reopen != nil &&
+		state.Reopen.Mode == "new-step" &&
+		state.Reopen.BaseStepCount > 0 &&
+		doc != nil &&
+		len(doc.Steps) <= state.Reopen.BaseStepCount &&
+		doc.CurrentStep() == nil &&
+		doc.AllStepsCompleted()
 }
 
 func loadManifest(path string) (*Manifest, error) {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -26,9 +26,7 @@ func TestStartCreatesRoundAndUpdatesState(t *testing.T) {
 	}
 
 	result := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Step 4: Implement the review-round contract",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check the state and artifact contract."},
 			{Name: "agent_ux", Instructions: "Check that outputs are agent-friendly."},
@@ -56,6 +54,9 @@ func TestStartCreatesRoundAndUpdatesState(t *testing.T) {
 	if state.ActiveReviewRound.Decision != "" {
 		t.Fatalf("expected empty decision before aggregate, got %#v", state.ActiveReviewRound)
 	}
+	if state.ActiveReviewRound.Step == nil || *state.ActiveReviewRound.Step != 1 || state.ActiveReviewRound.Revision != 1 {
+		t.Fatalf("expected inferred step 1 on revision 1, got %#v", state.ActiveReviewRound)
+	}
 }
 
 func TestStartAcceptsExecutionStartMilestoneWithoutLegacyExecutingLifecycle(t *testing.T) {
@@ -78,9 +79,7 @@ func TestStartAcceptsExecutionStartMilestoneWithoutLegacyExecutingLifecycle(t *t
 	}
 
 	result := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Step 1",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -93,7 +92,7 @@ func TestStartAcceptsExecutionStartMilestoneWithoutLegacyExecutingLifecycle(t *t
 func TestStartIgnoresLegacyTimestampReviewDirectoriesForCompactSequence(t *testing.T) {
 	root := t.TempDir()
 	planStem := "2026-03-18-review-contract"
-	writeExecutingPlan(t, root, "docs/plans/active/"+planStem+".md")
+	writeExecutingFinalizePlan(t, root, "docs/plans/active/"+planStem+".md")
 
 	legacyRoundDir := filepath.Join(root, ".local", "harness", "plans", planStem, "reviews", "review-20260318t010000000000000z-delta")
 	if err := os.MkdirAll(legacyRoundDir, 0o755); err != nil {
@@ -108,9 +107,7 @@ func TestStartIgnoresLegacyTimestampReviewDirectoriesForCompactSequence(t *testi
 	}
 
 	result := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "full",
-		Target:  "Full branch candidate before archive",
-		Trigger: "pre_archive",
+		Kind: "full",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -147,9 +144,7 @@ func TestStartUsesMaxExistingCompactReviewSequence(t *testing.T) {
 	}
 
 	result := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Follow-up delta review after sparse history",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -169,15 +164,11 @@ func TestStartRejectsInvalidSpec(t *testing.T) {
 	svc := review.Service{Workdir: root}
 	result := svc.Start(mustJSON(t, map[string]any{
 		"kind":       "delta",
-		"target":     "",
-		"trigger":    "",
 		"dimensions": []any{},
 	}))
 	if result.OK {
 		t.Fatalf("expected failure, got %#v", result)
 	}
-	assertStartError(t, result, "spec.target")
-	assertStartError(t, result, "spec.trigger")
 	assertStartError(t, result, "spec.dimensions")
 }
 
@@ -192,9 +183,7 @@ func TestSubmitStoresSubmissionAndUpdatesLedger(t *testing.T) {
 		},
 	}
 	start := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Step 4",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -231,9 +220,7 @@ func TestSubmitRejectsUnknownSlot(t *testing.T) {
 		},
 	}
 	start := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Step 4",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -262,9 +249,7 @@ func TestAggregateRejectsMissingSubmission(t *testing.T) {
 		},
 	}
 	start := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Step 4",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -291,9 +276,7 @@ func TestAggregateDeltaPassUpdatesState(t *testing.T) {
 		},
 	}
 	start := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Step 4",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -338,9 +321,7 @@ func TestAggregateRejectsNonActiveRound(t *testing.T) {
 		},
 	}
 	stale := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Step 4",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -358,10 +339,9 @@ func TestAggregateRejectsNonActiveRound(t *testing.T) {
 	svc.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 1, 5, 0, 0, time.UTC)
 	}
+	writeExecutingFinalizePlan(t, root, "docs/plans/active/2026-03-18-review-contract.md")
 	active := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "full",
-		Target:  "Full branch candidate before archive",
-		Trigger: "pre_archive",
+		Kind: "full",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -408,9 +388,7 @@ func TestStartRejectsWhenReviewMutationLockIsHeld(t *testing.T) {
 		},
 	}
 	result := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Step 4",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -433,9 +411,7 @@ func TestAggregateRejectsWhenReviewMutationLockIsHeld(t *testing.T) {
 		},
 	}
 	start := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "delta",
-		Target:  "Step 4",
-		Trigger: "step_closeout",
+		Kind: "delta",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -464,7 +440,7 @@ func TestAggregateRejectsWhenReviewMutationLockIsHeld(t *testing.T) {
 
 func TestAggregateFullWithBlockingFindings(t *testing.T) {
 	root := t.TempDir()
-	writeExecutingPlan(t, root, "docs/plans/active/2026-03-18-review-contract.md")
+	writeExecutingFinalizePlan(t, root, "docs/plans/active/2026-03-18-review-contract.md")
 
 	svc := review.Service{
 		Workdir: root,
@@ -473,9 +449,7 @@ func TestAggregateFullWithBlockingFindings(t *testing.T) {
 		},
 	}
 	start := svc.Start(mustJSON(t, review.Spec{
-		Kind:    "full",
-		Target:  "Full branch candidate before archive",
-		Trigger: "pre_archive",
+		Kind: "full",
 		Dimensions: []review.Dimension{
 			{Name: "correctness", Instructions: "Check correctness."},
 		},
@@ -522,6 +496,28 @@ func TestAggregateFullWithBlockingFindings(t *testing.T) {
 func writeExecutingPlan(t *testing.T, root, relPath string) string {
 	t.Helper()
 	path := writePlainReviewPlan(t, root, relPath)
+	if _, err := runstate.SaveState(root, strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath)), &runstate.State{
+		ExecutionStartedAt: "2026-03-18T01:00:00Z",
+		PlanPath:           relPath,
+		PlanStem:           strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath)),
+		Revision:           1,
+	}); err != nil {
+		t.Fatalf("save execute-start state: %v", err)
+	}
+	return path
+}
+
+func writeExecutingFinalizePlan(t *testing.T, root, relPath string) string {
+	t.Helper()
+	path := writePlainReviewPlan(t, root, relPath)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	content := strings.ReplaceAll(string(data), "- Done: [ ]", "- Done: [x]")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write finalized plan: %v", err)
+	}
 	if _, err := runstate.SaveState(root, strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath)), &runstate.State{
 		ExecutionStartedAt: "2026-03-18T01:00:00Z",
 		PlanPath:           relPath,

--- a/internal/runstate/state.go
+++ b/internal/runstate/state.go
@@ -41,7 +41,8 @@ type ReopenState struct {
 type ReviewRound struct {
 	RoundID    string `json:"round_id"`
 	Kind       string `json:"kind"`
-	Trigger    string `json:"trigger,omitempty"`
+	Step       *int   `json:"step,omitempty"`
+	Revision   int    `json:"revision,omitempty"`
 	Aggregated bool   `json:"aggregated"`
 	Decision   string `json:"decision,omitempty"`
 }
@@ -86,8 +87,9 @@ type reviewAggregate struct {
 }
 
 type reviewManifest struct {
-	Trigger string `json:"trigger"`
-	Target  string `json:"target"`
+	Summary  string `json:"summary,omitempty"`
+	Step     *int   `json:"step,omitempty"`
+	Revision int    `json:"revision,omitempty"`
 }
 
 func LoadCurrentPlan(workdir string) (*CurrentPlan, error) {
@@ -200,37 +202,7 @@ func EffectiveReviewDecision(workdir, planStem string, round *ReviewRound) (stri
 	return "", false, nil
 }
 
-func EffectiveReviewTrigger(workdir, planStem string, round *ReviewRound) (string, bool, error) {
-	if round == nil {
-		return "", false, nil
-	}
-	if trigger := strings.TrimSpace(round.Trigger); trigger != "" {
-		return trigger, true, nil
-	}
-	if strings.TrimSpace(round.RoundID) == "" {
-		return "", false, nil
-	}
-
-	path := filepath.Join(workdir, ".local", "harness", "plans", planStem, "reviews", round.RoundID, "manifest.json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", false, nil
-		}
-		return "", false, fmt.Errorf("read manifest.json for %s: %w", round.RoundID, err)
-	}
-
-	var manifest reviewManifest
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return "", false, fmt.Errorf("parse manifest.json for %s: %w", round.RoundID, err)
-	}
-	if trigger := strings.TrimSpace(manifest.Trigger); trigger != "" {
-		return trigger, true, nil
-	}
-	return "", false, nil
-}
-
-func EffectiveReviewTarget(workdir, planStem string, round *ReviewRound) (string, bool, error) {
+func EffectiveReviewSummary(workdir, planStem string, round *ReviewRound) (string, bool, error) {
 	if round == nil || strings.TrimSpace(round.RoundID) == "" {
 		return "", false, nil
 	}
@@ -248,8 +220,68 @@ func EffectiveReviewTarget(workdir, planStem string, round *ReviewRound) (string
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return "", false, fmt.Errorf("parse manifest.json for %s: %w", round.RoundID, err)
 	}
-	if target := strings.TrimSpace(manifest.Target); target != "" {
-		return target, true, nil
+	if summary := strings.TrimSpace(manifest.Summary); summary != "" {
+		return summary, true, nil
 	}
 	return "", false, nil
+}
+
+func EffectiveReviewStep(workdir, planStem string, round *ReviewRound) (int, bool, error) {
+	if round == nil {
+		return 0, false, nil
+	}
+	if round.Step != nil {
+		return *round.Step, true, nil
+	}
+	if strings.TrimSpace(round.RoundID) == "" {
+		return 0, false, nil
+	}
+
+	path := filepath.Join(workdir, ".local", "harness", "plans", planStem, "reviews", round.RoundID, "manifest.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("read manifest.json for %s: %w", round.RoundID, err)
+	}
+
+	var manifest reviewManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return 0, false, fmt.Errorf("parse manifest.json for %s: %w", round.RoundID, err)
+	}
+	if manifest.Step != nil {
+		return *manifest.Step, true, nil
+	}
+	return 0, false, nil
+}
+
+func EffectiveReviewRevision(workdir, planStem string, round *ReviewRound) (int, bool, error) {
+	if round == nil {
+		return 0, false, nil
+	}
+	if round.Revision > 0 {
+		return round.Revision, true, nil
+	}
+	if strings.TrimSpace(round.RoundID) == "" {
+		return 0, false, nil
+	}
+
+	path := filepath.Join(workdir, ".local", "harness", "plans", planStem, "reviews", round.RoundID, "manifest.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("read manifest.json for %s: %w", round.RoundID, err)
+	}
+
+	var manifest reviewManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return 0, false, fmt.Errorf("parse manifest.json for %s: %w", round.RoundID, err)
+	}
+	if manifest.Revision > 0 {
+		return manifest.Revision, true, nil
+	}
+	return 0, false, nil
 }

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -78,8 +78,9 @@ type StatusError struct {
 type reviewContext struct {
 	RoundID         string
 	Kind            string
+	Revision        int
 	Trigger         string
-	Target          string
+	Summary         string
 	Aggregated      bool
 	InFlight        bool
 	Decision        string
@@ -100,13 +101,9 @@ type missingStepCloseoutReminder struct {
 }
 
 type historicalReviewManifest struct {
-	Trigger string `json:"trigger"`
-	Target  string `json:"target"`
-}
-
-type historicalReviewAggregate struct {
-	Target   string `json:"target"`
-	Decision string `json:"decision"`
+	Summary  string `json:"summary,omitempty"`
+	Step     *int   `json:"step,omitempty"`
+	Revision int    `json:"revision,omitempty"`
 }
 
 type latestStepCloseoutRound struct {
@@ -121,7 +118,7 @@ type latestUnknownHistoricalReviewRound struct {
 }
 
 type latestStepCloseoutScan struct {
-	LatestByTarget      map[string]latestStepCloseoutRound
+	LatestByStepIndex   map[int]latestStepCloseoutRound
 	Warnings            []string
 	LatestUnscopedRound *latestUnknownHistoricalReviewRound
 }
@@ -218,7 +215,7 @@ func (s Service) Read() Result {
 	if reviewCtx != nil && isStructuralReviewTrigger(reviewCtx.Trigger) && !reviewCtx.UnsafeFallback {
 		facts.ReviewKind = reviewCtx.Kind
 		facts.ReviewTrigger = reviewCtx.Trigger
-		facts.ReviewTarget = reviewCtx.Target
+		facts.ReviewTarget = reviewCtx.Summary
 		switch {
 		case reviewCtx.InFlight:
 			facts.ReviewStatus = "in_progress"
@@ -415,16 +412,22 @@ func loadReviewContext(workdir, planStem string, doc *plan.Document, state *runs
 	}
 	warnings := make([]string, 0)
 
-	if trigger, known, err := runstate.EffectiveReviewTrigger(workdir, planStem, round); err != nil {
-		warnings = append(warnings, fmt.Sprintf("Unable to read the review trigger for %s; status may be conservative.", round.RoundID))
-	} else if known {
-		ctx.Trigger = trigger
+	revision, revisionKnown, err := runstate.EffectiveReviewRevision(workdir, planStem, round)
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("Unable to read the review revision for %s; status may be conservative.", round.RoundID))
+	} else if revisionKnown {
+		ctx.Revision = revision
 	}
 
-	if target, known, err := runstate.EffectiveReviewTarget(workdir, planStem, round); err != nil {
-		warnings = append(warnings, fmt.Sprintf("Unable to read the review target for %s; status may fall back to a conservative step match.", round.RoundID))
+	stepIndex, stepKnown, err := runstate.EffectiveReviewStep(workdir, planStem, round)
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("Unable to read the review step binding for %s; status may be conservative.", round.RoundID))
+	}
+
+	if summary, known, err := runstate.EffectiveReviewSummary(workdir, planStem, round); err != nil {
+		warnings = append(warnings, fmt.Sprintf("Unable to read the review summary for %s; status may be conservative.", round.RoundID))
 	} else if known {
-		ctx.Target = target
+		ctx.Summary = summary
 	}
 
 	if round.Aggregated {
@@ -440,30 +443,18 @@ func loadReviewContext(workdir, planStem string, doc *plan.Document, state *runs
 		}
 	}
 
-	if ctx.Trigger == "step_closeout" {
-		if index, matched := resolveReviewTargetStep(doc, ctx.Target); matched {
-			ctx.TargetStepIndex = index
+	if revisionKnown {
+		if stepKnown {
+			ctx.Trigger = "step_closeout"
+			ctx.TargetStepIndex = stepIndex - 1
+			if ctx.TargetStepIndex >= 0 && ctx.TargetStepIndex < len(doc.Steps) && strings.TrimSpace(ctx.Summary) == "" {
+				ctx.Summary = doc.Steps[ctx.TargetStepIndex].Title
+			}
 		} else {
-			ctx.TargetStepIndex, ctx.UnsafeFallback = fallbackReviewTargetStep(doc, state)
-			if strings.TrimSpace(ctx.Target) != "" {
-				warnings = append(warnings, fmt.Sprintf("Review target %q did not match a tracked step title; status fell back to the most likely step.", ctx.Target))
+			ctx.Trigger = "pre_archive"
+			if strings.TrimSpace(ctx.Summary) == "" {
+				ctx.Summary = defaultFinalizeReviewSummary(ctx.Kind)
 			}
-		}
-	} else if ctx.Trigger == "" {
-		if state != nil {
-			if index, ok := stepIndexFromNode(state.CurrentNode); ok {
-				ctx.TargetStepIndex = index
-				ctx.UnsafeFallback = true
-				warnings = append(warnings, "Review trigger metadata was missing; status is conservatively pinning the active round to the cached step node without treating it as structural review state.")
-			} else if index, _ := fallbackReviewTargetStep(doc, state); index >= 0 {
-				ctx.TargetStepIndex = index
-				ctx.UnsafeFallback = true
-				warnings = append(warnings, "Review trigger metadata was missing; status is conservatively pinning the active round to the most likely reviewed step without treating it as structural review state.")
-			}
-		} else if index, _ := fallbackReviewTargetStep(doc, state); index >= 0 {
-			ctx.TargetStepIndex = index
-			ctx.UnsafeFallback = true
-			warnings = append(warnings, "Review trigger metadata was missing; status is conservatively pinning the active round to the most likely reviewed step without treating it as structural review state.")
 		}
 	}
 
@@ -500,7 +491,7 @@ func loadMissingStepCloseoutReminder(workdir, planStem string, doc *plan.Documen
 	}
 
 	scan := loadLatestStepCloseoutScan(workdir, planStem, doc, reviewCtx)
-	latestTargets := scan.LatestByTarget
+	latestSteps := scan.LatestByStepIndex
 	warnings := scan.Warnings
 	missingTitles := make([]string, 0)
 	unscopedRoundID := ""
@@ -509,8 +500,7 @@ func loadMissingStepCloseoutReminder(workdir, planStem string, doc *plan.Documen
 		if !step.Done {
 			continue
 		}
-		target := normalizeReviewTarget(step.Title)
-		if latest, ok := latestTargets[target]; ok {
+		if latest, ok := latestSteps[index]; ok {
 			if latest.Decision == "pass" {
 				if scan.LatestUnscopedRound != nil && isUnknownHistoricalReviewRoundLaterThanStepCloseout(*scan.LatestUnscopedRound, latest) {
 					unscopedRoundID = scan.LatestUnscopedRound.RoundID
@@ -578,7 +568,13 @@ func loadSatisfiedStepCloseoutTargets(workdir, planStem string, doc *plan.Docume
 
 func loadLatestStepCloseoutTargets(workdir, planStem string, doc *plan.Document, reviewCtx *reviewContext) (map[string]latestStepCloseoutRound, []string) {
 	scan := loadLatestStepCloseoutScan(workdir, planStem, doc, reviewCtx)
-	return scan.LatestByTarget, scan.Warnings
+	latestByTarget := map[string]latestStepCloseoutRound{}
+	for index, record := range scan.LatestByStepIndex {
+		if index >= 0 && index < len(doc.Steps) {
+			latestByTarget[normalizeReviewTarget(doc.Steps[index].Title)] = record
+		}
+	}
+	return latestByTarget, scan.Warnings
 }
 
 func loadLatestStepCloseoutScan(workdir, planStem string, doc *plan.Document, reviewCtx *reviewContext) latestStepCloseoutScan {
@@ -586,15 +582,15 @@ func loadLatestStepCloseoutScan(workdir, planStem string, doc *plan.Document, re
 	entries, err := os.ReadDir(reviewsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return latestStepCloseoutScan{LatestByTarget: map[string]latestStepCloseoutRound{}}
+			return latestStepCloseoutScan{LatestByStepIndex: map[int]latestStepCloseoutRound{}}
 		}
 		return latestStepCloseoutScan{
-			LatestByTarget: map[string]latestStepCloseoutRound{},
-			Warnings:       []string{fmt.Sprintf("Unable to inspect historical step-closeout reviews: %v", err)},
+			LatestByStepIndex: map[int]latestStepCloseoutRound{},
+			Warnings:          []string{fmt.Sprintf("Unable to inspect historical step-closeout reviews: %v", err)},
 		}
 	}
 
-	latestByTarget := map[string]latestStepCloseoutRound{}
+	latestByStepIndex := map[int]latestStepCloseoutRound{}
 	warnings := make([]string, 0)
 	var latestUnscopedRound *latestUnknownHistoricalReviewRound
 	for _, entry := range entries {
@@ -613,56 +609,74 @@ func loadLatestStepCloseoutScan(workdir, planStem string, doc *plan.Document, re
 			Sequence: sequence,
 			Decision: "",
 		}
-		var aggregate historicalReviewAggregate
-		aggregateOK := readJSONFile(aggregatePath, &aggregate) == nil
-		if aggregateOK {
+		var aggregate struct {
+			Decision string `json:"decision"`
+		}
+		if readJSONFile(aggregatePath, &aggregate) == nil {
 			record.Decision = strings.TrimSpace(aggregate.Decision)
 		}
 
-		trigger := strings.TrimSpace(manifest.Trigger)
-		targetText := strings.TrimSpace(manifest.Target)
 		if manifestErr != nil {
 			warnings = append(warnings, fmt.Sprintf("Unable to read historical review manifest for %s; status may miss older step-closeout evidence.", roundID))
-			trigger = ""
-			targetText = ""
 			if reviewCtx != nil && reviewCtx.RoundID == roundID {
-				trigger = reviewCtx.Trigger
-				if reviewCtx.TargetStepIndex >= 0 && reviewCtx.TargetStepIndex < len(doc.Steps) {
-					targetText = doc.Steps[reviewCtx.TargetStepIndex].Title
+				if reviewCtx.Trigger == "step_closeout" && reviewCtx.TargetStepIndex >= 0 {
+					existing, ok := latestByStepIndex[reviewCtx.TargetStepIndex]
+					if ok && !isLaterHistoricalStepCloseoutRound(record, existing) {
+						continue
+					}
+					latestByStepIndex[reviewCtx.TargetStepIndex] = record
+					continue
 				}
-			} else if aggregateOK {
-				if index, matched := resolveReviewTargetStep(doc, aggregate.Target); matched {
-					trigger = "step_closeout"
-					targetText = doc.Steps[index].Title
-				}
-			}
-			if trigger == "" || (trigger == "step_closeout" && strings.TrimSpace(targetText) == "") {
-				candidate := latestUnknownHistoricalReviewRound{
-					RoundID:  roundID,
-					Sequence: sequence,
-				}
-				if latestUnscopedRound == nil || isLaterUnknownHistoricalReviewRound(candidate, *latestUnscopedRound) {
-					latestUnscopedRound = &candidate
+				if reviewCtx.Trigger == "pre_archive" {
+					continue
 				}
 			}
-		}
-		if trigger != "step_closeout" {
-			continue
-		}
-		target := normalizeReviewTarget(targetText)
-		if target == "" {
+			candidate := latestUnknownHistoricalReviewRound{
+				RoundID:  roundID,
+				Sequence: sequence,
+			}
+			if latestUnscopedRound == nil || isLaterUnknownHistoricalReviewRound(candidate, *latestUnscopedRound) {
+				latestUnscopedRound = &candidate
+			}
 			continue
 		}
 
-		existing, ok := latestByTarget[target]
+		if manifest.Revision <= 0 {
+			warnings = append(warnings, fmt.Sprintf("Historical review round %s is missing inferred review structure; inspect or rerun the closeout conservatively.", roundID))
+			candidate := latestUnknownHistoricalReviewRound{
+				RoundID:  roundID,
+				Sequence: sequence,
+			}
+			if latestUnscopedRound == nil || isLaterUnknownHistoricalReviewRound(candidate, *latestUnscopedRound) {
+				latestUnscopedRound = &candidate
+			}
+			continue
+		}
+		if manifest.Step == nil {
+			continue
+		}
+		if *manifest.Step <= 0 || *manifest.Step > len(doc.Steps) {
+			warnings = append(warnings, fmt.Sprintf("Historical review round %s points at invalid step %d; inspect or rerun the closeout conservatively.", roundID, *manifest.Step))
+			candidate := latestUnknownHistoricalReviewRound{
+				RoundID:  roundID,
+				Sequence: sequence,
+			}
+			if latestUnscopedRound == nil || isLaterUnknownHistoricalReviewRound(candidate, *latestUnscopedRound) {
+				latestUnscopedRound = &candidate
+			}
+			continue
+		}
+		stepIndex := *manifest.Step - 1
+
+		existing, ok := latestByStepIndex[stepIndex]
 		if ok && !isLaterHistoricalStepCloseoutRound(record, existing) {
 			continue
 		}
-		latestByTarget[target] = record
+		latestByStepIndex[stepIndex] = record
 	}
 
 	return latestStepCloseoutScan{
-		LatestByTarget:      latestByTarget,
+		LatestByStepIndex:   latestByStepIndex,
 		Warnings:            warnings,
 		LatestUnscopedRound: latestUnscopedRound,
 	}
@@ -1248,6 +1262,13 @@ func normalizeReviewTarget(value string) string {
 		return ' '
 	}, value)
 	return strings.Join(strings.Fields(value), " ")
+}
+
+func defaultFinalizeReviewSummary(kind string) string {
+	if kind == "full" {
+		return "Full branch candidate before archive"
+	}
+	return "Branch candidate before archive"
 }
 
 func readJSONFile(path string, target any) error {

--- a/internal/status/service_internal_test.go
+++ b/internal/status/service_internal_test.go
@@ -25,8 +25,9 @@ func TestLoadSatisfiedStepCloseoutTargetsUsesActiveReviewContextForUnreadableCur
 	}
 
 	writeHistoricalReviewJSON(t, root, planStem, "review-001-delta", "manifest.json", map[string]any{
-		"target":  internalStepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  internalStepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeHistoricalReviewJSON(t, root, planStem, "review-001-delta", "aggregate.json", map[string]any{
 		"decision": "pass",
@@ -40,7 +41,8 @@ func TestLoadSatisfiedStepCloseoutTargetsUsesActiveReviewContextForUnreadableCur
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeHistoricalReviewJSON(t, root, planStem, "review-002-delta", "aggregate.json", map[string]any{
-		"target":   "mystery historical target",
+		"summary":  "mystery historical target",
+		"revision": 1,
 		"decision": "changes_requested",
 	})
 
@@ -69,8 +71,9 @@ func TestLoadSatisfiedStepCloseoutTargetsUsesActiveInFlightReviewContextForUnrea
 	}
 
 	writeHistoricalReviewJSON(t, root, planStem, "review-001-delta", "manifest.json", map[string]any{
-		"target":  internalStepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  internalStepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeHistoricalReviewJSON(t, root, planStem, "review-001-delta", "aggregate.json", map[string]any{
 		"decision": "pass",

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -89,7 +89,6 @@ func TestStatusIgnoresNonStructuralReviewFactsForCurrentStep(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-011-delta",
 			"kind":       "delta",
-			"trigger":    "review_fix",
 			"aggregated": true,
 			"decision":   "pass",
 		},
@@ -117,13 +116,13 @@ func TestStatusExecutionStepReviewNode(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-001-delta",
 			"kind":       "delta",
-			"trigger":    "step_closeout",
 			"aggregated": false,
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -148,13 +147,13 @@ func TestStatusStepReviewMatchesTargetWithoutMarkdownPunctuation(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-001-delta",
 			"kind":       "delta",
-			"trigger":    "step_closeout",
 			"aggregated": false,
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  "Step 1: Resolve current_node",
-		"trigger": "step_closeout",
+		"summary":  "Step 1: Resolve current_node",
+		"step":     1,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -176,14 +175,15 @@ func TestStatusDoesNotWarnForEarlierCompletedStepWithCleanFullReview(t *testing.
 		"active_review_round": map[string]any{
 			"round_id":   "review-001-full",
 			"kind":       "full",
-			"trigger":    "step_closeout",
+			"revision":   1,
 			"aggregated": true,
 			"decision":   "pass",
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-full", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-full", map[string]any{
 		"decision": "pass",
@@ -231,15 +231,17 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutRoundIsNotClean(t *testing.T
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "changes_requested",
@@ -263,15 +265,17 @@ func TestStatusDoesNotWarnWhenLatestHistoricalStepCloseoutRepairsEarlierFailure(
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "changes_requested",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -295,15 +299,17 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutRoundIsStillInFlight(t *test
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -324,8 +330,9 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutManifestIsUnreadable(t *test
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -339,7 +346,7 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutManifestIsUnreadable(t *test
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":   stepOneTitle,
+		"summary":  stepOneTitle,
 		"decision": "changes_requested",
 	})
 
@@ -347,7 +354,7 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutManifestIsUnreadable(t *test
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
-	if len(result.Warnings) < 2 || !strings.Contains(result.Warnings[0], "Unable to read historical review manifest") || !strings.Contains(result.Warnings[1], stepOneTitle) {
+	if len(result.Warnings) < 2 || !strings.Contains(result.Warnings[0], "Unable to read historical review manifest") || !strings.Contains(result.Warnings[1], "could not be mapped back to a tracked step") {
 		t.Fatalf("expected unreadable latest manifest to preserve a warning, got %#v", result.Warnings)
 	}
 }
@@ -361,8 +368,9 @@ func TestStatusWarnsWhenLatestUnreadableHistoricalCloseoutCannotBeMapped(t *test
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -376,7 +384,8 @@ func TestStatusWarnsWhenLatestUnreadableHistoricalCloseoutCannotBeMapped(t *test
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":   "mystery historical target",
+		"summary":  "mystery historical target",
+		"revision": 1,
 		"decision": "changes_requested",
 	})
 
@@ -414,14 +423,15 @@ func TestStatusFinalizeArchiveSuppressesArchiveActionForUnscopedUnreadableHistor
 		"active_review_round": map[string]any{
 			"round_id":   "review-005-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": true,
 			"decision":   "pass",
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -435,7 +445,8 @@ func TestStatusFinalizeArchiveSuppressesArchiveActionForUnscopedUnreadableHistor
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":   "mystery historical target",
+		"summary":  "mystery historical target",
+		"revision": 1,
 		"decision": "changes_requested",
 	})
 
@@ -474,8 +485,9 @@ func TestStatusDoesNotLetUnreadableHistoryForOneStepUnsatisfyAnother(t *testing.
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -489,7 +501,7 @@ func TestStatusDoesNotLetUnreadableHistoryForOneStepUnsatisfyAnother(t *testing.
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":   stepTwoTitle,
+		"summary":  stepTwoTitle,
 		"decision": "changes_requested",
 	})
 
@@ -520,8 +532,9 @@ func TestStatusWarnsInFinalizeWhenCompletedStepStillLacksCloseout(t *testing.T) 
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepTwoTitle,
-		"trigger": "step_closeout",
+		"summary":  stepTwoTitle,
+		"step":     2,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -561,14 +574,15 @@ func TestStatusFinalizeArchiveSummaryAndActionsDoNotPretendReadyWhenCloseoutDebt
 		"active_review_round": map[string]any{
 			"round_id":   "review-005-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": true,
 			"decision":   "pass",
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepTwoTitle,
-		"trigger": "step_closeout",
+		"summary":  stepTwoTitle,
+		"step":     2,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -607,14 +621,15 @@ func TestStatusFinalizeArchiveKeepsBlockerGuidanceWhenCloseoutDebtAndArchiveBloc
 		"active_review_round": map[string]any{
 			"round_id":   "review-005-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": true,
 			"decision":   "pass",
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepTwoTitle,
-		"trigger": "step_closeout",
+		"summary":  stepTwoTitle,
+		"step":     2,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -660,13 +675,13 @@ func TestStatusDoesNotSuggestSecondReviewWhileStepReviewIsInFlight(t *testing.T)
 		"active_review_round": map[string]any{
 			"round_id":   "review-002-delta",
 			"kind":       "delta",
-			"trigger":    "step_closeout",
 			"aggregated": false,
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepTwoTitle,
-		"trigger": "step_closeout",
+		"summary":  stepTwoTitle,
+		"step":     2,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -692,44 +707,6 @@ func TestStatusDoesNotSuggestSecondReviewWhileStepReviewIsInFlight(t *testing.T)
 	}
 }
 
-func TestStatusDoesNotSuggestSecondReviewWhileFallbackImplementNodeHasInFlightRound(t *testing.T) {
-	root := t.TempDir()
-	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
-		return completeFirstStep(content)
-	})
-	writeState(t, root, "2026-03-18-status-plan", map[string]any{
-		"execution_started_at": "2026-03-18T10:05:00+08:00",
-		"current_node":         "execution/step-2/implement",
-		"active_review_round": map[string]any{
-			"round_id":   "review-002-delta",
-			"kind":       "delta",
-			"aggregated": false,
-		},
-	})
-	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target": stepTwoTitle,
-	})
-
-	result := status.Service{Workdir: root}.Read()
-	if result.State.CurrentNode != "execution/step-2/implement" {
-		t.Fatalf("expected conservative fallback to stay on implement, got %#v", result.State)
-	}
-	if len(result.NextAction) < 2 {
-		t.Fatalf("expected repair guidance plus aggregate action, got %#v", result.NextAction)
-	}
-	if !strings.Contains(result.NextAction[0].Description, "aggregate the active review round first") {
-		t.Fatalf("expected fallback implement repair guidance to mention aggregating first, got %#v", result.NextAction)
-	}
-	for _, action := range result.NextAction {
-		if action.Command != nil && *action.Command == "harness review start --spec <path>" {
-			t.Fatalf("did not expect a second review-start action while a fallback in-flight round exists, got %#v", result.NextAction)
-		}
-	}
-	if result.NextAction[1].Command == nil || !strings.Contains(*result.NextAction[1].Command, "harness review aggregate --round review-002-delta") {
-		t.Fatalf("expected aggregate action to remain available, got %#v", result.NextAction)
-	}
-}
-
 func TestStatusDoesNotSuggestSecondReviewWhileFinalizeReviewIsInFlight(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
@@ -740,20 +717,21 @@ func TestStatusDoesNotSuggestSecondReviewWhileFinalizeReviewIsInFlight(t *testin
 		"active_review_round": map[string]any{
 			"round_id":   "review-003-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": false,
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepTwoTitle,
-		"trigger": "step_closeout",
+		"summary":  stepTwoTitle,
+		"step":     2,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-003-full", map[string]any{
-		"target":  "Full branch candidate before archive",
-		"trigger": "pre_archive",
+		"summary":  "Full branch candidate before archive",
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -808,8 +786,9 @@ func TestStatusNoReviewNeededMarkerDoesNotHideLaterFailedCloseout(t *testing.T) 
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "changes_requested",
@@ -834,8 +813,9 @@ func TestStatusNoReviewNeededMarkerDoesNotHideLaterInFlightCloseout(t *testing.T
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -857,8 +837,9 @@ func TestStatusNoReviewNeededMarkerAllowsLaterCleanCloseoutToStaySatisfied(t *te
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -885,20 +866,22 @@ func TestStatusUnreadableFinalizeManifestDoesNotMasqueradeAsStepDebt(t *testing.
 		"active_review_round": map[string]any{
 			"round_id":   "review-003-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": false,
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepTwoTitle,
-		"trigger": "step_closeout",
+		"summary":  stepTwoTitle,
+		"step":     2,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -939,13 +922,14 @@ func TestStatusFinalizeReviewUsesAggregateFirstGuidanceForUnscopedUnreadableHist
 		"active_review_round": map[string]any{
 			"round_id":   "review-003-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": false,
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -959,12 +943,13 @@ func TestStatusFinalizeReviewUsesAggregateFirstGuidanceForUnscopedUnreadableHist
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":   "mystery historical target",
+		"summary":  "mystery historical target",
+		"revision": 1,
 		"decision": "changes_requested",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-003-full", map[string]any{
-		"target":  "Full branch candidate before archive",
-		"trigger": "pre_archive",
+		"summary":  "Full branch candidate before archive",
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -991,8 +976,9 @@ func TestStatusFinalizeReviewSummaryForUnscopedUnreadableHistoryWithoutActiveRou
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -1006,7 +992,8 @@ func TestStatusFinalizeReviewSummaryForUnscopedUnreadableHistoryWithoutActiveRou
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":   "mystery historical target",
+		"summary":  "mystery historical target",
+		"revision": 1,
 		"decision": "changes_requested",
 	})
 
@@ -1041,14 +1028,15 @@ func TestStatusFinalizeFixSummaryForUnscopedUnreadableHistory(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-004-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": true,
 			"decision":   "changes_requested",
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -1062,7 +1050,8 @@ func TestStatusFinalizeFixSummaryForUnscopedUnreadableHistory(t *testing.T) {
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":   "mystery historical target",
+		"summary":  "mystery historical target",
+		"revision": 1,
 		"decision": "changes_requested",
 	})
 
@@ -1099,7 +1088,8 @@ func TestStatusFailedStepReviewUsesCachedStepWhenManifestIsMissing(t *testing.T)
 		"active_review_round": map[string]any{
 			"round_id":   "review-001-delta",
 			"kind":       "delta",
-			"trigger":    "step_closeout",
+			"step":       1,
+			"revision":   1,
 			"aggregated": true,
 			"decision":   "changes_requested",
 		},
@@ -1118,101 +1108,6 @@ func TestStatusFailedStepReviewUsesCachedStepWhenManifestIsMissing(t *testing.T)
 	}
 }
 
-func TestStatusMissingReviewTriggerStaysConservativeOnCachedStep(t *testing.T) {
-	root := t.TempDir()
-	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
-		return completeFirstStep(content)
-	})
-	writeState(t, root, "2026-03-18-status-plan", map[string]any{
-		"execution_started_at": "2026-03-18T10:05:00+08:00",
-		"current_node":         "execution/step-1/implement",
-		"active_review_round": map[string]any{
-			"round_id":   "review-001-delta",
-			"kind":       "delta",
-			"aggregated": true,
-			"decision":   "changes_requested",
-		},
-	})
-
-	result := status.Service{Workdir: root}.Read()
-	if result.State.CurrentNode != "execution/step-1/implement" {
-		t.Fatalf("expected missing trigger metadata to stay on the cached step, got %#v", result.State)
-	}
-	if len(result.Warnings) == 0 || !strings.Contains(result.Warnings[0], "trigger metadata was missing") {
-		t.Fatalf("expected conservative trigger warning, got %#v", result.Warnings)
-	}
-}
-
-func TestStatusMissingReviewTriggerWithTargetSkipsCacheWrite(t *testing.T) {
-	root := t.TempDir()
-	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
-		return completeFirstStep(content)
-	})
-	writeState(t, root, "2026-03-18-status-plan", map[string]any{
-		"execution_started_at": "2026-03-18T10:05:00+08:00",
-		"active_review_round": map[string]any{
-			"round_id":   "review-001-delta",
-			"kind":       "delta",
-			"aggregated": true,
-			"decision":   "changes_requested",
-		},
-	})
-	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target": stepOneTitle,
-	})
-
-	result := status.Service{Workdir: root}.Read()
-	if result.State.CurrentNode != "execution/step-1/implement" {
-		t.Fatalf("expected conservative fallback to the reviewed step, got %#v", result.State)
-	}
-	state, _, err := runstate.LoadState(root, "2026-03-18-status-plan")
-	if err != nil {
-		t.Fatalf("load state: %v", err)
-	}
-	if state == nil || state.CurrentNode != "" {
-		t.Fatalf("expected unsafe fallback to skip current_node cache refresh, got %#v", state)
-	}
-}
-
-func TestStatusStepReviewTargetMismatchSkipsCacheWrite(t *testing.T) {
-	root := t.TempDir()
-	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
-		return completeFirstStep(content)
-	})
-	writeState(t, root, "2026-03-18-status-plan", map[string]any{
-		"execution_started_at": "2026-03-18T10:05:00+08:00",
-		"active_review_round": map[string]any{
-			"round_id":   "review-001-delta",
-			"kind":       "delta",
-			"trigger":    "step_closeout",
-			"aggregated": true,
-			"decision":   "pass",
-		},
-	})
-	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  "Step 99: Unknown reviewed step",
-		"trigger": "step_closeout",
-	})
-
-	result := status.Service{Workdir: root}.Read()
-	if result.State.CurrentNode != "execution/step-1/implement" {
-		t.Fatalf("expected target mismatch to stay conservative on the fallback step, got %#v", result.State)
-	}
-	if result.Facts == nil || result.Facts.CurrentStep != stepOneTitle || result.Facts.ReviewStatus != "" || result.Facts.ReviewTrigger != "" {
-		t.Fatalf("expected unsafe fallback to hide structural review facts, got %#v", result.Facts)
-	}
-	if len(result.Warnings) == 0 || !strings.Contains(result.Warnings[0], "did not match a tracked step title") {
-		t.Fatalf("expected target mismatch warning, got %#v", result.Warnings)
-	}
-	state, _, err := runstate.LoadState(root, "2026-03-18-status-plan")
-	if err != nil {
-		t.Fatalf("load state: %v", err)
-	}
-	if state == nil || state.CurrentNode != "" {
-		t.Fatalf("expected unsafe fallback to skip current_node cache refresh, got %#v", state)
-	}
-}
-
 func TestStatusUnknownAggregatedReviewDecisionStaysConservative(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
@@ -1223,13 +1118,13 @@ func TestStatusUnknownAggregatedReviewDecisionStaysConservative(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-001-delta",
 			"kind":       "delta",
-			"trigger":    "step_closeout",
 			"aggregated": true,
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -1254,14 +1149,14 @@ func TestStatusFailedStepReviewPinsReviewedStep(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-002-delta",
 			"kind":       "delta",
-			"trigger":    "step_closeout",
 			"aggregated": true,
 			"decision":   "changes_requested",
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -1286,14 +1181,14 @@ func TestStatusAdvancesToNextStepAfterCleanStepReview(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-003-delta",
 			"kind":       "delta",
-			"trigger":    "step_closeout",
 			"aggregated": true,
 			"decision":   "pass",
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-003-delta", map[string]any{
-		"target":  stepOneTitle,
-		"trigger": "step_closeout",
+		"summary":  stepOneTitle,
+		"step":     1,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -1333,14 +1228,14 @@ func TestStatusFinalizeReviewClearsPriorStepReviewFacts(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-003-delta",
 			"kind":       "delta",
-			"trigger":    "step_closeout",
 			"aggregated": true,
 			"decision":   "pass",
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-003-delta", map[string]any{
-		"target":  stepTwoTitle,
-		"trigger": "step_closeout",
+		"summary":  stepTwoTitle,
+		"step":     2,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -1365,7 +1260,7 @@ func TestStatusFinalizeReviewInFlightIncludesReviewFacts(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-004-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": false,
 		},
 	})
@@ -1389,7 +1284,7 @@ func TestStatusFinalizeFixNodeAfterFailedFinalizeReview(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-004-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": true,
 			"decision":   "changes_requested",
 		},
@@ -1414,7 +1309,7 @@ func TestStatusFinalizeArchiveNodeAfterCleanFinalizeReview(t *testing.T) {
 		"active_review_round": map[string]any{
 			"round_id":   "review-005-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": true,
 			"decision":   "pass",
 		},
@@ -1455,8 +1350,9 @@ func TestStatusWarnsInArchivedPublishWhenCompletedStepStillLacksCloseout(t *test
 	})
 	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepTwoTitle,
-		"trigger": "step_closeout",
+		"summary":  stepTwoTitle,
+		"step":     2,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -1530,7 +1426,8 @@ func TestStatusArchivedNodesRequireReopenForUnscopedUnreadableHistory(t *testing
 				t.Fatalf("write unreadable manifest: %v", err)
 			}
 			writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-				"target":   "mystery historical target",
+				"summary":  "mystery historical target",
+				"revision": 1,
 				"decision": "changes_requested",
 			})
 
@@ -1633,8 +1530,9 @@ func TestStatusWarnsInAwaitMergeWhenCompletedStepStillLacksCloseout(t *testing.T
 	})
 	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"target":  stepTwoTitle,
-		"trigger": "step_closeout",
+		"summary":  stepTwoTitle,
+		"step":     2,
+		"revision": 1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -2055,7 +1953,7 @@ func TestStatusConsumedReopenedNewStepDoesNotForceAnotherStepAfterLaterFinding(t
 		"active_review_round": map[string]any{
 			"round_id":   "review-005-full",
 			"kind":       "full",
-			"trigger":    "pre_archive",
+			"revision":   1,
 			"aggregated": true,
 			"decision":   "changes_requested",
 		},

--- a/tests/e2e/coverage_test.go
+++ b/tests/e2e/coverage_test.go
@@ -27,7 +27,7 @@ var canonicalTransitionFamilies = []transitionFamily{
 	{ID: "plan_self", From: "plan", To: "plan", Driver: "state-preserving", RequiredInputs: "state-preserving update"},
 	{ID: "plan_to_step_implement", From: "plan", To: "execution/step-<n>/implement", Driver: "harness execute start", RequiredInputs: "Current plan is approved for execution and has at least one unfinished step"},
 	{ID: "step_implement_self", From: "execution/step-<n>/implement", To: "execution/step-<n>/implement", Driver: "state-preserving", RequiredInputs: "state-preserving update"},
-	{ID: "step_implement_to_review", From: "execution/step-<n>/implement", To: "execution/step-<n>/review", Driver: "harness review start", RequiredInputs: "Review round targets the current step"},
+	{ID: "step_implement_to_review", From: "execution/step-<n>/implement", To: "execution/step-<n>/review", Driver: "harness review start", RequiredInputs: "The command binds the new round to the current step"},
 	{ID: "step_implement_to_next_step_implement", From: "execution/step-<n>/implement", To: "execution/step-<m>/implement", Driver: "Derived from tracked plan edits", RequiredInputs: "Step `<n>` becomes durably complete, any required step review is clean, and another unfinished step exists"},
 	{ID: "step_implement_to_finalize_review", From: "execution/step-<n>/implement", To: "execution/finalize/review", Driver: "Derived from tracked plan edits", RequiredInputs: "Step `<n>` becomes durably complete, any required step review is clean, and no unfinished steps remain"},
 	{ID: "step_review_self", From: "execution/step-<n>/review", To: "execution/step-<n>/review", Driver: "state-preserving", RequiredInputs: "state-preserving update"},

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -116,7 +116,9 @@ type aggregateResult struct {
 type aggregateArtifact struct {
 	RoundID             string `json:"round_id"`
 	Kind                string `json:"kind"`
-	Target              string `json:"target"`
+	Step                *int   `json:"step,omitempty"`
+	Revision            int    `json:"revision"`
+	Summary             string `json:"summary"`
 	Decision            string `json:"decision"`
 	AggregatedAt        string `json:"aggregated_at"`
 	NonBlockingFindings []struct {
@@ -128,6 +130,9 @@ type aggregateArtifact struct {
 
 type reviewManifest struct {
 	RoundID    string            `json:"round_id"`
+	Step       *int              `json:"step,omitempty"`
+	Revision   int               `json:"revision"`
+	Summary    string            `json:"summary"`
 	PlanPath   string            `json:"plan_path"`
 	Dimensions []reviewDimension `json:"dimensions"`
 }
@@ -198,7 +203,8 @@ type runState struct {
 		RoundID    string `json:"round_id"`
 		Aggregated bool   `json:"aggregated"`
 		Decision   string `json:"decision"`
-		Trigger    string `json:"trigger"`
+		Step       *int   `json:"step,omitempty"`
+		Revision   int    `json:"revision"`
 		Kind       string `json:"kind"`
 	} `json:"active_review_round"`
 }
@@ -309,9 +315,7 @@ func runPassingDeltaReview(t *testing.T, workspace *support.Workspace, stepTitle
 
 	target := trackedStepTitle(stepNumber, stepTitle)
 	startPayload := startReviewRound(t, workspace, fmt.Sprintf("tmp/step-%d-review-spec.json", stepNumber), map[string]any{
-		"kind":    "delta",
-		"target":  target,
-		"trigger": "step_closeout",
+		"kind": "delta",
 		"dimensions": []map[string]any{
 			{
 				"name":         "correctness",
@@ -353,9 +357,7 @@ func runPassingFinalizeReview(t *testing.T, workspace *support.Workspace) string
 	t.Helper()
 
 	startPayload := startReviewRound(t, workspace, "tmp/finalize-passing-review-spec.json", map[string]any{
-		"kind":    "full",
-		"target":  "Full branch candidate before archive",
-		"trigger": "pre_archive",
+		"kind": "full",
 		"dimensions": []map[string]any{
 			{
 				"name":         "correctness",

--- a/tests/e2e/review_repair_loop_test.go
+++ b/tests/e2e/review_repair_loop_test.go
@@ -229,15 +229,12 @@ NONE
 func runBlockingStepReview(t *testing.T, workspace *support.Workspace, stepTitle string, stepNumber int) string {
 	t.Helper()
 
-	target := trackedStepTitle(stepNumber, stepTitle)
 	aggregatePayload := runSingleSlotReviewWithFindings(
 		t,
 		workspace,
 		fmt.Sprintf("tmp/step-%d-blocking-review-spec.json", stepNumber),
 		map[string]any{
-			"kind":    "delta",
-			"target":  target,
-			"trigger": "step_closeout",
+			"kind": "delta",
 			"dimensions": []map[string]any{
 				{
 					"name":         "correctness",
@@ -268,9 +265,7 @@ func runBlockingFinalizeReview(t *testing.T, workspace *support.Workspace) strin
 		workspace,
 		"tmp/finalize-blocking-review-spec.json",
 		map[string]any{
-			"kind":    "full",
-			"target":  "Full branch candidate before archive",
-			"trigger": "pre_archive",
+			"kind": "full",
 			"dimensions": []map[string]any{
 				{
 					"name":         "correctness",

--- a/tests/e2e/review_workflow_test.go
+++ b/tests/e2e/review_workflow_test.go
@@ -120,9 +120,7 @@ func TestReviewWorkflowWithBuiltBinary(t *testing.T) {
 	}
 
 	specPath := workspace.WriteJSON(t, "tmp/review-spec.json", map[string]any{
-		"kind":    "full",
-		"target":  "Full branch candidate before archive",
-		"trigger": "pre_archive",
+		"kind": "full",
 		"dimensions": []map[string]any{
 			{
 				"name":         "correctness",
@@ -303,7 +301,7 @@ func TestReviewWorkflowWithBuiltBinary(t *testing.T) {
 	if aggregateArtifact.RoundID != startPayload.Artifacts.RoundID || aggregateArtifact.Kind != "full" {
 		t.Fatalf("unexpected aggregate artifact: %#v", aggregateArtifact)
 	}
-	if aggregateArtifact.Target != "Full branch candidate before archive" || aggregateArtifact.Decision != "pass" || aggregateArtifact.AggregatedAt == "" {
+	if aggregateArtifact.Summary != "Full branch candidate before archive" || aggregateArtifact.Decision != "pass" || aggregateArtifact.AggregatedAt == "" {
 		t.Fatalf("unexpected aggregate artifact contents: %#v", aggregateArtifact)
 	}
 	if len(aggregateArtifact.NonBlockingFindings) != 1 || aggregateArtifact.NonBlockingFindings[0].Title != "Review path exercised across multiple slots" {


### PR DESCRIPTION
## Summary
- remove agent-authored structural review metadata from routine review start
- persist inferred step/revision bindings and use them for status/archive gating
- update docs, skills, and regression coverage to reflect the reduced contract

## Validation
- `go test ./...`
- `harness plan lint docs/plans/archived/2026-03-26-simplify-review-metadata-and-inference.md`
- step closeout review rounds `review-002-delta`, `review-003-delta`, and `review-006-delta`
- finalize review round `review-007-full`
