### PR TITLE
Generate user-facing harness contract schemas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,8 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Check generated schemas
+        run: scripts/update-schemas --check
+
       - name: Run tests
         run: go test ./...

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ step.
 
 High-level guidance lives in [AGENTS.md](./AGENTS.md). The durable contracts
 for plans and CLI behavior live in [docs/specs/index.md](./docs/specs/index.md).
+Generated JSON Schema references for command and local JSON surfaces live in
+[docs/schemas/](./docs/schemas/).
 Execution detail for agents lives in `.agents/skills/`.
 
 ## Repository Layout
@@ -181,6 +183,7 @@ Execution detail for agents lives in `.agents/skills/`.
 - `internal/`: CLI implementation
 - `docs/plans/`: tracked plans
 - `docs/specs/`: durable repo contracts
+- `docs/schemas/`: generated JSON Schema references for command and local JSON surfaces
 - `.agents/skills/`: repo-local workflow skills
 - `.local/harness/`: disposable runtime state, current-plan/last-landed
   markers, review artifacts, evidence artifacts, and trajectory

--- a/cmd/schemagen/main.go
+++ b/cmd/schemagen/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/catu-ai/easyharness/internal/contracts"
+)
+
+func main() {
+	outputDir := flag.String("output-dir", "docs/schemas", "Directory to write generated JSON Schemas into.")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "Usage: schemagen [--output-dir <dir>]")
+		os.Exit(2)
+	}
+	if err := contracts.GenerateSchemaFiles(*outputDir); err != nil {
+		fmt.Fprintf(os.Stderr, "generate schemas: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/plans/archived/2026-03-30-generated-contract-schemas.md
+++ b/docs/plans/archived/2026-03-30-generated-contract-schemas.md
@@ -1,0 +1,345 @@
+---
+template_version: 0.2.0
+created_at: "2026-03-30T23:45:08+08:00"
+source_type: issue
+source_refs:
+    - '#72'
+---
+
+# Make harness contracts discoverable through generated schemas
+
+## Goal
+
+Make the current harness command and local-artifact contracts discoverable as
+checked-in JSON Schema files that users, docs, and downstream tools can inspect
+without reverse-engineering Go structs or prose specs.
+
+This slice should reduce field-level source-of-truth drift by treating Go
+contract types as the canonical definition for JSON payload shapes, exporting
+schemas from those types into the repository, and updating spec docs to point
+readers at the generated schema artifacts rather than duplicating field tables
+by hand. The slice must not change existing command behavior or rewrite the
+workflow model.
+
+## Scope
+
+### In Scope
+
+- Identify the user-facing JSON surfaces that should be published in a first
+  schema set, including stateful command results, command JSON inputs, and
+  command-owned local JSON artifacts.
+- Introduce a single Go-owned contract layer that existing command
+  implementations can use or alias without changing their runtime behavior.
+- Add an automated schema-generation path that exports checked-in JSON Schema
+  files under `docs/schemas/`.
+- Update tracked docs so specs explain semantics and workflow rules while
+  linking to the generated schemas for field-level detail.
+- Add reproducibility and drift checks so schema files stay aligned with the Go
+  contract definitions over time.
+
+### Out of Scope
+
+- Changing the meaning, sequencing, or validation behavior of existing harness
+  commands.
+- Redesigning the v0.2 workflow, canonical node model, or tracked plan
+  lifecycle.
+- Converting the markdown tracked-plan document itself into a JSON-schema-first
+  artifact.
+- Normalizing legacy output shapes such as lifecycle command envelopes in the
+  same slice unless that falls out as a no-behavior-change refactor needed to
+  share contract types.
+
+## Acceptance Criteria
+
+- [x] A checked-in schema set exists under `docs/schemas/` for the selected
+      first-class JSON surfaces, and those files are generated from Go-owned
+      contract types rather than handwritten as a separate field-definition
+      source.
+- [x] The generated schema set covers at least the current stateful command
+      result envelopes plus the JSON input or artifact shapes that users or
+      tooling are expected to inspect directly, without changing the current
+      wire behavior of those commands.
+- [x] `docs/specs/cli-contract.md` and related spec entry points describe
+      command semantics and workflow rules while pointing readers to the schema
+      files for exact field-level structure instead of restating those fields in
+      prose tables.
+- [x] A single automated regeneration path exists, and repository validation
+      fails when the checked-in schema files drift from the Go contract
+      definitions.
+- [x] Focused automated coverage proves the generator output is reproducible and
+      that representative command payloads or fixtures still satisfy the
+      exported schemas.
+
+## Deferred Items
+
+- Publishing schemas as release assets or serving them from a versioned hosted
+  docs site.
+- Replacing all runtime JSON decoding with schema-driven validation in the same
+  slice.
+- Any follow-up contract cleanup that intentionally changes current command
+  shapes to remove legacy fields or improve consistency.
+
+## Work Breakdown
+
+### Step 1: Define the Go-owned public contract surface and schema generator
+
+- Done: [x]
+
+#### Objective
+
+Establish a single Go contract layer for the selected public JSON surfaces and
+add the generator that can export those contracts as JSON Schema files.
+
+#### Details
+
+This step should answer the key source-of-truth question in code: which Go
+types now define the public JSON surfaces, and how existing command packages
+reuse or reference those types without changing command behavior. The selected
+surface should include the shared result-envelope building blocks where they
+already exist, command-specific payloads that users submit directly, and local
+artifact records that users or tools are expected to inspect. The generator
+should be repo-local and deterministic so later CI or tests can rerun it
+without hand edits.
+
+#### Expected Files
+
+- `go.mod`
+- `internal/contracts/`
+- `cmd/schemagen/main.go`
+- `internal/status/service.go`
+- `internal/review/service.go`
+- `internal/evidence/service.go`
+- `internal/lifecycle/service.go`
+- `internal/plan/lint.go`
+
+#### Validation
+
+- The repository has one clear Go-owned location for the exported command or
+  artifact contracts selected for this slice.
+- Running the schema generator produces deterministic output for those
+  contracts without requiring manual edits to the generated files.
+- Existing command behavior remains unchanged aside from any harmless import or
+  type-sharing refactors needed to point implementations at the shared
+  contracts.
+
+#### Execution Notes
+
+Added a new `internal/contracts/` package that centralizes the exported JSON
+contract types for status, lifecycle, review, evidence, plan lint, and
+runstate artifacts without changing the current wire shapes. Existing service
+and runstate packages now alias those shared contract types instead of owning
+independent copies.
+
+Added `cmd/schemagen` plus `contracts.GenerateSchemaFiles`, and pinned
+`github.com/google/jsonschema-go` in `go.mod` so the repository can export
+checked-in JSON Schemas directly from the Go-owned contract layer.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This contract-layer extraction is tightly coupled to the
+generated schema publishing and drift-check work in Steps 2 and 3, so a
+separate Step 1 review would have duplicated the later review pass over the
+fully wired slice.
+
+### Step 2: Publish checked-in schemas and point specs at them
+
+- Done: [x]
+
+#### Objective
+
+Generate the initial checked-in schema set and make the tracked docs use those
+artifacts as the field-level reference surface.
+
+#### Details
+
+Keep the docs focused on semantics, ownership, workflow, and non-obvious
+constraints. They should link to the generated schema files instead of copying
+field lists into prose. The checked-in schema set should be organized so a cold
+reader can find the relevant command result, command input, or local artifact
+schema without reading generator code first.
+
+#### Expected Files
+
+- `docs/schemas/`
+- `docs/specs/index.md`
+- `docs/specs/cli-contract.md`
+- `README.md`
+
+#### Validation
+
+- A reader starting from the specs can navigate directly to the generated schema
+  files for exact field-level structure.
+- The schema file names and layout are clear enough that downstream tooling can
+  consume them without guessing which file corresponds to which command surface.
+- No spec doc reintroduces a second handwritten field-definition source for the
+  same JSON surface.
+
+#### Execution Notes
+
+Generated the first checked-in schema set under `docs/schemas/` for command
+results, structured command inputs, and command-owned local JSON artifacts.
+Added `docs/schemas/index.md` and updated the CLI/spec entry points so docs now
+link to the generated schema files for field-level detail instead of growing
+more handwritten field tables.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 only becomes meaningful together with the
+generator and drift-check wiring from Steps 1 and 3, so a standalone review at
+this boundary would have been an incomplete contract scan.
+
+### Step 3: Automate regeneration and drift checks
+
+- Done: [x]
+
+#### Objective
+
+Make schema generation part of the normal repository workflow so checked-in
+schemas stay synchronized with the Go contract layer.
+
+#### Details
+
+Add one obvious regeneration entry point, such as `go generate` support, a repo
+script, or both, and wire repository validation to fail when generated schema
+artifacts are stale. Favor the lightest mechanism that fits the current repo:
+`go test ./...` already runs in CI, so the drift check can live in tests, CI,
+or both, as long as a contributor gets a clear failure and a single command to
+repair it.
+
+#### Expected Files
+
+- `scripts/update-schemas`
+- `.github/workflows/ci.yml`
+- `internal/contracts/`
+- `tests/`
+
+#### Validation
+
+- There is one documented command for regenerating the schema files locally.
+- CI or test validation catches schema drift deterministically.
+- Focused automated coverage proves representative generated schemas are
+  reproducible and that representative command outputs or fixtures still conform
+  to them.
+
+#### Execution Notes
+
+Added a single regeneration path through `scripts/update-schemas` plus a
+`go:generate` directive on `internal/contracts/schemas.go`. Added contract
+tests that compare regenerated schemas to the checked-in files and validate
+representative payloads against those exported schemas. CI now runs
+`scripts/update-schemas --check` before `go test ./...`.
+
+Follow-up review repairs made the schema index generated from the same contract
+registry as the `.schema.json` files, restored full-tree drift checking, and
+made regeneration replace stale files so renames or removals do not leave dead
+schemas behind.
+
+#### Review Notes
+
+Step-closeout review `review-001-delta` found one important issue: the schema
+index could drift because it was hand-maintained and excluded from the
+drift-check path. Follow-up review `review-002-delta` then found one more
+important issue: regeneration did not remove stale files after schema renames
+or deletions. Repaired both problems by generating `docs/schemas/index.md`
+from the contract registry and by clearing the output tree before regeneration.
+Follow-up review `review-003-delta` reran clean with a pass decision.
+
+## Validation Strategy
+
+- Run `harness plan lint` on the tracked plan before execution starts.
+- Add focused Go tests around the new contract or schema-generation package so
+  generator output and schema loading are deterministic.
+- Validate representative command outputs or stored fixture payloads against the
+  exported schemas without changing runtime command semantics.
+- Run `go test ./...` once the slice is ready so the new generator, shared
+  types, and drift checks are exercised in the existing repository test path.
+
+## Risks
+
+- Risk: The slice could accidentally create a fourth source of truth by keeping
+  the old per-package structs, the new shared contract types, handwritten docs,
+  and generated schemas all alive at once.
+  - Mitigation: Treat the shared Go contract layer as the only field-level
+    source, generate schemas from it, and update docs to link to those schemas
+    instead of duplicating field tables.
+- Risk: A cleanup refactor could quietly change command payload shapes while
+  trying to centralize contract types.
+  - Mitigation: Keep acceptance criteria explicit about no behavior changes and
+    add schema/fixture validation that proves current command shapes still hold.
+- Risk: Schema generation could become cumbersome if contributors have to
+  remember multiple ad hoc commands.
+  - Mitigation: Provide one obvious regeneration path and enforce drift through
+    deterministic repository validation.
+
+## Validation Summary
+
+- `harness plan lint docs/plans/active/2026-03-30-generated-contract-schemas.md`
+  passed after each major tracked-plan update.
+- `scripts/update-schemas` and `scripts/update-schemas --check` now pass with
+  generated `.schema.json` files plus the generated `docs/schemas/index.md`.
+- Focused package validation passed for the extracted contract layer and schema
+  automation: `go test ./internal/contracts ./internal/status
+  ./internal/evidence ./internal/review ./internal/lifecycle ./internal/plan
+  ./internal/runstate ./internal/cli`.
+- Repository-level validation passed with `go test ./...`.
+- Follow-up repair validation after review findings passed with
+  `go test ./internal/contracts ./internal/cli ./tests/smoke -count=1`, plus
+  the final full-suite run of `go test ./...`.
+
+## Review Summary
+
+- Step-closeout review `review-001-delta` found one important issue: the schema
+  index was hand-maintained and excluded from drift checking.
+- Follow-up review `review-002-delta` found one important issue: regeneration
+  left stale generated files behind after schema removals or renames.
+- Follow-up review `review-003-delta` reran the bounded repair clean with a
+  pass decision.
+- Finalize full review `review-004-full` passed on `correctness`, `tests`, and
+  `docs_consistency` with no findings.
+
+## Archive Summary
+
+- Archived At: 2026-03-31T00:43:59+08:00
+- Revision: 1
+- PR: NONE. Publish evidence should record the PR URL after archive.
+- Ready: `review-004-full` passed as the pre-archive full review, all tracked
+  steps are complete, acceptance criteria are satisfied, and the branch now
+  leaves the repository with generated contract schemas, a generated schema
+  index, and drift checks that cover stale-file cleanup as well as index drift.
+- Merge Handoff: Run `harness archive`, commit the archive move plus the
+  contract/schema/docs/test changes, push the branch, open the PR, then record
+  publish, CI, and sync evidence until status reaches merge approval.
+
+## Outcome Summary
+
+### Delivered
+
+- Added a new Go-owned `internal/contracts` layer for command results, command
+  inputs, and command-owned local JSON artifacts without changing the existing
+  wire behavior.
+- Added `cmd/schemagen`, `scripts/update-schemas`, and a `go:generate`
+  directive so the repository can regenerate checked-in schemas from the shared
+  contract registry.
+- Generated the initial schema set under `docs/schemas/`, including command
+  result envelopes, structured inputs, runstate artifacts, review artifacts,
+  and evidence artifacts.
+- Made `docs/schemas/index.md` generated from the same registry as the schema
+  files so schema discovery and drift checking stay in sync.
+- Added contract-level regression tests plus CI drift checking for generated
+  schemas, including stale-file cleanup coverage.
+- Updated README and spec entry points to reference generated schemas instead
+  of growing more handwritten field-definition docs.
+
+### Not Delivered
+
+- Generated schemas are not yet published outside the repository checkout or
+  attached to release artifacts.
+- Runtime schema-driven validation was intentionally deferred; the current
+  candidate keeps the existing Go validation paths.
+- Remaining legacy/public-shape cleanup, including any future lifecycle-result
+  convergence work, was intentionally deferred to a follow-up slice.
+
+### Follow-Up Issues
+
+- #74: Publish generated schema references outside the repository.
+- #75: Evaluate schema-driven validation and remaining contract cleanup.

--- a/docs/plans/archived/2026-03-30-generated-contract-schemas.md
+++ b/docs/plans/archived/2026-03-30-generated-contract-schemas.md
@@ -285,6 +285,8 @@ Follow-up review `review-003-delta` reran clean with a pass decision.
 - Follow-up repair validation after review findings passed with
   `go test ./internal/contracts ./internal/cli ./tests/smoke -count=1`, plus
   the final full-suite run of `go test ./...`.
+- After reopening in `finalize-fix` mode for sync freshness, the branch merged
+  `origin/main` cleanly and reran `go test ./...` on revision 2.
 
 ## Review Summary
 
@@ -296,19 +298,23 @@ Follow-up review `review-003-delta` reran clean with a pass decision.
   pass decision.
 - Finalize full review `review-004-full` passed on `correctness`, `tests`, and
   `docs_consistency` with no findings.
+- After sync-driven reopen to revision 2, finalize delta review
+  `review-005-delta` found one blocker: the reopened plan still carried stale
+  reopen sentinel markers in the durable summary sections.
+- Follow-up finalize delta review `review-006-delta` reran clean with a pass
+  decision after the revision 2 durable summary sections were refreshed.
 
 ## Archive Summary
 
-- Archived At: 2026-03-31T00:43:59+08:00
-- Revision: 1
-- PR: NONE. Publish evidence should record the PR URL after archive.
-- Ready: `review-004-full` passed as the pre-archive full review, all tracked
-  steps are complete, acceptance criteria are satisfied, and the branch now
-  leaves the repository with generated contract schemas, a generated schema
-  index, and drift checks that cover stale-file cleanup as well as index drift.
-- Merge Handoff: Run `harness archive`, commit the archive move plus the
-  contract/schema/docs/test changes, push the branch, open the PR, then record
-  publish, CI, and sync evidence until status reaches merge approval.
+- Archived At: 2026-03-31T00:52:59+08:00
+- Revision: 2
+- PR: https://github.com/catu-ai/easyharness/pull/76
+- Ready: The revision 2 candidate merged the narrow `origin/main` baseline
+  change cleanly, reran `go test ./...`, and passed `review-006-delta` as the
+  finalize repair review, so the reopened candidate is ready to archive again.
+- Merge Handoff: Re-archive the plan, push the updated branch to PR #76, and
+  refresh publish, CI, and sync evidence until status reaches merge approval
+  again.
 
 ## Outcome Summary
 

--- a/docs/schemas/artifacts/evidence.ci.record.schema.json
+++ b/docs/schemas/artifacts/evidence.ci.record.schema.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "properties": {
+    "record_id": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "plan_path": {
+      "type": "string"
+    },
+    "plan_stem": {
+      "type": "string"
+    },
+    "revision": {
+      "type": "integer"
+    },
+    "recorded_at": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "provider": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "record_id",
+    "kind",
+    "plan_path",
+    "plan_stem",
+    "revision",
+    "recorded_at",
+    "status"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/artifacts/evidence.publish.record.schema.json
+++ b/docs/schemas/artifacts/evidence.publish.record.schema.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "properties": {
+    "record_id": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "plan_path": {
+      "type": "string"
+    },
+    "plan_stem": {
+      "type": "string"
+    },
+    "revision": {
+      "type": "integer"
+    },
+    "recorded_at": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "pr_url": {
+      "type": "string"
+    },
+    "branch": {
+      "type": "string"
+    },
+    "base": {
+      "type": "string"
+    },
+    "commit": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "record_id",
+    "kind",
+    "plan_path",
+    "plan_stem",
+    "revision",
+    "recorded_at",
+    "status"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/artifacts/evidence.sync.record.schema.json
+++ b/docs/schemas/artifacts/evidence.sync.record.schema.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "properties": {
+    "record_id": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "plan_path": {
+      "type": "string"
+    },
+    "plan_stem": {
+      "type": "string"
+    },
+    "revision": {
+      "type": "integer"
+    },
+    "recorded_at": {
+      "type": "string"
+    },
+    "status": {
+      "type": "string"
+    },
+    "base_ref": {
+      "type": "string"
+    },
+    "head_ref": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "record_id",
+    "kind",
+    "plan_path",
+    "plan_stem",
+    "revision",
+    "recorded_at",
+    "status"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/artifacts/review.aggregate.schema.json
+++ b/docs/schemas/artifacts/review.aggregate.schema.json
@@ -1,0 +1,107 @@
+{
+  "type": "object",
+  "properties": {
+    "round_id": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "step": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "revision": {
+      "type": "integer"
+    },
+    "review_title": {
+      "type": "string"
+    },
+    "decision": {
+      "type": "string"
+    },
+    "blocking_findings": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "slot": {
+            "type": "string"
+          },
+          "dimension": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "details": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "slot",
+          "dimension",
+          "severity",
+          "title",
+          "details"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "non_blocking_findings": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "slot": {
+            "type": "string"
+          },
+          "dimension": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "details": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "slot",
+          "dimension",
+          "severity",
+          "title",
+          "details"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "aggregated_at": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "round_id",
+    "kind",
+    "revision",
+    "decision",
+    "blocking_findings",
+    "non_blocking_findings",
+    "aggregated_at"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/artifacts/review.ledger.schema.json
+++ b/docs/schemas/artifacts/review.ledger.schema.json
@@ -1,0 +1,54 @@
+{
+  "type": "object",
+  "properties": {
+    "round_id": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string"
+    },
+    "slots": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "slot": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "submission_path": {
+            "type": "string"
+          },
+          "submitted_at": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "slot",
+          "status",
+          "submission_path"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "round_id",
+    "kind",
+    "updated_at",
+    "slots"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/artifacts/review.manifest.schema.json
+++ b/docs/schemas/artifacts/review.manifest.schema.json
@@ -1,0 +1,84 @@
+{
+  "type": "object",
+  "properties": {
+    "round_id": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string"
+    },
+    "step": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "revision": {
+      "type": "integer"
+    },
+    "review_title": {
+      "type": "string"
+    },
+    "plan_path": {
+      "type": "string"
+    },
+    "plan_stem": {
+      "type": "string"
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "dimensions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "slot": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "submission_path": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "slot",
+          "instructions",
+          "submission_path"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "ledger_path": {
+      "type": "string"
+    },
+    "aggregate_path": {
+      "type": "string"
+    },
+    "submissions_dir": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "round_id",
+    "kind",
+    "revision",
+    "plan_path",
+    "plan_stem",
+    "created_at",
+    "dimensions",
+    "ledger_path",
+    "aggregate_path",
+    "submissions_dir"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/artifacts/review.submission.schema.json
+++ b/docs/schemas/artifacts/review.submission.schema.json
@@ -1,0 +1,55 @@
+{
+  "type": "object",
+  "properties": {
+    "round_id": {
+      "type": "string"
+    },
+    "slot": {
+      "type": "string"
+    },
+    "dimension": {
+      "type": "string"
+    },
+    "submitted_at": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "details": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "severity",
+          "title",
+          "details"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "round_id",
+    "slot",
+    "dimension",
+    "submitted_at",
+    "summary",
+    "findings"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/artifacts/runstate.current-plan.schema.json
+++ b/docs/schemas/artifacts/runstate.current-plan.schema.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "plan_path": {
+      "type": "string"
+    },
+    "last_landed_plan_path": {
+      "type": "string"
+    },
+    "last_landed_at": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/artifacts/runstate.state.schema.json
+++ b/docs/schemas/artifacts/runstate.state.schema.json
@@ -1,0 +1,242 @@
+{
+  "type": "object",
+  "properties": {
+    "execution_started_at": {
+      "type": "string"
+    },
+    "current_node": {
+      "type": "string"
+    },
+    "plan_path": {
+      "type": "string"
+    },
+    "plan_stem": {
+      "type": "string"
+    },
+    "revision": {
+      "type": "integer"
+    },
+    "reopen": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string"
+        },
+        "reopened_at": {
+          "type": "string"
+        },
+        "base_step_count": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "mode"
+      ],
+      "additionalProperties": false
+    },
+    "active_review_round": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "round_id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "step": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "revision": {
+          "type": "integer"
+        },
+        "aggregated": {
+          "type": "boolean"
+        },
+        "decision": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "round_id",
+        "kind",
+        "aggregated"
+      ],
+      "additionalProperties": false
+    },
+    "latest_evidence": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "ci": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "recorded_at": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "record_id",
+            "path"
+          ],
+          "additionalProperties": false
+        },
+        "publish": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "recorded_at": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "record_id",
+            "path"
+          ],
+          "additionalProperties": false
+        },
+        "sync": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "record_id": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "recorded_at": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "record_id",
+            "path"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "land": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "pr_url": {
+          "type": "string"
+        },
+        "commit": {
+          "type": "string"
+        },
+        "landed_at": {
+          "type": "string"
+        },
+        "completed_at": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "latest_ci": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "snapshot_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "snapshot_id",
+        "status"
+      ],
+      "additionalProperties": false
+    },
+    "sync": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "freshness": {
+          "type": "string"
+        },
+        "conflicts": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "freshness",
+        "conflicts"
+      ],
+      "additionalProperties": false
+    },
+    "latest_publish": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "attempt_id": {
+          "type": "string"
+        },
+        "pr_url": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "attempt_id",
+        "pr_url"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/commands/evidence.submit.result.schema.json
+++ b/docs/schemas/commands/evidence.submit.result.schema.json
@@ -1,0 +1,98 @@
+{
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "artifacts": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "plan_path": {
+          "type": "string"
+        },
+        "local_state_path": {
+          "type": "string"
+        },
+        "record_id": {
+          "type": "string"
+        },
+        "record_path": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "plan_path",
+        "record_id",
+        "record_path",
+        "kind"
+      ],
+      "additionalProperties": false
+    },
+    "next_actions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "command",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "errors": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "ok",
+    "command",
+    "summary",
+    "next_actions"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/commands/lifecycle.result.schema.json
+++ b/docs/schemas/commands/lifecycle.result.schema.json
@@ -1,0 +1,114 @@
+{
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "state": {
+      "type": "object",
+      "properties": {
+        "plan_status": {
+          "type": "string"
+        },
+        "lifecycle": {
+          "type": "string"
+        },
+        "revision": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "plan_status",
+        "lifecycle",
+        "revision"
+      ],
+      "additionalProperties": false
+    },
+    "artifacts": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "from_plan_path": {
+          "type": "string"
+        },
+        "to_plan_path": {
+          "type": "string"
+        },
+        "local_state_path": {
+          "type": "string"
+        },
+        "current_plan_path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "from_plan_path",
+        "to_plan_path"
+      ],
+      "additionalProperties": false
+    },
+    "next_actions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "command",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "errors": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "ok",
+    "command",
+    "summary",
+    "state",
+    "next_actions"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/commands/plan.lint.result.schema.json
+++ b/docs/schemas/commands/plan.lint.result.schema.json
@@ -1,0 +1,57 @@
+{
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "artifacts": {
+      "type": "object",
+      "properties": {
+        "plan_path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "plan_path"
+      ],
+      "additionalProperties": false
+    },
+    "supported_template_version": {
+      "type": "string"
+    },
+    "errors": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "ok",
+    "command",
+    "summary"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/commands/review.aggregate.result.schema.json
+++ b/docs/schemas/commands/review.aggregate.result.schema.json
@@ -1,0 +1,201 @@
+{
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "artifacts": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "round_id": {
+          "type": "string"
+        },
+        "aggregate_path": {
+          "type": "string"
+        },
+        "local_state_path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "round_id",
+        "aggregate_path",
+        "local_state_path"
+      ],
+      "additionalProperties": false
+    },
+    "review": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "round_id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "step": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "revision": {
+          "type": "integer"
+        },
+        "review_title": {
+          "type": "string"
+        },
+        "decision": {
+          "type": "string"
+        },
+        "blocking_findings": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "slot": {
+                "type": "string"
+              },
+              "dimension": {
+                "type": "string"
+              },
+              "severity": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "details": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "slot",
+              "dimension",
+              "severity",
+              "title",
+              "details"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "non_blocking_findings": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "slot": {
+                "type": "string"
+              },
+              "dimension": {
+                "type": "string"
+              },
+              "severity": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "details": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "slot",
+              "dimension",
+              "severity",
+              "title",
+              "details"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "aggregated_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "round_id",
+        "kind",
+        "revision",
+        "decision",
+        "blocking_findings",
+        "non_blocking_findings",
+        "aggregated_at"
+      ],
+      "additionalProperties": false
+    },
+    "next_actions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "command",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "errors": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "ok",
+    "command",
+    "summary",
+    "next_actions"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/commands/review.start.result.schema.json
+++ b/docs/schemas/commands/review.start.result.schema.json
@@ -1,0 +1,134 @@
+{
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "artifacts": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "plan_path": {
+          "type": "string"
+        },
+        "local_state_path": {
+          "type": "string"
+        },
+        "round_id": {
+          "type": "string"
+        },
+        "manifest_path": {
+          "type": "string"
+        },
+        "ledger_path": {
+          "type": "string"
+        },
+        "aggregate_path": {
+          "type": "string"
+        },
+        "slots": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "slot": {
+                "type": "string"
+              },
+              "instructions": {
+                "type": "string"
+              },
+              "submission_path": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "slot",
+              "instructions",
+              "submission_path"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "plan_path",
+        "local_state_path",
+        "round_id",
+        "manifest_path",
+        "ledger_path",
+        "aggregate_path",
+        "slots"
+      ],
+      "additionalProperties": false
+    },
+    "next_actions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "command",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "errors": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "ok",
+    "command",
+    "summary",
+    "next_actions"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/commands/review.submit.result.schema.json
+++ b/docs/schemas/commands/review.submit.result.schema.json
@@ -1,0 +1,95 @@
+{
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "artifacts": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "round_id": {
+          "type": "string"
+        },
+        "slot": {
+          "type": "string"
+        },
+        "submission_path": {
+          "type": "string"
+        },
+        "ledger_path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "round_id",
+        "slot",
+        "submission_path",
+        "ledger_path"
+      ],
+      "additionalProperties": false
+    },
+    "next_actions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "command",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "errors": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "ok",
+    "command",
+    "summary",
+    "next_actions"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/commands/status.result.schema.json
+++ b/docs/schemas/commands/status.result.schema.json
@@ -1,0 +1,196 @@
+{
+  "type": "object",
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    },
+    "command": {
+      "type": "string"
+    },
+    "summary": {
+      "type": "string"
+    },
+    "state": {
+      "type": "object",
+      "properties": {
+        "current_node": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "current_node"
+      ],
+      "additionalProperties": false
+    },
+    "facts": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "current_step": {
+          "type": "string"
+        },
+        "revision": {
+          "type": "integer"
+        },
+        "reopen_mode": {
+          "type": "string"
+        },
+        "review_kind": {
+          "type": "string"
+        },
+        "review_trigger": {
+          "type": "string"
+        },
+        "review_title": {
+          "type": "string"
+        },
+        "review_status": {
+          "type": "string"
+        },
+        "archive_blocker_count": {
+          "type": "integer"
+        },
+        "publish_status": {
+          "type": "string"
+        },
+        "pr_url": {
+          "type": "string"
+        },
+        "ci_status": {
+          "type": "string"
+        },
+        "sync_status": {
+          "type": "string"
+        },
+        "land_pr_url": {
+          "type": "string"
+        },
+        "land_commit": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "artifacts": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "plan_path": {
+          "type": "string"
+        },
+        "local_state_path": {
+          "type": "string"
+        },
+        "review_round_id": {
+          "type": "string"
+        },
+        "ci_record_id": {
+          "type": "string"
+        },
+        "publish_record_id": {
+          "type": "string"
+        },
+        "sync_record_id": {
+          "type": "string"
+        },
+        "last_landed_plan_path": {
+          "type": "string"
+        },
+        "last_landed_at": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "next_actions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "command",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "blockers": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "warnings": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "errors": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "message"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "ok",
+    "command",
+    "summary",
+    "state",
+    "next_actions"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/index.md
+++ b/docs/schemas/index.md
@@ -1,0 +1,41 @@
+# Generated Schemas
+
+This file is generated from the Go-owned contract types in `internal/contracts/`.
+Do not edit the schema files or this index by hand.
+
+Regenerate them with:
+
+```bash
+scripts/update-schemas
+```
+
+## Commands
+
+- [commands/evidence.submit.result.schema.json](./commands/evidence.submit.result.schema.json)
+- [commands/lifecycle.result.schema.json](./commands/lifecycle.result.schema.json)
+- [commands/plan.lint.result.schema.json](./commands/plan.lint.result.schema.json)
+- [commands/review.aggregate.result.schema.json](./commands/review.aggregate.result.schema.json)
+- [commands/review.start.result.schema.json](./commands/review.start.result.schema.json)
+- [commands/review.submit.result.schema.json](./commands/review.submit.result.schema.json)
+- [commands/status.result.schema.json](./commands/status.result.schema.json)
+
+## Inputs
+
+- [inputs/evidence.ci.schema.json](./inputs/evidence.ci.schema.json)
+- [inputs/evidence.publish.schema.json](./inputs/evidence.publish.schema.json)
+- [inputs/evidence.sync.schema.json](./inputs/evidence.sync.schema.json)
+- [inputs/review.spec.schema.json](./inputs/review.spec.schema.json)
+- [inputs/review.submission.schema.json](./inputs/review.submission.schema.json)
+
+## Artifacts
+
+- [artifacts/evidence.ci.record.schema.json](./artifacts/evidence.ci.record.schema.json)
+- [artifacts/evidence.publish.record.schema.json](./artifacts/evidence.publish.record.schema.json)
+- [artifacts/evidence.sync.record.schema.json](./artifacts/evidence.sync.record.schema.json)
+- [artifacts/review.aggregate.schema.json](./artifacts/review.aggregate.schema.json)
+- [artifacts/review.ledger.schema.json](./artifacts/review.ledger.schema.json)
+- [artifacts/review.manifest.schema.json](./artifacts/review.manifest.schema.json)
+- [artifacts/review.submission.schema.json](./artifacts/review.submission.schema.json)
+- [artifacts/runstate.current-plan.schema.json](./artifacts/runstate.current-plan.schema.json)
+- [artifacts/runstate.state.schema.json](./artifacts/runstate.state.schema.json)
+

