### PR TITLE
[codex] Lower Go baseline to 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Supported alpha release targets are:
 - `linux/arm64`
 
 Contributors should use the Go toolchain recorded in `go.mod`, which is
-currently `go 1.26.0`.
+currently `go 1.25.0`.
 
 Typical verification flow:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -84,4 +84,4 @@ The formula name remains `easyharness`, while the installed binary remains
 ## Contributor Baseline
 
 Release and CI jobs use the Go version recorded in `go.mod`, which is currently
-`go 1.26.0`.
+`go 1.25.0`.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/catu-ai/easyharness
 
-go 1.26.0
+go 1.25.0
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## Summary
- lower the declared Go module baseline from 1.26.0 to 1.25.0
- update contributor and release docs to match the new baseline
- keep CI and release workflows following `go.mod`

## Why
Issue #8 asks us to make an explicit baseline decision and verify whether 1.26-only features are actually required. The codebase and test suite still work on Go 1.25, so keeping the lower baseline gives wider source-build compatibility without changing behavior.

## Validation
- `go test ./...`
- `GOTOOLCHAIN=go1.25.4 go test ./...`

Closes #8.
