### PR TITLE
Protect runstate writes with atomic saves and state locks

### DIFF
--- a/docs/plans/archived/2026-03-26-protect-runstate-writes-with-atomic-saves-and-locks.md
+++ b/docs/plans/archived/2026-03-26-protect-runstate-writes-with-atomic-saves-and-locks.md
@@ -1,0 +1,309 @@
+---
+template_version: 0.2.0
+created_at: "2026-03-26T22:54:50+08:00"
+source_type: issue
+source_refs:
+    - '#51'
+---
+
+# Protect runstate writes with atomic saves and state locks
+
+## Goal
+
+Prevent local harness runstate files from becoming corrupted when multiple
+commands write them close together or when a write is interrupted mid-flight.
+
+This slice hardens the CLI-owned persistence layer by making `state.json` and
+`current-plan.json` writes atomic, and by serializing plan-local `state.json`
+mutations behind a shared fail-fast lock. It intentionally keeps `harness
+status` writing its thin cache on every run rather than changing the cache
+policy in the same slice.
+
+## Scope
+
+### In Scope
+
+- Make `internal/runstate` persist `state.json` with same-directory temp-file
+  replacement instead of direct overwrite writes.
+- Apply the same atomic write behavior to `current-plan.json` so the local
+  runstate write strategy is consistent across CLI-owned JSON files.
+- Add a shared per-plan state-mutation lock for command paths that rewrite
+  `state.json`, with clear fail-fast errors when another state mutation is
+  already in progress.
+- Route `status`, `evidence`, `lifecycle`, and any other plan-local
+  `state.json` writer through the shared state lock without collapsing review
+  mutation locking into the same primitive.
+- Add deterministic regression coverage for atomic-save helpers and lock
+  contention on representative command flows.
+- Update tracked docs/specs so the atomic-save and fail-fast state-lock
+  behavior is explicit for future agents and maintainers.
+
+### Out of Scope
+
+- Changing `harness status` into a read-only command or skipping writes when
+  the cached node is unchanged.
+- Replacing the existing review-mutation lock with a broader unified mutation
+  lock for every local plan artifact.
+- Adding background retries, waiting behavior, or automatic backoff when the
+  state lock is already held.
+- Broad resilience work beyond the targeted runstate-write corruption and
+  contention coverage needed for `#51`.
+
+## Acceptance Criteria
+
+- [x] `state.json` and `current-plan.json` are written via atomic replacement
+      rather than direct `os.WriteFile` overwrites.
+- [x] Commands that mutate a plan-local `state.json` fail fast with a clear,
+      user-facing error when another state mutation for the same plan is
+      already in progress.
+- [x] Focused regression tests cover at least one lock-contention path and the
+      persistence helper behavior needed to keep runstate JSON parseable after
+      interrupted or overlapping saves.
+- [x] The tracked CLI/state-model docs describe the new atomic-save and
+      per-plan state-lock expectations for CLI-owned runstate files.
+
+## Deferred Items
+
+- Whether `harness status` should later skip cache writes when the resolved
+  node is unchanged.
+- Whether review locking and state locking should later converge on a single
+  broader mutation primitive.
+- Whether additional evidence/reopen/archive E2E concurrency coverage is worth
+  adding after the targeted regression tests land.
+
+## Work Breakdown
+
+### Step 1: Add atomic runstate persistence helpers
+
+- Done: [x]
+
+#### Objective
+
+Centralize CLI-owned JSON persistence in `internal/runstate` so both
+`state.json` and `current-plan.json` use atomic same-directory replacement.
+
+#### Details
+
+Introduce a reusable helper that writes marshaled JSON to a temp file in the
+destination directory and renames it into place only after the content is
+fully staged. Preserve existing file locations and payload shapes so the slice
+changes durability semantics without redesigning the runstate model.
+
+#### Expected Files
+
+- `internal/runstate/state.go`
+- `internal/runstate/state_test.go`
+
+#### Validation
+
+- New helper-level tests prove the atomic persistence path produces parseable
+  JSON files at the canonical runstate locations.
+- Existing runstate callers continue loading the same JSON schema after the
+  helper swap.
+
+#### Execution Notes
+
+Added an atomic JSON persistence helper in `internal/runstate/state.go` and
+switched both `SaveState` and `saveCurrentPlan` to use same-directory temp-file
+replacement plus `fsync` before rename. Added `internal/runstate/state_test.go`
+to verify both `state.json` and `current-plan.json` are rewritten to the exact
+expected JSON payload without stale trailing content from older writes.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This helper-only precursor was completed together with
+Steps 2 and 3 as one tightly coupled runstate-hardening slice, so a separate
+Step 1 review would have duplicated the later broader risk scan.
+
+### Step 2: Serialize plan-local state mutations with a shared fail-fast lock
+
+- Done: [x]
+
+#### Objective
+
+Ensure every command path that rewrites `state.json` acquires the same per-plan
+state lock before persisting local runstate.
+
+#### Details
+
+Add a plan-local lock helper separate from the existing review-mutation lock so
+`status`, `evidence`, and lifecycle flows can fail fast when another
+state-mutation command already owns the lock for the same plan. Keep the review
+lock in place for review-specific sequencing rather than broadening this slice
+into a repository-wide mutation-lock refactor.
+
+#### Expected Files
+
+- `internal/runstate/state.go`
+- `internal/status/service.go`
+- `internal/evidence/service.go`
+- `internal/lifecycle/service.go`
+- `internal/review/service.go`
+
+#### Validation
+
+- Representative state-writing commands return a clear contention error when
+  the shared state lock is already held for the target plan.
+- Normal single-command flows still update `state.json` successfully after the
+  lock integration.
+
+#### Execution Notes
+
+Added a shared per-plan state-mutation lock in `internal/runstate/state.go` and
+wired `status`, `evidence`, lifecycle commands, and review start/aggregate
+through it so their `state.json` read-modify-write paths are serialized and
+fail fast on contention. Lifecycle and evidence loaders now acquire the lock
+before loading local state, and `status` now refuses to refresh the
+`current_node` cache when another command is already mutating plan-local state.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 is the main behavior change, but it remained
+entangled with Step 3's contention coverage and doc contract updates, so a
+separate step-bound review before those protections landed would have been
+misleading duplication.
+
+### Step 3: Lock the behavior with regression coverage and docs
+
+- Done: [x]
+
+#### Objective
+
+Make the new durability and contention behavior explicit through focused tests
+and tracked contract updates.
+
+#### Details
+
+Add deterministic regression coverage around lock contention and runstate
+writing, favoring package-level tests over broad infrastructure fuzzing. Update
+the relevant tracked docs so future agents know that CLI-owned runstate writes
+are atomic and that plan-local `state.json` mutation now uses a fail-fast
+state lock.
+
+#### Expected Files
+
+- `internal/status/service_test.go`
+- `internal/evidence/service_test.go`
+- `internal/lifecycle/service_test.go`
+- `docs/specs/cli-contract.md`
+- `docs/specs/state-model.md`
+
+#### Validation
+
+- Focused package-level tests for the touched services pass with the new
+  lock-contention and persistence coverage.
+- `go test ./...` passes once the slice is ready for broader verification.
+
+#### Execution Notes
+
+Added contention tests in `internal/status/service_test.go`,
+`internal/evidence/service_test.go`, and `internal/lifecycle/service_test.go`
+that hold the new state lock and assert the commands fail clearly. Updated
+`docs/specs/state-model.md` and `docs/specs/cli-contract.md` to document
+atomic CLI-owned runstate writes and the shared fail-fast per-plan state lock.
+Validated with `go test ./internal/runstate ./internal/status ./internal/evidence ./internal/lifecycle ./internal/review`
+and `go test ./...`. Finalize review `review-001-full` then found a locked-plan
+TOCTOU gap plus two regression gaps, so the slice added
+`plan.DetectCurrentPathLocked`, review state-lock contention tests, and a
+rename-failure atomic-save test before rerunning validation.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 3 only added the deterministic contention coverage
+and spec wording needed to lock in the completed Step 2 behavior, so a
+separate closeout review would have duplicated the finalize review that follows
+immediately after the full slice.
+
+## Validation Strategy
+
+- Add helper-level tests for atomic runstate persistence because the main risk
+  is malformed local JSON after interrupted or overlapping writes, not parser
+  behavior itself.
+- Add focused service-level contention tests that hold the new state lock and
+  assert representative commands fail fast without mutating local state.
+- Run targeted package tests during implementation, then `go test ./...`
+  before archive so the persistence changes are validated against broader CLI
+  expectations.
+
+## Risks
+
+- Risk: Introducing a new shared state lock could deadlock or create confusing
+  interaction with existing review locking if command ordering is inconsistent.
+  - Mitigation: Keep the new lock narrowly scoped to `state.json` mutation,
+    preserve the existing review lock semantics, and add contention tests that
+    exercise representative command entry points.
+- Risk: Atomic-save refactoring could accidentally change file permissions,
+  directories, or payload formatting relied on by existing tests.
+  - Mitigation: Reuse the existing file paths and JSON marshaling code, and add
+    direct persistence tests around the canonical runstate files before wiring
+    callers to the helper.
+
+## Validation Summary
+
+- Added helper-level persistence coverage in `internal/runstate/state_test.go`
+  for exact JSON replacement plus a rename-failure rollback case that preserves
+  the original file.
+- Added fail-fast state-lock contention coverage for `status`, `evidence`,
+  lifecycle, and review state-writer entry points.
+- Added `internal/plan/current_test.go` coverage for the locked-plan-stem guard
+  that prevents mixing one plan's document with another plan's `state.json`
+  after lock acquisition.
+- Validated the repaired candidate with `go test ./internal/plan ./internal/runstate ./internal/status ./internal/evidence ./internal/lifecycle ./internal/review`
+  and `go test ./...`.
+
+## Review Summary
+
+- Finalize review `review-001-full` found three blocking issues: the initial
+  lock-integration still had a plan-selection TOCTOU gap, review start/aggregate
+  lacked direct state-lock contention tests, and atomic-save coverage did not
+  exercise rename-failure rollback.
+- The repair slice added `plan.DetectCurrentPathLocked`, extended review tests
+  to cover shared state-lock contention, and added a rename-failure
+  `writeJSONAtomic` regression.
+- Follow-up finalize review `review-002-full` passed clean across the
+  `correctness`, `tests`, and `docs_consistency` slots with no findings.
+
+## Archive Summary
+
+- Archived At: 2026-03-26T23:18:23+08:00
+- Revision: 1
+- PR: not created yet; publish evidence should record the PR URL after archive.
+- Ready: `review-002-full` passed clean, acceptance criteria are satisfied, and
+  the validation evidence listed above makes the candidate ready for
+  `harness archive`.
+- Merge Handoff: Archive the plan, commit the tracked move plus the code/doc
+  changes, push the branch, open or update the PR, and record publish/CI/sync
+  evidence before treating the candidate as merge-ready.
+
+## Outcome Summary
+
+### Delivered
+
+- Hardened CLI-owned runstate persistence so both `state.json` and
+  `current-plan.json` use atomic same-directory replacement instead of direct
+  overwrite writes.
+- Added a shared fail-fast per-plan state-mutation lock and wired the main
+  `state.json` writers through it, including `status`, `evidence`, lifecycle
+  flows, and review start/aggregate.
+- Closed the locked-plan TOCTOU gap by requiring post-lock plan detection to
+  resolve to the same plan stem, and documented the resulting runstate
+  durability contract in the tracked specs.
+- Added deterministic regression coverage for atomic-save rollback, locked-plan
+  detection, and shared state-lock contention across the touched command paths.
+
+### Not Delivered
+
+- `harness status` still rewrites the thin cache on every successful run even
+  when the resolved node is unchanged.
+- Review sequencing still uses a separate `.review-mutation.lock`; this slice
+  did not collapse review and state serialization into one broader primitive.
+- This slice added targeted regression coverage, not the broader
+  archive/evidence/status concurrency scenarios suggested as future hardening.
+
+### Follow-Up Issues
+
+- #56 Add broader concurrency coverage for archive, reopen, evidence, and
+  status runstate updates
+- #57 Evaluate whether review and state mutations should share one lock
+  primitive
+- #58 Consider skipping no-op current_node cache writes in harness status

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -73,6 +73,18 @@ Every command must have complete `--help` text that explains:
 Skills may refer to `harness --help` or `harness <subcommand> --help`, but the
 CLI should remain understandable without repository-specific prompt text.
 