--- a/docs/schemas/inputs/evidence.ci.schema.json
+++ b/docs/schemas/inputs/evidence.ci.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string"
+    },
+    "provider": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "status"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/inputs/evidence.publish.schema.json
+++ b/docs/schemas/inputs/evidence.publish.schema.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string"
+    },
+    "pr_url": {
+      "type": "string"
+    },
+    "branch": {
+      "type": "string"
+    },
+    "base": {
+      "type": "string"
+    },
+    "commit": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "status"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/inputs/evidence.sync.schema.json
+++ b/docs/schemas/inputs/evidence.sync.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string"
+    },
+    "base_ref": {
+      "type": "string"
+    },
+    "head_ref": {
+      "type": "string"
+    },
+    "reason": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "status"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/inputs/review.spec.schema.json
+++ b/docs/schemas/inputs/review.spec.schema.json
@@ -1,0 +1,44 @@
+{
+  "type": "object",
+  "properties": {
+    "step": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "kind": {
+      "type": "string"
+    },
+    "review_title": {
+      "type": "string"
+    },
+    "dimensions": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "instructions"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "kind",
+    "dimensions"
+  ],
+  "additionalProperties": false
+}

--- a/docs/schemas/inputs/review.submission.schema.json
+++ b/docs/schemas/inputs/review.submission.schema.json
@@ -1,0 +1,39 @@
+{
+  "type": "object",
+  "properties": {
+    "summary": {
+      "type": "string"
+    },
+    "findings": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "severity": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "details": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "severity",
+          "title",
+          "details"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "summary",
+    "findings"
+  ],
+  "additionalProperties": false
+}

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -12,6 +12,11 @@ JSON envelopes described here assume the canonical-node runtime model from
 [State Model](./state-model.md) and the exact transition matrix from
 [State Transitions](./state-transitions.md).
 
