### PR TITLE
Fix release namespace workflow dispatch compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
           EASYHARNESS_RUN_LIVE_GH_SMOKE: "1"
           EASYHARNESS_LIVE_GH_REPO: ${{ github.repository }}
           EASYHARNESS_LIVE_GH_TAG: ${{ steps.release-version.outputs.version }}
+          EASYHARNESS_LIVE_GH_ASSET: easyharness_${{ steps.release-version.outputs.version }}_linux_amd64.zip
         run: go test ./tests/smoke -run TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled -count=1
 
       - name: Render Homebrew formula


### PR DESCRIPTION
## Summary
- add the legacy `EASYHARNESS_LIVE_GH_ASSET` env to the release namespace verification step
- keep the current multi-asset smoke path intact while making workflow-dispatch compatible with the observed runner expectation

## Validation
- go test ./tests/smoke -run 'TestReleaseWorkflowWiresHomebrewTapPublishing|TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled' -count=1

## Context
A `workflow_dispatch` rerun for `v0.1.0-alpha.5` failed in the `Verify published release namespace` step before the Homebrew tap update could run. This patch restores compatibility so the release backfill can proceed.