+### Crash-Safe Runstate Writes
+
+Commands that rewrite CLI-owned JSON runstate must protect those files against
+interrupted or overlapping writes.
+
+- write `.local/harness/current-plan.json` and any plan-local `state.json`
+  through atomic replacement in the destination directory
+- acquire a shared per-plan state-mutation lock before loading and rewriting
+  `.local/harness/plans/<plan-stem>/state.json`
+- fail with a clear contention error when that state lock is already held
+  instead of waiting silently or risking a stale overwrite
+
 ## Shared Output Envelope
 
 Stateful commands should return an envelope shaped like:
@@ -294,6 +306,10 @@ Contract:
   step, keep the current node stable, preserve a conservative warning, and
   steer the controller toward repairing artifacts or rerunning the relevant
   step-closeout review instead of silently trusting older clean passes
+- when refreshing the cached `current_node`, acquire the shared per-plan state
+  lock before loading and rewriting `state.json`; if another command is already
+  mutating local state, return a clear contention error instead of risking a
+  stale cache overwrite
 
 Recommended next action examples:
 

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -43,6 +43,20 @@ Agents do not set `current_node` directly. The CLI resolves it from tracked
 plan content plus command-owned artifacts and may cache the latest answer in a
 thin CLI-owned `state.json`.
 