+Generated JSON Schema references for the current command and local-artifact
+surfaces live under [docs/schemas/](../schemas/index.md). This spec focuses on
+workflow semantics, ownership, and command behavior; the schema files are the
+field-level reference for the exported JSON shapes.
+
 ## Command Surface
 
 The current command surface is:
@@ -251,6 +256,10 @@ Purpose:
 
 - validate a plan against the tracked-plan schema
 
+Schema reference:
+
+- [Plan lint result](../schemas/commands/plan.lint.result.schema.json)
+
 Contract:
 
 - stop with targeted structural errors instead of guessing or silently fixing
@@ -312,6 +321,12 @@ Contract:
   mutating local state, return a clear contention error instead of risking a
   stale cache overwrite
 
+Schema reference:
+
+- [Status result](../schemas/commands/status.result.schema.json)
+- [Runstate state artifact](../schemas/artifacts/runstate.state.schema.json)
+- [Runstate current-plan artifact](../schemas/artifacts/runstate.current-plan.schema.json)
+
 Recommended next action examples:
 
 - continue the current step
@@ -332,6 +347,13 @@ Purpose:
 
 - begin a deterministic review round without embedding runtime-specific agent
   spawning in the CLI
+
+Schema reference:
+
+- [Review spec input](../schemas/inputs/review.spec.schema.json)
+- [Review start result](../schemas/commands/review.start.result.schema.json)
+- [Review manifest artifact](../schemas/artifacts/review.manifest.schema.json)
+- [Review ledger artifact](../schemas/artifacts/review.ledger.schema.json)
 
 Contract:
 
