### PR TITLE
[codex] Unify bootstrap sync source and drift checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,20 @@ scripts/install-dev-harness
 If you change Go CLI code, rerun the installer before relying on the direct
 `harness` command again.
 
+## Bootstrap Asset Editing
+
+This repository dogsfoods the same bootstrap assets that `harness install`
+packages for other repositories.
+
+- Edit `assets/bootstrap/` when changing the harness-managed skill pack or the
+  managed `AGENTS.md` block content.
+- Treat `.agents/skills/` in this repository as tracked materialized output from
+  `assets/bootstrap/`, not as a hand-edited source tree.
+- After editing `assets/bootstrap/`, run `scripts/sync-bootstrap-assets` to
+  refresh `.agents/skills/` and the managed block in this root `AGENTS.md`.
+- Keep easyharness-specific guidance in this root `AGENTS.md` outside the
+  managed markers below.
+
 The block below is the same harness-managed repository contract that
 `harness install --scope agents` would install into another repository.
 Keep easyharness-specific guidance outside the managed markers.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ harness --version
 After changing Go CLI code, rerun `scripts/install-dev-harness` so the direct
 `harness` command stays in sync with the working tree.
 
+When changing the harness-managed bootstrap contract that this repository
+dogsfoods, edit `assets/bootstrap/` instead of hand-editing `.agents/skills/`.
+The `.agents/skills/` tree and this repository's managed `AGENTS.md` block are
+tracked materialized outputs of those packaged bootstrap assets. Refresh them
+with:
+
+```bash
+scripts/sync-bootstrap-assets
+scripts/sync-bootstrap-assets --check
+```
+
 If the installer reports that `harness` still resolves to a different binary,
 either install into an earlier directory with `--install-dir` or move the
 chosen install directory earlier in `PATH`.
@@ -221,15 +232,19 @@ workflow starts.
 
 High-level guidance lives in [AGENTS.md](./AGENTS.md). The durable contracts
 for plans and CLI behavior live in [docs/specs/index.md](./docs/specs/index.md).
-Execution detail for agents lives in `.agents/skills/`.
+Execution detail for agents is materialized into `.agents/skills/` from the
+canonical bootstrap assets under `assets/bootstrap/`.
 
 ## Repository Layout
 
 - `cmd/harness/`: CLI entrypoint
 - `internal/`: CLI implementation
+- `assets/bootstrap/`: canonical source for packaged bootstrap assets that this
+  repository dogsfoods
 - `docs/plans/`: tracked active plans for both profiles plus archived standard plans
 - `docs/specs/`: durable repo contracts
-- `.agents/skills/`: repo-local workflow skills
+- `.agents/skills/`: tracked materialized repo-local workflow skills generated
+  from `assets/bootstrap/`
 - `AGENTS.md`: repo-specific guidance plus the harness-managed install block
 - `.local/harness/`: disposable runtime state, current-plan/last-landed
   markers, archived lightweight plan snapshots, review artifacts, evidence

