### PR TITLE
[codex] Add harness install bootstrap flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ brew install catu-ai/tap/easyharness
 harness --version
 ```
 
+First-run repository bootstrap after installing the binary:
+
+```bash
+cd /path/to/your-repo
+harness install --dry-run
+harness install
+```
+
+`harness install` writes the minimum harness-managed repository contract for a
+repo: a managed block inside `AGENTS.md` plus the repo-local skill pack under
+`.agents/skills/`. The command is safe to rerun after upgrades. Repeated runs
+either refresh the known managed assets in place or report a no-op when the
+repository is already current. User-owned `AGENTS.md` content outside the
+managed block is preserved.
+
 Upgrade a Homebrew install with:
 
 ```bash
@@ -124,6 +139,7 @@ checkout.
 
 - `harness plan template`
 - `harness plan lint`
+- `harness install`
 - `harness execute start`
 - `harness evidence submit`
 - `harness status`
@@ -169,7 +185,9 @@ run `harness land complete` so status returns to `idle`. If an archived
 candidate becomes invalid before merge, reopen it with
 `harness reopen --mode finalize-fix` for narrow repair or
 `harness reopen --mode new-step` when the change deserves a new unfinished
-step.
+step. If a repository has not been bootstrapped yet, run `harness install`
+first so the managed `AGENTS.md` block and repo-local skills exist before the
+workflow starts.
 
 High-level guidance lives in [AGENTS.md](./AGENTS.md). The durable contracts
 for plans and CLI behavior live in [docs/specs/index.md](./docs/specs/index.md).
@@ -182,6 +200,7 @@ Execution detail for agents lives in `.agents/skills/`.
 - `docs/plans/`: tracked plans
 - `docs/specs/`: durable repo contracts
 - `.agents/skills/`: repo-local workflow skills
+- `AGENTS.md`: repo-specific guidance plus the harness-managed install block
 - `.local/harness/`: disposable runtime state, current-plan/last-landed
   markers, review artifacts, evidence artifacts, and trajectory
 

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -1,37 +1,3 @@
-# AGENTS.md
-
-This document defines repo-specific guidance for how humans and Codex
-collaborate in `easyharness`.
-
-## Mission
-
-Build `easyharness` as a thin, git-native, agent-first harness system that is
-easier to understand and maintain than a scripts-heavy workflow. The project
-name is `easyharness`; the CLI executable remains `harness`.
-
-## Development Prerequisite
-
-Before using repo-local skills that call `harness`, make sure the command is
-available:
-
-```bash
-command -v harness
-```
-
-If not, bootstrap it from this repository:
-
-```bash
-scripts/install-dev-harness
-```
-
-If you change Go CLI code, rerun the installer before relying on the direct
-`harness` command again.
-
-The block below is the same harness-managed repository contract that
-`harness install --scope agents` would install into another repository.
-Keep easyharness-specific guidance outside the managed markers.
-
-<!-- easyharness:begin -->
 ## Harness Working Agreement
 
 1. Humans steer. Agents execute.
@@ -109,19 +75,3 @@ When entering the repository or resuming after compaction:
      `execution/finalize/await_merge` and a human has explicitly approved
      merge
    - `harness-reviewer` only inside spawned reviewer subagents
-<!-- easyharness:end -->
-
-## Git and PR Rules
-
-- main branch: `main`
-- working branches: `codex/<topic>`
-- commits: small and reviewable
-- append `Co-authored-by: Codex <codex@openai.com>` unless the human requests
-  otherwise
-- when writing multi-line git or gh bodies, prefer heredocs so shell quoting
-  does not eat backticks or other structured text
-- default merge strategy: `Merge commit`
-- do not rewrite shared history without explicit approval
-
-If work creates durable deferred scope, create or update GitHub issues before
-archive and record them in the plan.

