### PR TITLE
Add explicit global fallback control to dev installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,39 @@ By default the installer:
 
 - builds the binary at `.local/bin/harness`
 - installs a small worktree-aware `harness` wrapper in a user-local bin dir
-- uses `~/.local/bin` by default, or `~/bin` when that is already on `PATH`
+- uses `~/.local/bin` by default
 - keeps parallel worktrees isolated by dispatching to the current worktree's
   `.local/bin/harness`
-- falls back outside `easyharness` worktrees to the binary from the worktree
-  that last installed the wrapper
+- only updates the outside-source-tree fallback when you install with
+  `--global`
 
 Useful options:
 
 ```bash
 scripts/install-dev-harness --help
+scripts/install-dev-harness --global
 scripts/install-dev-harness --install-dir "$HOME/.local/bin"
 scripts/install-dev-harness --force
 ```
+
+Development installs expect `~/.local/bin` to be on `PATH` so the wrapper can
+be called directly:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+When you want a checkout to provide the fallback used outside easyharness
+source trees, refresh it explicitly:
+
+```bash
+cd ~/Workspace/superharness
+scripts/install-dev-harness --global
+```
+
+Inside any easyharness source tree, the wrapper still dispatches to that
+checkout's local `.local/bin/harness` and does not silently fall back to the
+global binary.
 
 Verify the command is available:
 