@@ -449,6 +471,12 @@ Purpose:
 
 - record one reviewer result for a specific review round and reviewer slot
 
+Schema reference:
+
+- [Review submission input](../schemas/inputs/review.submission.schema.json)
+- [Review submit result](../schemas/commands/review.submit.result.schema.json)
+- [Review submission artifact](../schemas/artifacts/review.submission.schema.json)
+
 This command is primarily for reviewer subagents rather than the main
 controller agent.
 
@@ -476,6 +504,11 @@ Purpose:
 
 - aggregate a review round into a concise decision surface for the controller
   agent
+
+Schema reference:
+
+- [Review aggregate result](../schemas/commands/review.aggregate.result.schema.json)
+- [Review aggregate artifact](../schemas/artifacts/review.aggregate.schema.json)
 
 Contract:
 
@@ -535,6 +568,10 @@ Purpose:
 
 - freeze the tracked plan locally for merge handoff
 
+Schema reference:
+
+- [Lifecycle result](../schemas/commands/lifecycle.result.schema.json)
+
 Contract:
 
 - validate that the plan is active and archive-ready
@@ -593,6 +630,10 @@ Purpose:
 
 - restore an archived plan to active execution
 
+Schema reference:
+
+- [Lifecycle result](../schemas/commands/lifecycle.result.schema.json)
+
 Contract:
 
 - move the plan from `docs/plans/archived/` back to `docs/plans/active/`
@@ -619,6 +660,16 @@ Purpose:
 - record append-only publish, CI, or sync evidence for the current archived
   candidate
 
+Schema reference:
+
+- [Evidence submit result](../schemas/commands/evidence.submit.result.schema.json)
+- [CI evidence input](../schemas/inputs/evidence.ci.schema.json)
+- [Publish evidence input](../schemas/inputs/evidence.publish.schema.json)
+- [Sync evidence input](../schemas/inputs/evidence.sync.schema.json)
+- [CI evidence artifact](../schemas/artifacts/evidence.ci.record.schema.json)
+- [Publish evidence artifact](../schemas/artifacts/evidence.publish.record.schema.json)
+- [Sync evidence artifact](../schemas/artifacts/evidence.sync.record.schema.json)
+
 Contract:
 
 - require the current tracked plan to be archived before accepting evidence
@@ -637,6 +688,10 @@ Purpose:
 - record merge confirmation for the current archived candidate and enter land
   cleanup
 
+Schema reference:
+
+- [Lifecycle result](../schemas/commands/lifecycle.result.schema.json)
+
 Contract:
 
 - require the current tracked plan to still be the archived candidate
@@ -651,6 +706,10 @@ Contract:
 Purpose:
 
 - record post-merge cleanup completion and restore idle worktree state
+
+Schema reference:
+
+- [Lifecycle result](../schemas/commands/lifecycle.result.schema.json)
 
 Contract:
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -10,6 +10,8 @@
   state expectations.
 - [CLI Contract](./cli-contract.md): agent-facing command surface and JSON
   contract.
+- [Generated Schemas](../schemas/index.md): checked-in JSON Schema references
+  for user-facing command payloads and command-owned local JSON artifacts.
 
 ## Proposals
 

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -23,6 +23,9 @@ Command-owned local artifacts live under:
 - `.local/harness/plans/<plan-stem>/reviews/`
 - `.local/harness/plans/<plan-stem>/evidence/`
 
+Generated JSON Schema references for the command-owned local JSON artifacts live
+under [docs/schemas/artifacts/](../schemas/index.md).
+
 The tracked plan is the durable contract. `.local` is disposable execution
 support and trajectory.
 

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/catu-ai/easyharness
 go 1.26.0
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/google/jsonschema-go v0.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/contracts/common.go
+++ b/internal/contracts/common.go
@@ -1,0 +1,13 @@
+package contracts
+
+// JSONError is a compact machine-readable error entry returned by commands.
+type JSONError struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+// NextAction is a suggested next step for the operator or controller agent.
+type NextAction struct {
+	Command     *string `json:"command"`
+	Description string  `json:"description"`
+}

