### PR TITLE
Unify review title naming

### DIFF
--- a/.agents/skills/harness-execute/references/review-orchestration.md
+++ b/.agents/skills/harness-execute/references/review-orchestration.md
@@ -47,7 +47,7 @@ Use a compact JSON shape like:
 ```json
 {
   "kind": "delta",
-  "summary": "Check the completed step for contract mistakes and handoff clarity.",
+  "review_title": "Step 2: Refactor review metadata",
   "dimensions": [
     {
       "name": "correctness",
@@ -67,8 +67,8 @@ Field rules:
   - enum: `delta` or `full`
   - `delta` is for a completed step or narrow follow-up change
   - `full` is for an archive candidate or another broad branch-level pass
-- `summary`
-  - optional human-readable note for the controller and reviewers
+- `review_title`
+  - optional human-readable review title for the controller and reviewers
 - `step`
   - optional 1-based tracked step number
   - usually omit it and let `harness` bind the round automatically
@@ -146,7 +146,7 @@ You are the reviewer for one harness review slot.
 Use the harness-reviewer skill and follow it exactly.
 
 Round ID: <round-id>
-Target: <review-target>
+Review title: <review-title>
 Revision: <candidate-revision-or-none>
 Slot: <slot>
 Assigned dimension: <dimension-name>
@@ -162,7 +162,7 @@ review. Those boundaries always start with fresh reviewers.
 Resume is only valid while the review scope itself is still the same:
 
 - for step review, the same tracked step title
-- for finalize review, the same candidate summary for the same revision
+- for finalize review, the same candidate review title for the same revision
 
 If reopen, a new tracked step, a new revision, or a new finalize candidate
 changes that scope, start with fresh reviewers.
@@ -175,7 +175,7 @@ You are resuming the same harness review slot you handled earlier.
 Use the harness-reviewer skill and follow it exactly.
 
 New round ID: <new-round-id>
-Target: <review-target>
+Review title: <review-title>
 Revision: <candidate-revision-or-none>
 Slot: <slot>
 Assigned dimension: <dimension-name>

--- a/.agents/skills/harness-reviewer/SKILL.md
+++ b/.agents/skills/harness-reviewer/SKILL.md
@@ -9,7 +9,7 @@ description: Use when acting as a dedicated reviewer subagent for one assigned h
 
 Use this skill only in reviewer subagents, including a reviewer subagent that
 the controller later resumes for the same slot within the same tracked step
-review boundary or for the same finalize review target in the same revision.
+review boundary or for the same finalize review title in the same revision.
 
 The reviewer agent owns exactly one review slot in an existing review round. It
 does not start rounds, aggregate rounds, orchestrate other reviewers, or infer
@@ -66,7 +66,7 @@ deferral stale.
 
 ## Workflow
 
-1. Read the controller's round ID, target, revision context when present, slot,
+1. Read the controller's round ID, review title, revision context when present, slot,
    and assigned instructions.
 2. If the controller did not give enough information to submit cleanly, report
    the missing input back to the controller instead of improvising.
@@ -78,8 +78,8 @@ deferral stale.
 7. Stop once the receipt is reported. The controller agent is responsible for
    closing reviewer subagents after verifying the successful submission.
 8. If the controller later resumes you for the same slot within the same
-   tracked step review boundary or for the same finalize review target in the
-   same revision, treat the newest round ID, target, revision context, slot,
+   tracked step review boundary or for the same finalize review title in the
+   same revision, treat the newest round ID, review title, revision context, slot,
    and instructions as authoritative for that new assignment. Reuse your prior
    context only to understand the bounded follow-up the controller asked you to
    verify.

--- a/docs/plans/archived/2026-03-26-unify-review-summary-naming.md
+++ b/docs/plans/archived/2026-03-26-unify-review-summary-naming.md
@@ -1,0 +1,276 @@
+---
+template_version: 0.2.0
+created_at: "2026-03-26T00:00:00Z"
+source_type: issue
+source_refs:
+    - '#52'
+---
+
+# Unify human-facing review title naming
+
+## Goal
+
+Remove the remaining mixed naming for the human-readable review text so a cold
+reader no longer has to translate between `summary`, `review_target`, and
+older "target" wording.
+
+Choose one stable human-facing name for that field and apply it consistently
+across status facts, local review artifacts, docs, and regression coverage
+without reintroducing structural ambiguity.
+
+## Scope
+
+### In Scope
+
+- Pick the canonical user-facing name for the human-readable review title.
+- Rename status facts and any related helper/test contracts to that canonical
+  name.
+- Align local review artifact structs, CLI/spec docs, skills, and tests with
+  the chosen name where they expose the human-facing field.
+- Update regression coverage so the renamed field is exercised end to end.
+
+### Out of Scope
+
+- Reworking the structural review model introduced in issue #50 follow-up.
+- Adding new advanced review-start escape hatches outside routine
+  step/finalize flows.
+- Changing reviewer submission `summary`, which is already a distinct concept.
+
+## Acceptance Criteria
+
+- [x] One canonical name is used for the human-facing review title across
+      status facts, local review artifacts, docs, and tests.
+- [x] `harness status` no longer exposes the mixed `review_target` naming when
+      referring to the human-readable review title.
+- [x] The renamed field stays clearly separated from structural review facts
+      like step binding, revision, and derived review trigger.
+- [x] Unit and e2e coverage are updated to assert the renamed field directly,
+      without leaving mixed-name compatibility shims in shared helpers.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Choose and document the canonical name
+
+- Done: [x]
+
+#### Objective
+
+Decide the stable human-facing field name and fold that decision into the
+tracked docs and plan context before code changes begin.
+
+#### Details
+
+This step should answer one key design question cleanly: whether the
+human-readable review text should standardize on `review_title` or another
+explicit name. The decision should optimize for clarity against
+reviewer-submission summaries and avoid reviving the older `target`
+terminology.
+
+#### Expected Files
+
+- `docs/specs/cli-contract.md`
+- `docs/plans/active/2026-03-26-unify-review-summary-naming.md`
+- `.agents/skills/harness-execute/references/review-orchestration.md`
+
+#### Validation
+
+- The plan and specs state `review_title` as the canonical name and explain
+  why it is distinct
+  from structural review metadata and reviewer submission summaries.
+- A future execution agent could implement the rename from the tracked plan
+  alone.
+
+#### Execution Notes
+
+Settled the canonical human-facing field name on `review_title` after
+clarifying that the field is a review title, not a structural step binding and
+not a generic summary. Updated the tracked plan language, CLI contract, and
+review orchestration references to use that name explicitly and to keep it
+separate from command/status summaries and reviewer submission summaries.
+
+This slice changed tracked docs and review-related contracts rather than
+introducing a new algorithm, so focused contract regression coverage was more
+appropriate than strict Red/Green/Refactor TDD. Validation so far:
+`harness plan lint docs/plans/active/2026-03-26-unify-review-summary-naming.md`
+and focused Go coverage after the runtime rename landed.
+
+#### Review Notes
+
+Clean delta review `review-001-delta` passed on the `docs_consistency` slot
+with no findings. The reviewer confirmed that `review_title` is used
+consistently for the human-facing review title and remains distinct from
+command/status summaries and reviewer submission `summary`.
+
+### Step 2: Apply the rename through status and artifacts
+
+- Done: [x]
+
+#### Objective
+
+Rename the runtime/user-facing field everywhere it materially surfaces.
+
+#### Details
+
+Touch the narrowest set of runtime structs and outputs that expose the
+human-readable review title. Keep structural fields (`step`, `revision`,
+derived trigger) unchanged, but make the human-facing review title use the new
+name consistently in status facts and local review artifact readers/writers.
+
+#### Expected Files
+
+- `internal/status/service.go`
+- `internal/review/service.go`
+- `internal/runstate/state.go`
+- `internal/cli/app.go`
+
+#### Validation
+
+- `harness status` and the affected local artifact structs expose
+  `review_title` consistently.
+- The rename does not break step/finalize gating or reopen/archive behavior.
+
+#### Execution Notes
+
+Renamed the runtime-facing review field from mixed `summary`/`review_target`
+wording to `review_title` across review specs, manifests, aggregates,
+runstate helpers, status facts, and CLI help text. Structural review fields
+(`step`, `revision`, `kind`, derived trigger) stayed unchanged; only the
+human-facing review title contract moved.
+
+Because the direct `harness` command had been rebuilt from earlier code, this
+step also reran `scripts/install-dev-harness` before relying on live CLI
+output. Validation after the rename: `go test ./internal/review
+./internal/runstate ./internal/status ./internal/cli ./tests/e2e/...` and
+`harness status`, which now exposes `facts.review_title` on the active review
+path.
+
+#### Review Notes
+
+Clean delta review `review-002-delta` passed on the `correctness` slot with
+no findings. The reviewer confirmed that `review_title` now flows through
+review specs, manifests, aggregates, runstate readers, status facts, and CLI
+help without regressing step/finalize gating.
+
+### Step 3: Update regression coverage and fixture contracts
+
+- Done: [x]
+
+#### Objective
+
+Make the tests speak `review_title` directly and remove any mixed-name test
+contracts that would undermine the rename.
+
+#### Details
+
+Update unit tests, shared e2e helpers, and any coverage tables or assertions
+that still refer to the old name. Prefer direct fixtures over compatibility
+translation in shared helpers so the regression suite proves the new naming
+end to end.
+
+#### Expected Files
+
+- `internal/status/service_test.go`
+- `internal/status/service_internal_test.go`
+- `tests/e2e/helpers_test.go`
+- `tests/e2e/review_workflow_test.go`
+
+#### Validation
+
+- Focused unit and e2e coverage passes with the renamed field.
+- Shared helpers no longer preserve the old mixed-name contract where
+  `review_title` should be expressed directly.
+
+#### Execution Notes
+
+Updated the shared status/e2e fixture contracts to speak `review_title`
+directly, including status facts, persisted review manifests/aggregates, and
+end-to-end assertions that exercise step review, finalize review, and repair
+loops. Also refreshed the reviewer-facing docs so controller/reviewer prompts
+now talk about review titles instead of review targets when they refer to the
+human-facing review label.
+
+Validation for this slice relied on the focused suite named in the plan:
+`go test ./internal/review ./internal/runstate ./internal/status ./internal/cli
+./tests/e2e/...`. Those tests now pass against the renamed fixture and output
+contracts without any compatibility translation layer in the shared helpers.
+
+#### Review Notes
+
+Clean delta review `review-003-delta` passed on the `tests` slot with no
+findings. The reviewer confirmed that the shared helpers, unit fixtures, and
+e2e assertions now use `review_title` directly and do not leave an old-name
+compatibility shim behind.
+
+## Validation Strategy
+
+- Lint the tracked plan with `harness plan lint`.
+- Run focused Go tests for status, review, and e2e review workflow coverage.
+- Inspect representative `harness status` output to confirm the human-facing
+  review title uses `review_title` consistently.
+
+## Risks
+
+- Risk: A naive rename could blur the difference between review-round summary
+  and reviewer-submission summary.
+  - Mitigation: Document that distinction explicitly in the plan and specs
+    before touching runtime output, and keep structural review facts unchanged.
+
+## Validation Summary
+
+- `harness plan lint docs/plans/active/2026-03-26-unify-review-summary-naming.md`
+  passed after the `review_title` contract was finalized in the tracked plan.
+- `go test ./internal/review ./internal/runstate ./internal/status
+  ./internal/cli ./tests/e2e/...` passed after the runtime/docs/test rename
+  landed.
+- Live `harness status` output during step and finalize review now exposes
+  `facts.review_title`, confirming the direct CLI contract matches the updated
+  unit and e2e coverage.
+
+## Review Summary
+
+- Step closeout review `review-001-delta` passed on `docs_consistency` with no
+  findings.
+- Step closeout review `review-002-delta` passed on `correctness` with no
+  findings.
+- Step closeout review `review-003-delta` passed on `tests` with no findings.
+- Finalize full review `review-004-full` passed on `correctness` and
+  `docs_consistency` with no findings.
+
+## Archive Summary
+
+- Archived At: 2026-03-26T21:22:33+08:00
+- Revision: 1
+- PR: NONE. Publish evidence should record the PR URL after archive.
+- Ready: `review-004-full` passed as the structural `pre_archive` gate, all
+  tracked steps are complete, the acceptance criteria are satisfied, and the
+  candidate now leaves the repository with one canonical human-facing review
+  title: `review_title`.
+- Merge Handoff: Run `harness archive`, commit the archive move plus the
+  tracked runtime/docs/test updates, push the branch, open the PR, then record
+  publish, CI, and sync evidence until the candidate reaches merge approval.
+
+## Outcome Summary
+
+### Delivered
+
+- Renamed the review-round human-facing field to `review_title` across review
+  specs, manifests, aggregates, runstate helpers, status facts, and CLI help.
+- Updated the tracked CLI contract and review/reviewer guidance so they all
+  describe the same `review_title` concept and keep it distinct from command
+  or submission summaries.
+- Refreshed shared fixtures and regression coverage so unit tests and e2e
+  helpers assert `review_title` directly with no compatibility shim.
+
+### Not Delivered
+
+- No advanced escape hatch for non-routine review starts was added here; that
+  remains deferred to issue `#53`.
+
+### Follow-Up Issues
+
+- #53: Design an explicit advanced review-start escape hatch outside routine
+  step/finalize nodes.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -156,8 +156,8 @@ help explain the node:
 - `review_kind`
 - `review_trigger`
   - optional derived label such as `step_closeout` or `pre_archive`