--- a/cmd/bootstrap-sync/main.go
+++ b/cmd/bootstrap-sync/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/catu-ai/easyharness/internal/bootstrapsync"
+)
+
+func main() {
+	var workdir string
+	var check bool
+
+	flag.StringVar(&workdir, "workdir", ".", "repository root to sync or check")
+	flag.BoolVar(&check, "check", false, "fail when tracked dogfood outputs drift from assets/bootstrap")
+	flag.Parse()
+
+	var err error
+	if check {
+		_, err = bootstrapsync.Check(workdir)
+		if err == nil {
+			fmt.Fprintln(os.Stdout, "Bootstrap dogfood outputs are in sync with assets/bootstrap.")
+			return
+		}
+	} else {
+		result, syncErr := bootstrapsync.Sync(workdir)
+		err = syncErr
+		if err == nil {
+			fmt.Fprintln(os.Stdout, result.Summary)
+			return
+		}
+	}
+
+	var driftErr *bootstrapsync.DriftError
+	if errors.As(err, &driftErr) {
+		fmt.Fprintln(os.Stderr, driftErr.Error())
+		os.Exit(1)
+	}
+
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/docs/plans/archived/2026-03-31-unify-bootstrap-skill-source-and-drift-checks.md
+++ b/docs/plans/archived/2026-03-31-unify-bootstrap-skill-source-and-drift-checks.md
@@ -1,0 +1,306 @@
+---
+template_version: 0.2.0
+created_at: "2026-03-31T13:25:46+08:00"
+source_type: direct_request
+source_refs: []
+---
+
+# Unify bootstrap skill source and drift checks
+
+## Goal
+
+Make `assets/bootstrap/` the only hand-edited source for the harness-managed
+bootstrap contract that this repository dogsfoods and that release builds embed
+for `harness install`. The dogfood copies under `.agents/skills/` and the
+managed block content mirrored in this repository's `AGENTS.md` should become
+materialized outputs derived from those packaged assets instead of a second set
+of independently edited files.
+
+The resulting workflow should stay self-contained for release users: `harness
+install` must continue to install ordinary repository files with no network or
+symlink dependency. In this repository, humans and agents should have one clear
+editing surface, one explicit refresh path for dogfood outputs, and automated
+drift checks that fail when the tracked materialized files diverge from
+`assets/bootstrap/`.
+
+## Scope
+
+### In Scope
+
+- Define and document `assets/bootstrap/` as the canonical editing surface for
+  bootstrap skills and the harness-managed `AGENTS.md` block.
+- Add a repo-local sync path that refreshes tracked dogfood outputs from
+  `assets/bootstrap/` into `.agents/skills/` and the root `AGENTS.md` managed
+  block while preserving repo-specific `AGENTS.md` guidance outside the managed
+  markers.
+- Update repo-visible guidance for both humans and agents so future edits land
+  in the canonical source instead of the materialized outputs.
+- Add automated drift validation so test or CI fails when tracked materialized
+  outputs no longer match the canonical bootstrap assets.
+- Preserve the current release contract: embedded bootstrap assets still ship in
+  the binary and `harness install` still writes normal files into target repos.
+
+### Out of Scope
+
+- Switching dogfood skills to symlinks.
+- Introducing a separate `bootstrap-src/` source tree in this slice.
+- Changing `harness install` to fetch remote assets or install anything other
+  than normal repository files.
+- Broad redesign of the harness install scope model beyond the canonical-source
+  and drift-guard changes above.
+
+## Acceptance Criteria
+
+- [x] Repository guidance states that bootstrap skill and managed-block edits
+      belong in `assets/bootstrap/`, and that `.agents/skills/` is a
+      materialized output that should not be edited directly.
+- [x] A deterministic repo-local sync path can regenerate the tracked
+      `.agents/skills/**` files and this repository's managed `AGENTS.md` block
+      from `assets/bootstrap/` without disturbing repo-specific `AGENTS.md`
+      content outside the markers.
+- [x] Automated validation detects drift between `assets/bootstrap/` and the
+      tracked dogfood outputs, so forgetting to resync fails local tests and
+      CI paths that already run the relevant suite.
+- [x] Existing bootstrap behavior remains intact for release users: embedded
+      assets still back `harness install`, and install/smoke coverage continues
+      to pass with the new canonical-source workflow.
+
+## Deferred Items
+
+- A later split between human-authored bootstrap source and generated
+  embed-ready assets if `assets/bootstrap/` becomes too overloaded.
+- Optional developer ergonomics such as a dedicated CLI subcommand for
+  bootstrap syncing instead of a repo-local script.
+
+## Work Breakdown
+
+### Step 1: Define the canonical bootstrap-editing contract
+
+- Done: [x]
+
+#### Objective
+
+Make the source-of-truth boundary explicit in tracked docs so a future agent can
+tell, without chat history, which files are hand-edited and which are generated
+dogfood outputs.
+
+#### Details
+
+Document that `assets/bootstrap/` is the only hand-edited source for packaged
+bootstrap content in this repository. Clarify that `.agents/skills/` is a
+tracked materialization of those packaged assets, and that the harness-managed
+block inside this repository's `AGENTS.md` is likewise refreshed from
+`assets/bootstrap/agents-managed-block.md` while the easyharness-specific
+guidance outside the markers remains hand-owned repo documentation.
+
+#### Expected Files
+
+- `AGENTS.md`
+- `README.md`
+- `docs/specs/cli-contract.md`
+
+#### Validation
+
+- A cold reader can identify the canonical editing surface and the materialized
+  outputs directly from tracked docs.
+- The documented workflow still matches the existing install contract in
+  `docs/specs/cli-contract.md`.
+
+#### Execution Notes
+
+Clarified the canonical editing contract in `AGENTS.md`, `README.md`, and
+`docs/specs/cli-contract.md`: bootstrap-skill and managed-block edits now point
+to `assets/bootstrap/`, while `.agents/skills/` and the root `AGENTS.md`
+managed block are documented as tracked materialized outputs. Validation:
+`scripts/sync-bootstrap-assets --check`, `go test ./internal/install`, and
+`go test ./tests/smoke -run 'TestSyncBootstrapAssetsCheckPassesForCurrentRepo|TestInstall'`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This step is documentation-only and was reviewed
+together with the coupled sync implementation in the later full finalize
+review.
+
+### Step 2: Add deterministic dogfood materialization from bootstrap assets
+
+- Done: [x]
+
+#### Objective
+
+Introduce one repo-local sync path that refreshes this repository's tracked
+dogfood bootstrap outputs from `assets/bootstrap/` instead of maintaining those
+outputs by hand.
+
+#### Details
+
+The implementation should choose one clear maintenance entrypoint, such as a
+repo-local script, and use it to refresh `.agents/skills/**` plus the managed
+block inside the root `AGENTS.md`. The sync path must preserve repo-specific
+guidance outside the managed markers, keep line-ending handling deterministic,
+and avoid turning `harness install` itself into the repository-maintenance
+mechanism. `assets/bootstrap/embed.go` should remain the source of packaged
+release assets, not become another editable copy.
+
+#### Expected Files
+
+- `assets/bootstrap/embed.go`
+- `assets/bootstrap/agents-managed-block.md`
+- `assets/bootstrap/skills/**`
+- `scripts/sync-bootstrap-assets`
+- `.agents/skills/**`
+- `AGENTS.md`
+
+#### Validation
+
+- Running the chosen sync path after editing `assets/bootstrap/` deterministically
+  updates the tracked dogfood outputs and produces no unrelated file churn.
+- Existing install tests and smoke tests still pass after the sync mechanism is
+  introduced or refactored.
+
+#### Execution Notes
+
+Added a repo-local sync entrypoint at `scripts/sync-bootstrap-assets`, backed by
+`cmd/bootstrap-sync` and `internal/bootstrapsync`, so this repository can
+refresh `.agents/skills/**` and the root `AGENTS.md` managed block from
+`assets/bootstrap/` without using `harness install` as the human-facing
+maintenance command. Finalize review then caught an orphan-file gap, so the
+sync helper now also detects and removes stale materialized skill files that no
+longer exist in `assets/bootstrap/`. Validation:
+`scripts/sync-bootstrap-assets`, `scripts/sync-bootstrap-assets --check`,
+`go test ./cmd/bootstrap-sync`, and `go test ./internal/bootstrapsync ./internal/install`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: The sync helper and its enforcement tests landed as one
+tightly coupled slice and are covered together by the branch-level full
+finalize review.
+
+### Step 3: Enforce drift checks in automated validation
+
+- Done: [x]
+
+#### Objective
+
+Make drift between `assets/bootstrap/` and the tracked dogfood outputs fail
+automatically instead of relying on contributor memory.
+
+#### Details
+
+Prefer enforcement that naturally rides on the repository's existing automated
+test paths so CI picks it up without bespoke human steps. The checks should
+verify both sides of the dogfood contract: `.agents/skills/**` matches the
+packaged bootstrap skills, and the harness-managed block in the root
+`AGENTS.md` matches `assets/bootstrap/agents-managed-block.md`. If the chosen
+test suite is not already covered by CI, update the relevant workflow or test
+entrypoint so the drift guard runs by default.
+
+#### Expected Files
+
+- `internal/install/service_test.go`
+- `tests/smoke/smoke_test.go`
+- additional focused test files under `internal/` or `tests/` if the execution
+  path warrants them
+
+#### Validation
+
+- Intentionally introducing bootstrap drift causes the automated check to fail.
+- After rerunning the sync path, the same automated check passes again.
+- The repository's standard validation instructions make the drift guard easy to
+  discover for both humans and future agents.
+
+#### Execution Notes
+
+Added drift enforcement in `internal/bootstrapsync` tests and a smoke test that
+runs `scripts/sync-bootstrap-assets --check` against the current repository so
+CI-covered validation fails when tracked dogfood outputs drift from
+`assets/bootstrap/`, including orphaned files under `.agents/skills/`.
+Validation: `go test ./internal/bootstrapsync` and `go test ./tests/smoke -run 'TestSyncBootstrapAssetsCheckPassesForCurrentRepo|TestInstall'`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This step adds automated enforcement around the Step 2
+sync path and is covered by the same full finalize review.
+
+## Validation Strategy
+
+- Lint the tracked plan before approval and keep it self-contained enough for a
+  future agent to execute without discovery chat.
+- Validate the implementation with focused unit or smoke coverage around the
+  sync path and drift checks, then rerun the broader install-related tests that
+  cover `harness install` behavior.
+- Confirm the repository docs, dogfood outputs, and packaged bootstrap assets
+  agree after the sync path runs with no residual drift.
+
+## Risks
+
+- Risk: Contributors may continue editing `.agents/skills/` directly because the
+  repository currently treats those files as ordinary tracked content.
+  - Mitigation: Put the canonical-source rule in repo-visible docs and back it
+    with automated drift failures.
+- Risk: Syncing the root `AGENTS.md` managed block could accidentally overwrite
+  easyharness-specific guidance outside the managed markers.
+  - Mitigation: Reuse the existing managed-block replacement behavior and add
+    explicit validation for preserving surrounding content.
+- Risk: A bespoke sync flow could diverge from the packaged assets used by
+  `harness install`.
+  - Mitigation: Treat `assets/bootstrap/` as the only editable source and keep
+    install-path tests in the validation loop.
+
+## Validation Summary
+
+- `scripts/sync-bootstrap-assets`
+- `scripts/sync-bootstrap-assets --check`
+- `go test ./cmd/bootstrap-sync`
+- `go test ./internal/bootstrapsync ./internal/install`
+- `go test ./tests/smoke -run 'TestSyncBootstrapAssetsCheckPassesForCurrentRepo|TestInstall'`
+
+## Review Summary
+
+- `review-001-full`: changes requested after `correctness` found that
+  orphaned `.agents/skills` files were invisible to the initial drift check
+- `review-002-full`: full finalize review passed with no findings after the
+  orphan-detection and orphan-removal repair landed
+
+## Archive Summary
+
+- Archived At: 2026-03-31T13:48:36+08:00
+- Revision: 1
+- PR: NONE
+- Ready: The candidate satisfies the acceptance criteria, the canonical-source
+  docs now point edits at `assets/bootstrap/`, the repo-local sync path is
+  deterministic, and the final finalize review passed after the orphan-file
+  repair.
+- Merge Handoff: Commit the candidate on `codex/bootstrap-sync-canonical-source`,
+  push the branch, open a PR, then record publish/CI/sync evidence until
+  `harness status` reaches `execution/finalize/await_merge`.
+
+## Outcome Summary
+
+### Delivered
+
+- Established `assets/bootstrap/` as the single hand-edited source for the
+  bootstrap skill pack and the managed `AGENTS.md` block content in this repo.
+- Added repo-visible guidance in `AGENTS.md`, `README.md`, and the CLI contract
+  that tells humans and agents to edit `assets/bootstrap/` and treat
+  `.agents/skills/` as materialized output.
+- Added `scripts/sync-bootstrap-assets`, backed by `cmd/bootstrap-sync` and
+  `internal/bootstrapsync`, so this repository can refresh dogfood outputs
+  without using `harness install` as the human-facing maintenance command.
+- Added drift detection and repair for orphaned `.agents/skills` files that no
+  longer exist in `assets/bootstrap/`.
+- Added focused unit coverage for sync/apply drift paths and a smoke test that
+  enforces `scripts/sync-bootstrap-assets --check` against the current repo.
+
+### Not Delivered
+
+- A later split between human-authored bootstrap source and generated
+  embed-ready assets remains deferred.
+- A dedicated first-class `harness` subcommand for repo-local bootstrap syncing
+  remains deferred.
+
+### Follow-Up Issues
+
+- [#82](https://github.com/catu-ai/easyharness/issues/82): Evaluate splitting
+  `assets/bootstrap` into authored source and generated embed assets.
+- [#83](https://github.com/catu-ai/easyharness/issues/83): Decide whether
+  bootstrap sync should become a first-class `harness` subcommand.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -237,6 +237,10 @@ Contract:
   files in that tree
 - package the bootstrap assets with the harness release so the command works
   without network access
+- in this repository, treat `assets/bootstrap/` as the canonical hand-edited
+  source for those packaged assets; any dogfood copies under `.agents/skills/`
+  or the root `AGENTS.md` managed block should be derived from that source
+  rather than maintained as a second handwritten contract
 - return a JSON envelope that reports `mode`, `scope`, and per-file actions;
   workflow `state` may be omitted because the command does not mutate tracked
   plan lifecycle state

--- a/internal/bootstrapsync/sync.go
+++ b/internal/bootstrapsync/sync.go
@@ -1,0 +1,192 @@
+package bootstrapsync
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	bootstrapassets "github.com/catu-ai/easyharness/assets/bootstrap"
+	"github.com/catu-ai/easyharness/internal/install"
+)
+
+const actionDelete = "delete"
+
+type DriftError struct {
+	Actions []install.Action
+}
+
+func (e *DriftError) Error() string {
+	if len(e.Actions) == 0 {
+		return "bootstrap dogfood outputs drifted from assets/bootstrap"
+	}
+
+	lines := make([]string, 0, len(e.Actions)+1)
+	lines = append(lines, "bootstrap dogfood outputs drifted from assets/bootstrap:")
+	for _, action := range e.Actions {
+		lines = append(lines, fmt.Sprintf("- %s: %s (%s)", action.Path, action.Kind, action.Details))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func Sync(workdir string) (install.Result, error) {
+	result := install.Service{Workdir: workdir}.Install(install.Options{})
+	if !result.OK {
+		return result, resultError(result)
+	}
+
+	deletions, err := removeOrphanedSkillFiles(workdir)
+	if err != nil {
+		return result, err
+	}
+	if len(deletions) > 0 {
+		result.Actions = append(result.Actions, deletions...)
+		result.Summary = summarizeApply(result.Summary, len(deletions))
+	}
+	return result, nil
+}
+
+func Check(workdir string) (install.Result, error) {
+	result := install.Service{Workdir: workdir}.Install(install.Options{DryRun: true})
+	if !result.OK {
+		return result, resultError(result)
+	}
+
+	drifted := make([]install.Action, 0, len(result.Actions))
+	for _, action := range result.Actions {
+		if action.Kind != install.ActionNoop {
+			drifted = append(drifted, action)
+		}
+	}
+	orphaned, err := findOrphanedSkillFiles(workdir)
+	if err != nil {
+		return result, err
+	}
+	drifted = append(drifted, orphaned...)
+	if len(drifted) > 0 {
+		return result, &DriftError{Actions: drifted}
+	}
+	return result, nil
+}
+
+func resultError(result install.Result) error {
+	if len(result.Errors) == 0 {
+		return errors.New(result.Summary)
+	}
+
+	lines := make([]string, 0, len(result.Errors)+1)
+	lines = append(lines, result.Summary)
+	for _, err := range result.Errors {
+		lines = append(lines, fmt.Sprintf("- %s: %s", err.Path, err.Message))
+	}
+	return errors.New(strings.Join(lines, "\n"))
+}
+
+func findOrphanedSkillFiles(workdir string) ([]install.Action, error) {
+	root := filepath.Join(workdir, ".agents", "skills")
+	entries, err := existingSkillFiles(root)
+	if err != nil {
+		return nil, err
+	}
+
+	canonical, err := bootstrapassets.SkillFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	orphaned := make([]install.Action, 0)
+	for _, relPath := range entries {
+		canonicalPath := filepath.ToSlash(relPath)
+		if _, ok := canonical[canonicalPath]; ok {
+			continue
+		}
+		orphaned = append(orphaned, install.Action{
+			Path:    filepath.ToSlash(filepath.Join(".agents/skills", relPath)),
+			Kind:    actionDelete,
+			Details: "Remove stale materialized skill file that no longer exists in assets/bootstrap.",
+		})
+	}
+	return orphaned, nil
+}
+
+func removeOrphanedSkillFiles(workdir string) ([]install.Action, error) {
+	orphaned, err := findOrphanedSkillFiles(workdir)
+	if err != nil {
+		return nil, err
+	}
+
+	deletions := make([]install.Action, 0, len(orphaned))
+	for _, action := range orphaned {
+		absPath := filepath.Join(workdir, filepath.FromSlash(action.Path))
+		if err := os.Remove(absPath); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("remove orphaned skill file %s: %w", action.Path, err)
+		}
+		deletions = append(deletions, action)
+		pruneEmptyParents(filepath.Dir(absPath), filepath.Join(workdir, ".agents", "skills"))
+	}
+	return deletions, nil
+}
+
+func existingSkillFiles(root string) ([]string, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat .agents/skills: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf(".agents/skills is not a directory")
+	}
+
+	files := make([]string, 0)
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, relPath)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk .agents/skills: %w", err)
+	}
+	return files, nil
+}
+
+func pruneEmptyParents(dir, stop string) {
+	stop = filepath.Clean(stop)
+	for {
+		cleanDir := filepath.Clean(dir)
+		if cleanDir == stop || cleanDir == filepath.Dir(cleanDir) {
+			return
+		}
+
+		entries, err := os.ReadDir(cleanDir)
+		if err != nil || len(entries) > 0 {
+			return
+		}
+		if err := os.Remove(cleanDir); err != nil {
+			return
+		}
+		dir = filepath.Dir(cleanDir)
+	}
+}
+
+func summarizeApply(base string, deletions int) string {
+	if deletions == 0 {
+		return base
+	}
+	if base == "Harness-managed repository assets are already up to date." {
+		return fmt.Sprintf("Refreshed bootstrap dogfood outputs. %d stale materialized skill file(s) removed.", deletions)
+	}
+	return fmt.Sprintf("%s Removed %d stale materialized skill file(s).", base, deletions)
+}