--- a/docs/plans/archived/2026-04-08-global-fallback-dev-wrapper.md
+++ b/docs/plans/archived/2026-04-08-global-fallback-dev-wrapper.md
@@ -1,0 +1,234 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-08T22:27:00+08:00"
+source_type: direct_request
+source_refs:
+    - chat://current-session
+---
+
+# Add Explicit Global Fallback Control To Dev Wrapper Install
+
+## Goal
+
+Adjust `scripts/install-dev-harness` so parallel easyharness worktrees can keep
+their current worktree-local behavior without letting an arbitrary linked
+worktree become the default fallback used from unrelated repositories.
+
+The installer should keep the worktree-aware wrapper model, add an explicit
+`--global` path for refreshing the fallback used outside easyharness source
+trees, and keep easyharness source trees pinned to their own local
+`./.local/bin/harness` binaries. This slice also resolves issue `#31` by
+locking the default wrapper install directory policy to `~/.local/bin` and
+documenting that development installs require that directory on `PATH`.
+
+## Scope
+
+### In Scope
+
+- Add explicit `--global` installer behavior for updating the out-of-tree
+  fallback binary used by the wrapper.
+- Keep easyharness source-tree detection authoritative so any easyharness
+  checkout still prefers its own local binary and does not silently run the
+  global fallback.
+- Update installer smoke coverage for the new `--global` behavior and the
+  revised fallback rules.
+- Update README install guidance to state the `~/.local/bin` default and the
+  development PATH prerequisite.
+- Close the open decision tracked by issue `#31` via docs and installer policy
+  updates in this slice.
+
+### Out of Scope
+
+- Changing release/distribution channels such as GitHub Releases or Homebrew.
+- Replacing the wrapper model with a standalone globally installed binary.
+- Broad PATH scanning, `GOBIN` detection, or new automatic install-location
+  heuristics beyond the chosen `~/.local/bin` default and existing explicit
+  `--install-dir` override.
+
+## Acceptance Criteria
+
+- [x] `scripts/install-dev-harness` accepts `--global` and only updates the
+      out-of-tree fallback binary when that flag is present.
+- [x] The installed wrapper continues to use the current easyharness source
+      tree's `./.local/bin/harness` whenever the current directory resolves to
+      an easyharness checkout, even without Git metadata.
+- [x] Outside easyharness source trees, the wrapper uses the explicit global
+      fallback when one has been installed and reports a clear actionable error
+      when none exists.
+- [x] The default wrapper install directory policy is documented as
+      `~/.local/bin`, with `--install-dir` remaining the explicit override.
+- [x] Smoke coverage demonstrates both the worktree-local preference and the
+      explicit global fallback behavior.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Rework installer fallback ownership
+
+- Done: [x]
+
+#### Objective
+
+Refactor `scripts/install-dev-harness` and the generated wrapper so global
+fallback refresh becomes explicit with `--global` while easyharness source
+trees remain strictly local-binary-first.
+
+#### Details
+
+The wrapper should keep its existing source-tree detection approach: if the
+current directory belongs to an easyharness checkout, resolve
+`<repo>/.local/bin/harness` and fail locally if that binary is missing. Only
+when the current directory is not part of an easyharness source tree should the
+wrapper attempt the installed global fallback path. The installer should stop
+rewriting the out-of-tree fallback on every run; instead, `--global` should be
+required to refresh that fallback and normal installs should leave it alone.
+
+#### Expected Files
+
+- `scripts/install-dev-harness`
+
+#### Validation
+
+- `bash -n scripts/install-dev-harness`
+- Manual or automated verification that a normal install leaves the previously
+  configured global fallback untouched.
+- Automated verification that `--global` refreshes the fallback path used
+  outside easyharness source trees.
+
+#### Execution Notes
+
+Added `--global` to `scripts/install-dev-harness`, moved the wrapper's
+out-of-tree fallback to a dedicated user-level path, and changed ordinary
+installs so they no longer overwrite that fallback implicitly. The wrapper now
+always prefers the current easyharness source tree's `.local/bin/harness` and
+only uses the global fallback when invoked outside an easyharness source tree.
+Validated with `bash -n scripts/install-dev-harness`, a local rerun of
+`scripts/install-dev-harness`, and the installer-focused smoke suite.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 and Step 2 shipped as one bounded installer slice
+and were reviewed together at the candidate level instead of forcing an
+artificial mid-slice review boundary.
+
+### Step 2: Cover behavior and document the policy
+
+- Done: [x]
+
+#### Objective
+
+Update smoke coverage and README guidance so the new installer contract and the
+`#31` default-directory decision are explicit and testable.
+
+#### Details
+
+Tests should cover source-tree detection with and without Git metadata, confirm
+that easyharness source trees never silently use the global fallback, and prove
+that unrelated repositories can use the global fallback after an explicit
+`--global` install. README updates should state that development installs place
+the wrapper in `~/.local/bin` by default, require that directory on `PATH`, and
+use `--install-dir` only for explicit overrides.
+
+#### Expected Files
+
+- `tests/smoke/install_dev_harness_test.go`
+- `README.md`
+
+#### Validation
+
+- `go test ./tests/smoke/... -count=1`
+- Any narrower targeted test invocation needed if the smoke package layout
+  requires a different package path.
+- Review the README install section for consistency with the new CLI behavior.
+
+#### Execution Notes
+
+Updated installer smoke coverage for explicit `--global` fallback setup,
+outside-source-tree failure without a global fallback, preservation of an
+existing global fallback on ordinary installs, and refusal to use the global
+fallback from inside an easyharness source tree without a local binary. README
+now states that development installs default to `~/.local/bin`, require that
+directory on `PATH`, and use `--global` to refresh the fallback consumed
+outside easyharness source trees. Validated with
+`go test ./tests/smoke -run InstallDevHarness -count=1`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 is inseparable from Step 1's installer contract
+change, so the controller deferred review to the integrated branch candidate.
+
+## Validation Strategy
+
+- Run shell validation for the installer script.
+- Run the installer smoke suite covering wrapper refresh and fallback behavior.
+- Re-run `scripts/install-dev-harness` after script changes before relying on
+  direct `harness` commands in this worktree.
+
+## Risks
+
+- Risk: The wrapper could accidentally fall back to the global binary from
+  inside an easyharness checkout and hide missing local installs.
+  - Mitigation: Keep source-tree detection ahead of fallback resolution and add
+    smoke coverage for both Git and non-Git source-tree layouts.
+- Risk: The new `--global` flow could make the external fallback hard to
+  discover or stale.
+  - Mitigation: Document the flag clearly in README/help text and ensure the
+    wrapper emits a clear error when no global fallback has been installed.
+
+## Validation Summary
+
+- `bash -n scripts/install-dev-harness`
+- `scripts/install-dev-harness`
+- `go test ./tests/smoke -run InstallDevHarness -count=1`
+
+## Review Summary
+
+- `review-001-full` requested one blocking tests finding about missing
+  precedence coverage when both a worktree-local binary and a global fallback
+  are present.
+- Added the missing precedence assertion to
+  `TestInstallDevHarnessWrapperDispatchesToCurrentWorktree` and reran
+  `go test ./tests/smoke -run InstallDevHarness -count=1`.
+- `review-002-delta` passed cleanly for the bounded review-fix.
+- `review-003-full` passed with one non-blocking tests note about missing smoke
+  coverage for the default `scripts/install-dev-harness --global` path; that
+  follow-up is tracked in `#119`.
+
+## Archive Summary
+
+- Archived At: 2026-04-08T22:56:18+08:00
+- Revision: 1
+- PR: not created yet; publish evidence will record the PR URL after archive.
+- Ready: `review-003-full` passed as the archive-gating finalize review, all
+  acceptance criteria are satisfied, and only archive/publish handoff remains.
+- Merge Handoff: Archive this plan, then commit and push the archive move plus
+  tracked code/doc changes, open the PR, record publish/CI/sync evidence, and
+  wait for merge approval.
+
+## Outcome Summary
+
+### Delivered
+
+- Added explicit `--global` control to `scripts/install-dev-harness` so normal
+  dev installs no longer overwrite the out-of-tree fallback binary
+  implicitly.
+- Kept easyharness source-tree detection authoritative so any easyharness
+  checkout still prefers its own `.local/bin/harness`, while unrelated
+  repositories can use the explicitly installed global fallback.
+- Locked the default wrapper install directory policy to `~/.local/bin` and
+  documented the required PATH setup in `README.md`.
+- Expanded installer smoke coverage for the explicit global fallback contract,
+  preservation of an existing global fallback on ordinary installs, and
+  worktree-vs-global precedence.
+
+### Not Delivered
+
+- Default-path smoke coverage for `scripts/install-dev-harness --global`
+  without `--install-dir`; tracked as `#119`.
+
+### Follow-Up Issues
+
+- `#119` Add smoke coverage for the default `--global` installer path.