-- `review_target`
-  - optional derived human-readable review summary
+- `review_title`
+  - optional derived human-readable review title
 - `review_status`
 - `archive_blocker_count`
 - `publish_status`
@@ -353,7 +353,7 @@ Canonical input shape:
 ```json
 {
   "kind": "delta",
-  "summary": "Check the completed step for state-machine mistakes and handoff clarity.",
+  "review_title": "Check the completed step for state-machine mistakes and handoff clarity.",
   "dimensions": [
     {
       "name": "correctness",
@@ -388,9 +388,9 @@ Review-spec semantics:
 - `dimensions`
   - required
   - one reviewer slot per normalized dimension
-- `summary`
+- `review_title`
   - optional
-  - human-readable note shown back to the controller and reviewers
+  - human-readable review title shown back to the controller and reviewers
 - `step`
   - optional 1-based tracked step number
   - usually omitted
@@ -409,7 +409,7 @@ Round identifiers should be short and plan-local:
 - keep precise timestamps in the manifest and aggregate artifacts rather than
   embedding them in the round ID
 
-If `summary` is omitted, the CLI fills one in:
+If `review_title` is omitted, the CLI fills one in:
 
 - step-bound review defaults to the tracked step title
 - finalize `full` review defaults to `Full branch candidate before archive`

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -412,7 +412,7 @@ func (a *App) runReviewStart(args []string) int {
 		fmt.Fprintln(a.Stderr, "Usage: harness review start [--spec <path>]")
 		fmt.Fprintln(a.Stderr)
 		fmt.Fprintln(a.Stderr, "Create a deterministic review round from a minimal review spec.")
-		fmt.Fprintln(a.Stderr, "The spec must include `kind` and `dimensions`, and may include optional `summary` or `step`.")
+		fmt.Fprintln(a.Stderr, "The spec must include `kind` and `dimensions`, and may include optional `review_title` or `step`.")
 		fmt.Fprintln(a.Stderr, "Harness infers whether the round is step-bound or finalize-bound from the current workflow state.")
 	}
 	if err := fs.Parse(args); err != nil {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -26,10 +26,10 @@ type Service struct {
 }
 
 type Spec struct {
-	Step       *int        `json:"step,omitempty"`
-	Kind       string      `json:"kind"`
-	Summary    string      `json:"summary,omitempty"`
-	Dimensions []Dimension `json:"dimensions"`
+	Step        *int        `json:"step,omitempty"`
+	Kind        string      `json:"kind"`
+	ReviewTitle string      `json:"review_title,omitempty"`
+	Dimensions  []Dimension `json:"dimensions"`
 }
 
 type Dimension struct {
@@ -42,7 +42,7 @@ type Manifest struct {
 	Kind        string         `json:"kind"`
 	Step        *int           `json:"step,omitempty"`
 	Revision    int            `json:"revision"`
-	Summary     string         `json:"summary,omitempty"`
+	ReviewTitle string         `json:"review_title,omitempty"`
 	PlanPath    string         `json:"plan_path"`
 	PlanStem    string         `json:"plan_stem"`
 	CreatedAt   string         `json:"created_at"`
@@ -99,7 +99,7 @@ type Aggregate struct {
 	Kind                string             `json:"kind"`
 	Step                *int               `json:"step,omitempty"`
 	Revision            int                `json:"revision"`
-	Summary             string             `json:"summary,omitempty"`
+	ReviewTitle         string             `json:"review_title,omitempty"`
 	Decision            string             `json:"decision"`
 	BlockingFindings    []AggregateFinding `json:"blocking_findings"`
 	NonBlockingFindings []AggregateFinding `json:"non_blocking_findings"`
@@ -211,7 +211,7 @@ func (s Service) Start(specBytes []byte) StartResult {
 			Errors:  issues,
 		}
 	}
-	inferredStep, revision, summary, err := inferReviewBinding(doc, state, spec)
+	inferredStep, revision, reviewTitle, err := inferReviewBinding(doc, state, spec)
 	if err != nil {
 		return StartResult{
 			OK:      false,
@@ -273,7 +273,7 @@ func (s Service) Start(specBytes []byte) StartResult {
 		Kind:        spec.Kind,
 		Step:        inferredStep,
 		Revision:    revision,
-		Summary:     summary,
+		ReviewTitle: reviewTitle,
 		PlanPath:    relPlanPath,
 		PlanStem:    planStem,
 		CreatedAt:   now.Format(time.RFC3339),
@@ -455,7 +455,7 @@ func (s Service) Submit(roundID, slot string, inputBytes []byte) SubmitResult {
 		NextAction: []NextAction{
 			{
 				Command:     nil,
-				Description: "Report the submission receipt to the controller agent and end the reviewer thread. If the same slot later needs a narrow follow-up for the same tracked step or the same finalize review target in the same revision, the controller may reopen this reviewer through the runtime's native resume mechanism only after this submission is verified and only while the slot instructions still materially match.",
+				Description: "Report the submission receipt to the controller agent and end the reviewer thread. If the same slot later needs a narrow follow-up for the same tracked step or the same finalize review title in the same revision, the controller may reopen this reviewer through the runtime's native resume mechanism only after this submission is verified and only while the slot instructions still materially match.",
 			},
 		},
 	}
@@ -549,7 +549,7 @@ func (s Service) Aggregate(roundID string) AggregateResult {
 		Kind:                manifest.Kind,
 		Step:                manifest.Step,
 		Revision:            manifest.Revision,
-		Summary:             manifest.Summary,
+		ReviewTitle:         manifest.ReviewTitle,
 		Decision:            decision,
 		BlockingFindings:    blocking,
 		NonBlockingFindings: nonBlocking,
@@ -828,12 +828,12 @@ func inferReviewBinding(doc *plan.Document, state *runstate.State, spec Spec) (*
 	if stepIndex, ok, err := inferReviewStepIndex(doc, state, spec); err != nil {
 		return nil, 0, "", err
 	} else if ok {
-		summary := strings.TrimSpace(spec.Summary)
-		if summary == "" {
-			summary = doc.Steps[stepIndex].Title
+		reviewTitle := strings.TrimSpace(spec.ReviewTitle)
+		if reviewTitle == "" {
+			reviewTitle = doc.Steps[stepIndex].Title
 		}
 		stepNumber := stepIndex + 1
-		return &stepNumber, revision, summary, nil
+		return &stepNumber, revision, reviewTitle, nil
 	}
 
 	if pendingNewStepReopen(doc, state) {
@@ -843,15 +843,15 @@ func inferReviewBinding(doc *plan.Document, state *runstate.State, spec Spec) (*
 		return nil, 0, "", fmt.Errorf("no reviewable tracked step could be inferred; set spec.step to select a tracked step explicitly")
 	}
 
-	summary := strings.TrimSpace(spec.Summary)
-	if summary == "" {
+	reviewTitle := strings.TrimSpace(spec.ReviewTitle)
+	if reviewTitle == "" {
 		if spec.Kind == "full" {
-			summary = "Full branch candidate before archive"
+			reviewTitle = "Full branch candidate before archive"
 		} else {
-			summary = "Branch candidate before archive"
+			reviewTitle = "Branch candidate before archive"
 		}
 	}
-	return nil, revision, summary, nil
+	return nil, revision, reviewTitle, nil
 }
 
 func inferReviewStepIndex(doc *plan.Document, state *runstate.State, spec Spec) (int, bool, error) {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -204,7 +204,7 @@ func TestSubmitStoresSubmissionAndUpdatesLedger(t *testing.T) {
 	if _, err := os.Stat(result.Artifacts.SubmissionPath); err != nil {
 		t.Fatalf("submission missing: %v", err)
 	}
-	if len(result.NextAction) != 1 || result.NextAction[0].Description != "Report the submission receipt to the controller agent and end the reviewer thread. If the same slot later needs a narrow follow-up for the same tracked step or the same finalize review target in the same revision, the controller may reopen this reviewer through the runtime's native resume mechanism only after this submission is verified and only while the slot instructions still materially match." {
+	if len(result.NextAction) != 1 || result.NextAction[0].Description != "Report the submission receipt to the controller agent and end the reviewer thread. If the same slot later needs a narrow follow-up for the same tracked step or the same finalize review title in the same revision, the controller may reopen this reviewer through the runtime's native resume mechanism only after this submission is verified and only while the slot instructions still materially match." {
 		t.Fatalf("unexpected submit next action: %#v", result.NextAction)
 	}
 }

--- a/internal/runstate/state.go
+++ b/internal/runstate/state.go
@@ -87,9 +87,9 @@ type reviewAggregate struct {
 }
 
 type reviewManifest struct {
-	Summary  string `json:"summary,omitempty"`
-	Step     *int   `json:"step,omitempty"`
-	Revision int    `json:"revision,omitempty"`
+	ReviewTitle string `json:"review_title,omitempty"`
+	Step        *int   `json:"step,omitempty"`
+	Revision    int    `json:"revision,omitempty"`
 }
 
 func LoadCurrentPlan(workdir string) (*CurrentPlan, error) {
@@ -202,7 +202,7 @@ func EffectiveReviewDecision(workdir, planStem string, round *ReviewRound) (stri
 	return "", false, nil
 }
 
-func EffectiveReviewSummary(workdir, planStem string, round *ReviewRound) (string, bool, error) {
+func EffectiveReviewTitle(workdir, planStem string, round *ReviewRound) (string, bool, error) {
 	if round == nil || strings.TrimSpace(round.RoundID) == "" {
 		return "", false, nil
 	}
@@ -220,8 +220,8 @@ func EffectiveReviewSummary(workdir, planStem string, round *ReviewRound) (strin
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return "", false, fmt.Errorf("parse manifest.json for %s: %w", round.RoundID, err)
 	}
-	if summary := strings.TrimSpace(manifest.Summary); summary != "" {
-		return summary, true, nil
+	if reviewTitle := strings.TrimSpace(manifest.ReviewTitle); reviewTitle != "" {
+		return reviewTitle, true, nil
 	}
 	return "", false, nil
 }

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -43,7 +43,7 @@ type Facts struct {
 	ReopenMode          string `json:"reopen_mode,omitempty"`
 	ReviewKind          string `json:"review_kind,omitempty"`
 	ReviewTrigger       string `json:"review_trigger,omitempty"`
-	ReviewTarget        string `json:"review_target,omitempty"`
+	ReviewTitle         string `json:"review_title,omitempty"`
 	ReviewStatus        string `json:"review_status,omitempty"`
 	ArchiveBlockerCount int    `json:"archive_blocker_count,omitempty"`
 	PublishStatus       string `json:"publish_status,omitempty"`
@@ -80,7 +80,7 @@ type reviewContext struct {
 	Kind            string
 	Revision        int
 	Trigger         string
-	Summary         string
+	ReviewTitle     string
 	Aggregated      bool
 	InFlight        bool
 	Decision        string
@@ -101,9 +101,9 @@ type missingStepCloseoutReminder struct {
 }
 
 type historicalReviewManifest struct {
-	Summary  string `json:"summary,omitempty"`
-	Step     *int   `json:"step,omitempty"`
-	Revision int    `json:"revision,omitempty"`
+	ReviewTitle string `json:"review_title,omitempty"`
+	Step        *int   `json:"step,omitempty"`
+	Revision    int    `json:"revision,omitempty"`
 }
 
 type latestStepCloseoutRound struct {
@@ -215,7 +215,7 @@ func (s Service) Read() Result {
 	if reviewCtx != nil && isStructuralReviewTrigger(reviewCtx.Trigger) && !reviewCtx.UnsafeFallback {
 		facts.ReviewKind = reviewCtx.Kind
 		facts.ReviewTrigger = reviewCtx.Trigger
-		facts.ReviewTarget = reviewCtx.Summary
+		facts.ReviewTitle = reviewCtx.ReviewTitle
 		switch {
 		case reviewCtx.InFlight:
 			facts.ReviewStatus = "in_progress"
@@ -310,7 +310,7 @@ func clearStepCloseoutReviewMetadata(facts *Facts, artifacts *Artifacts) {
 	if facts != nil {
 		facts.ReviewKind = ""
 		facts.ReviewTrigger = ""
-		facts.ReviewTarget = ""
+		facts.ReviewTitle = ""
 		facts.ReviewStatus = ""
 	}
 	if artifacts != nil {
@@ -424,10 +424,10 @@ func loadReviewContext(workdir, planStem string, doc *plan.Document, state *runs
 		warnings = append(warnings, fmt.Sprintf("Unable to read the review step binding for %s; status may be conservative.", round.RoundID))
 	}
 
-	if summary, known, err := runstate.EffectiveReviewSummary(workdir, planStem, round); err != nil {
-		warnings = append(warnings, fmt.Sprintf("Unable to read the review summary for %s; status may be conservative.", round.RoundID))
+	if reviewTitle, known, err := runstate.EffectiveReviewTitle(workdir, planStem, round); err != nil {
+		warnings = append(warnings, fmt.Sprintf("Unable to read the review title for %s; status may be conservative.", round.RoundID))
 	} else if known {
-		ctx.Summary = summary
+		ctx.ReviewTitle = reviewTitle
 	}
 
 	if round.Aggregated {
@@ -447,13 +447,13 @@ func loadReviewContext(workdir, planStem string, doc *plan.Document, state *runs
 		if stepKnown {
 			ctx.Trigger = "step_closeout"
 			ctx.TargetStepIndex = stepIndex - 1
-			if ctx.TargetStepIndex >= 0 && ctx.TargetStepIndex < len(doc.Steps) && strings.TrimSpace(ctx.Summary) == "" {
-				ctx.Summary = doc.Steps[ctx.TargetStepIndex].Title
+			if ctx.TargetStepIndex >= 0 && ctx.TargetStepIndex < len(doc.Steps) && strings.TrimSpace(ctx.ReviewTitle) == "" {
+				ctx.ReviewTitle = doc.Steps[ctx.TargetStepIndex].Title
 			}
 		} else {
 			ctx.Trigger = "pre_archive"
-			if strings.TrimSpace(ctx.Summary) == "" {
-				ctx.Summary = defaultFinalizeReviewSummary(ctx.Kind)
+			if strings.TrimSpace(ctx.ReviewTitle) == "" {
+				ctx.ReviewTitle = defaultFinalizeReviewTitle(ctx.Kind)
 			}
 		}
 	}
@@ -571,7 +571,7 @@ func loadLatestStepCloseoutTargets(workdir, planStem string, doc *plan.Document,
 	latestByTarget := map[string]latestStepCloseoutRound{}
 	for index, record := range scan.LatestByStepIndex {
 		if index >= 0 && index < len(doc.Steps) {
-			latestByTarget[normalizeReviewTarget(doc.Steps[index].Title)] = record
+			latestByTarget[normalizeReviewTitle(doc.Steps[index].Title)] = record
 		}
 	}
 	return latestByTarget, scan.Warnings
@@ -1240,20 +1240,20 @@ func currentStepIndex(doc *plan.Document) int {
 	return -1
 }
 
-func resolveReviewTargetStep(doc *plan.Document, target string) (int, bool) {
-	target = normalizeReviewTarget(target)
-	if target == "" {
+func resolveReviewTitleStep(doc *plan.Document, reviewTitle string) (int, bool) {
+	reviewTitle = normalizeReviewTitle(reviewTitle)
+	if reviewTitle == "" {
 		return -1, false
 	}
 	for index, step := range doc.Steps {
-		if normalizeReviewTarget(step.Title) == target {
+		if normalizeReviewTitle(step.Title) == reviewTitle {
 			return index, true
 		}
 	}
 	return -1, false
 }
 
-func normalizeReviewTarget(value string) string {
+func normalizeReviewTitle(value string) string {
 	value = strings.TrimSpace(strings.ToLower(value))
 	value = strings.Map(func(r rune) rune {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsSpace(r) {
@@ -1264,7 +1264,7 @@ func normalizeReviewTarget(value string) string {
 	return strings.Join(strings.Fields(value), " ")
 }
 
-func defaultFinalizeReviewSummary(kind string) string {
+func defaultFinalizeReviewTitle(kind string) string {
 	if kind == "full" {
 		return "Full branch candidate before archive"
 	}
@@ -1282,7 +1282,7 @@ func readJSONFile(path string, target any) error {
 	return nil
 }
 
-func fallbackReviewTargetStep(doc *plan.Document, state *runstate.State) (int, bool) {
+func fallbackReviewTitleStep(doc *plan.Document, state *runstate.State) (int, bool) {
 	if state != nil {
 		if index, ok := stepIndexFromNode(state.CurrentNode); ok {
 			return index, false
@@ -1363,7 +1363,7 @@ func (f *Facts) empty() bool {
 		strings.TrimSpace(f.ReopenMode) == "" &&
 		strings.TrimSpace(f.ReviewKind) == "" &&
 		strings.TrimSpace(f.ReviewTrigger) == "" &&
-		strings.TrimSpace(f.ReviewTarget) == "" &&
+		strings.TrimSpace(f.ReviewTitle) == "" &&
 		strings.TrimSpace(f.ReviewStatus) == "" &&
 		f.ArchiveBlockerCount == 0 &&
 		strings.TrimSpace(f.PublishStatus) == "" &&

--- a/internal/status/service_internal_test.go
+++ b/internal/status/service_internal_test.go
@@ -25,9 +25,9 @@ func TestLoadSatisfiedStepCloseoutTargetsUsesActiveReviewContextForUnreadableCur
 	}
 
 	writeHistoricalReviewJSON(t, root, planStem, "review-001-delta", "manifest.json", map[string]any{
-		"summary":  internalStepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": internalStepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeHistoricalReviewJSON(t, root, planStem, "review-001-delta", "aggregate.json", map[string]any{
 		"decision": "pass",
@@ -41,9 +41,9 @@ func TestLoadSatisfiedStepCloseoutTargetsUsesActiveReviewContextForUnreadableCur
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeHistoricalReviewJSON(t, root, planStem, "review-002-delta", "aggregate.json", map[string]any{
-		"summary":  "mystery historical target",
-		"revision": 1,
-		"decision": "changes_requested",
+		"review_title": "mystery historical target",
+		"revision":     1,
+		"decision":     "changes_requested",
 	})
 
 	reviewCtx := &reviewContext{
@@ -52,7 +52,7 @@ func TestLoadSatisfiedStepCloseoutTargetsUsesActiveReviewContextForUnreadableCur
 		TargetStepIndex: 0,
 	}
 	satisfied, warnings := loadSatisfiedStepCloseoutTargets(root, planStem, doc, reviewCtx)
-	if satisfied[normalizeReviewTarget(internalStepOneTitle)] {
+	if satisfied[normalizeReviewTitle(internalStepOneTitle)] {
 		t.Fatalf("expected active reviewCtx fallback to keep step 1 unsatisfied, got %#v", satisfied)
 	}
 	if len(warnings) == 0 {
@@ -71,9 +71,9 @@ func TestLoadSatisfiedStepCloseoutTargetsUsesActiveInFlightReviewContextForUnrea
 	}
 
 	writeHistoricalReviewJSON(t, root, planStem, "review-001-delta", "manifest.json", map[string]any{
-		"summary":  internalStepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": internalStepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeHistoricalReviewJSON(t, root, planStem, "review-001-delta", "aggregate.json", map[string]any{
 		"decision": "pass",
@@ -94,7 +94,7 @@ func TestLoadSatisfiedStepCloseoutTargetsUsesActiveInFlightReviewContextForUnrea
 		InFlight:        true,
 	}
 	satisfied, warnings := loadSatisfiedStepCloseoutTargets(root, planStem, doc, reviewCtx)
-	if satisfied[normalizeReviewTarget(internalStepOneTitle)] {
+	if satisfied[normalizeReviewTitle(internalStepOneTitle)] {
 		t.Fatalf("expected active in-flight reviewCtx fallback to keep step 1 unsatisfied, got %#v", satisfied)
 	}
 	if len(warnings) == 0 {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -120,16 +120,16 @@ func TestStatusExecutionStepReviewNode(t *testing.T) {
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
 	if result.State.CurrentNode != "execution/step-1/review" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
-	if result.Facts == nil || result.Facts.ReviewStatus != "in_progress" || result.Facts.CurrentStep != stepOneTitle || result.Facts.ReviewTarget != stepOneTitle || result.Facts.ReviewTrigger != "step_closeout" {
+	if result.Facts == nil || result.Facts.ReviewStatus != "in_progress" || result.Facts.CurrentStep != stepOneTitle || result.Facts.ReviewTitle != stepOneTitle || result.Facts.ReviewTrigger != "step_closeout" {
 		t.Fatalf("unexpected facts: %#v", result.Facts)
 	}
 	if result.Artifacts == nil || result.Artifacts.ReviewRoundID != "review-001-delta" {
@@ -151,9 +151,9 @@ func TestStatusStepReviewMatchesTargetWithoutMarkdownPunctuation(t *testing.T) {
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  "Step 1: Resolve current_node",
-		"step":     1,
-		"revision": 1,
+		"review_title": "Step 1: Resolve current_node",
+		"step":         1,
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -181,9 +181,9 @@ func TestStatusDoesNotWarnForEarlierCompletedStepWithCleanFullReview(t *testing.
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-full", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-full", map[string]any{
 		"decision": "pass",
@@ -231,17 +231,17 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutRoundIsNotClean(t *testing.T
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "changes_requested",
@@ -265,17 +265,17 @@ func TestStatusDoesNotWarnWhenLatestHistoricalStepCloseoutRepairsEarlierFailure(
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "changes_requested",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -299,17 +299,17 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutRoundIsStillInFlight(t *test
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -330,9 +330,9 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutManifestIsUnreadable(t *test
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -346,8 +346,8 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutManifestIsUnreadable(t *test
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"decision": "changes_requested",
+		"review_title": stepOneTitle,
+		"decision":     "changes_requested",
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -368,9 +368,9 @@ func TestStatusWarnsWhenLatestUnreadableHistoricalCloseoutCannotBeMapped(t *test
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -384,9 +384,9 @@ func TestStatusWarnsWhenLatestUnreadableHistoricalCloseoutCannotBeMapped(t *test
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  "mystery historical target",
-		"revision": 1,
-		"decision": "changes_requested",
+		"review_title": "mystery historical target",
+		"revision":     1,
+		"decision":     "changes_requested",
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -429,9 +429,9 @@ func TestStatusFinalizeArchiveSuppressesArchiveActionForUnscopedUnreadableHistor
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -445,9 +445,9 @@ func TestStatusFinalizeArchiveSuppressesArchiveActionForUnscopedUnreadableHistor
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  "mystery historical target",
-		"revision": 1,
-		"decision": "changes_requested",
+		"review_title": "mystery historical target",
+		"revision":     1,
+		"decision":     "changes_requested",
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -485,9 +485,9 @@ func TestStatusDoesNotLetUnreadableHistoryForOneStepUnsatisfyAnother(t *testing.
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -501,8 +501,8 @@ func TestStatusDoesNotLetUnreadableHistoryForOneStepUnsatisfyAnother(t *testing.
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"decision": "changes_requested",
+		"review_title": stepTwoTitle,
+		"decision":     "changes_requested",
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -532,9 +532,9 @@ func TestStatusWarnsInFinalizeWhenCompletedStepStillLacksCloseout(t *testing.T) 
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"step":     2,
-		"revision": 1,
+		"review_title": stepTwoTitle,
+		"step":         2,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -580,9 +580,9 @@ func TestStatusFinalizeArchiveSummaryAndActionsDoNotPretendReadyWhenCloseoutDebt
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"step":     2,
-		"revision": 1,
+		"review_title": stepTwoTitle,
+		"step":         2,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -627,9 +627,9 @@ func TestStatusFinalizeArchiveKeepsBlockerGuidanceWhenCloseoutDebtAndArchiveBloc
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"step":     2,
-		"revision": 1,
+		"review_title": stepTwoTitle,
+		"step":         2,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -679,9 +679,9 @@ func TestStatusDoesNotSuggestSecondReviewWhileStepReviewIsInFlight(t *testing.T)
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"step":     2,
-		"revision": 1,
+		"review_title": stepTwoTitle,
+		"step":         2,
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -722,16 +722,16 @@ func TestStatusDoesNotSuggestSecondReviewWhileFinalizeReviewIsInFlight(t *testin
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"step":     2,
-		"revision": 1,
+		"review_title": stepTwoTitle,
+		"step":         2,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-003-full", map[string]any{
-		"summary":  "Full branch candidate before archive",
-		"revision": 1,
+		"review_title": "Full branch candidate before archive",
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -786,9 +786,9 @@ func TestStatusNoReviewNeededMarkerDoesNotHideLaterFailedCloseout(t *testing.T) 
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "changes_requested",
@@ -813,9 +813,9 @@ func TestStatusNoReviewNeededMarkerDoesNotHideLaterInFlightCloseout(t *testing.T
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -837,9 +837,9 @@ func TestStatusNoReviewNeededMarkerAllowsLaterCleanCloseoutToStaySatisfied(t *te
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -871,17 +871,17 @@ func TestStatusUnreadableFinalizeManifestDoesNotMasqueradeAsStepDebt(t *testing.
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"step":     2,
-		"revision": 1,
+		"review_title": stepTwoTitle,
+		"step":         2,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -927,9 +927,9 @@ func TestStatusFinalizeReviewUsesAggregateFirstGuidanceForUnscopedUnreadableHist
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -943,13 +943,13 @@ func TestStatusFinalizeReviewUsesAggregateFirstGuidanceForUnscopedUnreadableHist
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  "mystery historical target",
-		"revision": 1,
-		"decision": "changes_requested",
+		"review_title": "mystery historical target",
+		"revision":     1,
+		"decision":     "changes_requested",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-003-full", map[string]any{
-		"summary":  "Full branch candidate before archive",
-		"revision": 1,
+		"review_title": "Full branch candidate before archive",
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -976,9 +976,9 @@ func TestStatusFinalizeReviewSummaryForUnscopedUnreadableHistoryWithoutActiveRou
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -992,9 +992,9 @@ func TestStatusFinalizeReviewSummaryForUnscopedUnreadableHistoryWithoutActiveRou
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  "mystery historical target",
-		"revision": 1,
-		"decision": "changes_requested",
+		"review_title": "mystery historical target",
+		"revision":     1,
+		"decision":     "changes_requested",
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -1034,9 +1034,9 @@ func TestStatusFinalizeFixSummaryForUnscopedUnreadableHistory(t *testing.T) {
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
 		"decision": "pass",
@@ -1050,9 +1050,9 @@ func TestStatusFinalizeFixSummaryForUnscopedUnreadableHistory(t *testing.T) {
 		t.Fatalf("write unreadable manifest: %v", err)
 	}
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  "mystery historical target",
-		"revision": 1,
-		"decision": "changes_requested",
+		"review_title": "mystery historical target",
+		"revision":     1,
+		"decision":     "changes_requested",
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -1122,9 +1122,9 @@ func TestStatusUnknownAggregatedReviewDecisionStaysConservative(t *testing.T) {
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-001-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -1154,9 +1154,9 @@ func TestStatusFailedStepReviewPinsReviewedStep(t *testing.T) {
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -1186,9 +1186,9 @@ func TestStatusAdvancesToNextStepAfterCleanStepReview(t *testing.T) {
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-003-delta", map[string]any{
-		"summary":  stepOneTitle,
-		"step":     1,
-		"revision": 1,
+		"review_title": stepOneTitle,
+		"step":         1,
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -1233,16 +1233,16 @@ func TestStatusFinalizeReviewClearsPriorStepReviewFacts(t *testing.T) {
 		},
 	})
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-003-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"step":     2,
-		"revision": 1,
+		"review_title": stepTwoTitle,
+		"step":         2,
+		"revision":     1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
-	if result.Facts != nil && (result.Facts.ReviewStatus != "" || result.Facts.ReviewTarget != "" || result.Facts.ReviewTrigger != "" || result.Facts.ReviewKind != "") {
+	if result.Facts != nil && (result.Facts.ReviewStatus != "" || result.Facts.ReviewTitle != "" || result.Facts.ReviewTrigger != "" || result.Facts.ReviewKind != "") {
 		t.Fatalf("expected prior step-review facts to be cleared at finalize review, got %#v", result.Facts)
 	}
 	if result.Artifacts != nil && result.Artifacts.ReviewRoundID != "" {
@@ -1350,9 +1350,9 @@ func TestStatusWarnsInArchivedPublishWhenCompletedStepStillLacksCloseout(t *test
 	})
 	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"step":     2,
-		"revision": 1,
+		"review_title": stepTwoTitle,
+		"step":         2,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",
@@ -1426,9 +1426,9 @@ func TestStatusArchivedNodesRequireReopenForUnscopedUnreadableHistory(t *testing
 				t.Fatalf("write unreadable manifest: %v", err)
 			}
 			writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-				"summary":  "mystery historical target",
-				"revision": 1,
-				"decision": "changes_requested",
+				"review_title": "mystery historical target",
+				"revision":     1,
+				"decision":     "changes_requested",
 			})
 
 			if tc.withMergeEvidence {
@@ -1530,9 +1530,9 @@ func TestStatusWarnsInAwaitMergeWhenCompletedStepStillLacksCloseout(t *testing.T
 	})
 	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
 	writeReviewManifest(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
-		"summary":  stepTwoTitle,
-		"step":     2,
-		"revision": 1,
+		"review_title": stepTwoTitle,
+		"step":         2,
+		"revision":     1,
 	})
 	writeReviewAggregate(t, root, "2026-03-18-status-plan", "review-002-delta", map[string]any{
 		"decision": "pass",

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -118,7 +118,7 @@ type aggregateArtifact struct {
 	Kind                string `json:"kind"`
 	Step                *int   `json:"step,omitempty"`
 	Revision            int    `json:"revision"`
-	Summary             string `json:"summary"`
+	ReviewTitle         string `json:"review_title"`
 	Decision            string `json:"decision"`
 	AggregatedAt        string `json:"aggregated_at"`
 	NonBlockingFindings []struct {
@@ -129,12 +129,12 @@ type aggregateArtifact struct {
 }
 
 type reviewManifest struct {
-	RoundID    string            `json:"round_id"`
-	Step       *int              `json:"step,omitempty"`
-	Revision   int               `json:"revision"`
-	Summary    string            `json:"summary"`
-	PlanPath   string            `json:"plan_path"`
-	Dimensions []reviewDimension `json:"dimensions"`
+	RoundID     string            `json:"round_id"`
+	Step        *int              `json:"step,omitempty"`
+	Revision    int               `json:"revision"`
+	ReviewTitle string            `json:"review_title"`
+	PlanPath    string            `json:"plan_path"`
+	Dimensions  []reviewDimension `json:"dimensions"`
 }
 
 type reviewLedger struct {
@@ -172,7 +172,7 @@ type statusResult struct {
 	Facts struct {
 		CurrentStep   string `json:"current_step"`
 		ReviewStatus  string `json:"review_status"`
-		ReviewTarget  string `json:"review_target"`
+		ReviewTitle   string `json:"review_title"`
 		ReopenMode    string `json:"reopen_mode"`
 		Revision      int    `json:"revision"`
 		PublishStatus string `json:"publish_status"`
@@ -332,7 +332,7 @@ func runPassingDeltaReview(t *testing.T, workspace *support.Workspace, stepTitle
 
 	reviewStatus := runStatus(t, workspace.Root)
 	assertNode(t, reviewStatus, fmt.Sprintf("execution/step-%d/review", stepNumber))
-	if reviewStatus.Facts.CurrentStep != target || reviewStatus.Facts.ReviewStatus != "in_progress" || reviewStatus.Facts.ReviewTarget != target {
+	if reviewStatus.Facts.CurrentStep != target || reviewStatus.Facts.ReviewStatus != "in_progress" || reviewStatus.Facts.ReviewTitle != target {
 		t.Fatalf("expected active step-review facts for %q, got %#v", target, reviewStatus)
 	}
 
@@ -341,7 +341,7 @@ func runPassingDeltaReview(t *testing.T, workspace *support.Workspace, stepTitle
 
 	stillInReviewStatus := runStatus(t, workspace.Root)
 	assertNode(t, stillInReviewStatus, fmt.Sprintf("execution/step-%d/review", stepNumber))
-	if stillInReviewStatus.Facts.CurrentStep != target || stillInReviewStatus.Facts.ReviewStatus != "in_progress" || stillInReviewStatus.Facts.ReviewTarget != target {
+	if stillInReviewStatus.Facts.CurrentStep != target || stillInReviewStatus.Facts.ReviewStatus != "in_progress" || stillInReviewStatus.Facts.ReviewTitle != target {
 		t.Fatalf("expected submission-only update to preserve active step-review facts for %q, got %#v", target, stillInReviewStatus)
 	}
 
@@ -371,7 +371,7 @@ func runPassingFinalizeReview(t *testing.T, workspace *support.Workspace) string
 
 	inReviewStatus := runStatus(t, workspace.Root)
 	assertNode(t, inReviewStatus, "execution/finalize/review")
-	if inReviewStatus.Facts.ReviewStatus != "in_progress" || inReviewStatus.Facts.ReviewTarget != "Full branch candidate before archive" {
+	if inReviewStatus.Facts.ReviewStatus != "in_progress" || inReviewStatus.Facts.ReviewTitle != "Full branch candidate before archive" {
 		t.Fatalf("expected active finalize-review facts, got %#v", inReviewStatus)
 	}
 
@@ -379,7 +379,7 @@ func runPassingFinalizeReview(t *testing.T, workspace *support.Workspace) string
 
 	stillInReviewStatus := runStatus(t, workspace.Root)
 	assertNode(t, stillInReviewStatus, "execution/finalize/review")
-	if stillInReviewStatus.Facts.ReviewStatus != "in_progress" || stillInReviewStatus.Facts.ReviewTarget != "Full branch candidate before archive" {
+	if stillInReviewStatus.Facts.ReviewStatus != "in_progress" || stillInReviewStatus.Facts.ReviewTitle != "Full branch candidate before archive" {
 		t.Fatalf("expected submission-only update to preserve active finalize-review facts, got %#v", stillInReviewStatus)
 	}
 

--- a/tests/e2e/review_repair_loop_test.go
+++ b/tests/e2e/review_repair_loop_test.go
@@ -47,7 +47,7 @@ func TestReviewRepairLoopsWithBuiltBinary(t *testing.T) {
 	blockingStepRound := runBlockingStepReview(t, workspace, reviewRepairStepOne, 1)
 	postStepFailure := runStatus(t, workspace.Root)
 	assertNode(t, postStepFailure, "execution/step-1/implement")
-	if postStepFailure.Facts.ReviewStatus != "changes_requested" || postStepFailure.Facts.ReviewTarget != trackedStepTitle(1, reviewRepairStepOne) {
+	if postStepFailure.Facts.ReviewStatus != "changes_requested" || postStepFailure.Facts.ReviewTitle != trackedStepTitle(1, reviewRepairStepOne) {
 		t.Fatalf("expected step-review failure facts after %s, got %#v", blockingStepRound, postStepFailure)
 	}
 	if !strings.Contains(postStepFailure.Summary, "requested changes") {

--- a/tests/e2e/review_workflow_test.go
+++ b/tests/e2e/review_workflow_test.go
@@ -71,7 +71,7 @@ func TestReviewWorkflowWithBuiltBinary(t *testing.T) {
 	stepOneRound := runPassingDeltaReview(t, workspace, stepOneTitle, 1)
 	postStepOneReview := runStatus(t, workspace.Root)
 	assertNode(t, postStepOneReview, "execution/step-1/implement")
-	if postStepOneReview.Facts.ReviewStatus != "pass" || postStepOneReview.Facts.ReviewTarget != trackedStepTitle(1, stepOneTitle) {
+	if postStepOneReview.Facts.ReviewStatus != "pass" || postStepOneReview.Facts.ReviewTitle != trackedStepTitle(1, stepOneTitle) {
 		t.Fatalf("expected clean step-one review facts after aggregate, got %#v", postStepOneReview)
 	}
 	support.CompleteStep(
@@ -91,7 +91,7 @@ func TestReviewWorkflowWithBuiltBinary(t *testing.T) {
 	stepTwoRound := runPassingDeltaReview(t, workspace, stepTwoTitle, 2)
 	postStepTwoReview := runStatus(t, workspace.Root)
 	assertNode(t, postStepTwoReview, "execution/step-2/implement")
-	if postStepTwoReview.Facts.ReviewStatus != "pass" || postStepTwoReview.Facts.ReviewTarget != trackedStepTitle(2, stepTwoTitle) {
+	if postStepTwoReview.Facts.ReviewStatus != "pass" || postStepTwoReview.Facts.ReviewTitle != trackedStepTitle(2, stepTwoTitle) {
 		t.Fatalf("expected clean step-two review facts after aggregate, got %#v", postStepTwoReview)
 	}
 
@@ -109,7 +109,7 @@ func TestReviewWorkflowWithBuiltBinary(t *testing.T) {
 	if preReviewStatus.Summary != "Plan has finished its tracked steps and needs finalize review before archive." {
 		t.Fatalf("expected finalize-review preflight summary, got %#v", preReviewStatus)
 	}
-	if preReviewStatus.Facts.ReviewStatus != "" || preReviewStatus.Facts.ReviewTarget != "" {
+	if preReviewStatus.Facts.ReviewStatus != "" || preReviewStatus.Facts.ReviewTitle != "" {
 		t.Fatalf("expected finalize preflight to clear prior step-review facts, got %#v", preReviewStatus)
 	}
 	if preReviewStatus.Artifacts.ReviewRoundID != "" {
@@ -301,7 +301,7 @@ func TestReviewWorkflowWithBuiltBinary(t *testing.T) {
 	if aggregateArtifact.RoundID != startPayload.Artifacts.RoundID || aggregateArtifact.Kind != "full" {
 		t.Fatalf("unexpected aggregate artifact: %#v", aggregateArtifact)
 	}
-	if aggregateArtifact.Summary != "Full branch candidate before archive" || aggregateArtifact.Decision != "pass" || aggregateArtifact.AggregatedAt == "" {
+	if aggregateArtifact.ReviewTitle != "Full branch candidate before archive" || aggregateArtifact.Decision != "pass" || aggregateArtifact.AggregatedAt == "" {
 		t.Fatalf("unexpected aggregate artifact contents: %#v", aggregateArtifact)
 	}
 	if len(aggregateArtifact.NonBlockingFindings) != 1 || aggregateArtifact.NonBlockingFindings[0].Title != "Review path exercised across multiple slots" {


### PR DESCRIPTION
## Summary
- rename the review-round human-facing field to `review_title` across runtime artifacts and status facts
- align CLI/spec/reviewer docs with the new review-title terminology
- update unit and e2e fixtures so they assert `review_title` directly

## Validation
- `harness plan lint docs/plans/archived/2026-03-26-unify-review-summary-naming.md`
- `go test ./...`
- `harness status`

Closes #52