--- a/internal/bootstrapsync/sync_test.go
+++ b/internal/bootstrapsync/sync_test.go
@@ -1,0 +1,168 @@
+package bootstrapsync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	bootstrapassets "github.com/catu-ai/easyharness/assets/bootstrap"
+)
+
+func TestSyncRefreshesManagedOutputsFromBootstrapAssets(t *testing.T) {
+	root := t.TempDir()
+
+	agents := strings.Join([]string{
+		"# AGENTS.md",
+		"",
+		"Repo-specific intro.",
+		"",
+		"<!-- easyharness:begin -->",
+		"stale managed content",
+		"<!-- easyharness:end -->",
+		"",
+		"Repo-specific footer.",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(agents), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+
+	skillPath := filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("stale skill"), 0o644); err != nil {
+		t.Fatalf("write stale skill: %v", err)
+	}
+
+	if _, err := Sync(root); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	agentsData, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	rendered := string(agentsData)
+	if !strings.Contains(rendered, "Repo-specific intro.") || !strings.Contains(rendered, "Repo-specific footer.") {
+		t.Fatalf("expected repo-specific AGENTS content to survive, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "stale managed content") {
+		t.Fatalf("expected managed block refresh, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, bootstrapassets.AgentsManagedBlock()) {
+		t.Fatalf("expected AGENTS managed block to match bootstrap asset, got:\n%s", rendered)
+	}
+
+	skillData, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read skill: %v", err)
+	}
+	files, err := bootstrapassets.SkillFiles()
+	if err != nil {
+		t.Fatalf("load skill files: %v", err)
+	}
+	expected := files["harness-discovery/SKILL.md"]
+	if string(skillData) != expected {
+		t.Fatalf("expected synced skill content, got:\n%s", skillData)
+	}
+}
+
+func TestCheckReportsDriftWhenManagedOutputsAreStale(t *testing.T) {
+	root := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("# AGENTS.md\n\nstale\n"), 0o644); err != nil {
+		t.Fatalf("write AGENTS.md: %v", err)
+	}
+	skillPath := filepath.Join(root, ".agents/skills/harness-reviewer/SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("mkdir skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale skill: %v", err)
+	}
+
+	result, err := Check(root)
+	if err == nil {
+		t.Fatalf("expected drift error, got success %#v", result)
+	}
+	driftErr, ok := err.(*DriftError)
+	if !ok {
+		t.Fatalf("expected DriftError, got %T: %v", err, err)
+	}
+	if len(driftErr.Actions) == 0 {
+		t.Fatalf("expected drift actions, got %#v", driftErr)
+	}
+}
+
+func TestCheckReportsOrphanedManagedSkillFiles(t *testing.T) {
+	root := t.TempDir()
+
+	if _, err := Sync(root); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	orphanPath := filepath.Join(root, ".agents/skills/orphan/SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(orphanPath), 0o755); err != nil {
+		t.Fatalf("mkdir orphan dir: %v", err)
+	}
+	if err := os.WriteFile(orphanPath, []byte("orphan"), 0o644); err != nil {
+		t.Fatalf("write orphan skill: %v", err)
+	}
+
+	_, err := Check(root)
+	if err == nil {
+		t.Fatalf("expected drift error for orphaned file")
+	}
+	driftErr, ok := err.(*DriftError)
+	if !ok {
+		t.Fatalf("expected DriftError, got %T: %v", err, err)
+	}
+
+	found := false
+	for _, action := range driftErr.Actions {
+		if action.Path == ".agents/skills/orphan/SKILL.md" && action.Kind == actionDelete {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected orphaned file drift action, got %#v", driftErr.Actions)
+	}
+}
+
+func TestSyncRemovesOrphanedManagedSkillFiles(t *testing.T) {
+	root := t.TempDir()
+
+	if _, err := Sync(root); err != nil {
+		t.Fatalf("initial sync: %v", err)
+	}
+
+	orphanPath := filepath.Join(root, ".agents/skills/orphan/SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(orphanPath), 0o755); err != nil {
+		t.Fatalf("mkdir orphan dir: %v", err)
+	}
+	if err := os.WriteFile(orphanPath, []byte("orphan"), 0o644); err != nil {
+		t.Fatalf("write orphan skill: %v", err)
+	}
+
+	result, err := Sync(root)
+	if err != nil {
+		t.Fatalf("sync with orphan: %v", err)
+	}
+	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
+		t.Fatalf("expected orphaned file removal, err=%v", err)
+	}
+
+	found := false
+	for _, action := range result.Actions {
+		if action.Path == ".agents/skills/orphan/SKILL.md" && action.Kind == actionDelete {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected delete action in sync result, got %#v", result.Actions)
+	}
+}

--- a/scripts/sync-bootstrap-assets
+++ b/scripts/sync-bootstrap-assets
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+
+cd "${repo_root}"
+exec go run ./cmd/bootstrap-sync --workdir "${repo_root}" "$@"

--- a/tests/smoke/bootstrap_sync_test.go
+++ b/tests/smoke/bootstrap_sync_test.go
@@ -1,0 +1,23 @@
+package smoke_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/catu-ai/easyharness/tests/support"
+)
+
+func TestSyncBootstrapAssetsCheckPassesForCurrentRepo(t *testing.T) {
+	repoRoot := support.RepoRoot(t)
+	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "sync-bootstrap-assets"), "--check")
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sync-bootstrap-assets --check: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "Bootstrap dogfood outputs are in sync with assets/bootstrap.") {
+		t.Fatalf("unexpected check output:\n%s", output)
+	}
+}