--- a/docs/plans/archived/2026-04-08-global-fallback-dev-wrapper.md
+++ b/docs/plans/archived/2026-04-08-global-fallback-dev-wrapper.md
@@ -194,19 +194,29 @@ change, so the controller deferred review to the integrated branch candidate.
   `go test ./tests/smoke -run InstallDevHarness -count=1`.
 - `review-002-delta` passed cleanly for the bounded review-fix.
 - `review-003-full` passed with one non-blocking tests note about missing smoke
-  coverage for the default `scripts/install-dev-harness --global` path; that
-  follow-up is tracked in `#119`.
+  coverage for the default `scripts/install-dev-harness --global` path.
+- Reopened in `finalize-fix` mode for revision `2`, added the missing default
+  `--global` smoke coverage, and reran
+  `go test ./tests/smoke -run InstallDevHarness -count=1`.
+- `review-004-full` then requested two blocking findings: validate
+  wrapper-vs-fallback path conflicts before mutating the global fallback, and
+  prove that `--global` refreshes an already-populated stale fallback.
+- The repair now validates the wrapper target before writing the fallback and
+  adds smoke coverage for stale-fallback refresh plus the conflict path.
+- `review-005-delta` passed cleanly for that bounded follow-up.
 
 ## Archive Summary
 
-- Archived At: 2026-04-08T22:56:18+08:00
-- Revision: 1
-- PR: not created yet; publish evidence will record the PR URL after archive.
-- Ready: `review-003-full` passed as the archive-gating finalize review, all
-  acceptance criteria are satisfied, and only archive/publish handoff remains.
-- Merge Handoff: Archive this plan, then commit and push the archive move plus
-  tracked code/doc changes, open the PR, record publish/CI/sync evidence, and
-  wait for merge approval.
+- Archived At: 2026-04-08T23:22:48+08:00
+- Revision: 2
+- PR: existing PR `https://github.com/catu-ai/easyharness/pull/120` stays open
+  for the reopened finalize-fix candidate.
+- Ready: `review-005-delta` passed cleanly for the bounded revision-2 repair,
+  all acceptance criteria remain satisfied, and the candidate is ready to
+  re-enter publish/merge handoff after re-archive.
+- Merge Handoff: Re-archive this plan, push the revision-2 repair to the
+  existing branch and PR, refresh publish/CI/sync evidence, and wait for merge
+  approval once status returns to `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
@@ -221,14 +231,14 @@ change, so the controller deferred review to the integrated branch candidate.
 - Locked the default wrapper install directory policy to `~/.local/bin` and
   documented the required PATH setup in `README.md`.
 - Expanded installer smoke coverage for the explicit global fallback contract,
-  preservation of an existing global fallback on ordinary installs, and
-  worktree-vs-global precedence.
+  preservation of an existing global fallback on ordinary installs,
+  worktree-vs-global precedence, and the default
+  `scripts/install-dev-harness --global` path.
 
 ### Not Delivered
 
-- Default-path smoke coverage for `scripts/install-dev-harness --global`
-  without `--install-dir`; tracked as `#119`.
+None.
 
 ### Follow-Up Issues
 
-- `#119` Add smoke coverage for the default `--global` installer path.
+NONE