+### Safe Local Persistence
+
+CLI-owned runstate files must stay parseable even when commands run close
+together or a process exits during persistence.
+
+- `.local/harness/current-plan.json` must be written with atomic replacement
+  rather than in-place overwrite writes
+- `.local/harness/plans/<plan-stem>/state.json` must also use atomic
+  replacement
+- any command that mutates a plan-local `state.json` must acquire a shared
+  per-plan state-mutation lock before it loads and rewrites that file
+- if the per-plan state lock is already held, the command should fail with a
+  clear error rather than waiting silently or risking a stale overwrite
+
 ### Durable Plan, Disposable Runtime
 
 Tracked plans remain the durable source of scope, step closeout, and archive
@@ -96,6 +110,10 @@ root
 - land entry and land completion milestones
 - the thin `state.json` cache containing the latest resolved `current_node`
   plus latest artifact pointers
+
+These CLI-owned JSON artifacts are disposable runtime state, but they still
+need crash-safe persistence so the controller can trust `harness status` after
+any interrupted or overlapping command.
 
 ### Agents Must Not Directly Edit
 

--- a/internal/evidence/service.go
+++ b/internal/evidence/service.go
@@ -114,11 +114,12 @@ type SyncRecord struct {
 
 func (s Service) Submit(kind string, inputBytes []byte) Result {
 	now := s.now().Format(time.RFC3339)
-	planPath, relPlanPath, planStem, state, statePath, result := s.loadCurrentArchivedPlan()
+	planPath, relPlanPath, planStem, state, statePath, release, result := s.loadCurrentArchivedPlan()
 	if result != nil {
 		result.Command = "evidence submit"
 		return *result
 	}
+	defer release()
 
 	kind = strings.TrimSpace(strings.ToLower(kind))
 	switch kind {
@@ -490,10 +491,30 @@ func writeJSONFile(path string, value any) error {
 	return os.WriteFile(path, data, 0o644)
 }
 
-func (s Service) loadCurrentArchivedPlan() (string, string, string, *runstate.State, string, *Result) {
+func (s Service) loadCurrentArchivedPlan() (string, string, string, *runstate.State, string, func(), *Result) {
+	release := func() {}
 	planPath, err := plan.DetectCurrentPath(s.Workdir)
 	if err != nil {
-		return "", "", "", nil, "", &Result{
+		return "", "", "", nil, "", release, &Result{
+			OK:      false,
+			Summary: "Unable to determine the current plan.",
+			Errors:  []CommandError{{Path: "plan", Message: err.Error()}},
+		}
+	}
+	planStem := strings.TrimSuffix(filepath.Base(planPath), filepath.Ext(planPath))
+	release, err = runstate.AcquireStateMutationLock(s.Workdir, planStem)
+	if err != nil {
+		return "", "", "", nil, "", func() {}, &Result{
+			OK:      false,
+			Summary: "Another local state mutation is already in progress.",
+			Errors:  []CommandError{{Path: "state", Message: err.Error()}},
+		}
+	}
+
+	planPath, err = plan.DetectCurrentPathLocked(s.Workdir, planStem)
+	if err != nil {
+		release()
+		return "", "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Unable to determine the current plan.",
 			Errors:  []CommandError{{Path: "plan", Message: err.Error()}},
@@ -501,16 +522,17 @@ func (s Service) loadCurrentArchivedPlan() (string, string, string, *runstate.St
 	}
 	doc, err := plan.LoadFile(planPath)
 	if err != nil {
-		return "", "", "", nil, "", &Result{
+		release()
+		return "", "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Unable to read the current plan.",
 			Errors:  []CommandError{{Path: "plan", Message: err.Error()}},
 		}
 	}
-	planStem := strings.TrimSuffix(filepath.Base(planPath), filepath.Ext(planPath))
 	relPlanPath, err := filepath.Rel(s.Workdir, planPath)
 	if err != nil {
-		return "", "", "", nil, "", &Result{
+		release()
+		return "", "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Unable to relativize the current plan path.",
 			Errors:  []CommandError{{Path: "plan", Message: err.Error()}},
@@ -519,14 +541,16 @@ func (s Service) loadCurrentArchivedPlan() (string, string, string, *runstate.St
 	relPlanPath = filepath.ToSlash(relPlanPath)
 	state, statePath, err := runstate.LoadState(s.Workdir, planStem)
 	if err != nil {
-		return "", "", "", nil, "", &Result{
+		release()
+		return "", "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Unable to read local harness state.",
 			Errors:  []CommandError{{Path: "state", Message: err.Error()}},
 		}
 	}
 	if doc.DerivedPlanStatus() != "archived" || doc.DerivedLifecycle(state) != "awaiting_merge_approval" {
-		return "", "", "", nil, "", &Result{
+		release()
+		return "", "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Evidence commands require the current archived candidate.",
 			Errors: []CommandError{{
@@ -539,7 +563,8 @@ func (s Service) loadCurrentArchivedPlan() (string, string, string, *runstate.St
 		(state.Land != nil &&
 			strings.TrimSpace(state.Land.LandedAt) != "" &&
 			strings.TrimSpace(state.Land.CompletedAt) == "")) {
-		return "", "", "", nil, "", &Result{
+		release()
+		return "", "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Evidence commands are not allowed after merge confirmation enters land cleanup.",
 			Errors: []CommandError{{
@@ -548,7 +573,7 @@ func (s Service) loadCurrentArchivedPlan() (string, string, string, *runstate.St
 			}},
 		}
 	}
-	return planPath, relPlanPath, planStem, state, statePath, nil
+	return planPath, relPlanPath, planStem, state, statePath, release, nil
 }
 
 func (s Service) now() time.Time {

--- a/internal/evidence/service_test.go
+++ b/internal/evidence/service_test.go
@@ -208,6 +208,31 @@ func TestSubmitEvidenceRejectsLandInProgress(t *testing.T) {
 	}
 }
 
+func TestSubmitEvidenceRejectsWhenStateMutationLockIsHeld(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	release, err := runstate.AcquireStateMutationLock(root, "2026-03-21-evidence-plan")
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	result := evidence.Service{Workdir: root}.Submit("ci", []byte(`{"status":"success"}`))
+	if result.OK {
+		t.Fatalf("expected state-lock contention failure, got %#v", result)
+	}
+	if result.Summary != "Another local state mutation is already in progress." {
+		t.Fatalf("unexpected summary: %#v", result)
+	}
+	if len(result.Errors) != 1 || result.Errors[0].Path != "state" {
+		t.Fatalf("unexpected errors: %#v", result.Errors)
+	}
+}
+
 func writeArchivedPlan(t *testing.T, root, relPath string) string {
 	t.Helper()
 	return writePlan(t, root, relPath, "Archived Evidence Plan")

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -59,11 +59,12 @@ type editablePlan struct {
 
 func (s Service) ExecuteStart() Result {
 	now := s.now()
-	_, doc, _, planStem, relCurrentPath, state, statePath, result := s.loadCurrentPlan()
+	_, doc, _, planStem, relCurrentPath, state, statePath, release, result := s.loadCurrentPlan()
 	if result != nil {
 		result.Command = "execute start"
 		return *result
 	}
+	defer release()
 
 	if doc.DerivedPlanStatus() != "active" {
 		return errorResult("execute start", "Current plan is not active.", []CommandError{{
@@ -133,11 +134,12 @@ func (s Service) ExecuteStart() Result {
 
 func (s Service) Archive() Result {
 	now := s.now()
-	currentPath, doc, editable, planStem, relCurrentPath, state, statePath, result := s.loadCurrentPlan()
+	currentPath, doc, editable, planStem, relCurrentPath, state, statePath, release, result := s.loadCurrentPlan()
 	if result != nil {
 		result.Command = "archive"
 		return *result
 	}
+	defer release()
 	if doc.DerivedPlanStatus() != "active" || doc.DerivedLifecycle(state) != "executing" {
 		return errorResult("archive", "Current plan is not archive-ready.", []CommandError{{
 			Path:    "plan.lifecycle",
@@ -244,11 +246,12 @@ func (s Service) Archive() Result {
 
 func (s Service) Reopen(mode string) Result {
 	now := s.now()
-	currentPath, doc, editable, planStem, relCurrentPath, state, statePath, result := s.loadCurrentPlan()
+	currentPath, doc, editable, planStem, relCurrentPath, state, statePath, release, result := s.loadCurrentPlan()
 	if result != nil {
 		result.Command = "reopen"
 		return *result
 	}
+	defer release()
 	if doc.DerivedPlanStatus() != "archived" || doc.DerivedLifecycle(state) != "awaiting_merge_approval" {
 		return errorResult("reopen", "Current plan is not archived.", []CommandError{{
 			Path:    "plan.lifecycle",
@@ -380,11 +383,12 @@ func (s Service) Reopen(mode string) Result {
 
 func (s Service) Land(prURL, commit string) Result {
 	now := s.now()
-	currentPath, doc, _, planStem, relCurrentPath, state, statePath, result := s.loadCurrentPlan()
+	currentPath, doc, _, planStem, relCurrentPath, state, statePath, release, result := s.loadCurrentPlan()
 	if result != nil {
 		result.Command = "land"
 		return *result
 	}
+	defer release()
 	if doc.DerivedPlanStatus() != "archived" || doc.DerivedLifecycle(state) != "awaiting_merge_approval" {
 		return errorResult("land", "Current plan is not archived.", []CommandError{{
 			Path:    "plan.lifecycle",
@@ -496,11 +500,12 @@ func (s Service) Land(prURL, commit string) Result {
 
 func (s Service) LandComplete() Result {
 	now := s.now()
-	currentPath, doc, _, planStem, relCurrentPath, state, statePath, result := s.loadCurrentPlan()
+	currentPath, doc, _, planStem, relCurrentPath, state, statePath, release, result := s.loadCurrentPlan()
 	if result != nil {
 		result.Command = "land complete"
 		return *result
 	}
+	defer release()
 	if doc.DerivedPlanStatus() != "archived" || doc.DerivedLifecycle(state) != "awaiting_merge_approval" {
 		return errorResult("land complete", "Current plan is not archived.", []CommandError{{
 			Path:    "plan.lifecycle",
@@ -551,10 +556,29 @@ func (s Service) LandComplete() Result {
 	}
 }
 
-func (s Service) loadCurrentPlan() (string, *plan.Document, *editablePlan, string, string, *runstate.State, string, *Result) {
+func (s Service) loadCurrentPlan() (string, *plan.Document, *editablePlan, string, string, *runstate.State, string, func(), *Result) {
+	release := func() {}
 	currentPath, err := plan.DetectCurrentPath(s.Workdir)
 	if err != nil {
-		return "", nil, nil, "", "", nil, "", &Result{
+		return "", nil, nil, "", "", nil, "", release, &Result{
+			OK:      false,
+			Summary: "Unable to determine the current plan.",
+			Errors:  []CommandError{{Path: "plan", Message: err.Error()}},
+		}
+	}
+	planStem := strings.TrimSuffix(filepath.Base(currentPath), filepath.Ext(currentPath))
+	release, err = runstate.AcquireStateMutationLock(s.Workdir, planStem)
+	if err != nil {
+		return "", nil, nil, "", "", nil, "", func() {}, &Result{
+			OK:      false,
+			Summary: "Another local state mutation is already in progress.",
+			Errors:  []CommandError{{Path: "state", Message: err.Error()}},
+		}
+	}
+	currentPath, err = plan.DetectCurrentPathLocked(s.Workdir, planStem)
+	if err != nil {
+		release()
+		return "", nil, nil, "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Unable to determine the current plan.",
 			Errors:  []CommandError{{Path: "plan", Message: err.Error()}},
@@ -562,7 +586,8 @@ func (s Service) loadCurrentPlan() (string, *plan.Document, *editablePlan, strin
 	}
 	doc, err := plan.LoadFile(currentPath)
 	if err != nil {
-		return "", nil, nil, "", "", nil, "", &Result{
+		release()
+		return "", nil, nil, "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Unable to read the current plan.",
 			Errors:  []CommandError{{Path: "plan", Message: err.Error()}},
@@ -570,16 +595,17 @@ func (s Service) loadCurrentPlan() (string, *plan.Document, *editablePlan, strin
 	}
 	editable, err := loadEditablePlan(currentPath)
 	if err != nil {
-		return "", nil, nil, "", "", nil, "", &Result{
+		release()
+		return "", nil, nil, "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Unable to load the editable plan representation.",
 			Errors:  []CommandError{{Path: "plan", Message: err.Error()}},
 		}
 	}
-	planStem := strings.TrimSuffix(filepath.Base(currentPath), filepath.Ext(currentPath))
 	relCurrentPath, err := filepath.Rel(s.Workdir, currentPath)
 	if err != nil {
-		return "", nil, nil, "", "", nil, "", &Result{
+		release()
+		return "", nil, nil, "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Unable to relativize the current plan path.",
 			Errors:  []CommandError{{Path: "path", Message: err.Error()}},
@@ -588,13 +614,14 @@ func (s Service) loadCurrentPlan() (string, *plan.Document, *editablePlan, strin
 	relCurrentPath = filepath.ToSlash(relCurrentPath)
 	state, statePath, err := runstate.LoadState(s.Workdir, planStem)
 	if err != nil {
-		return "", nil, nil, "", "", nil, "", &Result{
+		release()
+		return "", nil, nil, "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Unable to read local harness state.",
 			Errors:  []CommandError{{Path: "state", Message: err.Error()}},
 		}
 	}
-	return currentPath, doc, editable, planStem, relCurrentPath, state, statePath, nil
+	return currentPath, doc, editable, planStem, relCurrentPath, state, statePath, release, nil
 }
 
 func loadEditablePlan(path string) (*editablePlan, error) {

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -192,6 +192,29 @@ func TestExecuteStartIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestExecuteStartRejectsWhenStateMutationLockIsHeld(t *testing.T) {
+	root := t.TempDir()
+	activeRelPath := "docs/plans/active/2026-03-18-execute-start-locked.md"
+	writeFile(t, filepath.Join(root, activeRelPath), buildAwaitingPlan(t, "Execute Start Locked"))
+
+	release, err := runstate.AcquireStateMutationLock(root, "2026-03-18-execute-start-locked")
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	result := lifecycle.Service{Workdir: root}.ExecuteStart()
+	if result.OK {
+		t.Fatalf("expected execute start failure while state lock is held, got %#v", result)
+	}
+	if result.Summary != "Another local state mutation is already in progress." {
+		t.Fatalf("unexpected summary: %#v", result)
+	}
+	if len(result.Errors) != 1 || result.Errors[0].Path != "state" {
+		t.Fatalf("unexpected errors: %#v", result.Errors)
+	}
+}
+
 func TestExecuteStartRollsBackWhenCurrentPlanWriteFails(t *testing.T) {
 	root := t.TempDir()
 	activeRelPath := "docs/plans/active/2026-03-18-execute-start-rollback.md"

--- a/internal/plan/current.go
+++ b/internal/plan/current.go
@@ -56,6 +56,18 @@ func DetectCurrentPath(workdir string) (string, error) {
 	return "", ErrNoCurrentPlan
 }
 
+func DetectCurrentPathLocked(workdir, lockedPlanStem string) (string, error) {
+	currentPath, err := DetectCurrentPath(workdir)
+	if err != nil {
+		return "", err
+	}
+	currentStem := strings.TrimSuffix(filepath.Base(currentPath), filepath.Ext(currentPath))
+	if currentStem != strings.TrimSpace(lockedPlanStem) {
+		return "", fmt.Errorf("current plan changed from %q to %q while acquiring the local state lock; retry", lockedPlanStem, currentStem)
+	}
+	return currentPath, nil
+}
+
 func containsPath(paths []string, target string) bool {
 	for _, path := range paths {
 		if filepath.Clean(path) == target {

--- a/internal/plan/current_test.go
+++ b/internal/plan/current_test.go
@@ -74,6 +74,36 @@ func TestDetectCurrentPathDoesNotFallBackToArchivedPlanWithoutPointer(t *testing
 	}
 }
 
+func TestDetectCurrentPathLockedAllowsSameStem(t *testing.T) {
+	root := t.TempDir()
+	activePath := filepath.Join(root, "docs", "plans", "active", "2026-03-18-first.md")
+	writeTestFile(t, activePath)
+
+	got, err := DetectCurrentPathLocked(root, "2026-03-18-first")
+	if err != nil {
+		t.Fatalf("DetectCurrentPathLocked: %v", err)
+	}
+	if got != activePath {
+		t.Fatalf("expected %s, got %s", activePath, got)
+	}
+}
+
+func TestDetectCurrentPathLockedRejectsStemChange(t *testing.T) {
+	root := t.TempDir()
+	activePathA := filepath.Join(root, "docs", "plans", "active", "2026-03-18-first.md")
+	activePathB := filepath.Join(root, "docs", "plans", "active", "2026-03-18-second.md")
+	writeTestFile(t, activePathA)
+	writeTestFile(t, activePathB)
+
+	if _, err := runstate.SaveCurrentPlan(root, filepath.ToSlash(filepath.Join("docs", "plans", "active", "2026-03-18-second.md"))); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	if _, err := DetectCurrentPathLocked(root, "2026-03-18-first"); err == nil {
+		t.Fatal("expected DetectCurrentPathLocked to reject stem change")
+	}
+}
+
 func writeTestFile(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -187,6 +187,17 @@ func (s Service) Start(specBytes []byte) StartResult {
 			Errors:  []CommandError{{Path: "review", Message: err.Error()}},
 		}
 	}
+	planStem := strings.TrimSuffix(filepath.Base(lockedPlanPath), filepath.Ext(lockedPlanPath))
+	releaseState, err := runstate.AcquireStateMutationLock(s.Workdir, planStem)
+	if err != nil {
+		return StartResult{
+			OK:      false,
+			Command: "review start",
+			Summary: "Another local state mutation is already in progress.",
+			Errors:  []CommandError{{Path: "state", Message: err.Error()}},
+		}
+	}
+	defer releaseState()
 
 	now := s.now()
 	planPath, doc, planStem, relPlanPath, state, statePath, errResult := s.loadCurrentExecutingPlan(lockedPlanPath)
@@ -473,6 +484,17 @@ func (s Service) Aggregate(roundID string) AggregateResult {
 			Errors:  []CommandError{{Path: "review", Message: err.Error()}},
 		}
 	}
+	planStem := strings.TrimSuffix(filepath.Base(lockedPlanPath), filepath.Ext(lockedPlanPath))
+	releaseState, err := runstate.AcquireStateMutationLock(s.Workdir, planStem)
+	if err != nil {
+		return AggregateResult{
+			OK:      false,
+			Command: "review aggregate",
+			Summary: "Another local state mutation is already in progress.",
+			Errors:  []CommandError{{Path: "state", Message: err.Error()}},
+		}
+	}
+	defer releaseState()
 
 	_, _, planStem, _, state, statePath, errResult := s.loadCurrentExecutingPlan(lockedPlanPath)
 	if errResult != nil {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -399,6 +399,34 @@ func TestStartRejectsWhenReviewMutationLockIsHeld(t *testing.T) {
 	assertStartError(t, result, "review")
 }
 
+func TestStartRejectsWhenStateMutationLockIsHeld(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-03-18-review-contract"
+	writeExecutingPlan(t, root, "docs/plans/active/"+planStem+".md")
+	release, err := runstate.AcquireStateMutationLock(root, planStem)
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	svc := review.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 1, 0, 0, 0, time.UTC)
+		},
+	}
+	result := svc.Start(mustJSON(t, review.Spec{
+		Kind: "delta",
+		Dimensions: []review.Dimension{
+			{Name: "correctness", Instructions: "Check correctness."},
+		},
+	}))
+	if result.OK {
+		t.Fatalf("expected start failure while state lock is held, got %#v", result)
+	}
+	assertStartError(t, result, "state")
+}
+
 func TestAggregateRejectsWhenReviewMutationLockIsHeld(t *testing.T) {
 	root := t.TempDir()
 	planStem := "2026-03-18-review-contract"
@@ -435,6 +463,49 @@ func TestAggregateRejectsWhenReviewMutationLockIsHeld(t *testing.T) {
 	assertAggregateError(t, result, "review")
 	if _, err := os.Stat(filepath.Join(root, ".local", "harness", "plans", planStem, "reviews", start.Artifacts.RoundID, "aggregate.json")); !os.IsNotExist(err) {
 		t.Fatalf("expected no aggregate artifact while lock is held, got %v", err)
+	}
+}
+
+func TestAggregateRejectsWhenStateMutationLockIsHeld(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-03-18-review-contract"
+	writeExecutingPlan(t, root, "docs/plans/active/"+planStem+".md")
+
+	svc := review.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 1, 0, 0, 0, time.UTC)
+		},
+	}
+	start := svc.Start(mustJSON(t, review.Spec{
+		Kind: "delta",
+		Dimensions: []review.Dimension{
+			{Name: "correctness", Instructions: "Check correctness."},
+		},
+	}))
+	if !start.OK {
+		t.Fatalf("start failed: %#v", start)
+	}
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+		Summary: "Looks good.",
+	}))
+	if !submit.OK {
+		t.Fatalf("submit failed: %#v", submit)
+	}
+
+	release, err := runstate.AcquireStateMutationLock(root, planStem)
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	result := svc.Aggregate(start.Artifacts.RoundID)
+	if result.OK {
+		t.Fatalf("expected aggregate failure while state lock is held, got %#v", result)
+	}
+	assertAggregateError(t, result, "state")
+	if _, err := os.Stat(filepath.Join(root, ".local", "harness", "plans", planStem, "reviews", start.Artifacts.RoundID, "aggregate.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no aggregate artifact while state lock is held, got %v", err)
 	}
 }
 

--- a/internal/runstate/state.go
+++ b/internal/runstate/state.go
@@ -2,11 +2,15 @@ package runstate
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
+
+var renameFile = os.Rename
 
 type CurrentPlan struct {
 	PlanPath           string `json:"plan_path,omitempty"`
@@ -128,7 +132,7 @@ func saveCurrentPlan(workdir string, current CurrentPlan) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal current-plan.json: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := writeJSONAtomic(path, data, 0o644); err != nil {
 		return "", err
 	}
 	return path, nil
@@ -159,10 +163,79 @@ func SaveState(workdir, planStem string, state *State) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal state.json: %w", err)
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := writeJSONAtomic(path, data, 0o644); err != nil {
 		return "", err
 	}
 	return path, nil
+}
+
+func AcquireStateMutationLock(workdir, planStem string) (func(), error) {
+	return acquirePlanFileLock(workdir, planStem, ".state-mutation.lock",
+		fmt.Sprintf("another command is already mutating local state for plan %q; retry after it finishes", planStem))
+}
+
+func writeJSONAtomic(path string, data []byte, perm os.FileMode) (err error) {
+	dir := filepath.Dir(path)
+	tempFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	defer func() {
+		if err == nil {
+			return
+		}
+		_ = tempFile.Close()
+		_ = os.Remove(tempPath)
+	}()
+
+	if err := tempFile.Chmod(perm); err != nil {
+		return err
+	}
+	if _, err := tempFile.Write(data); err != nil {
+		return err
+	}
+	if err := tempFile.Sync(); err != nil {
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := renameFile(tempPath, path); err != nil {
+		return err
+	}
+
+	dirFile, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer dirFile.Close()
+	if err := dirFile.Sync(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func acquirePlanFileLock(workdir, planStem, lockFileName, contentionMessage string) (func(), error) {
+	lockPath := filepath.Join(workdir, ".local", "harness", "plans", planStem, lockFileName)
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, errors.New(contentionMessage)
+		}
+		return nil, err
+	}
+	return func() {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+	}, nil
 }
 
 func CurrentRevision(state *State) int {

--- a/internal/runstate/state_test.go
+++ b/internal/runstate/state_test.go
@@ -1,0 +1,129 @@
+package runstate
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveCurrentPlanWritesExactJSON(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".local", "harness", "current-plan.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir current plan dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"plan_path":"old","last_landed_plan_path":"stale-trailing-bytes-should-disappear"}`), 0o644); err != nil {
+		t.Fatalf("seed current-plan.json: %v", err)
+	}
+
+	savedPath, err := SaveCurrentPlan(root, "docs/plans/active/example.md")
+	if err != nil {
+		t.Fatalf("SaveCurrentPlan: %v", err)
+	}
+	if savedPath != path {
+		t.Fatalf("saved path = %q, want %q", savedPath, path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read current-plan.json: %v", err)
+	}
+	want, err := json.MarshalIndent(CurrentPlan{PlanPath: "docs/plans/active/example.md"}, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal expected current plan: %v", err)
+	}
+	if string(data) != string(want) {
+		t.Fatalf("current-plan.json mismatch:\n got: %s\nwant: %s", data, want)
+	}
+}
+
+func TestSaveStateWritesExactJSON(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-03-26-atomic-save"
+	path := filepath.Join(root, ".local", "harness", "plans", planStem, "state.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"current_node":"execution/step-999/review","plan_path":"stale","plan_stem":"old","revision":999}`), 0o644); err != nil {
+		t.Fatalf("seed state.json: %v", err)
+	}
+
+	state := &State{
+		CurrentNode: "execution/step-1/implement",
+		PlanPath:    "docs/plans/active/example.md",
+		PlanStem:    planStem,
+		Revision:    1,
+	}
+	savedPath, err := SaveState(root, planStem, state)
+	if err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	if savedPath != path {
+		t.Fatalf("saved path = %q, want %q", savedPath, path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read state.json: %v", err)
+	}
+	want, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal expected state: %v", err)
+	}
+	if string(data) != string(want) {
+		t.Fatalf("state.json mismatch:\n got: %s\nwant: %s", data, want)
+	}
+
+	loaded, _, err := LoadState(root, planStem)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if loaded == nil {
+		t.Fatalf("LoadState returned nil state")
+	}
+	if loaded.CurrentNode != state.CurrentNode || loaded.PlanPath != state.PlanPath || loaded.PlanStem != state.PlanStem || loaded.Revision != state.Revision {
+		t.Fatalf("loaded state = %#v, want %#v", loaded, state)
+	}
+}
+
+func TestWriteJSONAtomicPreservesOriginalFileWhenRenameFails(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".local", "harness", "current-plan.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir current plan dir: %v", err)
+	}
+	original := []byte(`{"plan_path":"docs/plans/active/original.md"}`)
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatalf("seed current-plan.json: %v", err)
+	}
+
+	restoreRename := renameFile
+	renameFile = func(_, _ string) error {
+		return errors.New("rename failed")
+	}
+	defer func() {
+		renameFile = restoreRename
+	}()
+
+	if err := writeJSONAtomic(path, []byte(`{"plan_path":"docs/plans/active/new.md"}`), 0o644); err == nil {
+		t.Fatal("expected writeJSONAtomic to fail when rename fails")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read current-plan.json: %v", err)
+	}
+	if string(data) != string(original) {
+		t.Fatalf("expected original file to remain intact, got %s", data)
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("read current plan dir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "current-plan.json" {
+		t.Fatalf("expected failed atomic write to clean up temp files, got %#v", entries)
+	}
+}

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -147,6 +147,31 @@ func (s Service) Read() Result {
 		}
 	}
 
+	planStem := strings.TrimSuffix(filepath.Base(planPath), filepath.Ext(planPath))
+	release, err := runstate.AcquireStateMutationLock(s.Workdir, planStem)
+	if err != nil {
+		return Result{
+			OK:      false,
+			Command: "status",
+			Summary: "Another local state mutation is already in progress.",
+			Artifacts: &Artifacts{
+				PlanPath: planPath,
+			},
+			Errors: []StatusError{{Path: "state", Message: err.Error()}},
+		}
+	}
+	defer release()
+
+	planPath, err = plan.DetectCurrentPathLocked(s.Workdir, planStem)
+	if err != nil {
+		return Result{
+			OK:      false,
+			Command: "status",
+			Summary: "Unable to determine the current plan.",
+			Errors:  []StatusError{{Path: "plan", Message: err.Error()}},
+		}
+	}
+
 	doc, err := plan.LoadFile(planPath)
 	if err != nil {
 		return Result{
@@ -159,8 +184,6 @@ func (s Service) Read() Result {
 			Errors: []StatusError{{Path: "plan", Message: err.Error()}},
 		}
 	}
-
-	planStem := strings.TrimSuffix(filepath.Base(planPath), filepath.Ext(planPath))
 	state, statePath, err := runstate.LoadState(s.Workdir, planStem)
 	if err != nil {
 		return Result{

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -79,6 +79,30 @@ func TestStatusExecutionStepImplementNode(t *testing.T) {
 	}
 }
 
+func TestStatusRejectsWhenStateMutationLockIsHeld(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
+		return content
+	})
+
+	release, err := runstate.AcquireStateMutationLock(root, "2026-03-18-status-plan")
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	result := status.Service{Workdir: root}.Read()
+	if result.OK {
+		t.Fatalf("expected status failure while state lock is held, got %#v", result)
+	}
+	if result.Summary != "Another local state mutation is already in progress." {
+		t.Fatalf("unexpected summary: %#v", result)
+	}
+	if len(result.Errors) != 1 || result.Errors[0].Path != "state" {
+		t.Fatalf("unexpected errors: %#v", result.Errors)
+	}
+}
+
 func TestStatusIgnoresNonStructuralReviewFactsForCurrentStep(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {


### PR DESCRIPTION
## Summary

- make `state.json` and `current-plan.json` use atomic replacement writes
- add a shared fail-fast per-plan state lock for `state.json` mutations
- add regression coverage and spec updates for the new runstate guarantees

## Validation

- `go test ./internal/plan ./internal/runstate ./internal/status ./internal/evidence ./internal/lifecycle ./internal/review`
- `go test ./...`

Fixes #51

Follow-up issues: #56, #57, #58