### PR DESCRIPTION
## What changed

This makes `assets/bootstrap/` the single hand-edited source of truth for the repo's dogfood bootstrap contract.

- documented that bootstrap skill and managed-block edits belong in `assets/bootstrap/`
- added `scripts/sync-bootstrap-assets` plus a small Go helper/command to materialize `.agents/skills/` and the root `AGENTS.md` managed block from those packaged assets
- added drift checks for both normal mismatch and orphaned `.agents/skills` files that no longer exist in `assets/bootstrap/`
- archived the tracked plan for this slice with review and validation closeout

## Why

Before this change, the repo was effectively maintaining the same bootstrap contract in more than one place. That made dogfood maintenance easy to drift and left contributors without a clear editing surface.

## Impact

Contributors now edit one canonical bootstrap tree and use `scripts/sync-bootstrap-assets` to refresh dogfood outputs. The repo also fails validation if those outputs drift from the canonical source.

## Root cause

The dogfood bootstrap contract had split source-of-truth ownership, and the first pass of the new sync/check flow still missed orphaned materialized skill files until finalize review caught that gap.

## Validation

- `scripts/sync-bootstrap-assets`
- `scripts/sync-bootstrap-assets --check`
- `go test ./cmd/bootstrap-sync`
- `go test ./internal/bootstrapsync ./internal/install`
- `go test ./tests/smoke -run 'TestSyncBootstrapAssetsCheckPassesForCurrentRepo|TestInstall'`