--- a/assets/bootstrap/embed.go
+++ b/assets/bootstrap/embed.go
@@ -1,0 +1,58 @@
+package bootstrap
+
+import (
+	"embed"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+)
+
+var (
+	//go:embed agents-managed-block.md skills
+	embeddedAssets embed.FS
+)
+
+func AgentsManagedBlock() string {
+	data, err := fs.ReadFile(embeddedAssets, "agents-managed-block.md")
+	if err != nil {
+		panic(err)
+	}
+	return strings.TrimSpace(string(data)) + "\n"
+}
+
+func SkillFiles() (map[string]string, error) {
+	files := map[string]string{}
+	err := fs.WalkDir(embeddedAssets, "skills", func(filePath string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		data, err := fs.ReadFile(embeddedAssets, filePath)
+		if err != nil {
+			return err
+		}
+		rel := strings.TrimPrefix(filePath, "skills/")
+		files[path.Clean(rel)] = string(data)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func SortedSkillPaths() ([]string, error) {
+	files, err := SkillFiles()
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(files))
+	for filePath := range files {
+		paths = append(paths, filePath)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}

--- a/assets/bootstrap/skills/harness-discovery/SKILL.md
+++ b/assets/bootstrap/skills/harness-discovery/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: harness-discovery
+description: Run interactive, Socratic pre-implementation discovery for medium/large or ambiguous work in a harness-driven repository by clarifying goals, constraints, tradeoffs, and workflow direction before planning or execution. Use this whenever the next move is unclear, the user needs help choosing an approach, or archived work may need to reopen.
+---
+
+# Harness Discovery
+
+## Overview
+
+Run discovery before implementation when the task needs real clarification.
+Discovery is conversation-only. It should reduce ambiguity, surface tradeoffs,
+and end with a clear next workflow step.
+
+## Inputs
+
+- the human's objective or problem statement
+- relevant plans, specs, or design context from the repository
+- current `harness status` output when the repository already has an active
+  plan and local state
+
+## Execution Contract
+
+1. If the task is still fuzzy, ask one concise clarification question before
+   doing broader discovery.
+2. Read the most relevant repository context needed to ask sharper questions.
+   Be comprehensive enough to avoid shallow questions, but do not disappear
+   into aimless exploration.
+3. Ask exactly one high-leverage question per turn.
+4. Use Socratic questioning to clarify:
+   - purpose
+   - constraints
+   - non-goals
+   - success criteria
+   - workflow direction
+5. When a decision benefits from framing, present 2-4 realistic options.
+6. For each option, give:
+   - a short label
+   - one clear upside
+   - one clear downside
+   - when it fits
+7. Recommend a direction when the tradeoffs are asymmetric.
+8. Converge on a concrete approach, draft acceptance criteria, and state the
+   next workflow step explicitly.
+9. Hand off to `harness-plan` only after the human confirms the direction.
+
+## Option Framing Pattern
+
+When you offer options, keep them concise and decision-shaped. A good pattern
+is:
+
+1. `Option A`
+   - upside
+   - downside
+   - best when ...
+2. `Option B`
+   - upside
+   - downside
+   - best when ...
+3. `Option C`
+   - upside
+   - downside
+   - best when ...
+
+Then add a short recommendation and why.
+
+## Output
+
+Discovery should end with a concise conversation summary containing:
+
+- the problem statement
+- key constraints and non-goals
+- the accepted direction
+- rejected alternatives with short rationale
+- draft acceptance criteria
+- the next workflow step
+
+## Guardrails
+
+- Do not implement code in this skill.
+- Do not write or modify repository files during discovery.
+- Do not ask bundled multi-question prompts; keep one question per turn.
+- Do not offer weak filler options just to reach four.
+- Do not turn option framing into long compare tables or verbose essays.
+- Do not proceed until the human has enough clarity to approve the next step.
+- Do not turn discovery into a hidden plan that only exists in chat.

--- a/assets/bootstrap/skills/harness-execute/SKILL.md
+++ b/assets/bootstrap/skills/harness-execute/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: harness-execute
+description: Use when a tracked harness plan has been approved and the controller agent should drive implementation, review, archive closeout, publish/CI/sync evidence work, and merge-readiness follow-up until the archived candidate is genuinely ready to wait for merge approval. This is the main controller skill for day-to-day execution after approval.
+---
+
+# Harness Execute
+
+## Purpose
+
+Use this skill after plan approval to drive the repository from active work to
+an archived, merge-ready candidate.
+
+ALWAYS use `harness-execute` whenever `harness status` resolves a current
+approved tracked plan and `state.current_node` is still in `plan` or
+`execution/...`, or the archived candidate still needs publish follow-up
+before human merge approval. That includes fresh sessions, resumed sessions
+after compaction, and pick-up work where the safest next move is to follow the
+current plan instead of improvising a new workflow.
+
+The controller agent stays in `harness-execute` for the whole execution loop,
+including review orchestration. Do not switch the controller into
+`harness-reviewer`; that skill is only for spawned reviewer subagents assigned
+to specific review slots.
+
+Run `harness status` at controller checkpoints, not just once per session:
+
+- at start or resume
+- before marking a step done
+- after each review aggregate
+- before trusting later-step or finalize progression after warnings, repair, or
+  review follow-up
+
+Routine review progression is controller-owned. Once the approved plan reaches
+an ordinary step-closeout or finalize-review boundary, the controller should
+start that review flow without asking the human to micromanage it.
+
+If the approved plan is likely to require reviewer subagents and explicit
+authorization has not been obtained yet, ask for that authorization as soon as
+the need becomes foreseeable. Do not wait until reviewer spawning is the only
+remaining next action before surfacing the request.
+If execution still reaches a reviewer-subagent boundary without that explicit
+approval, pause only long enough to request it, then continue the review flow
+once the human answers.
+
+Keep exactly one active review round at a time. The detailed review rules live
+in [review-orchestration.md](references/review-orchestration.md).
+
+For behavior-changing work, default to Red/Green/Refactor TDD. Only skip TDD
+when it is genuinely impractical, and record the reason in the step's
+`Execution Notes`.
+
+## Start Here
+
+1. Run `harness status`.
+2. If `harness status` points to a current tracked plan that is already
+   approved for execution, stay in `harness-execute` and open that plan from
+   `plan_path`.
+3. Identify the active or next plan step.
+4. Use the status output to answer four questions:
+   - which tracked plan is current
+   - which `current_node` the worktree is currently in
+   - which step or finalize phase is active or next
+   - whether local state already shows review, evidence, or land work in flight
+5. If `harness` is unavailable or resolves to the wrong binary, first follow
+   the repository's documented setup path. If no setup path is documented, ask
+   the human to install or expose the correct `harness` command.
+6. Read only the references needed for the current part of the loop.
+
+## Node Hints
+
+- `plan`
+  - wait for approval or update the plan if scope changed before
+    `harness execute start`
+- `execution/step-<n>/implement`
+  - continue the current step, fix review findings, or mark the step done once
+    the slice is genuinely complete
+  - rerun `harness status` before marking the step done so the next action
+    reflects whether review, repair, or a warning-driven follow-up is due
+- `execution/step-<n>/review`
+  - review is in flight; aggregate or wait for reviewer submissions rather
+    than continuing implementation blindly
+- `execution/finalize/review|fix|archive`
+  - the step list is done and the branch is in closeout, review, or
+    archive-prep work
+  - treat `execution/finalize/review` as a continuation state: start or
+    aggregate finalize review as the status guidance indicates instead of
+    stopping to ask the human whether routine review closeout should happen
+- `execution/finalize/publish`
+  - the plan is archived, but publish, CI, or sync evidence still needs work
+- `execution/finalize/await_merge`
+  - the archived candidate is merge-ready; stay in execute until explicit
+    human merge approval switches the controller into `harness-land`
+
+## Reference Guide
+
+- Read [step-inner-loop.md](references/step-inner-loop.md) when implementing or
+  validating the current plan step.
+- Read [review-orchestration.md](references/review-orchestration.md) whenever a
+  review round is active or about to start.
+- Read [publish-ci-sync.md](references/publish-ci-sync.md) when publish, CI, or
+  remote-sync work becomes relevant.
+- Read [closeout-and-archive.md](references/closeout-and-archive.md) before any
+  archive attempt.
+
+## Exit Criteria
+
+Execute is done when:
+
+- the plan is archived
+- `harness status` resolves `state.current_node` to
+  `execution/finalize/await_merge`
+- durable closeout summaries are written into the tracked plan
+
+## Do Not
+
+- Do not ask the human to micromanage routine execution once the plan is
+  approved.
+- Do not ask the human whether routine step-closeout or finalize review should
+  start once `harness status` and the tracked plan make the next review action
+  clear.
+- Do not silently stall at review orchestration because reviewer subagent
+  authorization is missing; request it explicitly as soon as you know it will
+  be required, and if you still reach the reviewer boundary without approval,
+  pause only long enough to ask and then resume once the answer arrives.
+- Do not bypass node or review gates just because the next action feels obvious.
+- Do not skip TDD for behavior changes without documenting why the usual
+  Red/Green/Refactor loop was not practical.
+- Do not rely on chat memory when `harness status`, the tracked plan, or local
+  artifacts can tell you the truth more directly.
+- Do not archive based on memory alone; use the current plan plus `.local`
+  artifacts.

--- a/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
+++ b/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
@@ -1,0 +1,52 @@
+# Closeout and Archive
+
+Archive is a freeze-and-summarize step, not just a file move.
+
+## Before Archive
+
+1. Run `harness status` and confirm the plan is actually archive-ready.
+   - If `status` returns `blockers`, fix those first instead of learning them
+     from a failing `harness archive`.
+2. Make sure acceptance criteria are checked and steps are completed.
+3. Read the latest finalize review artifacts under `.local` and confirm the
+   branch really is in `execution/finalize/archive` rather than still needing
+   review or repair.
+4. Update the tracked plan's durable summaries from those artifacts:
+   - `Validation Summary`
+   - `Review Summary`
+   - `Archive Summary`
+   - `Outcome Summary`
+5. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
+   with durable handoff details before archive. Issue links are fine, but the
+   main rule is that it must not stay `NONE`.
+6. Run:
+
+   ```bash
+   harness plan lint <plan-path>
+   ```
+
+7. Archive the plan:
+
+   ```bash
+   harness archive
+   ```
+
+## After Archive
+
+Archive changes tracked files, so it still needs the normal git flow:
+
+1. Commit the archive move and summary updates.
+2. Push the branch.
+3. Open or update the PR.
+4. Run `harness status` again to confirm the archived candidate now reports the
+   expected `execution/finalize/publish` or
+   `execution/finalize/await_merge` node for this worktree.
+5. Record publish, CI, and sync facts through `harness evidence submit`.
+6. Wait for human merge approval or switch to `harness-land` only when asked
+   once status reaches `execution/finalize/await_merge`.
+
+If new feedback or remote changes invalidate the archived candidate, use:
+
+```bash
+harness reopen --mode <finalize-fix|new-step>
+```

--- a/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
+++ b/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
@@ -1,0 +1,40 @@
+# Publish, CI, and Sync
+
+Once implementation is materially complete, the execute loop expands beyond the
+current step and eventually into archived-candidate handoff.
+
+## Publish and CI
+
+1. commit reviewable progress
+2. push the branch
+3. open or update the PR
+4. wait for required CI
+5. fix failures
+6. decide whether the repair needs delta review or full review
+
+For archived candidates, use the same sequence as post-archive handoff work,
+but record the observed external facts through `harness evidence submit`:
+
+1. commit the archive move
+2. push the branch
+3. open or update the PR
+4. run `harness evidence submit --kind publish` once the PR or handoff target
+   exists
+5. wait for post-archive CI and record updates with
+   `harness evidence submit --kind ci`
+6. refresh remote readiness and record it with
+   `harness evidence submit --kind sync`
+7. only then treat the candidate as ready to enter
+   `execution/finalize/await_merge`
+
+## Remote Freshness
+
+Refresh remote state before merge-sensitive handoff work.
+
+If remote changes introduce real conflict work:
+
+- resolve the conflicts
+- rerun focused validation
+- run delta or full review depending on how broad the repair was
+
+Do not create a new review round while an earlier one is still active.

--- a/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
+++ b/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
@@ -1,0 +1,254 @@
+# Review Orchestration
+
+Keep exactly one active review round at a time.
+
+Do not start a new review round until the current round has been aggregated and
+its outcome has been addressed, or until the plan has explicitly changed enough
+that the current round should be abandoned.
+
+The controller agent stays in `harness-execute` during review orchestration.
+Only the spawned reviewer subagents should switch to `harness-reviewer`.
+
+Starting routine review is controller-owned. Once `harness status`, the tracked
+plan, and the current step state make ordinary step-closeout or finalize review
+the next action, start that review without asking the human for permission.
+
+## When to Use Delta vs Full
+
+- use `delta` after a completed step or a narrow follow-up change
+- use `full` for step closeout when a narrower pass would be misleading or the
+  slice needs a broader risk scan
+- use `full` when the branch looks like an archive candidate
+- after reopen:
+  - narrow follow-up work may use `delta`
+  - broad follow-up work should rerun `full`
+
+## Routine Start Rules
+
+- After a completed step becomes reviewable, start a step-bound review before
+  treating the step as durably done, unless the step will instead record
+  `NO_STEP_REVIEW_NEEDED: <reason>` in `Review Notes`.
+- Once all tracked steps are complete and no warning-driven repair remains,
+  start finalize review for the full candidate before archive closeout.
+- If `harness status` surfaces an earlier completed step that still lacks
+  review closeout, resolve that warning before trusting later-step or finalize
+  progression.
+
+## Review Spec
+
+Create a review spec and pass it to:
+
+```bash
+harness review start --spec <path>
+```
+
+Use a compact JSON shape like:
+
+```json
+{
+  "kind": "delta",
+  "review_title": "Step 2: Refactor review metadata",
+  "dimensions": [
+    {
+      "name": "correctness",
+      "instructions": "Look for contract mistakes, stale assumptions, or missing negative-path handling."
+    },
+    {
+      "name": "agent_ux",
+      "instructions": "Check whether another agent could resume the task cleanly from the updated docs and skills."
+    }
+  ]
+}
+```
+
+Field rules:
+
+- `kind`
+  - enum: `delta` or `full`
+  - `delta` is for a completed step or narrow follow-up change
+  - `full` is for an archive candidate or another broad branch-level pass
+- `review_title`
+  - optional human-readable review title for the controller and reviewers
+- `step`
+  - optional 1-based tracked step number
+  - usually omit it and let `harness` bind the round automatically
+  - only include it when you need to point review at a specific tracked step explicitly
+- `dimensions`
+  - one reviewer slot per dimension after normalization
+  - each dimension should have a short name and a concrete instruction
+
+The controller agent should not invent workflow metadata like `trigger` or
+`target`. `harness review start` infers whether the round is step-bound or
+finalize-bound from the current node and persists that structure itself.
+
+Suggested dimensions:
+
+- `correctness`
+  - logic, node-resolution, and contract mistakes
+- `tests`
+  - missing coverage, weak validation, or misleading smoke claims
+- `docs_consistency`
+  - README, AGENTS, skills, and plan drift
+- `agent_ux`
+  - handoff quality, clarity, and next-action guidance
+- `risk_scan`
+  - unresolved blockers, deferred risks that leaked back in, or unsafe defaults
+
+Choose only the dimensions that fit the current change. Do not force every
+round to use the same set.
+
+## Controller Flow
+
+1. Create the round:
+
+   ```bash
+   harness review start --spec <path>
+   ```
+
+2. Spawn multiple reviewer subagents in parallel: one reviewer per returned
+   slot or review dimension.
+   For a slot's first pass in a tracked step or for one finalize review scope
+   in one revision, or whenever reuse is not clearly safe, use clean reviewer
+   subagents. Moving to a different tracked step, moving from step review into
+   finalize review, or moving to a different revision always starts with fresh
+   reviewers. Do not inherit the controller's long chat context into reviewer
+   threads. Use only the fixed reviewer prompt template for reviewer spawning.
+3. Use a fixed reviewer prompt template so model or runtime changes do not
+   silently change the reviewer contract.
+4. Keep track of every spawned reviewer agent ID.
+5. Wait for all reviewer subagents to finish before aggregation.
+6. Verify each reviewer actually submitted a valid result for its slot.
+7. Close the finished reviewer agent after verification, even when its
+   submission was missing or invalid. Closed is the default steady state
+   between rounds; do not leave reviewer agents hanging open just in case they
+   might be useful later.
+8. If a reviewer finished without a valid submission, respawn a clean reviewer
+   for that slot immediately.
+9. Only after every expected reviewer slot has a valid submission and every
+   reviewer agent is closed, run:
+
+   ```bash
+   harness review aggregate --round <round-id>
+   ```
+
+## Fixed Reviewer Prompt Template
+
+The returned `manifest_path` is for the controller, not the reviewer. Use it
+when you need to inspect the CLI-normalized slots, expected artifact paths, or
+ledger-owned review metadata. Reviewer subagents do not need it unless your
+runtime prefers passing a single manifest pointer.
+
+Use this controller prompt shape when spawning a reviewer subagent:
+
+```text
+You are the reviewer for one harness review slot.
+
+Use the harness-reviewer skill and follow it exactly.
+
+Round ID: <round-id>
+Review title: <review-title>
+Revision: <candidate-revision-or-none>
+Slot: <slot>
+Assigned dimension: <dimension-name>
+Instructions: <dimension-instructions>
+```
+
+## Fixed Reviewer Resume Prompt Template
+
+Use resume only for a narrow same-slot follow-up after the controller has
+already verified and closed that reviewer's earlier successful submission.
+Do not resume across tracked steps, or from a step review into finalize
+review. Those boundaries always start with fresh reviewers.
+Resume is only valid while the review scope itself is still the same:
+
+- for step review, the same tracked step title
+- for finalize review, the same candidate review title for the same revision
+
+If reopen, a new tracked step, a new revision, or a new finalize candidate
+changes that scope, start with fresh reviewers.
+
+Use this controller prompt shape when resuming a previously closed reviewer:
+
+```text
+You are resuming the same harness review slot you handled earlier.
+
+Use the harness-reviewer skill and follow it exactly.
+
+New round ID: <new-round-id>
+Review title: <review-title>
+Revision: <candidate-revision-or-none>
+Slot: <slot>
+Assigned dimension: <dimension-name>
+Instructions: <dimension-instructions>
+Follow-up scope: Verify only the bounded changes since your last submission.
+Change summary since your last submission: <bounded-change-summary>
+```
+
+## Codex-Specific Subagent Rules
+
+Codex reviewer subagents are asynchronous.
+
+- `spawn_agent` returns immediately.
+- `wait_agent(ids=[...])` waits for whichever agent finishes first, not for all
+  of them automatically.
+- A completed reviewer agent may still remain open in the background until you
+  close it.
+- Use `spawn_agent(..., fork_context=false)` for reviewer slots so the reviewer
+  starts from a clean context and sees only the fixed reviewer prompt.
+- After a reviewer is cleanly closed, `resume_agent` may reopen that same
+  reviewer later, but only for a narrow same-slot follow-up where continuity is
+  genuinely helpful.
+- Do not append extra controller reasoning, artifact tours, or side
+  instructions to the fixed reviewer prompt when spawning Codex reviewer
+  subagents.
+
+Prefer `resume_agent` only when all of these are true:
+
+- the earlier reviewer submission for that agent was valid and already verified
+  by the controller
+- the new round is still narrow enough for `delta` review
+- the new round stays within the same tracked step review boundary, or within
+  the same finalize review scope for the same revision
+- the new round keeps the same review scope as the earlier submission
+- the reviewer keeps the same slot and materially the same dimension
+  instructions
+- the controller can give a bounded change summary that is directly tied to the
+  earlier findings
+
+Treat the closed reviewer as retired for this follow-up and spawn a fresh clean
+reviewer instead when any of these are true:
+
+- the earlier submission was missing, invalid, or never verified
+- the controller is moving to a different tracked step, or from a step review
+  into finalize review
+- the review scope changed because of reopen, a new tracked step, a new
+  revision, or a later finalize pass against a different candidate
+- the follow-up broadened into `full` review or otherwise changed scope
+  materially
+- the slot or instructions changed enough that the old reviewer context would
+  mislead more than help
+- the repair batch includes unrelated changes, remote-sync churn, or other
+  broad context that deserves a clean reread
+- you want an unbiased second look more than continuity
+
+Use this pattern:
+
+1. keep a pending set of reviewer agent IDs
+2. call `wait_agent` on the pending set
+3. remove whichever reviewer finished
+4. verify it submitted a valid result for its assigned slot
+5. call `close_agent` for that reviewer immediately after verification
+6. if the submission was missing or invalid, respawn that reviewer slot
+   immediately
+7. repeat until the pending set is empty and every expected slot is filled
+8. aggregate only after all reviewer agents are both finished and closed
+
+After a later repair round starts, you may either spawn fresh reviewers again
+or reopen an eligible closed reviewer with `resume_agent` only for the same
+tracked step, or for the same finalize review scope in the same revision,
+then deliver only the fixed resume prompt for the new round. Even when you
+reuse a reviewer this way, close it again immediately after the new submission
+is verified.
+
+This is required to avoid premature aggregation, dangling background agents,
+and stale-context leakage.

--- a/assets/bootstrap/skills/harness-execute/references/step-inner-loop.md
+++ b/assets/bootstrap/skills/harness-execute/references/step-inner-loop.md
@@ -1,0 +1,45 @@
+# Step Inner Loop
+
+The inner loop is how you finish one plan step cleanly.
+
+## Inner Loop
+
+1. Confirm the current step from `harness status` and the tracked plan.
+2. For behavior changes, run Red/Green/Refactor:
+   - Red: write or update a test that fails for the intended behavior.
+   - Green: implement the smallest change that makes the test pass.
+   - Refactor: improve structure without changing the behavior you just proved.
+3. If TDD is genuinely impractical for this slice, record the reason in
+   `Execution Notes` before continuing.
+4. Run focused validation for the slice.
+5. Update the step's `Execution Notes` with a concise summary.
+6. If the slice is green and meaningfully reviewable, make a small commit.
+7. Run `harness status` before step closeout so the next action reflects the
+   current step, any active review, and any warning-driven follow-up.
+8. If the slice is ready for review, run step-closeout review now. Use `delta`
+   by default for a completed step, but use `full` when a narrower review would
+   be misleading or the slice needs a broader pass.
+9. If no step-closeout review is needed, record
+   `NO_STEP_REVIEW_NEEDED: <reason>` in `Review Notes` before marking the step
+   done.
+10. Fix findings, rerun focused validation, and update `Review Notes`.
+11. Make another small commit when a review-driven fix meaningfully changes the
+   branch.
+12. Mark the step complete only when the step objective, validation, and review
+    closeout are genuinely satisfied.
+
+## Step Notes
+
+Keep step-local notes useful to the next agent:
+
+- `Execution Notes`
+  - what changed, what was validated, what remains
+- `Review Notes`
+  - latest delta/full review outcome, major findings, and what was fixed
+  - or `NO_STEP_REVIEW_NEEDED: <reason>` when the step was too small or low
+    risk to justify a separate closeout review
+
+Keep these notes high-signal and brief. Summarize the core change and outcome;
+do not turn them into transcripts.
+
+Do not wait until archive to reconstruct step history from memory.

--- a/assets/bootstrap/skills/harness-land/SKILL.md
+++ b/assets/bootstrap/skills/harness-land/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: harness-land
+description: Use when a tracked harness plan is already archived and the human has explicitly approved merge, so the agent should merge the PR and perform post-merge cleanup.
+---
+
+# Harness Land
+
+## Purpose
+
+Use land only after the plan is archived and a human has said it is time to
+merge.
+
+## Workflow
+
+1. Run `harness status`.
+2. If `state.current_node` is not `execution/finalize/await_merge`, stop.
+   - If the candidate is no longer valid, run
+     `harness reopen --mode finalize-fix` for narrow repair or
+     `harness reopen --mode new-step` when the change deserves a new step, and
+     then return to `harness-execute`.
+   - If the plan is still executing, stay in `harness-execute`.
+3. Verify the PR still looks merge-ready.
+4. Merge the PR.
+5. Prefer `Merge commit` unless the human explicitly asks for a different
+   strategy.
+6. Add any final PR comment or remote update that belongs on the permanent
+   record.
+7. Close or update linked issues when the merge resolves them.
+8. Run:
+
+   ```bash
+   harness land --pr <url> [--commit <sha>]
+   ```
+
+   This records merge confirmation and enters post-merge cleanup.
+9. Finish local cleanup, branch sync, and any final remote follow-up.
+10. Run:
+
+   ```bash
+   harness land complete
+   ```
+
+   This records cleanup completion, clears the current candidate pointer, and
+   records the last landed archived plan so `harness status` returns to
+   `idle` with the landed context preserved in artifacts.
+11. Sync local `main`, delete the feature branch if appropriate, and leave the
+    worktree clean.
+
+## Do Not
+
+- Do not merge without explicit human approval.
+- Do not edit the archived plan after merge just to record merge metadata.
+- Do not skip the explicit land milestones; run `harness land --pr <url>`
+  after merge and `harness land complete` after cleanup so status stops
+  reporting the archived candidate as current work.
+- Do not keep using `land` if the candidate is no longer valid; switch back to
+  `harness-execute` via `harness reopen --mode <finalize-fix|new-step>`.

--- a/assets/bootstrap/skills/harness-plan/SKILL.md
+++ b/assets/bootstrap/skills/harness-plan/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: harness-plan
+description: Create or update a tracked harness plan for medium/large work once the direction is clear enough to execute. Use this when work needs a self-contained plan that a future agent can complete from the repository alone, without relying on discovery chat or hidden session memory.
+---
+
+# Harness Plan
+
+## Purpose
+
+Use this skill to create or update the tracked plan that will drive execution.
+
+## When to Use
+
+- discovery has converged and the work needs a new tracked plan
+- an active plan needs a scoped update before archive
+- reopened work needs the tracked plan refreshed before execution resumes
+
+## Workflow
+
+1. Start from `harness plan template` when creating a new plan.
+2. Name the file with the plan-schema convention:
+   `YYYY-MM-DD-clear-topic.md`.
+3. Make the topic meaningful and specific. It should tell a cold reader what is
+   changing, not just name a vague area.
+4. Write a plan that is clear to both humans and future agents:
+   - concrete goal
+   - explicit scope and out-of-scope
+   - acceptance criteria
+   - reviewable work breakdown
+5. Make the plan self-contained. Fold in decisions from discovery or prior
+   discussion so another agent can execute from the plan plus repository state
+   alone.
+6. Keep execution detail concise. Push runtime mechanics into skills and CLI
+   contracts instead of bloating the plan.
+7. Reread the plan as if the chat history were unavailable. Fix anything that
+   still depends on hidden context.
+8. Run `harness plan lint <plan-path>`.
+9. Present the plan for approval before execution starts.
+   If the approved execution loop is likely to require reviewer subagents,
+   ask for explicit subagent authorization in the same approval exchange so
+   execution does not stall later at review time.
+
+## Commands
+
+- `harness plan template --help`
+- `harness plan lint --help`
+
+## Exit Criteria
+
+The plan is ready when:
+
+- lint passes
+- the resulting tracked plan would resolve to `plan` until
+  `harness execute start` is recorded
+- the human can approve or challenge it without hidden context
+- when reviewer subagents are likely later, the approval handoff makes that
+  expected authorization explicit instead of deferring it implicitly
+- a future agent could continue the work from the plan alone
+
+## Do Not
+
+- Do not start `harness-execute` before the plan is approved.
+- Do not duplicate full CLI enums or placeholder rules from the specs when a
+  command or spec already defines them.
+- Do not let deferred work float without being named clearly in the plan.
+- Do not leave key decisions only in discovery chat or session memory.

--- a/assets/bootstrap/skills/harness-reviewer/SKILL.md
+++ b/assets/bootstrap/skills/harness-reviewer/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: harness-reviewer
+description: Use when acting as a dedicated reviewer subagent for one assigned harness review slot in an existing review round and you need to inspect the change, write structured findings, and submit them through `harness review submit`. This skill is only for reviewer subagents, not for the controller agent.
+---
+
+# Harness Reviewer
+
+## Purpose
+
+Use this skill only in reviewer subagents, including a reviewer subagent that
+the controller later resumes for the same slot within the same tracked step
+review boundary or for the same finalize review title in the same revision.
+
+The reviewer agent owns exactly one review slot in an existing review round. It
+does not start rounds, aggregate rounds, orchestrate other reviewers, or infer
+workflow `current_node` on the controller's behalf.
+
+## Submission Contract
+
+Submit exactly one structured payload with:
+
+```bash
+harness review submit --round <round-id> --slot <slot> --input <path>
+```
+
+Use this payload shape:
+
+```json
+{
+  "summary": "Short review summary.",
+  "findings": [
+    {
+      "severity": "important",
+      "title": "Short finding title",
+      "details": "Concrete explanation of the issue and why it matters."
+    }
+  ]
+}
+```
+
+Rules:
+
+- `summary` is required
+- `findings` may be empty when the slot finds no issues
+- valid severities are `blocker`, `important`, and `minor`
+
+## Severity Guidance
+
+Use severities like this:
+
+- `blocker`
+  - correctness, safety, or workflow issue that must be fixed before the
+    reviewed slice can proceed
+- `important`
+  - meaningful issue that still blocks approval for the current round
+- `minor`
+  - non-blocking improvement or observation
+
+Prefer no finding over a vague finding. If the issue is real, say exactly what
+is wrong and why it matters to your assigned slot.
+
+If the current plan explicitly defers a risk and the implementation still
+matches that deferral, you do not need to raise it again as a finding. Raise it
+only if the change contradicts the deferral, expands the risk, or makes the
+deferral stale.
+
+## Workflow
+
+1. Read the controller's round ID, review title, revision context when present, slot,
+   and assigned instructions.
+2. If the controller did not give enough information to submit cleanly, report
+   the missing input back to the controller instead of improvising.
+3. Inspect the relevant diff, plan context, and local artifacts needed for that
+   slot.
+4. Produce a structured review result.
+5. Submit it with `harness review submit`.
+6. Report the submission receipt back to the controller agent.
+7. Stop once the receipt is reported. The controller agent is responsible for
+   closing reviewer subagents after verifying the successful submission.
+8. If the controller later resumes you for the same slot within the same
+   tracked step review boundary or for the same finalize review title in the
+   same revision, treat the newest round ID, review title, revision context, slot,
+   and instructions as authoritative for that new assignment. Reuse your prior
+   context only to understand the bounded follow-up the controller asked you to
+   verify.
+
+## Do Not
+
+- Do not call any harness command other than `harness review submit`.
+- Do not edit tracked files.
+- Do not keep exploring after a successful submission.
+- Do not assume an older round ID, revision context, or instructions still
+  apply after a resume.
+- Do not assume a resume carries across tracked steps or from step review into
+  finalize review.

--- a/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
+++ b/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
@@ -194,7 +194,9 @@ no-op reruns after refresh. Finalize review `review-001-full` then found one
 additional marker-parsing bug: inline user-owned mentions of the marker strings
 could be mistaken for the managed block. The repair tightened marker detection
 to whole-line markers only and added a focused regression test for the inline
-mention case.
+mention case. Finalize review `review-002-full` then found one more
+repeat-run edge case on CRLF `AGENTS.md` files; the repair widened marker-line
+matching so CRLF reruns refresh or noop instead of appending a duplicate block.
 
 #### Review Notes
 
@@ -248,7 +250,10 @@ and repeat-run no-op results. After finalize review `review-001-full`
 requested stronger coverage, the smoke suite also gained failing-install
 coverage for invalid scope and a wrapper-refresh path that starts from an
 existing user-authored `AGENTS.md`, refreshes the managed block, and proves the
-next rerun is a noop.
+next rerun is a noop. After finalize review `review-002-full`, the smoke suite
+also gained explicit CLI coverage for duplicate managed-block failure and the
+`--scope skills` bootstrap path so both install branches now have end-to-end
+coverage.
 
 Validation passed with `go test ./internal/install ./internal/cli ./tests/smoke
 -run 'TestInstall|TestHelpShowsTopLevelUsage' -count=1`, a repo-local

--- a/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
+++ b/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
@@ -261,7 +261,11 @@ also gained explicit CLI coverage for duplicate managed-block failure and the
 coverage. After finalize review `review-003-full`, the smoke suite gained one
 more apply-mode failure path by forcing `install --scope skills` to fail while
 `.agents` is a plain file, then verifying a cleaned-up rerun converges
-successfully.
+successfully. After finalize review `review-004-full`, the smoke suite also
+gained the default full-scope retry path: `harness install` now has an
+end-to-end test that writes `AGENTS.md`, fails mid-flight while refreshing a
+read-only managed skill file, then succeeds cleanly after the blocker is
+removed.
 
 Validation passed with `go test ./internal/install ./internal/cli ./tests/smoke
 -run 'TestInstall|TestHelpShowsTopLevelUsage' -count=1`, a repo-local

--- a/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
+++ b/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
@@ -267,6 +267,13 @@ end-to-end test that writes `AGENTS.md`, fails mid-flight while refreshing a
 read-only managed skill file, then succeeds cleanly after the blocker is
 removed.
 
+After the candidate was first archived and published as PR #81, `origin/main`
+advanced by two commits, including the merged Go-baseline change from #73.
+The archived candidate was therefore reopened with `harness reopen --mode
+finalize-fix`, merged with `origin/main`, and revalidated with
+`go test ./... -count=1` so revision 2 could go back through finalize review
+before re-archive.
+
 Validation passed with `go test ./internal/install ./internal/cli ./tests/smoke
 -run 'TestInstall|TestHelpShowsTopLevelUsage' -count=1`, a repo-local
 `harness install --scope agents --dry-run` no-op after dogfooding, and
@@ -305,6 +312,8 @@ slice and will be covered by full finalize review before archive.
 
 ## Validation Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - `go test ./internal/install ./internal/cli -count=1`
 - `go test ./internal/install ./tests/smoke -run 'TestInstall|TestHelpShowsTopLevelUsage' -count=1`
 - `go test ./internal/install ./tests/smoke -run 'TestInstallIgnoresLiteralMarkerMentionsInUserOwnedProse|TestInstallRejectsInvalidScopeViaCLI|TestInstallRefreshesExistingManagedWrapperAndThenNoops|TestInstall' -count=1`
@@ -315,6 +324,8 @@ slice and will be covered by full finalize review before archive.
 
 ## Review Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - `review-001-full`: changes requested for inline marker parsing and missing smoke coverage around failure paths and wrapper reruns
 - `review-002-full`: changes requested for CRLF marker recognition and missing smoke coverage for `skills` plus a structural CLI failure path
 - `review-003-full`: changes requested for CRLF newline preservation and apply-mode failure recovery coverage
@@ -322,6 +333,8 @@ slice and will be covered by full finalize review before archive.
 - `review-005-full`: full finalize review passed with no findings
 
 ## Archive Summary
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Archived At: 2026-03-31T01:01:53+08:00
 - Revision: 1
@@ -333,6 +346,8 @@ slice and will be covered by full finalize review before archive.
 
 ### Delivered
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - Added packaged bootstrap assets under `assets/bootstrap/` for the managed `AGENTS.md` delta and the repo-local harness skill pack.
 - Added `harness install` with direct-write default behavior, `--dry-run`, and `--scope agents|skills|all`.
 - Split this repo's `AGENTS.md` into easyharness-specific guidance plus the same managed harness contract that `harness install` installs elsewhere.
@@ -342,11 +357,15 @@ slice and will be covered by full finalize review before archive.
 
 ### Not Delivered
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - Optional remote skill-pack installation or agent-assisted downloads remain deferred.
 - User-selectable bootstrap templates beyond the minimum default contract remain deferred.
 - Drift detection and upgrade prompts for stale installed bootstrap assets remain deferred.
 
 ### Follow-Up Issues
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - [#71](https://github.com/catu-ai/easyharness/issues/71): Add repo-level harness customization via a tracked `.harness` directory.
 - [#80](https://github.com/catu-ai/easyharness/issues/80): Decide how `harness install` should detect stale repo bootstrap assets.

--- a/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
+++ b/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
@@ -1,0 +1,305 @@
+---
+template_version: 0.2.0
+created_at: 2026-03-31T00:08:51+08:00
+source_type: issue
+source_refs:
+    - '#68'
+---
+
+# Add a repeatable repository install flow for AGENTS delta and skills
+
+## Goal
+
+Add a first-run repository bootstrap flow that turns an ordinary repository
+into a harness-aware repository without forcing users to reverse-engineer this
+repo's local setup. The result should give `easyharness` one user-facing entry
+command, `harness install`, that can be run safely more than once and that
+manages the minimum repo-owned assets needed for the harness workflow.
+
+This slice should keep the bootstrap intentionally narrow. It should install or
+refresh the harness-managed `AGENTS.md` delta and the minimum repo-local skill
+pack, while preserving user-owned repository instructions outside the managed
+region. Richer customization models, remote template catalogs, and optional
+skill packs remain deferred.
+
+## Scope
+
+### In Scope
+
+- Define the first public repository-bootstrap contract around
+  `harness install`.
+- Split the bootstrap surfaces into one managed `AGENTS.md` delta and one
+  managed repo-local skill pack, while exposing them through a single command
+  with selectable scope.
+- Decide and document repeat-run behavior: install on first run, refresh on
+  later runs, and report no-op when the managed content is already current.
+- Add packaged bootstrap assets for the minimum distributable harness contract,
+  separate from this repository's easyharness-specific dogfood guidance.
+- Dogfood the split by refactoring this repo so its top-level `AGENTS.md`
+  contains both repo-specific guidance and the same harness-managed delta the
+  command would install elsewhere.
+- Update public docs and CLI contracts for release users who install
+  `easyharness` from Homebrew or GitHub Releases and then need to bootstrap a
+  repository.
+
+### Out of Scope
+
+- A full customization framework for arbitrary repo-specific bootstrap
+  templates.
+- Installing optional or remote skill packs from GitHub or a central catalog as
+  part of the first-run path.
+- Managing user-owned `AGENTS.md` content outside the harness-managed block.
+- A web UI or interactive wizard for bootstrap.
+- Automatic migration of every historical dogfood repo to the new contract.
+
+## Acceptance Criteria
+
+- [x] The CLI exposes `harness install` with a default direct-write mode plus a
+      `--dry-run` preview mode, and the command is safe to rerun.
+- [x] `harness install` can target `agents`, `skills`, or `all`, but the
+      product entrypoint remains a single command rather than separate top-level
+      subcommands.
+- [x] The installed `AGENTS.md` content is a harness-managed delta block with
+      stable markers; reruns update that block in place and never rewrite
+      user-owned content outside it.
+- [x] The installed skill pack is repository-owned content managed by the CLI,
+      and reruns refresh the known managed files without deleting unrelated
+      user-added files.
+- [x] This repository's tracked docs and dogfood setup distinguish
+      easyharness-specific repo guidance from the distributable harness
+      bootstrap contract.
+- [x] README, CLI help, and durable specs explain how a release-installed user
+      bootstraps a fresh repository and what happens on repeated installs.
+
+## Deferred Items
+
+- Optional remote skill-pack installation or agent-assisted downloads.
+- User-selectable bootstrap templates beyond the minimum default contract.
+- Automatic merging or semantic editing of arbitrary user-authored
+  `AGENTS.md` structures beyond the managed block protocol.
+- Versioned upgrade prompts or background reminders to rerun `harness install`
+  after every release upgrade.
+
+## Work Breakdown
+
+### Step 1: Define the distributable bootstrap contract and dogfood split
+
+- Done: [x]
+
+#### Objective
+
+Lock the minimum harness-managed bootstrap assets and separate them from this
+repo's easyharness-specific dogfood guidance.
+
+#### Details
+
+This step should capture the accepted product decisions from discovery so the
+implementation does not rely on chat memory. The command name should be
+`harness install`, not `init`, because the bootstrap must be safe to rerun for
+refreshes as well as first installs. The CLI should expose a single user-facing
+command with internal scope selection rather than multiple separate top-level
+install commands. `AGENTS.md` should be managed as a delta block with stable
+markers, while `.agents/skills/` should be managed as a repo-owned asset set.
+This repo must dogfood the same split by separating easyharness-specific
+development guidance from the distributable harness workflow contract.
+
+#### Expected Files
+
+- `docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md`
+- `AGENTS.md`
+- bootstrap asset files under a new packaged-assets location if the chosen
+  implementation records the split there
+
+#### Validation
+
+- The tracked plan and repo docs clearly distinguish user-owned repo guidance
+  from the distributable harness-managed contract.
+- A future agent can tell which `AGENTS.md` content is CLI-managed and which is
+  easyharness-specific dogfood content.
+
+#### Execution Notes
+
+Split the distributable bootstrap contract out of repo-specific guidance by
+adding packaged bootstrap assets under `assets/bootstrap/` and rewriting this
+repo's `AGENTS.md` into a repo-specific wrapper plus the same managed block
+that `harness install --scope agents` installs elsewhere. The distributable
+contract now covers the harness working agreement, source-of-truth split,
+workflow, review execution, and start points, while easyharness-specific
+mission, development setup, and git rules stay outside the managed markers.
+
+Dogfood validation included refreshing this repository's managed block through
+`harness install --scope agents` and confirming the repo then reports a no-op
+dry run for the managed block.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: the contract split landed as part of one integrated
+bootstrap slice and is covered by the branch-level finalize review.
+
+### Step 2: Implement `harness install` and packaged bootstrap assets
+
+- Done: [x]
+
+#### Objective
+
+Add the CLI command, packaged bootstrap assets, and safe repeat-run behavior
+for installing or refreshing the harness-managed repo contract.
+
+#### Details
+
+The implementation should embed or otherwise package the minimum bootstrap
+assets with the release binary so the first-run path does not depend on network
+access or a separate agent-side installer. `harness install` should default to
+writing changes directly, while `--dry-run` reports the intended file actions
+clearly enough for a human or another agent to apply them deliberately. For
+`AGENTS.md`, the command should insert the managed block on first install,
+replace exactly one valid existing managed block on rerun, and error when the
+managed markers are duplicated or structurally unsafe. For skills, the command
+should create or refresh the known managed files while leaving unrelated
+user-added files alone. If `--scope` is introduced, its values should cover
+`agents`, `skills`, and `all`.
+
+#### Expected Files
+
+- `internal/cli/app.go`
+- `internal/cli/*_test.go`
+- implementation packages for bootstrap asset loading and install behavior
+- packaged bootstrap assets for `AGENTS.md` delta and skill files
+- optional supporting tests under `internal/` or `tests/`
+
+#### Validation
+
+- Add or update focused tests for CLI parsing, dry-run output, safe rerun
+  semantics, marker-conflict failures, and skill-pack refresh behavior.
+- Verify the packaged bootstrap assets can be rendered or installed without
+  depending on network access.
+- Run the relevant test suites for the new command and affected support
+  packages.
+
+#### Execution Notes
+
+Added `assets/bootstrap/` as the packaged source of truth for the managed
+`AGENTS.md` block and repo-local skill files, then introduced
+`internal/install/` as the install engine for first-run bootstrap and repeat
+refreshes. The CLI now exposes `harness install` with `--scope` and `--dry-run`
+support, reports JSON actions for both preview and apply flows, and treats
+`AGENTS.md` plus the packaged skill pack as CLI-managed assets with safe rerun
+semantics.
+
+Focused TDD covered fresh installs, managed-block refresh, duplicate-marker
+errors, managed-skill refresh without deleting user files, repeat-run no-op
+behavior, and CLI help/JSON output. A repo-wrapper regression test fixed a
+newline-normalization bug so repo-specific `AGENTS.md` wrappers become stable
+no-op reruns after refresh.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: the implementation was developed and validated as one
+integrated bootstrap slice and will receive a full finalize review before
+archive.
+
+### Step 3: Publish the first-run install story and dogfood it end to end
+
+- Done: [x]
+
+#### Objective
+
+Document the release-user bootstrap flow and prove the new install contract is
+usable in this repository and in a fresh repo-like environment.
+
+#### Details
+
+The docs should explain that installing the `easyharness` binary does not by
+itself modify a repository; users then run `harness install` in the repository
+they want to bootstrap. The README, specs, and any release-facing maintainer
+docs should explain direct-write behavior, `--dry-run`, repeat-run semantics,
+and the managed-block boundary in `AGENTS.md`. Dogfood validation should cover
+this repo's split `AGENTS.md` contract and at least one deterministic fresh
+repo bootstrap path that exercises `agents`, `skills`, and repeat-run behavior.
+
+#### Expected Files
+
+- `README.md`
+- `docs/specs/cli-contract.md`
+- `docs/specs/index.md`
+- `AGENTS.md`
+- smoke or integration tests if needed for fresh-repo bootstrap coverage
+
+#### Validation
+
+- Update docs so a release-installed user can follow the first-run bootstrap
+  flow without hidden context from this repo.
+- Add or run deterministic validation for a fresh repository bootstrap and a
+  repeat install that produces either the expected refresh or a no-op result.
+- Run the broader affected test suite after docs and dogfood changes land.
+
+#### Execution Notes
+
+Updated the public and durable docs so release-installed users now have an
+explicit repository bootstrap story after installing the binary. `README.md`
+documents `harness install`, the managed `AGENTS.md` block, repo-local skills,
+and repeat-run behavior. The CLI contract now includes `harness install`, and
+the smoke suite exercises fresh-repo bootstrap, dry-run non-writing behavior,
+and repeat-run no-op results.
+
+Validation passed with `go test ./internal/install ./internal/cli ./tests/smoke
+-run 'TestInstall|TestHelpShowsTopLevelUsage' -count=1`, a repo-local
+`harness install --scope agents --dry-run` no-op after dogfooding, and
+`go test ./... -count=1`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: the docs and smoke updates close out the same integrated
+slice and will be covered by full finalize review before archive.
+
+## Validation Strategy
+
+- Use focused TDD around the install engine first, especially for `AGENTS.md`
+  managed-block insertion, replacement, duplicate-marker errors, and skill-pack
+  refresh semantics.
+- Add or extend integration coverage for fresh-repo bootstrap and repeat-run
+  behavior so the user-facing command contract is exercised end to end.
+- Re-run the broader Go test suite after the CLI, docs, and dogfood split are
+  aligned.
+
+## Risks
+
+- Risk: The command could accidentally overwrite user-owned `AGENTS.md`
+  content or delete repo-local customizations in `.agents/skills/`.
+  - Mitigation: Restrict writes to one managed block for `AGENTS.md`, update
+    only known managed skill files, and add focused failure-path tests for
+    ambiguous or unsafe file layouts.
+- Risk: The bootstrap contract could keep easyharness dogfood assumptions mixed
+  into the distributable assets, making the public install flow misleading.
+  - Mitigation: Split the repo-specific guidance from the distributable assets
+    first and dogfood the packaged contract in this repository before archive.
+- Risk: `install` could still read as a one-time initializer and confuse users
+  about reruns after upgrades.
+  - Mitigation: Make repeat-run semantics explicit in help text, docs, dry-run
+    output, and test coverage for safe refresh/no-op behavior.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
+++ b/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
@@ -197,6 +197,11 @@ to whole-line markers only and added a focused regression test for the inline
 mention case. Finalize review `review-002-full` then found one more
 repeat-run edge case on CRLF `AGENTS.md` files; the repair widened marker-line
 matching so CRLF reruns refresh or noop instead of appending a duplicate block.
+Finalize review `review-003-full` then found a second CRLF correctness issue in
+the surrounding trim/join path; the final repair taught the installer to detect
+the existing file's line-ending style, render the managed block with that same
+style, and trim preserved user sections against both `\r` and `\n` so Windows
+worktrees do not get mixed newlines or stray carriage returns.
 
 #### Review Notes
 
@@ -253,7 +258,10 @@ existing user-authored `AGENTS.md`, refreshes the managed block, and proves the
 next rerun is a noop. After finalize review `review-002-full`, the smoke suite
 also gained explicit CLI coverage for duplicate managed-block failure and the
 `--scope skills` bootstrap path so both install branches now have end-to-end
-coverage.
+coverage. After finalize review `review-003-full`, the smoke suite gained one
+more apply-mode failure path by forcing `install --scope skills` to fail while
+`.agents` is a plain file, then verifying a cleaned-up rerun converges
+successfully.
 
 Validation passed with `go test ./internal/install ./internal/cli ./tests/smoke
 -run 'TestInstall|TestHelpShowsTopLevelUsage' -count=1`, a repo-local

--- a/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
+++ b/docs/plans/active/2026-03-31-bootstrap-repo-install-contract.md
@@ -190,7 +190,11 @@ Focused TDD covered fresh installs, managed-block refresh, duplicate-marker
 errors, managed-skill refresh without deleting user files, repeat-run no-op
 behavior, and CLI help/JSON output. A repo-wrapper regression test fixed a
 newline-normalization bug so repo-specific `AGENTS.md` wrappers become stable
-no-op reruns after refresh.
+no-op reruns after refresh. Finalize review `review-001-full` then found one
+additional marker-parsing bug: inline user-owned mentions of the marker strings
+could be mistaken for the managed block. The repair tightened marker detection
+to whole-line markers only and added a focused regression test for the inline
+mention case.
 
 #### Review Notes
 
@@ -240,7 +244,11 @@ explicit repository bootstrap story after installing the binary. `README.md`
 documents `harness install`, the managed `AGENTS.md` block, repo-local skills,
 and repeat-run behavior. The CLI contract now includes `harness install`, and
 the smoke suite exercises fresh-repo bootstrap, dry-run non-writing behavior,
-and repeat-run no-op results.
+and repeat-run no-op results. After finalize review `review-001-full`
+requested stronger coverage, the smoke suite also gained failing-install
+coverage for invalid scope and a wrapper-refresh path that starts from an
+existing user-authored `AGENTS.md`, refreshes the managed block, and proves the
+next rerun is a noop.
 
 Validation passed with `go test ./internal/install ./internal/cli ./tests/smoke
 -run 'TestInstall|TestHelpShowsTopLevelUsage' -count=1`, a repo-local

--- a/docs/plans/archived/2026-03-31-bootstrap-repo-install-contract.md
+++ b/docs/plans/archived/2026-03-31-bootstrap-repo-install-contract.md
@@ -1,6 +1,6 @@
 ---
 template_version: 0.2.0
-created_at: 2026-03-31T00:08:51+08:00
+created_at: "2026-03-31T00:08:51+08:00"
 source_type: issue
 source_refs:
     - '#68'
@@ -305,26 +305,48 @@ slice and will be covered by full finalize review before archive.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `go test ./internal/install ./internal/cli -count=1`
+- `go test ./internal/install ./tests/smoke -run 'TestInstall|TestHelpShowsTopLevelUsage' -count=1`
+- `go test ./internal/install ./tests/smoke -run 'TestInstallIgnoresLiteralMarkerMentionsInUserOwnedProse|TestInstallRejectsInvalidScopeViaCLI|TestInstallRefreshesExistingManagedWrapperAndThenNoops|TestInstall' -count=1`
+- `go test ./internal/install ./tests/smoke -run 'TestInstallRecognizesManagedBlockWithCRLFLineEndings|TestInstallRejectsDuplicateManagedBlocksViaCLI|TestInstallSkillsScopeBootstrapsOnlySkills|TestInstall' -count=1`
+- `go test ./tests/smoke -run 'TestInstallDefaultScopeRecoversAfterMidFlightFailure' -count=1`
+- `go test ./... -count=1` after each finalize-repair batch, ending green on the final candidate
+- `harness install --scope agents --dry-run` in this repo after dogfooding the managed block, confirming the packaged contract now reruns as a no-op against the repo's own `AGENTS.md`
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- `review-001-full`: changes requested for inline marker parsing and missing smoke coverage around failure paths and wrapper reruns
+- `review-002-full`: changes requested for CRLF marker recognition and missing smoke coverage for `skills` plus a structural CLI failure path
+- `review-003-full`: changes requested for CRLF newline preservation and apply-mode failure recovery coverage
+- `review-004-full`: changes requested for one more end-to-end retry case on the default full-scope install path
+- `review-005-full`: full finalize review passed with no findings
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-03-31T01:01:53+08:00
+- Revision: 1
+- PR: NONE
+- Ready: Full finalize review passed in `review-005-full`; the candidate is ready for archive, publish evidence, and merge-handoff work.
+- Merge Handoff: Archive the plan, push the branch, open the PR, and record publish/CI/sync evidence until `harness status` reaches `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added packaged bootstrap assets under `assets/bootstrap/` for the managed `AGENTS.md` delta and the repo-local harness skill pack.
+- Added `harness install` with direct-write default behavior, `--dry-run`, and `--scope agents|skills|all`.
+- Split this repo's `AGENTS.md` into easyharness-specific guidance plus the same managed harness contract that `harness install` installs elsewhere.
+- Added focused unit and CLI tests for marker handling, scoped installs, repeat-run no-op behavior, CRLF reruns, and error cases.
+- Added smoke coverage for fresh bootstrap, dry-run, duplicate marker rejection, `skills`-scope recovery, and default full-scope retry after a mid-flight failure.
+- Updated README and CLI specs so release-installed users have a concrete repository bootstrap story after installing the binary.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Optional remote skill-pack installation or agent-assisted downloads remain deferred.
+- User-selectable bootstrap templates beyond the minimum default contract remain deferred.
+- Drift detection and upgrade prompts for stale installed bootstrap assets remain deferred.
 
 ### Follow-Up Issues
 
-NONE
+- [#71](https://github.com/catu-ai/easyharness/issues/71): Add repo-level harness customization via a tracked `.harness` directory.
+- [#80](https://github.com/catu-ai/easyharness/issues/80): Decide how `harness install` should detect stale repo bootstrap assets.

--- a/docs/plans/archived/2026-03-31-bootstrap-repo-install-contract.md
+++ b/docs/plans/archived/2026-03-31-bootstrap-repo-install-contract.md
@@ -312,8 +312,6 @@ slice and will be covered by full finalize review before archive.
 
 ## Validation Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 - `go test ./internal/install ./internal/cli -count=1`
 - `go test ./internal/install ./tests/smoke -run 'TestInstall|TestHelpShowsTopLevelUsage' -count=1`
 - `go test ./internal/install ./tests/smoke -run 'TestInstallIgnoresLiteralMarkerMentionsInUserOwnedProse|TestInstallRejectsInvalidScopeViaCLI|TestInstallRefreshesExistingManagedWrapperAndThenNoops|TestInstall' -count=1`
@@ -321,32 +319,28 @@ UPDATE_REQUIRED_AFTER_REOPEN
 - `go test ./tests/smoke -run 'TestInstallDefaultScopeRecoversAfterMidFlightFailure' -count=1`
 - `go test ./... -count=1` after each finalize-repair batch, ending green on the final candidate
 - `harness install --scope agents --dry-run` in this repo after dogfooding the managed block, confirming the packaged contract now reruns as a no-op against the repo's own `AGENTS.md`
+- After the archived revision 1 candidate was reopened for remote-sync repair, merged with `origin/main`, and committed as revision 2, `go test ./... -count=1` passed again on the refreshed candidate.
 
 ## Review Summary
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - `review-001-full`: changes requested for inline marker parsing and missing smoke coverage around failure paths and wrapper reruns
 - `review-002-full`: changes requested for CRLF marker recognition and missing smoke coverage for `skills` plus a structural CLI failure path
 - `review-003-full`: changes requested for CRLF newline preservation and apply-mode failure recovery coverage
 - `review-004-full`: changes requested for one more end-to-end retry case on the default full-scope install path
 - `review-005-full`: full finalize review passed with no findings
+- After reopen for the `origin/main` sync repair, `review-006-full` reran full finalize review against revision 2 and passed with no findings.
 
 ## Archive Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
-- Archived At: 2026-03-31T01:01:53+08:00
-- Revision: 1
-- PR: NONE
-- Ready: Full finalize review passed in `review-005-full`; the candidate is ready for archive, publish evidence, and merge-handoff work.
-- Merge Handoff: Archive the plan, push the branch, open the PR, and record publish/CI/sync evidence until `harness status` reaches `execution/finalize/await_merge`.
+- Archived At: 2026-03-31T01:10:45+08:00
+- Revision: 2
+- PR: [#81](https://github.com/catu-ai/easyharness/pull/81)
+- Ready: The candidate was reopened only for a remote-sync repair, merged cleanly with `origin/main`, revalidated with `go test ./... -count=1`, and passed fresh finalize review in `review-006-full`.
+- Merge Handoff: Re-archive the updated plan, push branch `codex/issue-68-repo-install`, refresh PR #81, and record publish/CI/sync evidence until `harness status` reaches `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Added packaged bootstrap assets under `assets/bootstrap/` for the managed `AGENTS.md` delta and the repo-local harness skill pack.
 - Added `harness install` with direct-write default behavior, `--dry-run`, and `--scope agents|skills|all`.
@@ -354,18 +348,15 @@ UPDATE_REQUIRED_AFTER_REOPEN
 - Added focused unit and CLI tests for marker handling, scoped installs, repeat-run no-op behavior, CRLF reruns, and error cases.
 - Added smoke coverage for fresh bootstrap, dry-run, duplicate marker rejection, `skills`-scope recovery, and default full-scope retry after a mid-flight failure.
 - Updated README and CLI specs so release-installed users have a concrete repository bootstrap story after installing the binary.
+- Revalidated the archived candidate after syncing `origin/main`, then reran full finalize review so the same install contract is now ready as revision 2 without reopening scope.
 
 ### Not Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Optional remote skill-pack installation or agent-assisted downloads remain deferred.
 - User-selectable bootstrap templates beyond the minimum default contract remain deferred.
 - Drift detection and upgrade prompts for stale installed bootstrap assets remain deferred.
 
 ### Follow-Up Issues
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - [#71](https://github.com/catu-ai/easyharness/issues/71): Add repo-level harness customization via a tracked `.harness` directory.
 - [#80](https://github.com/catu-ai/easyharness/issues/80): Decide how `harness install` should detect stale repo bootstrap assets.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -18,6 +18,7 @@ The current command surface is:
 
 - `harness plan template`
 - `harness plan lint`
+- `harness install`
 - `harness execute start`
 - `harness evidence submit`
 - `harness status`
@@ -61,6 +62,10 @@ default to markdown or plain text instead of the JSON envelope.
 
 `harness --version` is also a plain-text exception because it is a binary
 identity/debug probe rather than a workflow-state command.
+
+`harness install` is a JSON-first bootstrap command, but it may omit workflow
+`state` because it manages repo-owned bootstrap assets rather than the tracked
+plan lifecycle.
 
 ### Help Must Be Actionable
 
@@ -201,6 +206,38 @@ When a current step exists, `harness status` should infer it from the first
 unfinished tracked step and return it as `facts.current_step`.
 
 ## Command Contracts
+
+### `harness install`
+
+Purpose:
+
+- install or refresh the harness-managed bootstrap assets for the current
+  repository
+
+Contract:
+
+- default to direct-write behavior for the current repository
+- support `--dry-run` to preview the intended file actions without writing
+- support one command-level scope selector with values `agents`, `skills`, and
+  `all`, defaulting to `all`
+- manage `AGENTS.md` through one stable managed block delimited by explicit
+  markers instead of rewriting the whole file
+- insert the managed block when `AGENTS.md` exists without it, replace exactly
+  one valid existing managed block on rerun, and fail with a clear error when
+  marker layout is duplicated or otherwise ambiguous
+- treat the installed skill pack under `.agents/skills/` as CLI-managed files:
+  create or refresh known packaged files without deleting unrelated user-added
+  files in that tree
+- package the bootstrap assets with the harness release so the command works
+  without network access
+- return a JSON envelope that reports `mode`, `scope`, and per-file actions;
+  workflow `state` may be omitted because the command does not mutate tracked
+  plan lifecycle state
+
+Recommended next action:
+
+- run without `--dry-run` to apply the previewed bootstrap changes
+- open `AGENTS.md` and `.agents/skills/` to review the installed contract
 
 ### `harness plan template`
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -9,7 +9,7 @@
 - [Plan Schema](./plan-schema.md): durable tracked-plan contract plus local
   state expectations.
 - [CLI Contract](./cli-contract.md): agent-facing command surface and JSON
-  contract.
+  contract, including repository bootstrap through `harness install`.
 
 ## Proposals
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/catu-ai/easyharness/internal/evidence"
+	"github.com/catu-ai/easyharness/internal/install"
 	"github.com/catu-ai/easyharness/internal/lifecycle"
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/review"
@@ -64,6 +65,8 @@ func (a *App) Run(args []string) int {
 		return a.runReopen(args[1:])
 	case "status":
 		return a.runStatus(args[1:])
+	case "install":
+		return a.runInstall(args[1:])
 	case "-h", "--help", "help":
 		a.printRootUsage()
 		return 0
@@ -267,6 +270,40 @@ func (a *App) runLandEntry(args []string) int {
 		return 1
 	}
 	result := lifecycle.Service{Workdir: workdir, Now: a.Now}.Land(*prURL, *commit)
+	return a.writeJSONResult(result)
+}
+
+func (a *App) runInstall(args []string) int {
+	fs := flag.NewFlagSet("harness install", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	scope := fs.String("scope", install.ScopeAll, "Install scope: agents, skills, or all.")
+	dryRun := fs.Bool("dry-run", false, "Show the planned repository changes without writing files.")
+	fs.Usage = func() {
+		fmt.Fprintln(a.Stderr, "Usage: harness install [--scope <agents|skills|all>] [--dry-run]")
+		fmt.Fprintln(a.Stderr)
+		fmt.Fprintln(a.Stderr, "Install or refresh the harness-managed repository bootstrap for the current repo.")
+		fmt.Fprintln(a.Stderr)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+	workdir, err := a.Getwd()
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
+		return 1
+	}
+	result := install.Service{Workdir: workdir}.Install(install.Options{
+		Scope:  *scope,
+		DryRun: *dryRun,
+	})
 	return a.writeJSONResult(result)
 }
 
@@ -650,6 +687,7 @@ func (a *App) printRootUsage() {
 	fmt.Fprintln(a.Stderr, "  archive         Freeze the current active plan")
 	fmt.Fprintln(a.Stderr, "  reopen          Restore the current archived plan")
 	fmt.Fprintln(a.Stderr, "  status          Summarize the current plan and local execution state")
+	fmt.Fprintln(a.Stderr, "  install         Install or refresh the harness-managed repository bootstrap")
 }
 
 func (a *App) printPlanUsage() {
@@ -747,6 +785,10 @@ func (a *App) writeJSONResult(value any) int {
 			return 0
 		}
 	case lifecycle.Result:
+		if result.OK {
+			return 0
+		}
+	case install.Result:
 		if result.OK {
 			return 0
 		}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -208,6 +208,98 @@ func TestRootHelpMentionsVersionFlag(t *testing.T) {
 	if !strings.Contains(stderr.String(), "--version       Print concise debug information for the running harness binary") {
 		t.Fatalf("expected root help to mention --version, got %q", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), "install         Install or refresh the harness-managed repository bootstrap") {
+		t.Fatalf("expected root help to mention install, got %q", stderr.String())
+	}
+}
+
+func TestInstallCommandReturnsJSON(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+
+	exitCode := app.Run([]string{"install", "--dry-run"})
+	if exitCode != 0 {
+		t.Fatalf("install dry-run failed with %d: %s", exitCode, stderr.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON install output: %v\n%s", err, stdout.String())
+	}
+	if payload["command"] != "install" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	if payload["mode"] != "dry_run" {
+		t.Fatalf("expected dry_run mode, got %#v", payload)
+	}
+}
+
+func TestInstallCommandWritesManagedAssets(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+
+	exitCode := app.Run([]string{"install", "--scope", "agents"})
+	if exitCode != 0 {
+		t.Fatalf("install command failed with %d: %s", exitCode, stderr.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON install output: %v\n%s", err, stdout.String())
+	}
+	if payload["command"] != "install" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	if _, err := os.Stat(filepath.Join(root, "AGENTS.md")); err != nil {
+		t.Fatalf("expected AGENTS.md to be written: %v", err)
+	}
+}
+
+func TestInstallCommandRejectsInvalidScope(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+
+	exitCode := app.Run([]string{"install", "--scope", "bogus"})
+	if exitCode != 1 {
+		t.Fatalf("expected invalid scope exit code 1, got %d", exitCode)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON install output: %v\n%s", err, stdout.String())
+	}
+	if payload["command"] != "install" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	if ok, _ := payload["ok"].(bool); ok {
+		t.Fatalf("expected install failure, got %#v", payload)
+	}
+}
+
+func TestInstallHelpExitsZero(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"install", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected help exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "Usage: harness install") {
+		t.Fatalf("expected install help text, got %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout for install help, got %q", stdout.String())
+	}
 }
 
 func TestPlanLintHelpExitsZero(t *testing.T) {

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -1,0 +1,375 @@
+package install
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	bootstrapassets "github.com/catu-ai/easyharness/assets/bootstrap"
+)
+
+const (
+	ScopeAll    = "all"
+	ScopeAgents = "agents"
+	ScopeSkills = "skills"
+
+	ActionCreate = "create"
+	ActionUpdate = "update"
+	ActionNoop   = "noop"
+
+	agentsManagedBlockBegin = "<!-- easyharness:begin -->"
+	agentsManagedBlockEnd   = "<!-- easyharness:end -->"
+)
+
+type Service struct {
+	Workdir string
+}
+
+type Options struct {
+	Scope  string
+	DryRun bool
+}
+
+type Result struct {
+	OK         bool           `json:"ok"`
+	Command    string         `json:"command"`
+	Summary    string         `json:"summary"`
+	Mode       string         `json:"mode"`
+	Scope      string         `json:"scope"`
+	Actions    []Action       `json:"actions"`
+	NextAction []NextAction   `json:"next_actions"`
+	Errors     []CommandError `json:"errors,omitempty"`
+}
+
+type Action struct {
+	Path    string `json:"path"`
+	Kind    string `json:"kind"`
+	Details string `json:"details"`
+}
+
+type NextAction struct {
+	Command     *string `json:"command"`
+	Description string  `json:"description"`
+}
+
+type CommandError struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+type plannedWrite struct {
+	relPath string
+	absPath string
+	kind    string
+	details string
+	content []byte
+}
+
+func (s Service) Install(opts Options) Result {
+	scope := normalizeScope(opts.Scope)
+	if !isValidScope(scope) {
+		return Result{
+			OK:      false,
+			Command: "install",
+			Summary: "Unsupported install scope.",
+			Mode:    modeName(opts.DryRun),
+			Scope:   scope,
+			Actions: []Action{},
+			Errors: []CommandError{{
+				Path:    "scope",
+				Message: fmt.Sprintf("supported scopes are %q, %q, and %q", ScopeAgents, ScopeSkills, ScopeAll),
+			}},
+			NextAction: []NextAction{},
+		}
+	}
+
+	var writes []plannedWrite
+	var errs []CommandError
+
+	if scope == ScopeAll || scope == ScopeAgents {
+		planned, err := s.planAgents()
+		if err != nil {
+			errs = append(errs, *err)
+		} else {
+			writes = append(writes, planned)
+		}
+	}
+	if scope == ScopeAll || scope == ScopeSkills {
+		planned, skillErrs := s.planSkills()
+		writes = append(writes, planned...)
+		errs = append(errs, skillErrs...)
+	}
+	if len(errs) > 0 {
+		return Result{
+			OK:         false,
+			Command:    "install",
+			Summary:    "Unable to prepare the harness-managed repository install.",
+			Mode:       modeName(opts.DryRun),
+			Scope:      scope,
+			Actions:    toActions(writes),
+			Errors:     errs,
+			NextAction: []NextAction{},
+		}
+	}
+
+	if !opts.DryRun {
+		for _, write := range writes {
+			if write.kind == ActionNoop {
+				continue
+			}
+			if err := os.MkdirAll(filepath.Dir(write.absPath), 0o755); err != nil {
+				return Result{
+					OK:      false,
+					Command: "install",
+					Summary: "Unable to write the harness-managed repository install.",
+					Mode:    modeName(opts.DryRun),
+					Scope:   scope,
+					Actions: toActions(writes),
+					Errors: []CommandError{{
+						Path:    write.relPath,
+						Message: fmt.Sprintf("create parent directory: %v", err),
+					}},
+					NextAction: []NextAction{},
+				}
+			}
+			if err := os.WriteFile(write.absPath, write.content, 0o644); err != nil {
+				return Result{
+					OK:      false,
+					Command: "install",
+					Summary: "Unable to write the harness-managed repository install.",
+					Mode:    modeName(opts.DryRun),
+					Scope:   scope,
+					Actions: toActions(writes),
+					Errors: []CommandError{{
+						Path:    write.relPath,
+						Message: fmt.Sprintf("write file: %v", err),
+					}},
+					NextAction: []NextAction{},
+				}
+			}
+		}
+	}
+
+	summary := summarizeWrites(writes, opts.DryRun)
+	creates, updates := countWrites(writes)
+	nextActions := []NextAction{}
+	if opts.DryRun && (creates > 0 || updates > 0) {
+		runCommand := "harness install"
+		if scope != ScopeAll {
+			runCommand = fmt.Sprintf("harness install --scope %s", scope)
+		}
+		nextActions = append(nextActions, NextAction{
+			Command:     &runCommand,
+			Description: "Run without --dry-run to apply the planned harness-managed repository changes.",
+		})
+	}
+
+	return Result{
+		OK:         true,
+		Command:    "install",
+		Summary:    summary,
+		Mode:       modeName(opts.DryRun),
+		Scope:      scope,
+		Actions:    toActions(writes),
+		NextAction: nextActions,
+	}
+}
+
+func (s Service) planAgents() (plannedWrite, *CommandError) {
+	targetPath := filepath.Join(s.Workdir, "AGENTS.md")
+	managedBlock := renderManagedBlock()
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			content := "# AGENTS.md\n\n" + managedBlock
+			return plannedWrite{
+				relPath: "AGENTS.md",
+				absPath: targetPath,
+				kind:    ActionCreate,
+				details: "Create AGENTS.md with the harness-managed workflow block.",
+				content: []byte(content),
+			}, nil
+		}
+		return plannedWrite{}, &CommandError{Path: "AGENTS.md", Message: err.Error()}
+	}
+
+	existing := string(data)
+	beginCount := strings.Count(existing, agentsManagedBlockBegin)
+	endCount := strings.Count(existing, agentsManagedBlockEnd)
+	if beginCount != endCount || beginCount > 1 {
+		return plannedWrite{}, &CommandError{
+			Path:    "AGENTS.md",
+			Message: "expected zero or one easyharness managed block; found an ambiguous marker layout",
+		}
+	}
+
+	var next string
+	var kind string
+	var details string
+	switch beginCount {
+	case 0:
+		trimmed := strings.TrimSpace(existing)
+		if trimmed == "" {
+			next = "# AGENTS.md\n\n" + managedBlock
+			kind = ActionUpdate
+			details = "Populate the empty AGENTS.md file with the harness-managed workflow block."
+		} else {
+			next = strings.TrimRight(existing, "\n") + "\n\n" + managedBlock
+			kind = ActionUpdate
+			details = "Append the harness-managed workflow block to AGENTS.md."
+		}
+	default:
+		begin := strings.Index(existing, agentsManagedBlockBegin)
+		end := strings.Index(existing, agentsManagedBlockEnd)
+		if begin < 0 || end < 0 || begin > end {
+			return plannedWrite{}, &CommandError{
+				Path:    "AGENTS.md",
+				Message: "unable to locate a valid easyharness managed block",
+			}
+		}
+		end += len(agentsManagedBlockEnd)
+		before := strings.TrimRight(existing[:begin], "\n")
+		after := strings.Trim(existing[end:], "\n")
+		parts := []string{}
+		if before != "" {
+			parts = append(parts, before)
+		}
+		parts = append(parts, strings.TrimRight(managedBlock, "\n"))
+		if after != "" {
+			parts = append(parts, after)
+		}
+		next = strings.Join(parts, "\n\n") + "\n"
+		kind = ActionUpdate
+		details = "Refresh the existing harness-managed AGENTS.md block in place."
+	}
+
+	if next == existing {
+		kind = ActionNoop
+		details = "AGENTS.md already contains the current harness-managed workflow block."
+	}
+
+	return plannedWrite{
+		relPath: "AGENTS.md",
+		absPath: targetPath,
+		kind:    kind,
+		details: details,
+		content: []byte(next),
+	}, nil
+}
+
+func (s Service) planSkills() ([]plannedWrite, []CommandError) {
+	files, err := bootstrapassets.SkillFiles()
+	if err != nil {
+		return nil, []CommandError{{Path: ".agents/skills", Message: err.Error()}}
+	}
+	relPaths := make([]string, 0, len(files))
+	for relPath := range files {
+		relPaths = append(relPaths, relPath)
+	}
+	sort.Strings(relPaths)
+
+	writes := make([]plannedWrite, 0, len(relPaths))
+	for _, relPath := range relPaths {
+		rel := filepath.ToSlash(filepath.Join(".agents/skills", filepath.FromSlash(relPath)))
+		abs := filepath.Join(s.Workdir, filepath.FromSlash(rel))
+		content := []byte(files[relPath])
+		existing, err := os.ReadFile(abs)
+		if err != nil {
+			if os.IsNotExist(err) {
+				writes = append(writes, plannedWrite{
+					relPath: rel,
+					absPath: abs,
+					kind:    ActionCreate,
+					details: "Create the harness-managed repo-local skill file from packaged bootstrap assets.",
+					content: content,
+				})
+				continue
+			}
+			return writes, []CommandError{{Path: rel, Message: err.Error()}}
+		}
+		kind := ActionUpdate
+		details := "Refresh the harness-managed repo-local skill file from packaged bootstrap assets."
+		if string(existing) == string(content) {
+			kind = ActionNoop
+			details = "Repo-local skill file already matches the packaged bootstrap asset."
+		}
+		writes = append(writes, plannedWrite{
+			relPath: rel,
+			absPath: abs,
+			kind:    kind,
+			details: details,
+			content: content,
+		})
+	}
+	return writes, nil
+}
+
+func renderManagedBlock() string {
+	body := strings.TrimSpace(bootstrapassets.AgentsManagedBlock())
+	return agentsManagedBlockBegin + "\n" + body + "\n" + agentsManagedBlockEnd + "\n"
+}
+
+func normalizeScope(scope string) string {
+	scope = strings.TrimSpace(strings.ToLower(scope))
+	if scope == "" {
+		return ScopeAll
+	}
+	return scope
+}
+
+func isValidScope(scope string) bool {
+	switch scope {
+	case ScopeAll, ScopeAgents, ScopeSkills:
+		return true
+	default:
+		return false
+	}
+}
+
+func modeName(dryRun bool) string {
+	if dryRun {
+		return "dry_run"
+	}
+	return "apply"
+}
+
+func toActions(writes []plannedWrite) []Action {
+	actions := make([]Action, 0, len(writes))
+	for _, write := range writes {
+		actions = append(actions, Action{
+			Path:    write.relPath,
+			Kind:    write.kind,
+			Details: write.details,
+		})
+	}
+	return actions
+}
+
+func summarizeWrites(writes []plannedWrite, dryRun bool) string {
+	creates, updates := countWrites(writes)
+	if creates == 0 && updates == 0 {
+		if dryRun {
+			return "Dry run complete. Harness-managed repository assets are already up to date."
+		}
+		return "Harness-managed repository assets are already up to date."
+	}
+	if dryRun {
+		return fmt.Sprintf("Dry run complete. %d file(s) would be created and %d file(s) would be updated.", creates, updates)
+	}
+	return fmt.Sprintf("Installed or refreshed harness-managed repository assets. %d file(s) created and %d file(s) updated.", creates, updates)
+}
+
+func countWrites(writes []plannedWrite) (int, int) {
+	var creates, updates int
+	for _, write := range writes {
+		switch write.kind {
+		case ActionCreate:
+			creates++
+		case ActionUpdate:
+			updates++
+		}
+	}
+	return creates, updates
+}

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -25,8 +25,8 @@ const (
 )
 
 var (
-	agentsManagedBlockBeginPattern = regexp.MustCompile(`(?m)^<!-- easyharness:begin -->[ \t]*$`)
-	agentsManagedBlockEndPattern   = regexp.MustCompile(`(?m)^<!-- easyharness:end -->[ \t]*$`)
+	agentsManagedBlockBeginPattern = regexp.MustCompile(`(?m)^<!-- easyharness:begin -->[ \t]*\r?$`)
+	agentsManagedBlockEndPattern   = regexp.MustCompile(`(?m)^<!-- easyharness:end -->[ \t]*\r?$`)
 )
 
 type Service struct {

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -21,6 +22,11 @@ const (
 
 	agentsManagedBlockBegin = "<!-- easyharness:begin -->"
 	agentsManagedBlockEnd   = "<!-- easyharness:end -->"
+)
+
+var (
+	agentsManagedBlockBeginPattern = regexp.MustCompile(`(?m)^<!-- easyharness:begin -->[ \t]*$`)
+	agentsManagedBlockEndPattern   = regexp.MustCompile(`(?m)^<!-- easyharness:end -->[ \t]*$`)
 )
 
 type Service struct {
@@ -196,8 +202,10 @@ func (s Service) planAgents() (plannedWrite, *CommandError) {
 	}
 
 	existing := string(data)
-	beginCount := strings.Count(existing, agentsManagedBlockBegin)
-	endCount := strings.Count(existing, agentsManagedBlockEnd)
+	beginMatches := agentsManagedBlockBeginPattern.FindAllStringIndex(existing, -1)
+	endMatches := agentsManagedBlockEndPattern.FindAllStringIndex(existing, -1)
+	beginCount := len(beginMatches)
+	endCount := len(endMatches)
 	if beginCount != endCount || beginCount > 1 {
 		return plannedWrite{}, &CommandError{
 			Path:    "AGENTS.md",
@@ -221,15 +229,15 @@ func (s Service) planAgents() (plannedWrite, *CommandError) {
 			details = "Append the harness-managed workflow block to AGENTS.md."
 		}
 	default:
-		begin := strings.Index(existing, agentsManagedBlockBegin)
-		end := strings.Index(existing, agentsManagedBlockEnd)
+		begin := beginMatches[0][0]
+		end := endMatches[0][0]
 		if begin < 0 || end < 0 || begin > end {
 			return plannedWrite{}, &CommandError{
 				Path:    "AGENTS.md",
 				Message: "unable to locate a valid easyharness managed block",
 			}
 		}
-		end += len(agentsManagedBlockEnd)
+		end = endMatches[0][1]
 		before := strings.TrimRight(existing[:begin], "\n")
 		after := strings.Trim(existing[end:], "\n")
 		parts := []string{}

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -185,10 +185,10 @@ func (s Service) Install(opts Options) Result {
 
 func (s Service) planAgents() (plannedWrite, *CommandError) {
 	targetPath := filepath.Join(s.Workdir, "AGENTS.md")
-	managedBlock := renderManagedBlock()
 	data, err := os.ReadFile(targetPath)
 	if err != nil {
 		if os.IsNotExist(err) {
+			managedBlock := renderManagedBlock("\n")
 			content := "# AGENTS.md\n\n" + managedBlock
 			return plannedWrite{
 				relPath: "AGENTS.md",
@@ -202,6 +202,8 @@ func (s Service) planAgents() (plannedWrite, *CommandError) {
 	}
 
 	existing := string(data)
+	lineEnding := detectLineEnding(existing)
+	managedBlock := renderManagedBlock(lineEnding)
 	beginMatches := agentsManagedBlockBeginPattern.FindAllStringIndex(existing, -1)
 	endMatches := agentsManagedBlockEndPattern.FindAllStringIndex(existing, -1)
 	beginCount := len(beginMatches)
@@ -220,11 +222,11 @@ func (s Service) planAgents() (plannedWrite, *CommandError) {
 	case 0:
 		trimmed := strings.TrimSpace(existing)
 		if trimmed == "" {
-			next = "# AGENTS.md\n\n" + managedBlock
+			next = "# AGENTS.md" + lineEnding + lineEnding + managedBlock
 			kind = ActionUpdate
 			details = "Populate the empty AGENTS.md file with the harness-managed workflow block."
 		} else {
-			next = strings.TrimRight(existing, "\n") + "\n\n" + managedBlock
+			next = trimTrailingLineBreaks(existing) + lineEnding + lineEnding + managedBlock
 			kind = ActionUpdate
 			details = "Append the harness-managed workflow block to AGENTS.md."
 		}
@@ -238,17 +240,17 @@ func (s Service) planAgents() (plannedWrite, *CommandError) {
 			}
 		}
 		end = endMatches[0][1]
-		before := strings.TrimRight(existing[:begin], "\n")
-		after := strings.Trim(existing[end:], "\n")
+		before := trimTrailingLineBreaks(existing[:begin])
+		after := trimSurroundingLineBreaks(existing[end:])
 		parts := []string{}
 		if before != "" {
 			parts = append(parts, before)
 		}
-		parts = append(parts, strings.TrimRight(managedBlock, "\n"))
+		parts = append(parts, trimTrailingLineBreaks(managedBlock))
 		if after != "" {
 			parts = append(parts, after)
 		}
-		next = strings.Join(parts, "\n\n") + "\n"
+		next = strings.Join(parts, lineEnding+lineEnding) + lineEnding
 		kind = ActionUpdate
 		details = "Refresh the existing harness-managed AGENTS.md block in place."
 	}
@@ -314,9 +316,9 @@ func (s Service) planSkills() ([]plannedWrite, []CommandError) {
 	return writes, nil
 }
 
-func renderManagedBlock() string {
-	body := strings.TrimSpace(bootstrapassets.AgentsManagedBlock())
-	return agentsManagedBlockBegin + "\n" + body + "\n" + agentsManagedBlockEnd + "\n"
+func renderManagedBlock(lineEnding string) string {
+	body := normalizeLineEndings(strings.TrimSpace(bootstrapassets.AgentsManagedBlock()), lineEnding)
+	return agentsManagedBlockBegin + lineEnding + body + lineEnding + agentsManagedBlockEnd + lineEnding
 }
 
 func normalizeScope(scope string) string {
@@ -367,6 +369,27 @@ func summarizeWrites(writes []plannedWrite, dryRun bool) string {
 		return fmt.Sprintf("Dry run complete. %d file(s) would be created and %d file(s) would be updated.", creates, updates)
 	}
 	return fmt.Sprintf("Installed or refreshed harness-managed repository assets. %d file(s) created and %d file(s) updated.", creates, updates)
+}
+
+func detectLineEnding(content string) string {
+	if strings.Contains(content, "\r\n") {
+		return "\r\n"
+	}
+	return "\n"
+}
+
+func normalizeLineEndings(content, lineEnding string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+	return strings.ReplaceAll(content, "\n", lineEnding)
+}
+
+func trimTrailingLineBreaks(content string) string {
+	return strings.TrimRight(content, "\r\n")
+}
+
+func trimSurroundingLineBreaks(content string) string {
+	return strings.Trim(content, "\r\n")
 }
 
 func countWrites(writes []plannedWrite) (int, int) {

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -240,3 +240,34 @@ func TestInstallNoopsForRepoSpecificAgentsWrapperAfterRefresh(t *testing.T) {
 		t.Fatalf("expected repo-specific wrapper to become noop, got %#v", second.Actions)
 	}
 }
+
+func TestInstallRecognizesManagedBlockWithCRLFLineEndings(t *testing.T) {
+	root := t.TempDir()
+	content := strings.Join([]string{
+		"# AGENTS.md",
+		"",
+		"Repo-specific intro.",
+		"",
+		agentsManagedBlockBegin,
+		"old managed content",
+		agentsManagedBlockEnd,
+		"",
+	}, "\r\n")
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	svc := Service{Workdir: root}
+	first := svc.Install(Options{Scope: ScopeAgents})
+	if !first.OK {
+		t.Fatalf("first install failed: %#v", first)
+	}
+
+	second := svc.Install(Options{Scope: ScopeAgents})
+	if !second.OK {
+		t.Fatalf("second install failed: %#v", second)
+	}
+	if len(second.Actions) != 1 || second.Actions[0].Kind != ActionNoop {
+		t.Fatalf("expected CRLF rerun to noop, got %#v", second.Actions)
+	}
+}

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -1,0 +1,212 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallCreatesManagedAgentsFileWhenMissing(t *testing.T) {
+	root := t.TempDir()
+
+	result := Service{Workdir: root}.Install(Options{})
+	if !result.OK {
+		t.Fatalf("expected install success, got %#v", result)
+	}
+
+	path := filepath.Join(root, "AGENTS.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "# AGENTS.md") {
+		t.Fatalf("expected AGENTS heading, got:\n%s", content)
+	}
+	if !strings.Contains(content, agentsManagedBlockBegin) || !strings.Contains(content, agentsManagedBlockEnd) {
+		t.Fatalf("expected managed markers, got:\n%s", content)
+	}
+}
+
+func TestInstallUpdatesManagedBlockWithoutTouchingUserContent(t *testing.T) {
+	root := t.TempDir()
+	original := strings.Join([]string{
+		"# AGENTS.md",
+		"",
+		"User-owned intro.",
+		"",
+		agentsManagedBlockBegin,
+		"outdated managed content",
+		agentsManagedBlockEnd,
+		"",
+		"User-owned footer.",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(original), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	result := Service{Workdir: root}.Install(Options{Scope: ScopeAgents})
+	if !result.OK {
+		t.Fatalf("expected install success, got %#v", result)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "User-owned intro.") || !strings.Contains(content, "User-owned footer.") {
+		t.Fatalf("expected user content to survive, got:\n%s", content)
+	}
+	if strings.Contains(content, "outdated managed content") {
+		t.Fatalf("expected managed block refresh, got:\n%s", content)
+	}
+	if strings.Count(content, agentsManagedBlockBegin) != 1 || strings.Count(content, agentsManagedBlockEnd) != 1 {
+		t.Fatalf("expected exactly one managed block, got:\n%s", content)
+	}
+}
+
+func TestInstallRejectsDuplicateManagedBlocks(t *testing.T) {
+	root := t.TempDir()
+	content := strings.Join([]string{
+		"# AGENTS.md",
+		"",
+		agentsManagedBlockBegin,
+		"one",
+		agentsManagedBlockEnd,
+		"",
+		agentsManagedBlockBegin,
+		"two",
+		agentsManagedBlockEnd,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	result := Service{Workdir: root}.Install(Options{Scope: ScopeAgents})
+	if result.OK {
+		t.Fatalf("expected duplicate-block install failure, got %#v", result)
+	}
+	if len(result.Errors) == 0 {
+		t.Fatalf("expected duplicate-block errors, got %#v", result)
+	}
+}
+
+func TestInstallRefreshesManagedSkillsWithoutRemovingUserFiles(t *testing.T) {
+	root := t.TempDir()
+	managedPath := filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(managedPath), 0o755); err != nil {
+		t.Fatalf("mkdir managed skill dir: %v", err)
+	}
+	if err := os.WriteFile(managedPath, []byte("outdated skill content"), 0o644); err != nil {
+		t.Fatalf("write managed skill: %v", err)
+	}
+
+	customPath := filepath.Join(root, ".agents/skills/custom/SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(customPath), 0o755); err != nil {
+		t.Fatalf("mkdir custom skill dir: %v", err)
+	}
+	if err := os.WriteFile(customPath, []byte("user custom skill"), 0o644); err != nil {
+		t.Fatalf("write custom skill: %v", err)
+	}
+
+	result := Service{Workdir: root}.Install(Options{Scope: ScopeSkills})
+	if !result.OK {
+		t.Fatalf("expected skill install success, got %#v", result)
+	}
+
+	managedData, err := os.ReadFile(managedPath)
+	if err != nil {
+		t.Fatalf("read managed skill: %v", err)
+	}
+	if string(managedData) == "outdated skill content" {
+		t.Fatalf("expected managed skill refresh, got:\n%s", managedData)
+	}
+
+	customData, err := os.ReadFile(customPath)
+	if err != nil {
+		t.Fatalf("read custom skill: %v", err)
+	}
+	if string(customData) != "user custom skill" {
+		t.Fatalf("expected custom skill to survive untouched, got %q", customData)
+	}
+}
+
+func TestInstallDryRunReportsPlannedActionsWithoutWriting(t *testing.T) {
+	root := t.TempDir()
+
+	result := Service{Workdir: root}.Install(Options{DryRun: true})
+	if !result.OK {
+		t.Fatalf("expected dry-run success, got %#v", result)
+	}
+	if len(result.Actions) == 0 {
+		t.Fatalf("expected planned actions, got %#v", result)
+	}
+
+	if _, err := os.Stat(filepath.Join(root, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected dry run to avoid writing AGENTS.md, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".agents")); !os.IsNotExist(err) {
+		t.Fatalf("expected dry run to avoid writing skills, err=%v", err)
+	}
+}
+
+func TestInstallNoopsWhenManagedAssetsAreCurrent(t *testing.T) {
+	root := t.TempDir()
+	svc := Service{Workdir: root}
+	first := svc.Install(Options{})
+	if !first.OK {
+		t.Fatalf("first install failed: %#v", first)
+	}
+
+	second := svc.Install(Options{})
+	if !second.OK {
+		t.Fatalf("second install failed: %#v", second)
+	}
+	for _, action := range second.Actions {
+		if action.Kind != ActionNoop {
+			t.Fatalf("expected noop actions on repeat install, got %#v", second.Actions)
+		}
+	}
+	if len(second.NextAction) != 0 {
+		t.Fatalf("expected noop repeat install to have no next actions, got %#v", second.NextAction)
+	}
+}
+
+func TestInstallNoopsForRepoSpecificAgentsWrapperAfterRefresh(t *testing.T) {
+	root := t.TempDir()
+	content := strings.Join([]string{
+		"# AGENTS.md",
+		"",
+		"Repo-specific intro.",
+		"",
+		agentsManagedBlockBegin,
+		"old managed content",
+		agentsManagedBlockEnd,
+		"",
+		"## Repo Rules",
+		"",
+		"- Keep commits small.",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	svc := Service{Workdir: root}
+	first := svc.Install(Options{Scope: ScopeAgents})
+	if !first.OK {
+		t.Fatalf("first install failed: %#v", first)
+	}
+
+	second := svc.Install(Options{Scope: ScopeAgents})
+	if !second.OK {
+		t.Fatalf("second install failed: %#v", second)
+	}
+	if len(second.Actions) != 1 || second.Actions[0].Kind != ActionNoop {
+		t.Fatalf("expected repo-specific wrapper to become noop, got %#v", second.Actions)
+	}
+}

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -263,6 +263,15 @@ func TestInstallRecognizesManagedBlockWithCRLFLineEndings(t *testing.T) {
 		t.Fatalf("first install failed: %#v", first)
 	}
 
+	data, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read refreshed AGENTS.md: %v", err)
+	}
+	normalized := strings.ReplaceAll(string(data), "\r\n", "")
+	if strings.Contains(normalized, "\n") || strings.Contains(normalized, "\r") {
+		t.Fatalf("expected refreshed AGENTS.md to preserve consistent CRLF line endings, got:\n%q", string(data))
+	}
+
 	second := svc.Install(Options{Scope: ScopeAgents})
 	if !second.OK {
 		t.Fatalf("second install failed: %#v", second)

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -95,6 +95,36 @@ func TestInstallRejectsDuplicateManagedBlocks(t *testing.T) {
 	}
 }
 
+func TestInstallIgnoresLiteralMarkerMentionsInUserOwnedProse(t *testing.T) {
+	root := t.TempDir()
+	content := strings.Join([]string{
+		"# AGENTS.md",
+		"",
+		"User-owned note mentioning markers inline: `<!-- easyharness:begin -->` and `<!-- easyharness:end -->`.",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	result := Service{Workdir: root}.Install(Options{Scope: ScopeAgents})
+	if !result.OK {
+		t.Fatalf("expected install success, got %#v", result)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	rendered := string(data)
+	if !strings.Contains(rendered, "User-owned note mentioning markers inline") {
+		t.Fatalf("expected inline marker prose to survive, got:\n%s", rendered)
+	}
+	if len(agentsManagedBlockBeginPattern.FindAllStringIndex(rendered, -1)) != 1 || len(agentsManagedBlockEndPattern.FindAllStringIndex(rendered, -1)) != 1 {
+		t.Fatalf("expected a single managed block append, got:\n%s", rendered)
+	}
+}
+
 func TestInstallRefreshesManagedSkillsWithoutRemovingUserFiles(t *testing.T) {
 	root := t.TempDir()
 	managedPath := filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md")

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -224,6 +224,53 @@ func TestInstallRejectsInvalidScopeViaCLI(t *testing.T) {
 	}
 }
 
+func TestInstallRejectsDuplicateManagedBlocksViaCLI(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	agentsPath := workspace.Path("AGENTS.md")
+	content := strings.Join([]string{
+		"# AGENTS.md",
+		"",
+		"<!-- easyharness:begin -->",
+		"one",
+		"<!-- easyharness:end -->",
+		"",
+		"<!-- easyharness:begin -->",
+		"two",
+		"<!-- easyharness:end -->",
+		"",
+	}, "\n")
+	if err := os.WriteFile(agentsPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	result := support.Run(t, workspace.Root, "install", "--scope", "agents")
+	support.RequireExitCode(t, result, 1)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[installResult](t, result)
+	if payload.OK {
+		t.Fatalf("expected duplicate-block install failure, got %#v", payload)
+	}
+	if payload.Command != "install" || payload.Scope != "agents" {
+		t.Fatalf("unexpected duplicate-block payload: %#v", payload)
+	}
+}
+
+func TestInstallSkillsScopeBootstrapsOnlySkills(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	result := support.Run(t, workspace.Root, "install", "--scope", "skills")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[installResult](t, result)
+	if !payload.OK || payload.Scope != "skills" {
+		t.Fatalf("unexpected skills-scope payload: %#v", payload)
+	}
+	support.RequireFileExists(t, workspace.Path(".agents/skills/harness-discovery/SKILL.md"))
+	support.RequireFileMissing(t, workspace.Path("AGENTS.md"))
+}
+
 func TestInstallRefreshesExistingManagedWrapperAndThenNoops(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 	agentsPath := workspace.Path("AGENTS.md")

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -33,6 +33,18 @@ type lintResult struct {
 	} `json:"artifacts"`
 }
 
+type installResult struct {
+	OK      bool   `json:"ok"`
+	Command string `json:"command"`
+	Summary string `json:"summary"`
+	Mode    string `json:"mode"`
+	Scope   string `json:"scope"`
+	Actions []struct {
+		Path string `json:"path"`
+		Kind string `json:"kind"`
+	} `json:"actions"`
+}
+
 func TestHelpShowsTopLevelUsage(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
@@ -52,6 +64,7 @@ func TestHelpShowsTopLevelUsage(t *testing.T) {
 	support.RequireContains(t, result.CombinedOutput(), "archive         Freeze the current active plan")
 	support.RequireContains(t, result.CombinedOutput(), "reopen          Restore the current archived plan")
 	support.RequireContains(t, result.CombinedOutput(), "status          Summarize the current plan and local execution state")
+	support.RequireContains(t, result.CombinedOutput(), "install         Install or refresh the harness-managed repository bootstrap")
 }
 
 func TestVersionPrintsHumanReadableBuildInfo(t *testing.T) {
@@ -124,6 +137,75 @@ func TestPlanTemplatePrintsToStdoutByDefault(t *testing.T) {
 	support.RequireContains(t, result.Stdout, "created_at: 2026-03-22T00:00:00Z")
 	support.RequireContains(t, result.Stdout, "source_type: issue")
 	support.RequireContains(t, result.Stdout, "source_refs: [\"#6\"]")
+}
+
+func TestInstallBootstrapsFreshRepository(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	result := support.Run(t, workspace.Root, "install")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[installResult](t, result)
+	if !payload.OK || payload.Command != "install" {
+		t.Fatalf("expected install payload, got %#v", payload)
+	}
+	if payload.Mode != "apply" || payload.Scope != "all" {
+		t.Fatalf("unexpected install mode/scope: %#v", payload)
+	}
+
+	agentsPath := workspace.Path("AGENTS.md")
+	support.RequireFileExists(t, agentsPath)
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	support.RequireContains(t, string(agentsData), "<!-- easyharness:begin -->")
+	support.RequireContains(t, string(agentsData), "<!-- easyharness:end -->")
+
+	support.RequireFileExists(t, workspace.Path(".agents/skills/harness-execute/SKILL.md"))
+	support.RequireFileExists(t, workspace.Path(".agents/skills/harness-reviewer/SKILL.md"))
+}
+
+func TestInstallDryRunDoesNotWriteRepositoryFiles(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	result := support.Run(t, workspace.Root, "install", "--dry-run")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[installResult](t, result)
+	if payload.Mode != "dry_run" {
+		t.Fatalf("expected dry_run mode, got %#v", payload)
+	}
+	if len(payload.Actions) == 0 {
+		t.Fatalf("expected planned actions, got %#v", payload)
+	}
+
+	support.RequireFileMissing(t, workspace.Path("AGENTS.md"))
+	support.RequireFileMissing(t, workspace.Path(".agents"))
+}
+
+func TestInstallRepeatRunReportsNoopActions(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	first := support.Run(t, workspace.Root, "install")
+	support.RequireSuccess(t, first)
+	support.RequireNoStderr(t, first)
+
+	second := support.Run(t, workspace.Root, "install")
+	support.RequireSuccess(t, second)
+	support.RequireNoStderr(t, second)
+
+	payload := support.RequireJSONResult[installResult](t, second)
+	if !strings.Contains(payload.Summary, "already up to date") {
+		t.Fatalf("expected no-op summary, got %#v", payload)
+	}
+	for _, action := range payload.Actions {
+		if action.Kind != "noop" {
+			t.Fatalf("expected noop repeat install actions, got %#v", payload.Actions)
+		}
+	}
 }
 
 func TestSupportRunUsesBuiltBinaryInsteadOfPATH(t *testing.T) {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -302,6 +302,43 @@ func TestInstallSkillsScopeRecoversAfterApplyWriteFailure(t *testing.T) {
 	support.RequireFileExists(t, workspace.Path(".agents/skills/harness-reviewer/SKILL.md"))
 }
 
+func TestInstallDefaultScopeRecoversAfterMidFlightFailure(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	blockedSkillPath := workspace.Path(".agents/skills/harness-discovery/SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(blockedSkillPath), 0o755); err != nil {
+		t.Fatalf("mkdir blocked skill dir: %v", err)
+	}
+	if err := os.WriteFile(blockedSkillPath, []byte("stale skill"), 0o400); err != nil {
+		t.Fatalf("write blocked skill file: %v", err)
+	}
+
+	failed := support.Run(t, workspace.Root, "install")
+	support.RequireExitCode(t, failed, 1)
+	support.RequireNoStderr(t, failed)
+
+	failedPayload := support.RequireJSONResult[installResult](t, failed)
+	if failedPayload.OK {
+		t.Fatalf("expected default install failure, got %#v", failedPayload)
+	}
+	support.RequireFileExists(t, workspace.Path("AGENTS.md"))
+	support.RequireFileMissing(t, workspace.Path(".agents/skills/harness-reviewer/SKILL.md"))
+
+	if err := os.Chmod(blockedSkillPath, 0o644); err != nil {
+		t.Fatalf("chmod blocked skill file: %v", err)
+	}
+
+	retry := support.Run(t, workspace.Root, "install")
+	support.RequireSuccess(t, retry)
+	support.RequireNoStderr(t, retry)
+
+	retryPayload := support.RequireJSONResult[installResult](t, retry)
+	if !retryPayload.OK || retryPayload.Scope != "all" {
+		t.Fatalf("expected successful default-scope retry payload, got %#v", retryPayload)
+	}
+	support.RequireFileExists(t, workspace.Path("AGENTS.md"))
+	support.RequireFileExists(t, workspace.Path(".agents/skills/harness-reviewer/SKILL.md"))
+}
+
 func TestInstallRefreshesExistingManagedWrapperAndThenNoops(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 	agentsPath := workspace.Path("AGENTS.md")

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -271,6 +271,37 @@ func TestInstallSkillsScopeBootstrapsOnlySkills(t *testing.T) {
 	support.RequireFileMissing(t, workspace.Path("AGENTS.md"))
 }
 
+func TestInstallSkillsScopeRecoversAfterApplyWriteFailure(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	agentsRootPath := workspace.Path(".agents")
+	if err := os.WriteFile(agentsRootPath, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write blocking .agents file: %v", err)
+	}
+
+	failed := support.Run(t, workspace.Root, "install", "--scope", "skills")
+	support.RequireExitCode(t, failed, 1)
+	support.RequireNoStderr(t, failed)
+
+	failedPayload := support.RequireJSONResult[installResult](t, failed)
+	if failedPayload.OK {
+		t.Fatalf("expected apply-mode write failure, got %#v", failedPayload)
+	}
+
+	if err := os.Remove(agentsRootPath); err != nil {
+		t.Fatalf("remove blocking .agents file: %v", err)
+	}
+
+	retry := support.Run(t, workspace.Root, "install", "--scope", "skills")
+	support.RequireSuccess(t, retry)
+	support.RequireNoStderr(t, retry)
+
+	retryPayload := support.RequireJSONResult[installResult](t, retry)
+	if !retryPayload.OK || retryPayload.Scope != "skills" {
+		t.Fatalf("expected successful retry payload, got %#v", retryPayload)
+	}
+	support.RequireFileExists(t, workspace.Path(".agents/skills/harness-reviewer/SKILL.md"))
+}
+
 func TestInstallRefreshesExistingManagedWrapperAndThenNoops(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 	agentsPath := workspace.Path("AGENTS.md")

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -208,6 +208,72 @@ func TestInstallRepeatRunReportsNoopActions(t *testing.T) {
 	}
 }
 
+func TestInstallRejectsInvalidScopeViaCLI(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	result := support.Run(t, workspace.Root, "install", "--scope", "bogus")
+	support.RequireExitCode(t, result, 1)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[installResult](t, result)
+	if payload.OK {
+		t.Fatalf("expected install failure payload, got %#v", payload)
+	}
+	if payload.Command != "install" || payload.Scope != "bogus" {
+		t.Fatalf("unexpected invalid-scope payload: %#v", payload)
+	}
+}
+
+func TestInstallRefreshesExistingManagedWrapperAndThenNoops(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	agentsPath := workspace.Path("AGENTS.md")
+	initial := strings.Join([]string{
+		"# AGENTS.md",
+		"",
+		"Repo-owned intro.",
+		"",
+		"<!-- easyharness:begin -->",
+		"outdated managed content",
+		"<!-- easyharness:end -->",
+		"",
+		"## Repo Rules",
+		"",
+		"- Keep commits reviewable.",
+		"",
+	}, "\n")
+	if err := os.WriteFile(agentsPath, []byte(initial), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	refresh := support.Run(t, workspace.Root, "install", "--scope", "agents")
+	support.RequireSuccess(t, refresh)
+	support.RequireNoStderr(t, refresh)
+
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read refreshed AGENTS.md: %v", err)
+	}
+	agentsBody := string(agentsData)
+	support.RequireContains(t, agentsBody, "Repo-owned intro.")
+	support.RequireContains(t, agentsBody, "## Repo Rules")
+	support.RequireContains(t, agentsBody, "## Harness Working Agreement")
+	if strings.Contains(agentsBody, "outdated managed content") {
+		t.Fatalf("expected refreshed managed block, got:\n%s", agentsBody)
+	}
+
+	second := support.Run(t, workspace.Root, "install", "--scope", "agents")
+	support.RequireSuccess(t, second)
+	support.RequireNoStderr(t, second)
+
+	payload := support.RequireJSONResult[installResult](t, second)
+	if !strings.Contains(payload.Summary, "already up to date") {
+		t.Fatalf("expected noop wrapper rerun summary, got %#v", payload)
+	}
+	if len(payload.Actions) != 1 || payload.Actions[0].Kind != "noop" {
+		t.Fatalf("expected noop wrapper rerun action, got %#v", payload.Actions)
+	}
+}
+
 func TestSupportRunUsesBuiltBinaryInsteadOfPATH(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 	poisonDir := workspace.Path("tmp/poison-bin")


### PR DESCRIPTION
## What Changed

- added packaged bootstrap assets for the managed `AGENTS.md` block and repo-local harness skill pack
- added `harness install` with direct-write default behavior, `--dry-run`, and `--scope agents|skills|all`
- dogfooded the split in this repo's `AGENTS.md` and updated README/spec docs for the first-run bootstrap story
- added focused unit tests and smoke coverage for reruns, duplicate markers, CRLF handling, scoped installs, and failure recovery

## Why

`easyharness` could ship a binary, but a freshly installed user still had to reverse-engineer how to bootstrap a repository contract by hand. This slice makes repository bootstrap a first-class, repeatable CLI flow instead of a docs-only guess.

## Impact

Release users can now run `harness install` in a repository to materialize the managed harness contract. The command is safe to rerun, preserves user-owned `AGENTS.md` content outside the managed block, and surfaces preview/apply behavior through JSON output.

## Validation

- `go test ./... -count=1`
- finalize review rounds through `review-005-full`, ending in a clean pass