--- a/scripts/install-dev-harness
+++ b/scripts/install-dev-harness
@@ -3,12 +3,13 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/install-dev-harness [--install-dir <path>] [--force]
+Usage: scripts/install-dev-harness [--global] [--install-dir <path>] [--force]
 
 Build the current repo's harness binary into .local/bin and install a
 worktree-aware `harness` wrapper from a user-local directory.
 
 Options:
+  --global              Refresh the fallback binary used outside easyharness source trees.
   --install-dir <path>  Override the target directory for the harness wrapper.
   --force               Replace an existing non-matching harness entry.
   -h, --help            Show this help text.
@@ -16,10 +17,14 @@ EOF
 }
 
 install_dir=""
+install_global_fallback=0
 force=0
 
 while (($#)); do
   case "$1" in
+    --global)
+      install_global_fallback=1
+      ;;
     --install-dir)
       shift
       if (($# == 0)); then
@@ -95,14 +100,6 @@ choose_install_dir() {
   fi
 
   if [[ -n "${HOME:-}" ]]; then
-    if path_has_entry "${HOME}/.local/bin"; then
-      printf '%s\n' "${HOME}/.local/bin"
-      return
-    fi
-    if path_has_entry "${HOME}/bin"; then
-      printf '%s\n' "${HOME}/bin"
-      return
-    fi
     printf '%s\n' "${HOME}/.local/bin"
     return
   fi
@@ -125,8 +122,18 @@ choose_install_dir() {
   printf '%s\n' "${repo_root}/.local/dev-bin"
 }
 
+choose_global_fallback_path() {
+  if [[ -n "${HOME:-}" ]]; then
+    printf '%s\n' "${HOME}/.local/share/easyharness/dev/harness"
+    return
+  fi
+
+  printf '%s\n' ""
+}
+
 target_dir="$(choose_install_dir)"
 command_path="${target_dir}/harness"
+global_fallback_path="$(choose_global_fallback_path)"
 
 if [[ "${command_path}" == "${binary_path}" ]]; then
   echo "Refusing to install the wrapper over the repo-local binary at ${binary_path}." >&2
@@ -136,7 +143,7 @@ fi
 
 wrapper_content() {
   local fallback_binary_path template
-  fallback_binary_path="$(printf '%q' "${binary_path}")"
+  fallback_binary_path="$(printf '%q' "${global_fallback_path}")"
   template="$(cat <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -203,11 +210,11 @@ if repo_root="$(find_repo_root)"; then
     echo "Run scripts/install-dev-harness from this worktree first." >&2
     exit 1
   fi
-elif [[ -x "${fallback_binary_path}" ]]; then
+elif [[ -n "${fallback_binary_path}" && -x "${fallback_binary_path}" ]]; then
   binary_path="${fallback_binary_path}"
 else
-  echo "Could not find an easyharness worktree from ${PWD}, and the fallback harness binary is unavailable at ${fallback_binary_path}." >&2
-  echo "Run scripts/install-dev-harness from an easyharness worktree first." >&2
+  echo "Could not find an easyharness source tree from ${PWD}, and the global fallback harness binary is unavailable at ${fallback_binary_path:-<unset>}." >&2
+  echo "Run scripts/install-dev-harness --global from the easyharness checkout you want to use outside source trees." >&2
   exit 1
 fi
 
@@ -285,6 +292,19 @@ build_args=("-o" "${binary_path}" "-ldflags" "${build_ldflags[*]}" "./cmd/harnes
 )
 "${binary_path}" --help >/dev/null
 
+global_fallback_updated=0
+if [[ "${install_global_fallback}" -eq 1 ]]; then
+  if [[ -z "${global_fallback_path}" ]]; then
+    echo "Cannot install a global fallback without HOME set." >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "${global_fallback_path}")"
+  cp "${binary_path}" "${global_fallback_path}"
+  chmod 755 "${global_fallback_path}"
+  global_fallback_updated=1
+fi
+
 mkdir -p "${target_dir}"
 if [[ -e "${command_path}" || -L "${command_path}" ]]; then
   if [[ "${force}" -eq 1 ]]; then
@@ -311,7 +331,15 @@ fi
 echo "Built dev harness binary at ${binary_path}"
 echo "Installed harness wrapper at ${command_path}"
 echo "Verified the repo-local binary directly at ${binary_path}"
-echo "Wrapper fallback binary outside easyharness worktrees: ${binary_path}"
+if [[ -n "${global_fallback_path}" ]]; then
+  if [[ "${global_fallback_updated}" -eq 1 ]]; then
+    echo "Updated global fallback binary at ${global_fallback_path}"
+  elif [[ -x "${global_fallback_path}" ]]; then
+    echo "Global fallback binary remains at ${global_fallback_path}"
+  else
+    echo "No global fallback binary installed yet; run scripts/install-dev-harness --global to set one."
+  fi
+fi
 
 if [[ ":${PATH}:" == *":${target_dir}:"* ]]; then
   resolved_path="$(command -v harness || true)"

--- a/scripts/install-dev-harness
+++ b/scripts/install-dev-harness
@@ -135,6 +135,14 @@ target_dir="$(choose_install_dir)"
 command_path="${target_dir}/harness"
 global_fallback_path="$(choose_global_fallback_path)"
 
+normalize_path() {
+  local path="$1"
+  local dir base
+  dir="$(cd "$(dirname "${path}")" 2>/dev/null && pwd -P)" || return 1
+  base="$(basename "${path}")"
+  printf '%s/%s\n' "${dir}" "${base}"
+}
+
 if [[ "${command_path}" == "${binary_path}" ]]; then
   echo "Refusing to install the wrapper over the repo-local binary at ${binary_path}." >&2
   echo "Choose a different --install-dir." >&2
@@ -299,7 +307,16 @@ if [[ "${install_global_fallback}" -eq 1 ]]; then
     exit 1
   fi
 
+  mkdir -p "${target_dir}"
   mkdir -p "$(dirname "${global_fallback_path}")"
+  normalized_command_path="$(normalize_path "${command_path}")"
+  normalized_global_fallback_path="$(normalize_path "${global_fallback_path}")"
+  if [[ "${normalized_command_path}" == "${normalized_global_fallback_path}" ]]; then
+    echo "Refusing to install the wrapper over the global fallback binary at ${global_fallback_path}." >&2
+    echo "Choose a different --install-dir." >&2
+    exit 2
+  fi
+
   cp "${binary_path}" "${global_fallback_path}"
   chmod 755 "${global_fallback_path}"
   global_fallback_updated=1

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -104,16 +104,18 @@ func TestInstallDevHarnessWrapperDispatchesToCurrentWorktree(t *testing.T) {
 
 	repoRoot := copyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "global-bin")
+	homeDir := t.TempDir()
 
 	result := runCommand(
 		t,
 		repoRoot,
 		installerEnv(t, map[string]string{
-			"HOME": t.TempDir(),
+			"HOME": homeDir,
 			"PATH": installerPath(t),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--global",
 		"--install-dir", installDir,
 	)
 	if result.ExitCode != 0 {
@@ -122,6 +124,8 @@ func TestInstallDevHarnessWrapperDispatchesToCurrentWorktree(t *testing.T) {
 
 	wrapperPath := filepath.Join(installDir, "harness")
 	support.RequireFileExists(t, wrapperPath)
+	globalFallback := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
+	writeFixtureFile(t, globalFallback, "#!/bin/sh\nprintf 'unexpected-global\\n'\n", 0o755)
 
 	_, nestedDir := newFakeWorktree(t)
 	wrapperResult := runCommand(
@@ -139,9 +143,12 @@ func TestInstallDevHarnessWrapperDispatchesToCurrentWorktree(t *testing.T) {
 
 	support.RequireContains(t, wrapperResult.Stdout, "fake worktree harness")
 	support.RequireContains(t, wrapperResult.Stdout, "args=status")
+	if strings.Contains(wrapperResult.CombinedOutput(), "unexpected-global") {
+		t.Fatalf("expected wrapper to prefer the worktree-local binary over the global fallback\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
+	}
 }
 
-func TestInstallDevHarnessWrapperFallsBackOutsideWorktree(t *testing.T) {
+func TestInstallDevHarnessWrapperRequiresExplicitGlobalFallbackOutsideWorktree(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
@@ -177,11 +184,60 @@ func TestInstallDevHarnessWrapperFallsBackOutsideWorktree(t *testing.T) {
 		wrapperPath,
 		"--help",
 	)
-	if wrapperResult.ExitCode != 0 {
-		t.Fatalf("wrapper fallback failed with exit %d\nstdout:\n%s\nstderr:\n%s", wrapperResult.ExitCode, wrapperResult.Stdout, wrapperResult.Stderr)
+	if wrapperResult.ExitCode == 0 {
+		t.Fatalf("expected wrapper without --global fallback to fail outside easyharness source trees\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
 	}
 
-	support.RequireContains(t, wrapperResult.CombinedOutput(), "Usage: harness <command> [subcommand] [flags]")
+	support.RequireContains(t, wrapperResult.Stderr, "Could not find an easyharness source tree")
+	support.RequireContains(t, wrapperResult.Stderr, "scripts/install-dev-harness --global")
+}
+
+func TestInstallDevHarnessWrapperUsesExplicitGlobalFallbackOutsideWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	installDir := filepath.Join(t.TempDir(), "global-bin")
+	homeDir := t.TempDir()
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": homeDir,
+			"PATH": installerPath(t),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--global",
+		"--install-dir", installDir,
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	wrapperPath := filepath.Join(installDir, "harness")
+	support.RequireFileExists(t, wrapperPath)
+	globalFallback := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
+	support.RequireFileExists(t, globalFallback)
+	support.RequireContains(t, result.Stdout, "Updated global fallback binary at "+globalFallback)
+
+	otherProject := t.TempDir()
+	helpResult := runCommand(
+		t,
+		otherProject,
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t),
+		}),
+		wrapperPath,
+		"--help",
+	)
+	if helpResult.ExitCode != 0 {
+		t.Fatalf("wrapper global fallback failed with exit %d\nstdout:\n%s\nstderr:\n%s", helpResult.ExitCode, helpResult.Stdout, helpResult.Stderr)
+	}
+
+	support.RequireContains(t, helpResult.CombinedOutput(), "Usage: harness <command> [subcommand] [flags]")
 }
 
 func TestInstallDevHarnessVersionReportsDevModeAndPath(t *testing.T) {
@@ -193,16 +249,18 @@ func TestInstallDevHarnessVersionReportsDevModeAndPath(t *testing.T) {
 	installDir := filepath.Join(t.TempDir(), "global-bin")
 	expectedCommit := "0123456789abcdef0123456789abcdef01234567"
 	fakeGitDir := fakeGitDirForHeadCommit(t, repoRoot, expectedCommit)
+	homeDir := t.TempDir()
 
 	result := runCommand(
 		t,
 		repoRoot,
 		installerEnv(t, map[string]string{
-			"HOME": t.TempDir(),
+			"HOME": homeDir,
 			"PATH": installerPath(t, fakeGitDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--global",
 		"--install-dir", installDir,
 	)
 	if result.ExitCode != 0 {
@@ -232,7 +290,7 @@ func TestInstallDevHarnessVersionReportsDevModeAndPath(t *testing.T) {
 	if commit := requireVersionField(t, versionResult.Stdout, "commit"); commit != expectedCommit {
 		t.Fatalf("expected injected dev commit %q, got %q\noutput:\n%s", expectedCommit, commit, versionResult.Stdout)
 	}
-	expectedPath := filepath.Join(repoRoot, ".local", "bin", "harness")
+	expectedPath := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
 	if path := requireVersionField(t, versionResult.Stdout, "path"); path != expectedPath {
 		t.Fatalf("expected dev path %q, got %q\noutput:\n%s", expectedPath, path, versionResult.Stdout)
 	}
@@ -241,7 +299,7 @@ func TestInstallDevHarnessVersionReportsDevModeAndPath(t *testing.T) {
 	}
 }
 
-func TestInstallDevHarnessRefreshesManagedWrapperWithoutForce(t *testing.T) {
+func TestInstallDevHarnessNormalInstallDoesNotReplaceExistingGlobalFallback(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
@@ -249,34 +307,32 @@ func TestInstallDevHarnessRefreshesManagedWrapperWithoutForce(t *testing.T) {
 	repoOne := copyInstallerFixture(t)
 	repoTwo := copyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "global-bin")
+	homeDir := t.TempDir()
 
 	firstInstall := runCommand(
 		t,
 		repoOne,
 		installerEnv(t, map[string]string{
-			"HOME": t.TempDir(),
+			"HOME": homeDir,
 			"PATH": installerPath(t),
 		}),
 		"/bin/bash",
 		filepath.Join(repoOne, "scripts", "install-dev-harness"),
+		"--global",
 		"--install-dir", installDir,
 	)
 	if firstInstall.ExitCode != 0 {
 		t.Fatalf("first install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", firstInstall.ExitCode, firstInstall.Stdout, firstInstall.Stderr)
 	}
 
-	wrapperPath := filepath.Join(installDir, "harness")
-	before, err := os.ReadFile(wrapperPath)
-	if err != nil {
-		t.Fatalf("read first wrapper: %v", err)
-	}
-	support.RequireContains(t, string(before), filepath.Join(repoOne, ".local", "bin", "harness"))
+	globalFallback := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
+	writeFixtureFile(t, globalFallback, "#!/bin/sh\nprintf 'global-from-first\\n'\n", 0o755)
 
 	secondInstall := runCommand(
 		t,
 		repoTwo,
 		installerEnv(t, map[string]string{
-			"HOME": t.TempDir(),
+			"HOME": homeDir,
 			"PATH": installerPath(t),
 		}),
 		"/bin/bash",
@@ -287,14 +343,22 @@ func TestInstallDevHarnessRefreshesManagedWrapperWithoutForce(t *testing.T) {
 		t.Fatalf("second install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", secondInstall.ExitCode, secondInstall.Stdout, secondInstall.Stderr)
 	}
 
-	after, err := os.ReadFile(wrapperPath)
-	if err != nil {
-		t.Fatalf("read refreshed wrapper: %v", err)
+	support.RequireContains(t, secondInstall.Stdout, "Global fallback binary remains at "+globalFallback)
+
+	wrapperPath := filepath.Join(installDir, "harness")
+	wrapperResult := runCommand(
+		t,
+		t.TempDir(),
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t),
+		}),
+		wrapperPath,
+		"--help",
+	)
+	if wrapperResult.ExitCode != 0 {
+		t.Fatalf("wrapper with preserved global fallback failed with exit %d\nstdout:\n%s\nstderr:\n%s", wrapperResult.ExitCode, wrapperResult.Stdout, wrapperResult.Stderr)
 	}
-	support.RequireContains(t, string(after), filepath.Join(repoTwo, ".local", "bin", "harness"))
-	if strings.Contains(string(after), filepath.Join(repoOne, ".local", "bin", "harness")) {
-		t.Fatalf("expected refreshed wrapper to stop pointing at first worktree fallback\nwrapper:\n%s", string(after))
-	}
+	support.RequireContains(t, wrapperResult.Stdout, "global-from-first")
 }
 
 func TestInstallDevHarnessReplacesLegacyManagedWrapperWithoutForce(t *testing.T) {
@@ -449,9 +513,58 @@ func TestInstallDevHarnessReplacesLegacySymlinkedBinaryWithoutForce(t *testing.T
 			if err != nil {
 				t.Fatalf("read refreshed wrapper: %v", err)
 			}
-	support.RequireContains(t, string(refreshed), "# easyharness-install-dev-wrapper")
-			support.RequireContains(t, string(refreshed), filepath.Join(repoRoot, ".local", "bin", "harness"))
+			support.RequireContains(t, string(refreshed), "# easyharness-install-dev-wrapper")
 		})
+	}
+}
+
+func TestInstallDevHarnessWrapperDoesNotUseGlobalFallbackInsideSourceTreeWithoutLocalBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	installDir := filepath.Join(t.TempDir(), "global-bin")
+	homeDir := t.TempDir()
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": homeDir,
+			"PATH": installerPath(t),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--global",
+		"--install-dir", installDir,
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	_, nestedDir := newFakeWorktreeWithoutLocalBinary(t)
+	globalFallback := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
+	writeFixtureFile(t, globalFallback, "#!/bin/sh\nprintf 'unexpected-global-fallback\\n'\n", 0o755)
+
+	wrapperPath := filepath.Join(installDir, "harness")
+	wrapperResult := runCommand(
+		t,
+		nestedDir,
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t),
+		}),
+		wrapperPath,
+		"status",
+	)
+	if wrapperResult.ExitCode == 0 {
+		t.Fatalf("expected source-tree invocation without local binary to fail\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
+	}
+
+	support.RequireContains(t, wrapperResult.Stderr, "No repo-local harness binary found at ")
+	support.RequireContains(t, wrapperResult.Stderr, filepath.Join(".local", "bin", "harness"))
+	if strings.Contains(wrapperResult.CombinedOutput(), "unexpected-global-fallback") {
+		t.Fatalf("expected source-tree invocation to refuse the global fallback\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
 	}
 }
 
@@ -540,6 +653,27 @@ func newFakeWorktree(t *testing.T) (string, string) {
 		"#!/bin/sh\nprintf 'fake worktree harness\\n'\nprintf 'args=%s\\n' \"$*\"\n",
 		0o755,
 	)
+
+	return root, filepath.Join(root, "nested", "dir")
+}
+
+func newFakeWorktreeWithoutLocalBinary(t *testing.T) (string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	for _, dir := range []string{
+		filepath.Join(root, "scripts"),
+		filepath.Join(root, "cmd", "harness"),
+		filepath.Join(root, "nested", "dir"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	writeFixtureFile(t, filepath.Join(root, "scripts", "install-dev-harness"), "#!/usr/bin/env bash\n", 0o755)
+	writeFixtureFile(t, filepath.Join(root, "cmd", "harness", "main.go"), "package main\n", 0o644)
+	writeFixtureFile(t, filepath.Join(root, "go.mod"), "module github.com/catu-ai/easyharness\n", 0o644)
 
 	return root, filepath.Join(root, "nested", "dir")
 }

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -65,6 +65,112 @@ func TestInstallDevHarnessDefaultsToUserLocalBin(t *testing.T) {
 	}
 }
 
+func TestInstallDevHarnessGlobalDefaultsToUserLocalBinAndRefreshesFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	tempHome := t.TempDir()
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": tempHome,
+			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--global",
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness --global failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	expectedWrapper := filepath.Join(tempHome, ".local", "bin", "harness")
+	support.RequireFileExists(t, expectedWrapper)
+	support.RequireContains(t, result.Stdout, "Installed harness wrapper at "+expectedWrapper)
+
+	expectedGlobalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
+	support.RequireFileExists(t, expectedGlobalFallback)
+	support.RequireContains(t, result.Stdout, "Updated global fallback binary at "+expectedGlobalFallback)
+
+	writeFixtureFile(t, expectedGlobalFallback, "#!/bin/sh\nprintf 'stale-fallback\\n'\n", 0o755)
+
+	refreshResult := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": tempHome,
+			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--global",
+	)
+	if refreshResult.ExitCode != 0 {
+		t.Fatalf("second install-dev-harness --global failed with exit %d\nstdout:\n%s\nstderr:\n%s", refreshResult.ExitCode, refreshResult.Stdout, refreshResult.Stderr)
+	}
+
+	fallbackResult := runCommand(
+		t,
+		t.TempDir(),
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t),
+		}),
+		expectedWrapper,
+		"--help",
+	)
+	if fallbackResult.ExitCode != 0 {
+		t.Fatalf("wrapper using refreshed global fallback failed with exit %d\nstdout:\n%s\nstderr:\n%s", fallbackResult.ExitCode, fallbackResult.Stdout, fallbackResult.Stderr)
+	}
+	if strings.Contains(fallbackResult.CombinedOutput(), "stale-fallback") {
+		t.Fatalf("expected --global refresh to overwrite stale fallback contents\nstdout:\n%s\nstderr:\n%s", fallbackResult.Stdout, fallbackResult.Stderr)
+	}
+	support.RequireContains(t, refreshResult.Stdout, "Updated global fallback binary at "+expectedGlobalFallback)
+}
+
+func TestInstallDevHarnessGlobalRejectsWrapperInstallDirConflict(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	tempHome := t.TempDir()
+	conflictingDir := filepath.Join(tempHome, ".local", "share", "easyharness", "dev")
+	conflictingBinary := filepath.Join(conflictingDir, "harness")
+	if err := os.MkdirAll(conflictingDir, 0o755); err != nil {
+		t.Fatalf("mkdir conflicting dir: %v", err)
+	}
+	writeFixtureFile(t, conflictingBinary, "#!/bin/sh\nprintf 'old-global\\n'\n", 0o755)
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": tempHome,
+			"PATH": installerPath(t),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--global",
+		"--install-dir", conflictingDir,
+	)
+	if result.ExitCode == 0 {
+		t.Fatalf("expected conflicting --install-dir to fail\nstdout:\n%s\nstderr:\n%s", result.Stdout, result.Stderr)
+	}
+	support.RequireContains(t, result.Stderr, "Refusing to install the wrapper over the global fallback binary")
+
+	fallbackContents, err := os.ReadFile(conflictingBinary)
+	if err != nil {
+		t.Fatalf("read conflicting fallback after failed install: %v", err)
+	}
+	if string(fallbackContents) != "#!/bin/sh\nprintf 'old-global\\n'\n" {
+		t.Fatalf("expected failed install to leave existing fallback untouched, got:\n%s", string(fallbackContents))
+	}
+}
+
 func TestInstallDevHarnessVerifiesPATHResolvedWrapperWhenInstallDirIsAlreadyOnPATH(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")


### PR DESCRIPTION
## Summary

- add explicit `--global` control for the out-of-tree dev fallback instead of rewriting it on every install
- keep easyharness source trees pinned to their own `.local/bin/harness` while unrelated repos can use the global fallback
- lock the default dev wrapper install directory to `~/.local/bin`, update README guidance, and expand installer smoke coverage

## Validation

- `bash -n scripts/install-dev-harness`
- `scripts/install-dev-harness`
- `go test ./tests/smoke -run InstallDevHarness -count=1`

## Follow-Ups

- Resolves #31
- Follow-up: #119