--- a/internal/contracts/evidence.go
+++ b/internal/contracts/evidence.go
@@ -1,0 +1,82 @@
+package contracts
+
+type EvidenceResult struct {
+	OK         bool               `json:"ok"`
+	Command    string             `json:"command"`
+	Summary    string             `json:"summary"`
+	Artifacts  *EvidenceArtifacts `json:"artifacts,omitempty"`
+	NextAction []NextAction       `json:"next_actions"`
+	Errors     []JSONError        `json:"errors,omitempty"`
+}
+
+type EvidenceArtifacts struct {
+	PlanPath       string `json:"plan_path"`
+	LocalStatePath string `json:"local_state_path,omitempty"`
+	RecordID       string `json:"record_id"`
+	RecordPath     string `json:"record_path"`
+	Kind           string `json:"kind"`
+}
+
+type EvidenceCIInput struct {
+	Status   string `json:"status"`
+	Provider string `json:"provider,omitempty"`
+	URL      string `json:"url,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+type EvidencePublishInput struct {
+	Status string `json:"status"`
+	PRURL  string `json:"pr_url,omitempty"`
+	Branch string `json:"branch,omitempty"`
+	Base   string `json:"base,omitempty"`
+	Commit string `json:"commit,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type EvidenceSyncInput struct {
+	Status  string `json:"status"`
+	BaseRef string `json:"base_ref,omitempty"`
+	HeadRef string `json:"head_ref,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+type EvidenceCIRecord struct {
+	RecordID   string `json:"record_id"`
+	Kind       string `json:"kind"`
+	PlanPath   string `json:"plan_path"`
+	PlanStem   string `json:"plan_stem"`
+	Revision   int    `json:"revision"`
+	RecordedAt string `json:"recorded_at"`
+	Status     string `json:"status"`
+	Provider   string `json:"provider,omitempty"`
+	URL        string `json:"url,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+type EvidencePublishRecord struct {
+	RecordID   string `json:"record_id"`
+	Kind       string `json:"kind"`
+	PlanPath   string `json:"plan_path"`
+	PlanStem   string `json:"plan_stem"`
+	Revision   int    `json:"revision"`
+	RecordedAt string `json:"recorded_at"`
+	Status     string `json:"status"`
+	PRURL      string `json:"pr_url,omitempty"`
+	Branch     string `json:"branch,omitempty"`
+	Base       string `json:"base,omitempty"`
+	Commit     string `json:"commit,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+type EvidenceSyncRecord struct {
+	RecordID   string `json:"record_id"`
+	Kind       string `json:"kind"`
+	PlanPath   string `json:"plan_path"`
+	PlanStem   string `json:"plan_stem"`
+	Revision   int    `json:"revision"`
+	RecordedAt string `json:"recorded_at"`
+	Status     string `json:"status"`
+	BaseRef    string `json:"base_ref,omitempty"`
+	HeadRef    string `json:"head_ref,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+}

--- a/internal/contracts/lifecycle.go
+++ b/internal/contracts/lifecycle.go
@@ -1,0 +1,24 @@
+package contracts
+
+type LifecycleResult struct {
+	OK         bool            `json:"ok"`
+	Command    string          `json:"command"`
+	Summary    string          `json:"summary"`
+	State      LifecycleState  `json:"state"`
+	Artifacts  *LifecyclePaths `json:"artifacts,omitempty"`
+	NextAction []NextAction    `json:"next_actions"`
+	Errors     []JSONError     `json:"errors,omitempty"`
+}
+
+type LifecycleState struct {
+	PlanStatus string `json:"plan_status"`
+	Lifecycle  string `json:"lifecycle"`
+	Revision   int    `json:"revision"`
+}
+
+type LifecyclePaths struct {
+	FromPlanPath    string `json:"from_plan_path"`
+	ToPlanPath      string `json:"to_plan_path"`
+	LocalStatePath  string `json:"local_state_path,omitempty"`
+	CurrentPlanPath string `json:"current_plan_path,omitempty"`
+}

--- a/internal/contracts/plan.go
+++ b/internal/contracts/plan.go
@@ -1,0 +1,14 @@
+package contracts
+
+type PlanLintResult struct {
+	OK                       bool              `json:"ok"`
+	Command                  string            `json:"command"`
+	Summary                  string            `json:"summary"`
+	Artifacts                PlanLintArtifacts `json:"artifacts,omitempty"`
+	SupportedTemplateVersion string            `json:"supported_template_version,omitempty"`
+	Errors                   []JSONError       `json:"errors,omitempty"`
+}
+
+type PlanLintArtifacts struct {
+	PlanPath string `json:"plan_path"`
+}

--- a/internal/contracts/review.go
+++ b/internal/contracts/review.go
@@ -1,0 +1,141 @@
+package contracts
+
+type ReviewSpec struct {
+	Step        *int              `json:"step,omitempty"`
+	Kind        string            `json:"kind"`
+	ReviewTitle string            `json:"review_title,omitempty"`
+	Dimensions  []ReviewDimension `json:"dimensions"`
+}
+
+type ReviewDimension struct {
+	Name         string `json:"name"`
+	Instructions string `json:"instructions"`
+}
+
+type ReviewManifest struct {
+	RoundID     string               `json:"round_id"`
+	Kind        string               `json:"kind"`
+	Step        *int                 `json:"step,omitempty"`
+	Revision    int                  `json:"revision"`
+	ReviewTitle string               `json:"review_title,omitempty"`
+	PlanPath    string               `json:"plan_path"`
+	PlanStem    string               `json:"plan_stem"`
+	CreatedAt   string               `json:"created_at"`
+	Dimensions  []ReviewManifestSlot `json:"dimensions"`
+	LedgerPath  string               `json:"ledger_path"`
+	Aggregate   string               `json:"aggregate_path"`
+	Submissions string               `json:"submissions_dir"`
+}
+
+type ReviewManifestSlot struct {
+	Name           string `json:"name"`
+	Slot           string `json:"slot"`
+	Instructions   string `json:"instructions"`
+	SubmissionPath string `json:"submission_path"`
+}
+
+type ReviewLedger struct {
+	RoundID   string             `json:"round_id"`
+	Kind      string             `json:"kind"`
+	UpdatedAt string             `json:"updated_at"`
+	Slots     []ReviewLedgerSlot `json:"slots"`
+}
+
+type ReviewLedgerSlot struct {
+	Name           string `json:"name"`
+	Slot           string `json:"slot"`
+	Status         string `json:"status"`
+	SubmissionPath string `json:"submission_path"`
+	SubmittedAt    string `json:"submitted_at,omitempty"`
+}
+
+type ReviewSubmissionInput struct {
+	Summary  string          `json:"summary"`
+	Findings []ReviewFinding `json:"findings"`
+}
+
+type ReviewSubmission struct {
+	RoundID     string          `json:"round_id"`
+	Slot        string          `json:"slot"`
+	Dimension   string          `json:"dimension"`
+	SubmittedAt string          `json:"submitted_at"`
+	Summary     string          `json:"summary"`
+	Findings    []ReviewFinding `json:"findings"`
+}
+
+type ReviewFinding struct {
+	Severity string `json:"severity"`
+	Title    string `json:"title"`
+	Details  string `json:"details"`
+}
+
+type ReviewAggregate struct {
+	RoundID             string                   `json:"round_id"`
+	Kind                string                   `json:"kind"`
+	Step                *int                     `json:"step,omitempty"`
+	Revision            int                      `json:"revision"`
+	ReviewTitle         string                   `json:"review_title,omitempty"`
+	Decision            string                   `json:"decision"`
+	BlockingFindings    []ReviewAggregateFinding `json:"blocking_findings"`
+	NonBlockingFindings []ReviewAggregateFinding `json:"non_blocking_findings"`
+	AggregatedAt        string                   `json:"aggregated_at"`
+}
+
+type ReviewAggregateFinding struct {
+	Slot      string `json:"slot"`
+	Dimension string `json:"dimension"`
+	Severity  string `json:"severity"`
+	Title     string `json:"title"`
+	Details   string `json:"details"`
+}
+
+type ReviewStartResult struct {
+	OK         bool                  `json:"ok"`
+	Command    string                `json:"command"`
+	Summary    string                `json:"summary"`
+	Artifacts  *ReviewStartArtifacts `json:"artifacts,omitempty"`
+	NextAction []NextAction          `json:"next_actions"`
+	Errors     []JSONError           `json:"errors,omitempty"`
+}
+
+type ReviewStartArtifacts struct {
+	PlanPath       string               `json:"plan_path"`
+	LocalStatePath string               `json:"local_state_path"`
+	RoundID        string               `json:"round_id"`
+	ManifestPath   string               `json:"manifest_path"`
+	LedgerPath     string               `json:"ledger_path"`
+	AggregatePath  string               `json:"aggregate_path"`
+	Slots          []ReviewManifestSlot `json:"slots"`
+}
+
+type ReviewSubmitResult struct {
+	OK         bool                   `json:"ok"`
+	Command    string                 `json:"command"`
+	Summary    string                 `json:"summary"`
+	Artifacts  *ReviewSubmitArtifacts `json:"artifacts,omitempty"`
+	NextAction []NextAction           `json:"next_actions"`
+	Errors     []JSONError            `json:"errors,omitempty"`
+}
+
+type ReviewSubmitArtifacts struct {
+	RoundID        string `json:"round_id"`
+	Slot           string `json:"slot"`
+	SubmissionPath string `json:"submission_path"`
+	LedgerPath     string `json:"ledger_path"`
+}
+
+type ReviewAggregateResult struct {
+	OK         bool                      `json:"ok"`
+	Command    string                    `json:"command"`
+	Summary    string                    `json:"summary"`
+	Artifacts  *ReviewAggregateArtifacts `json:"artifacts,omitempty"`
+	Review     *ReviewAggregate          `json:"review,omitempty"`
+	NextAction []NextAction              `json:"next_actions"`
+	Errors     []JSONError               `json:"errors,omitempty"`
+}
+
+type ReviewAggregateArtifacts struct {
+	RoundID        string `json:"round_id"`
+	AggregatePath  string `json:"aggregate_path"`
+	LocalStatePath string `json:"local_state_path"`
+}

--- a/internal/contracts/runstate.go
+++ b/internal/contracts/runstate.go
@@ -1,0 +1,72 @@
+package contracts
+
+type RunstateCurrentPlan struct {
+	PlanPath           string `json:"plan_path,omitempty"`
+	LastLandedPlanPath string `json:"last_landed_plan_path,omitempty"`
+	LastLandedAt       string `json:"last_landed_at,omitempty"`
+}
+
+type RunstateState struct {
+	ExecutionStartedAt string                `json:"execution_started_at,omitempty"`
+	CurrentNode        string                `json:"current_node,omitempty"`
+	PlanPath           string                `json:"plan_path,omitempty"`
+	PlanStem           string                `json:"plan_stem,omitempty"`
+	Revision           int                   `json:"revision,omitempty"`
+	Reopen             *RunstateReopenState  `json:"reopen,omitempty"`
+	ActiveReviewRound  *RunstateReviewRound  `json:"active_review_round,omitempty"`
+	LatestEvidence     *RunstateEvidenceSet  `json:"latest_evidence,omitempty"`
+	Land               *RunstateLandState    `json:"land,omitempty"`
+	LatestCI           *RunstateCIState      `json:"latest_ci,omitempty"`
+	Sync               *RunstateSyncState    `json:"sync,omitempty"`
+	LatestPublish      *RunstatePublishState `json:"latest_publish,omitempty"`
+}
+
+type RunstateReopenState struct {
+	Mode          string `json:"mode"`
+	ReopenedAt    string `json:"reopened_at,omitempty"`
+	BaseStepCount int    `json:"base_step_count,omitempty"`
+}
+
+type RunstateReviewRound struct {
+	RoundID    string `json:"round_id"`
+	Kind       string `json:"kind"`
+	Step       *int   `json:"step,omitempty"`
+	Revision   int    `json:"revision,omitempty"`
+	Aggregated bool   `json:"aggregated"`
+	Decision   string `json:"decision,omitempty"`
+}
+
+type RunstateEvidenceSet struct {
+	CI      *RunstateEvidencePointer `json:"ci,omitempty"`
+	Publish *RunstateEvidencePointer `json:"publish,omitempty"`
+	Sync    *RunstateEvidencePointer `json:"sync,omitempty"`
+}
+
+type RunstateEvidencePointer struct {
+	Kind       string `json:"kind"`
+	RecordID   string `json:"record_id"`
+	Path       string `json:"path"`
+	RecordedAt string `json:"recorded_at,omitempty"`
+}
+
+type RunstateLandState struct {
+	PRURL       string `json:"pr_url,omitempty"`
+	Commit      string `json:"commit,omitempty"`
+	LandedAt    string `json:"landed_at,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+}
+
+type RunstateCIState struct {
+	SnapshotID string `json:"snapshot_id"`
+	Status     string `json:"status"`
+}
+
+type RunstateSyncState struct {
+	Freshness string `json:"freshness"`
+	Conflicts bool   `json:"conflicts"`
+}
+
+type RunstatePublishState struct {
+	AttemptID string `json:"attempt_id"`
+	PRURL     string `json:"pr_url"`
+}

--- a/internal/contracts/schemas.go
+++ b/internal/contracts/schemas.go
@@ -1,0 +1,120 @@
+package contracts
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+//go:generate go run ../../cmd/schemagen --output-dir ../../docs/schemas
+
+type SchemaSpec struct {
+	Path string
+	Type reflect.Type
+}
+
+func SchemaSpecs() []SchemaSpec {
+	specs := []SchemaSpec{
+		{Path: "artifacts/evidence.ci.record.schema.json", Type: typeOf[EvidenceCIRecord]()},
+		{Path: "artifacts/evidence.publish.record.schema.json", Type: typeOf[EvidencePublishRecord]()},
+		{Path: "artifacts/evidence.sync.record.schema.json", Type: typeOf[EvidenceSyncRecord]()},
+		{Path: "artifacts/review.aggregate.schema.json", Type: typeOf[ReviewAggregate]()},
+		{Path: "artifacts/review.ledger.schema.json", Type: typeOf[ReviewLedger]()},
+		{Path: "artifacts/review.manifest.schema.json", Type: typeOf[ReviewManifest]()},
+		{Path: "artifacts/review.submission.schema.json", Type: typeOf[ReviewSubmission]()},
+		{Path: "artifacts/runstate.current-plan.schema.json", Type: typeOf[RunstateCurrentPlan]()},
+		{Path: "artifacts/runstate.state.schema.json", Type: typeOf[RunstateState]()},
+		{Path: "commands/evidence.submit.result.schema.json", Type: typeOf[EvidenceResult]()},
+		{Path: "commands/lifecycle.result.schema.json", Type: typeOf[LifecycleResult]()},
+		{Path: "commands/plan.lint.result.schema.json", Type: typeOf[PlanLintResult]()},
+		{Path: "commands/review.aggregate.result.schema.json", Type: typeOf[ReviewAggregateResult]()},
+		{Path: "commands/review.start.result.schema.json", Type: typeOf[ReviewStartResult]()},
+		{Path: "commands/review.submit.result.schema.json", Type: typeOf[ReviewSubmitResult]()},
+		{Path: "commands/status.result.schema.json", Type: typeOf[StatusResult]()},
+		{Path: "inputs/evidence.ci.schema.json", Type: typeOf[EvidenceCIInput]()},
+		{Path: "inputs/evidence.publish.schema.json", Type: typeOf[EvidencePublishInput]()},
+		{Path: "inputs/evidence.sync.schema.json", Type: typeOf[EvidenceSyncInput]()},
+		{Path: "inputs/review.spec.schema.json", Type: typeOf[ReviewSpec]()},
+		{Path: "inputs/review.submission.schema.json", Type: typeOf[ReviewSubmissionInput]()},
+	}
+	slices.SortFunc(specs, func(a, b SchemaSpec) int {
+		switch {
+		case a.Path < b.Path:
+			return -1
+		case a.Path > b.Path:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return specs
+}
+
+func GenerateSchemaFiles(outputDir string) error {
+	specs := SchemaSpecs()
+	if err := os.RemoveAll(outputDir); err != nil {
+		return fmt.Errorf("reset schema output dir: %w", err)
+	}
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return fmt.Errorf("create schema output dir: %w", err)
+	}
+	for _, spec := range specs {
+		schema, err := jsonschema.ForType(spec.Type, nil)
+		if err != nil {
+			return fmt.Errorf("generate schema for %s: %w", spec.Path, err)
+		}
+		data, err := json.MarshalIndent(schema, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal schema for %s: %w", spec.Path, err)
+		}
+		target := filepath.Join(outputDir, spec.Path)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(target, append(data, '\n'), 0o644); err != nil {
+			return err
+		}
+	}
+	return writeSchemaIndex(outputDir, specs)
+}
+
+func typeOf[T any]() reflect.Type {
+	return reflect.TypeOf((*T)(nil)).Elem()
+}
+
+func writeSchemaIndex(outputDir string, specs []SchemaSpec) error {
+	indexPath := filepath.Join(outputDir, "index.md")
+	var builder strings.Builder
+	builder.WriteString("# Generated Schemas\n\n")
+	builder.WriteString("This file is generated from the Go-owned contract types in `internal/contracts/`.\n")
+	builder.WriteString("Do not edit the schema files or this index by hand.\n\n")
+	builder.WriteString("Regenerate them with:\n\n")
+	builder.WriteString("```bash\nscripts/update-schemas\n```\n\n")
+
+	groups := []struct {
+		label  string
+		prefix string
+	}{
+		{label: "Commands", prefix: "commands/"},
+		{label: "Inputs", prefix: "inputs/"},
+		{label: "Artifacts", prefix: "artifacts/"},
+	}
+	for _, group := range groups {
+		builder.WriteString("## " + group.label + "\n\n")
+		for _, spec := range specs {
+			if !strings.HasPrefix(spec.Path, group.prefix) {
+				continue
+			}
+			builder.WriteString("- [" + spec.Path + "](./" + spec.Path + ")\n")
+		}
+		builder.WriteString("\n")
+	}
+
+	return os.WriteFile(indexPath, []byte(builder.String()), 0o644)
+}

--- a/internal/contracts/schemas_test.go
+++ b/internal/contracts/schemas_test.go
@@ -1,0 +1,213 @@
+package contracts_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/catu-ai/easyharness/internal/contracts"
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+func TestGeneratedSchemasMatchCheckedInFiles(t *testing.T) {
+	root := repoRoot(t)
+	tempDir := t.TempDir()
+	if err := contracts.GenerateSchemaFiles(tempDir); err != nil {
+		t.Fatalf("generate schemas: %v", err)
+	}
+
+	got := schemaFileMap(t, tempDir)
+	want := schemaFileMap(t, filepath.Join(root, "docs", "schemas"))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("generated schemas differ from checked-in files")
+	}
+}
+
+func TestRepresentativePayloadsValidateAgainstCheckedInSchemas(t *testing.T) {
+	root := repoRoot(t)
+	tests := []struct {
+		name   string
+		schema string
+		value  any
+	}{
+		{
+			name:   "status result",
+			schema: "commands/status.result.schema.json",
+			value: contracts.StatusResult{
+				OK:      true,
+				Command: "status",
+				Summary: "Plan is ready.",
+				State:   contracts.StatusState{CurrentNode: "plan"},
+				NextAction: []contracts.NextAction{
+					{Description: "Run harness execute start."},
+				},
+			},
+		},
+		{
+			name:   "review spec",
+			schema: "inputs/review.spec.schema.json",
+			value: contracts.ReviewSpec{
+				Kind: "delta",
+				Dimensions: []contracts.ReviewDimension{
+					{Name: "correctness", Instructions: "Check contract drift."},
+				},
+			},
+		},
+		{
+			name:   "publish evidence input",
+			schema: "inputs/evidence.publish.schema.json",
+			value: contracts.EvidencePublishInput{
+				Status: "recorded",
+				PRURL:  "https://github.com/catu-ai/easyharness/pull/72",
+				Branch: "codex/issue-72-contract-schemas",
+				Base:   "main",
+			},
+		},
+		{
+			name:   "runstate state artifact",
+			schema: "artifacts/runstate.state.schema.json",
+			value: contracts.RunstateState{
+				ExecutionStartedAt: "2026-03-31T10:00:00+08:00",
+				CurrentNode:        "execution/step-1/implement",
+				PlanPath:           "docs/plans/active/2026-03-30-generated-contract-schemas.md",
+				PlanStem:           "2026-03-30-generated-contract-schemas",
+				Revision:           1,
+				ActiveReviewRound: &contracts.RunstateReviewRound{
+					RoundID:    "review-001-delta",
+					Kind:       "delta",
+					Step:       intPtr(1),
+					Revision:   1,
+					Aggregated: false,
+				},
+			},
+		},
+		{
+			name:   "review manifest artifact",
+			schema: "artifacts/review.manifest.schema.json",
+			value: contracts.ReviewManifest{
+				RoundID:     "review-001-delta",
+				Kind:        "delta",
+				Step:        intPtr(1),
+				Revision:    1,
+				ReviewTitle: "Step 1",
+				PlanPath:    "docs/plans/active/2026-03-30-generated-contract-schemas.md",
+				PlanStem:    "2026-03-30-generated-contract-schemas",
+				CreatedAt:   "2026-03-31T10:00:00+08:00",
+				Dimensions: []contracts.ReviewManifestSlot{
+					{
+						Name:           "correctness",
+						Slot:           "correctness",
+						Instructions:   "Check wire shape.",
+						SubmissionPath: ".local/harness/plans/x/reviews/review-001-delta/submissions/correctness.json",
+					},
+				},
+				LedgerPath:  ".local/harness/plans/x/reviews/review-001-delta/ledger.json",
+				Aggregate:   ".local/harness/plans/x/reviews/review-001-delta/aggregate.json",
+				Submissions: ".local/harness/plans/x/reviews/review-001-delta/submissions",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved := mustLoadResolvedSchema(t, filepath.Join(root, "docs", "schemas", tt.schema))
+			if err := resolved.Validate(toJSONValue(t, tt.value)); err != nil {
+				t.Fatalf("validate %s: %v", tt.schema, err)
+			}
+		})
+	}
+}
+
+func TestGenerateSchemaFilesRemovesStaleFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	stalePath := filepath.Join(tempDir, "commands", "stale.schema.json")
+	if err := os.MkdirAll(filepath.Dir(stalePath), 0o755); err != nil {
+		t.Fatalf("mkdir stale dir: %v", err)
+	}
+	if err := os.WriteFile(stalePath, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write stale file: %v", err)
+	}
+
+	if err := contracts.GenerateSchemaFiles(tempDir); err != nil {
+		t.Fatalf("generate schemas: %v", err)
+	}
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("expected stale schema file to be removed, got err=%v", err)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	return filepath.Clean(filepath.Join(wd, "..", ".."))
+}
+
+func schemaFileMap(t *testing.T, root string) map[string]string {
+	t.Helper()
+	files := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".json" && filepath.Base(path) != "index.md" {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return files
+}
+
+func mustLoadResolvedSchema(t *testing.T, path string) *jsonschema.Resolved {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read schema: %v", err)
+	}
+	var schema jsonschema.Schema
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	resolved, err := schema.Resolve(nil)
+	if err != nil {
+		t.Fatalf("resolve schema: %v", err)
+	}
+	return resolved
+}
+
+func toJSONValue(t *testing.T, value any) any {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal value: %v", err)
+	}
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal value: %v", err)
+	}
+	return decoded
+}
+
+func intPtr(v int) *int {
+	return &v
+}

--- a/internal/contracts/status.go
+++ b/internal/contracts/status.go
@@ -1,0 +1,46 @@
+package contracts
+
+type StatusResult struct {
+	OK         bool          `json:"ok"`
+	Command    string        `json:"command"`
+	Summary    string        `json:"summary"`
+	State      StatusState   `json:"state"`
+	Facts      *StatusFacts  `json:"facts,omitempty"`
+	Artifacts  *StatusOutput `json:"artifacts,omitempty"`
+	NextAction []NextAction  `json:"next_actions"`
+	Blockers   []JSONError   `json:"blockers,omitempty"`
+	Warnings   []string      `json:"warnings,omitempty"`
+	Errors     []JSONError   `json:"errors,omitempty"`
+}
+
+type StatusState struct {
+	CurrentNode string `json:"current_node"`
+}
+
+type StatusFacts struct {
+	CurrentStep         string `json:"current_step,omitempty"`
+	Revision            int    `json:"revision,omitempty"`
+	ReopenMode          string `json:"reopen_mode,omitempty"`
+	ReviewKind          string `json:"review_kind,omitempty"`
+	ReviewTrigger       string `json:"review_trigger,omitempty"`
+	ReviewTitle         string `json:"review_title,omitempty"`
+	ReviewStatus        string `json:"review_status,omitempty"`
+	ArchiveBlockerCount int    `json:"archive_blocker_count,omitempty"`
+	PublishStatus       string `json:"publish_status,omitempty"`
+	PRURL               string `json:"pr_url,omitempty"`
+	CIStatus            string `json:"ci_status,omitempty"`
+	SyncStatus          string `json:"sync_status,omitempty"`
+	LandPRURL           string `json:"land_pr_url,omitempty"`
+	LandCommit          string `json:"land_commit,omitempty"`
+}
+
+type StatusOutput struct {
+	PlanPath           string `json:"plan_path,omitempty"`
+	LocalStatePath     string `json:"local_state_path,omitempty"`
+	ReviewRoundID      string `json:"review_round_id,omitempty"`
+	CIRecordID         string `json:"ci_record_id,omitempty"`
+	PublishRecordID    string `json:"publish_record_id,omitempty"`
+	SyncRecordID       string `json:"sync_record_id,omitempty"`
+	LastLandedPlanPath string `json:"last_landed_plan_path,omitempty"`
+	LastLandedAt       string `json:"last_landed_at,omitempty"`
+}

--- a/internal/evidence/service.go
+++ b/internal/evidence/service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/catu-ai/easyharness/internal/contracts"
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/runstate"
 )
@@ -21,96 +22,16 @@ type Service struct {
 	Now     func() time.Time
 }
 
-type Result struct {
-	OK         bool           `json:"ok"`
-	Command    string         `json:"command"`
-	Summary    string         `json:"summary"`
-	Artifacts  *Artifacts     `json:"artifacts,omitempty"`
-	NextAction []NextAction   `json:"next_actions"`
-	Errors     []CommandError `json:"errors,omitempty"`
-}
-
-type Artifacts struct {
-	PlanPath       string `json:"plan_path"`
-	LocalStatePath string `json:"local_state_path,omitempty"`
-	RecordID       string `json:"record_id"`
-	RecordPath     string `json:"record_path"`
-	Kind           string `json:"kind"`
-}
-
-type NextAction struct {
-	Command     *string `json:"command"`
-	Description string  `json:"description"`
-}
-
-type CommandError struct {
-	Path    string `json:"path"`
-	Message string `json:"message"`
-}
-
-type CIInput struct {
-	Status   string `json:"status"`
-	Provider string `json:"provider,omitempty"`
-	URL      string `json:"url,omitempty"`
-	Reason   string `json:"reason,omitempty"`
-}
-
-type PublishInput struct {
-	Status string `json:"status"`
-	PRURL  string `json:"pr_url,omitempty"`
-	Branch string `json:"branch,omitempty"`
-	Base   string `json:"base,omitempty"`
-	Commit string `json:"commit,omitempty"`
-	Reason string `json:"reason,omitempty"`
-}
-
-type SyncInput struct {
-	Status  string `json:"status"`
-	BaseRef string `json:"base_ref,omitempty"`
-	HeadRef string `json:"head_ref,omitempty"`
-	Reason  string `json:"reason,omitempty"`
-}
-
-type CIRecord struct {
-	RecordID   string `json:"record_id"`
-	Kind       string `json:"kind"`
-	PlanPath   string `json:"plan_path"`
-	PlanStem   string `json:"plan_stem"`
-	Revision   int    `json:"revision"`
-	RecordedAt string `json:"recorded_at"`
-	Status     string `json:"status"`
-	Provider   string `json:"provider,omitempty"`
-	URL        string `json:"url,omitempty"`
-	Reason     string `json:"reason,omitempty"`
-}
-
-type PublishRecord struct {
-	RecordID   string `json:"record_id"`
-	Kind       string `json:"kind"`
-	PlanPath   string `json:"plan_path"`
-	PlanStem   string `json:"plan_stem"`
-	Revision   int    `json:"revision"`
-	RecordedAt string `json:"recorded_at"`
-	Status     string `json:"status"`
-	PRURL      string `json:"pr_url,omitempty"`
-	Branch     string `json:"branch,omitempty"`
-	Base       string `json:"base,omitempty"`
-	Commit     string `json:"commit,omitempty"`
-	Reason     string `json:"reason,omitempty"`
-}
-
-type SyncRecord struct {
-	RecordID   string `json:"record_id"`
-	Kind       string `json:"kind"`
-	PlanPath   string `json:"plan_path"`
-	PlanStem   string `json:"plan_stem"`
-	Revision   int    `json:"revision"`
-	RecordedAt string `json:"recorded_at"`
-	Status     string `json:"status"`
-	BaseRef    string `json:"base_ref,omitempty"`
-	HeadRef    string `json:"head_ref,omitempty"`
-	Reason     string `json:"reason,omitempty"`
-}
+type Result = contracts.EvidenceResult
+type Artifacts = contracts.EvidenceArtifacts
+type NextAction = contracts.NextAction
+type CommandError = contracts.JSONError
+type CIInput = contracts.EvidenceCIInput
+type PublishInput = contracts.EvidencePublishInput
+type SyncInput = contracts.EvidenceSyncInput
+type CIRecord = contracts.EvidenceCIRecord
+type PublishRecord = contracts.EvidencePublishRecord
+type SyncRecord = contracts.EvidenceSyncRecord
 
 func (s Service) Submit(kind string, inputBytes []byte) Result {
 	now := s.now().Format(time.RFC3339)

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/catu-ai/easyharness/internal/contracts"
 	"github.com/catu-ai/easyharness/internal/evidence"
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/runstate"
@@ -19,38 +20,11 @@ type Service struct {
 	Now     func() time.Time
 }
 
-type Result struct {
-	OK         bool           `json:"ok"`
-	Command    string         `json:"command"`
-	Summary    string         `json:"summary"`
-	State      State          `json:"state"`
-	Artifacts  *Artifacts     `json:"artifacts,omitempty"`
-	NextAction []NextAction   `json:"next_actions"`
-	Errors     []CommandError `json:"errors,omitempty"`
-}
-
-type State struct {
-	PlanStatus string `json:"plan_status"`
-	Lifecycle  string `json:"lifecycle"`
-	Revision   int    `json:"revision"`
-}
-
-type Artifacts struct {
-	FromPlanPath    string `json:"from_plan_path"`
-	ToPlanPath      string `json:"to_plan_path"`
-	LocalStatePath  string `json:"local_state_path,omitempty"`
-	CurrentPlanPath string `json:"current_plan_path,omitempty"`
-}
-
-type NextAction struct {
-	Command     *string `json:"command"`
-	Description string  `json:"description"`
-}
-
-type CommandError struct {
-	Path    string `json:"path"`
-	Message string `json:"message"`
-}
+type Result = contracts.LifecycleResult
+type State = contracts.LifecycleState
+type Artifacts = contracts.LifecyclePaths
+type NextAction = contracts.NextAction
+type CommandError = contracts.JSONError
 
 type editablePlan struct {
 	Frontmatter plan.Frontmatter

--- a/internal/plan/lint.go
+++ b/internal/plan/lint.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	templateassets "github.com/catu-ai/easyharness/assets/templates"
+	"github.com/catu-ai/easyharness/internal/contracts"
 	"gopkg.in/yaml.v3"
 )
 
@@ -65,23 +66,9 @@ type Frontmatter struct {
 	SourceRefs      []string `yaml:"source_refs"`
 }
 
-type LintIssue struct {
-	Path    string `json:"path"`
-	Message string `json:"message"`
-}
-
-type LintResult struct {
-	OK                       bool          `json:"ok"`
-	Command                  string        `json:"command"`
-	Summary                  string        `json:"summary"`
-	Artifacts                lintArtifacts `json:"artifacts,omitempty"`
-	SupportedTemplateVersion string        `json:"supported_template_version,omitempty"`
-	Errors                   []LintIssue   `json:"errors,omitempty"`
-}
-
-type lintArtifacts struct {
-	PlanPath string `json:"plan_path"`
-}
+type LintIssue = contracts.JSONError
+type LintResult = contracts.PlanLintResult
+type lintArtifacts = contracts.PlanLintArtifacts
 
 type lintContext struct {
 	path           string

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/catu-ai/easyharness/internal/contracts"
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/runstate"
 )
@@ -25,155 +26,25 @@ type Service struct {
 	Now     func() time.Time
 }
 
-type Spec struct {
-	Step        *int        `json:"step,omitempty"`
-	Kind        string      `json:"kind"`
-	ReviewTitle string      `json:"review_title,omitempty"`
-	Dimensions  []Dimension `json:"dimensions"`
-}
-
-type Dimension struct {
-	Name         string `json:"name"`
-	Instructions string `json:"instructions"`
-}
-
-type Manifest struct {
-	RoundID     string         `json:"round_id"`
-	Kind        string         `json:"kind"`
-	Step        *int           `json:"step,omitempty"`
-	Revision    int            `json:"revision"`
-	ReviewTitle string         `json:"review_title,omitempty"`
-	PlanPath    string         `json:"plan_path"`
-	PlanStem    string         `json:"plan_stem"`
-	CreatedAt   string         `json:"created_at"`
-	Dimensions  []ManifestSlot `json:"dimensions"`
-	LedgerPath  string         `json:"ledger_path"`
-	Aggregate   string         `json:"aggregate_path"`
-	Submissions string         `json:"submissions_dir"`
-}
-
-type ManifestSlot struct {
-	Name           string `json:"name"`
-	Slot           string `json:"slot"`
-	Instructions   string `json:"instructions"`
-	SubmissionPath string `json:"submission_path"`
-}
-
-type Ledger struct {
-	RoundID   string       `json:"round_id"`
-	Kind      string       `json:"kind"`
-	UpdatedAt string       `json:"updated_at"`
-	Slots     []LedgerSlot `json:"slots"`
-}
-
-type LedgerSlot struct {
-	Name           string `json:"name"`
-	Slot           string `json:"slot"`
-	Status         string `json:"status"`
-	SubmissionPath string `json:"submission_path"`
-	SubmittedAt    string `json:"submitted_at,omitempty"`
-}
-
-type SubmissionInput struct {
-	Summary  string    `json:"summary"`
-	Findings []Finding `json:"findings"`
-}
-
-type Submission struct {
-	RoundID     string    `json:"round_id"`
-	Slot        string    `json:"slot"`
-	Dimension   string    `json:"dimension"`
-	SubmittedAt string    `json:"submitted_at"`
-	Summary     string    `json:"summary"`
-	Findings    []Finding `json:"findings"`
-}
-
-type Finding struct {
-	Severity string `json:"severity"`
-	Title    string `json:"title"`
-	Details  string `json:"details"`
-}
-
-type Aggregate struct {
-	RoundID             string             `json:"round_id"`
-	Kind                string             `json:"kind"`
-	Step                *int               `json:"step,omitempty"`
-	Revision            int                `json:"revision"`
-	ReviewTitle         string             `json:"review_title,omitempty"`
-	Decision            string             `json:"decision"`
-	BlockingFindings    []AggregateFinding `json:"blocking_findings"`
-	NonBlockingFindings []AggregateFinding `json:"non_blocking_findings"`
-	AggregatedAt        string             `json:"aggregated_at"`
-}
-
-type AggregateFinding struct {
-	Slot      string `json:"slot"`
-	Dimension string `json:"dimension"`
-	Severity  string `json:"severity"`
-	Title     string `json:"title"`
-	Details   string `json:"details"`
-}
-
-type CommandError struct {
-	Path    string `json:"path"`
-	Message string `json:"message"`
-}
-
-type NextAction struct {
-	Command     *string `json:"command"`
-	Description string  `json:"description"`
-}
-
-type StartResult struct {
-	OK         bool            `json:"ok"`
-	Command    string          `json:"command"`
-	Summary    string          `json:"summary"`
-	Artifacts  *StartArtifacts `json:"artifacts,omitempty"`
-	NextAction []NextAction    `json:"next_actions"`
-	Errors     []CommandError  `json:"errors,omitempty"`
-}
-
-type StartArtifacts struct {
-	PlanPath       string         `json:"plan_path"`
-	LocalStatePath string         `json:"local_state_path"`
-	RoundID        string         `json:"round_id"`
-	ManifestPath   string         `json:"manifest_path"`
-	LedgerPath     string         `json:"ledger_path"`
-	AggregatePath  string         `json:"aggregate_path"`
-	Slots          []ManifestSlot `json:"slots"`
-}
-
-type SubmitResult struct {
-	OK         bool             `json:"ok"`
-	Command    string           `json:"command"`
-	Summary    string           `json:"summary"`
-	Artifacts  *SubmitArtifacts `json:"artifacts,omitempty"`
-	NextAction []NextAction     `json:"next_actions"`
-	Errors     []CommandError   `json:"errors,omitempty"`
-}
-
-type SubmitArtifacts struct {
-	RoundID        string `json:"round_id"`
-	Slot           string `json:"slot"`
-	SubmissionPath string `json:"submission_path"`
-	LedgerPath     string `json:"ledger_path"`
-}
-
-type AggregateResult struct {
-	OK         bool                `json:"ok"`
-	Command    string              `json:"command"`
-	Summary    string              `json:"summary"`
-	Artifacts  *AggregateArtifacts `json:"artifacts,omitempty"`
-	Review     *Aggregate          `json:"review,omitempty"`
-	NextAction []NextAction        `json:"next_actions"`
-	Errors     []CommandError      `json:"errors,omitempty"`
-}
-
-type AggregateArtifacts struct {
-	RoundID        string `json:"round_id"`
-	AggregatePath  string `json:"aggregate_path"`
-	LocalStatePath string `json:"local_state_path"`
-}
+type Spec = contracts.ReviewSpec
+type Dimension = contracts.ReviewDimension
+type Manifest = contracts.ReviewManifest
+type ManifestSlot = contracts.ReviewManifestSlot
+type Ledger = contracts.ReviewLedger
+type LedgerSlot = contracts.ReviewLedgerSlot
+type SubmissionInput = contracts.ReviewSubmissionInput
+type Submission = contracts.ReviewSubmission
+type Finding = contracts.ReviewFinding
+type Aggregate = contracts.ReviewAggregate
+type AggregateFinding = contracts.ReviewAggregateFinding
+type CommandError = contracts.JSONError
+type NextAction = contracts.NextAction
+type StartResult = contracts.ReviewStartResult
+type StartArtifacts = contracts.ReviewStartArtifacts
+type SubmitResult = contracts.ReviewSubmitResult
+type SubmitArtifacts = contracts.ReviewSubmitArtifacts
+type AggregateResult = contracts.ReviewAggregateResult
+type AggregateArtifacts = contracts.ReviewAggregateArtifacts
 
 func (s Service) Start(specBytes []byte) StartResult {
 	lockedPlanPath, release, err := s.acquireReviewMutationLock()

--- a/internal/runstate/state.go
+++ b/internal/runstate/state.go
@@ -8,83 +8,22 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/catu-ai/easyharness/internal/contracts"
 )
 
 var renameFile = os.Rename
 
-type CurrentPlan struct {
-	PlanPath           string `json:"plan_path,omitempty"`
-	LastLandedPlanPath string `json:"last_landed_plan_path,omitempty"`
-	LastLandedAt       string `json:"last_landed_at,omitempty"`
-}
-
-type State struct {
-	ExecutionStartedAt string       `json:"execution_started_at,omitempty"`
-	CurrentNode        string       `json:"current_node,omitempty"`
-	PlanPath           string       `json:"plan_path,omitempty"`
-	PlanStem           string       `json:"plan_stem,omitempty"`
-	Revision           int          `json:"revision,omitempty"`
-	Reopen             *ReopenState `json:"reopen,omitempty"`
-	ActiveReviewRound  *ReviewRound `json:"active_review_round,omitempty"`
-	LatestEvidence     *EvidenceSet `json:"latest_evidence,omitempty"`
-	Land               *LandState   `json:"land,omitempty"`
-
-	// Transitional cache fields retained until status fully stops reading v0.1
-	// handoff signals directly from state.json.
-	LatestCI      *CIState   `json:"latest_ci,omitempty"`
-	Sync          *SyncState `json:"sync,omitempty"`
-	LatestPublish *Publish   `json:"latest_publish,omitempty"`
-}
-
-type ReopenState struct {
-	Mode          string `json:"mode"`
-	ReopenedAt    string `json:"reopened_at,omitempty"`
-	BaseStepCount int    `json:"base_step_count,omitempty"`
-}
-
-type ReviewRound struct {
-	RoundID    string `json:"round_id"`
-	Kind       string `json:"kind"`
-	Step       *int   `json:"step,omitempty"`
-	Revision   int    `json:"revision,omitempty"`
-	Aggregated bool   `json:"aggregated"`
-	Decision   string `json:"decision,omitempty"`
-}
-
-type EvidenceSet struct {
-	CI      *EvidencePointer `json:"ci,omitempty"`
-	Publish *EvidencePointer `json:"publish,omitempty"`
-	Sync    *EvidencePointer `json:"sync,omitempty"`
-}
-
-type EvidencePointer struct {
-	Kind       string `json:"kind"`
-	RecordID   string `json:"record_id"`
-	Path       string `json:"path"`
-	RecordedAt string `json:"recorded_at,omitempty"`
-}
-
-type LandState struct {
-	PRURL       string `json:"pr_url,omitempty"`
-	Commit      string `json:"commit,omitempty"`
-	LandedAt    string `json:"landed_at,omitempty"`
-	CompletedAt string `json:"completed_at,omitempty"`
-}
-
-type CIState struct {
-	SnapshotID string `json:"snapshot_id"`
-	Status     string `json:"status"`
-}
-
-type SyncState struct {
-	Freshness string `json:"freshness"`
-	Conflicts bool   `json:"conflicts"`
-}
-
-type Publish struct {
-	AttemptID string `json:"attempt_id"`
-	PRURL     string `json:"pr_url"`
-}
+type CurrentPlan = contracts.RunstateCurrentPlan
+type State = contracts.RunstateState
+type ReopenState = contracts.RunstateReopenState
+type ReviewRound = contracts.RunstateReviewRound
+type EvidenceSet = contracts.RunstateEvidenceSet
+type EvidencePointer = contracts.RunstateEvidencePointer
+type LandState = contracts.RunstateLandState
+type CIState = contracts.RunstateCIState
+type SyncState = contracts.RunstateSyncState
+type Publish = contracts.RunstatePublishState
 
 type reviewAggregate struct {
 	Decision string `json:"decision"`

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/catu-ai/easyharness/internal/contracts"
 	"github.com/catu-ai/easyharness/internal/evidence"
 	"github.com/catu-ai/easyharness/internal/lifecycle"
 	"github.com/catu-ai/easyharness/internal/plan"
@@ -20,60 +21,12 @@ type Service struct {
 	Workdir string
 }
 
-type Result struct {
-	OK         bool          `json:"ok"`
-	Command    string        `json:"command"`
-	Summary    string        `json:"summary"`
-	State      State         `json:"state"`
-	Facts      *Facts        `json:"facts,omitempty"`
-	Artifacts  *Artifacts    `json:"artifacts,omitempty"`
-	NextAction []NextAction  `json:"next_actions"`
-	Blockers   []StatusError `json:"blockers,omitempty"`
-	Warnings   []string      `json:"warnings,omitempty"`
-	Errors     []StatusError `json:"errors,omitempty"`
-}
-
-type State struct {
-	CurrentNode string `json:"current_node"`
-}
-
-type Facts struct {
-	CurrentStep         string `json:"current_step,omitempty"`
-	Revision            int    `json:"revision,omitempty"`
-	ReopenMode          string `json:"reopen_mode,omitempty"`
-	ReviewKind          string `json:"review_kind,omitempty"`
-	ReviewTrigger       string `json:"review_trigger,omitempty"`
-	ReviewTitle         string `json:"review_title,omitempty"`
-	ReviewStatus        string `json:"review_status,omitempty"`
-	ArchiveBlockerCount int    `json:"archive_blocker_count,omitempty"`
-	PublishStatus       string `json:"publish_status,omitempty"`
-	PRURL               string `json:"pr_url,omitempty"`
-	CIStatus            string `json:"ci_status,omitempty"`
-	SyncStatus          string `json:"sync_status,omitempty"`
-	LandPRURL           string `json:"land_pr_url,omitempty"`
-	LandCommit          string `json:"land_commit,omitempty"`
-}
-
-type Artifacts struct {
-	PlanPath           string `json:"plan_path,omitempty"`
-	LocalStatePath     string `json:"local_state_path,omitempty"`
-	ReviewRoundID      string `json:"review_round_id,omitempty"`
-	CIRecordID         string `json:"ci_record_id,omitempty"`
-	PublishRecordID    string `json:"publish_record_id,omitempty"`
-	SyncRecordID       string `json:"sync_record_id,omitempty"`
-	LastLandedPlanPath string `json:"last_landed_plan_path,omitempty"`
-	LastLandedAt       string `json:"last_landed_at,omitempty"`
-}
-
-type NextAction struct {
-	Command     *string `json:"command"`
-	Description string  `json:"description"`
-}
-
-type StatusError struct {
-	Path    string `json:"path"`
-	Message string `json:"message"`
-}
+type Result = contracts.StatusResult
+type State = contracts.StatusState
+type Facts = contracts.StatusFacts
+type Artifacts = contracts.StatusOutput
+type NextAction = contracts.NextAction
+type StatusError = contracts.JSONError
 
 type reviewContext struct {
 	RoundID         string
@@ -304,7 +257,7 @@ func (s Service) Read() Result {
 		result.Warnings = append(result.Warnings, buildMissingStepCloseoutWarnings(result.State.CurrentNode, missingStepReminder)...)
 		result.NextAction = prependMissingStepCloseoutActions(result.State.CurrentNode, result.NextAction, facts, reviewCtx, missingStepReminder)
 	}
-	if facts.empty() {
+	if factsEmpty(facts) {
 		result.Facts = nil
 	} else {
 		result.Facts = facts
@@ -1377,7 +1330,7 @@ func isStructuralReviewTrigger(trigger string) bool {
 	return trigger == "step_closeout" || trigger == "pre_archive"
 }
 
-func (f *Facts) empty() bool {
+func factsEmpty(f *Facts) bool {
 	if f == nil {
 		return true
 	}

--- a/scripts/update-schemas
+++ b/scripts/update-schemas
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${repo_root}"
+
+check_mode=0
+if [[ "${1-}" == "--check" ]]; then
+  check_mode=1
+  shift
+fi
+
+if [[ $# -ne 0 ]]; then
+  echo "Usage: scripts/update-schemas [--check]" >&2
+  exit 2
+fi
+
+if [[ ${check_mode} -eq 0 ]]; then
+  go run ./cmd/schemagen --output-dir docs/schemas
+  exit 0
+fi
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+go run ./cmd/schemagen --output-dir "${temp_dir}"
+
+schema_diff="$(
+  diff -ruN \
+    "${temp_dir}" \
+    "${repo_root}/docs/schemas" || true
+)"
+
+if [[ -n "${schema_diff}" ]]; then
+  echo "Generated schemas are out of date. Run scripts/update-schemas." >&2
+  printf '%s\n' "${schema_diff}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add a shared Go-owned contract layer for harness JSON surfaces
- generate checked-in JSON Schemas plus a generated schema index under `docs/schemas/`
- add regeneration, drift checks, docs links, and validation coverage

## Validation

- `scripts/update-schemas --check`
- `go test ./...`
