### PR TITLE
[codex] shrink state.json to control-plane-only

### DIFF
--- a/docs/plans/archived/2026-04-09-shrink-state-json-to-control-plane-only.md
+++ b/docs/plans/archived/2026-04-09-shrink-state-json-to-control-plane-only.md
@@ -1,0 +1,319 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-09T09:36:00+08:00"
+source_type: direct_request
+source_refs:
+    - '#58'
+---
+
+# Shrink `state.json` to control-plane-only runtime state
+
+## Goal
+
+Reduce `state.json` from a mixed cache-and-control artifact into a small
+command-owned control-plane file that only preserves runtime facts that cannot
+be reconstructed cheaply and safely from tracked plans or append-only local
+artifacts.
+
+This slice removes cache-style fields such as `current_node`, plan path/stem
+pointers, and evidence pointers from `state.json`, keeps only the control
+surface needed to coordinate execution/review/reopen/land flows, and teaches
+`harness status` plus other readers to resolve the rest from the current plan,
+review artifacts, and evidence records directly.
+
+## Scope
+
+### In Scope
+
+- Redefine the plan-local `state.json` contract as a control-plane-only
+  artifact rather than a latest-resolution cache.
+- Remove cache-only fields from the runstate schema and code paths:
+  `current_node`, `plan_path`, `plan_stem`, `latest_evidence`, `latest_ci`,
+  `sync`, and `latest_publish`.
+- Keep the control-plane fields that still represent cross-command runtime
+  state: `execution_started_at`, `revision`, `reopen`,
+  `active_review_round`, and `land`.
+- Stop `harness status` from rewriting `state.json` during read-only status
+  resolution.
+- Teach evidence and status readers to discover the latest publish/ci/sync
+  facts from append-only evidence artifacts instead of state-file pointers.
+- Update specs, schemas, and tests so future agents can understand the
+  shrunken runtime model without discovery-chat context.
+
+### Out of Scope
+
+- Removing `state.json` entirely.
+- Removing `.local/harness/current-plan.json` or its last-landed handoff role.
+- Redesigning review artifacts, evidence artifact formats, or the broader
+  current-plan selection model.
+- Adding compatibility shims that preserve the old cache fields alongside the
+  new control-plane-only shape.
+
+## Acceptance Criteria
+
+- [x] `schema/artifacts/local-state.schema.json` and
+      `internal/contracts/runstate.go` describe `state.json` using only the
+      retained control-plane fields.
+- [x] `harness status` no longer writes `state.json` just to cache the latest
+      resolved node, plan path, or plan stem.
+- [x] Archived publish/ci/sync readiness is still resolved correctly when the
+      latest evidence must be discovered from append-only evidence records
+      rather than state-file pointers.
+- [x] Review, reopen, execute-start, and land flows still preserve the runtime
+      coordination they need after the cache fields are removed.
+- [x] Focused regression coverage proves the new model works without relying on
+      removed state-file caches, and the tracked specs describe the new split
+      clearly.
+
+## Deferred Items
+
+- Whether `execution_started_at` should eventually move out of `state.json`
+  into its own append-only execution artifact.
+- Whether the current active review round can later be derived fully from
+  review artifacts rather than being retained in `state.json`.
+- Whether a later slice should remove `state.json` entirely after the remaining
+  control-plane fields have dedicated artifact homes.
+
+## Work Breakdown
+
+### Step 1: Redefine the runstate contract around control-plane-only fields
+
+- Done: [x]
+
+#### Objective
+
+Make the `state.json` schema and normative docs describe only the runtime
+fields that must survive across command boundaries.
+
+#### Details
+
+Update the tracked contracts so a cold reader can see that `state.json` is no
+longer the place where `harness status` caches the latest resolved node or
+latest evidence pointers. The retained fields should match the actual
+cross-command coordination surfaces that still need persistence: execution
+start, active review context, reopen mode/revision baseline, plan-local
+revision, and in-progress land bookkeeping. `current-plan.json` should remain
+the worktree-level source for current-plan and last-landed pointers.
+
+#### Expected Files
+
+- `docs/specs/state-model.md`
+- `docs/specs/cli-contract.md`
+- `schema/artifacts/local-state.schema.json`
+- `internal/contracts/runstate.go`
+
+#### Validation
+
+- The docs and schema agree on the retained field set for `state.json`.
+- Any generated or checked-in contract tests continue to pass after the schema
+  and contract updates.
+
+#### Execution Notes
+
+Shrank the tracked `runstate.State` contract, local-state schema, and state
+specs down to control-plane-only fields. Removed `current_node`,
+plan path/stem pointers, and evidence pointer caches from the normative model
+so the retained runtime surface now matches the fields still required for
+execute-start, active review coordination, reopen bookkeeping, revision
+tracking, and in-progress land state.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This contract-definition slice was implemented as part
+of one coupled repo-wide state-model refactor, so finalize review covers the
+integrated candidate rather than a standalone step-closeout round.
+
+Reviewed the schema/spec/code contract together by re-running
+`scripts/sync-contract-artifacts --check` and updating package + e2e tests
+that previously assumed cache fields still existed in `state.json`.
+
+### Step 2: Remove cache-field writes and derive runtime facts from artifacts
+
+- Done: [x]
+
+#### Objective
+
+Refactor runtime readers and mutators so `state.json` is no longer treated as
+the storage location for cached node/evidence/path answers.
+
+#### Details
+
+Delete the `harness status` cache-refresh path entirely rather than replacing
+it with another no-op cache layer. Update lifecycle, review, and evidence
+writers so they only persist the retained control-plane fields. Replace
+state-based evidence pointers with direct latest-record discovery from the
+append-only evidence directories. Any consumers that previously consulted
+`state.current_node` or state-held plan/evidence pointers should instead rely
+on retained control-plane fields or direct artifact inspection.
+
+#### Expected Files
+
+- `internal/status/service.go`
+- `internal/evidence/service.go`
+- `internal/lifecycle/service.go`
+- `internal/review/service.go`
+- `internal/reviewui/service.go`
+- `internal/plan/runtime.go`
+
+#### Validation
+
+- `harness status` resolves the same workflow nodes without persisting a cache
+  write.
+- Publish/ci/sync readiness still resolves correctly after evidence is
+  discovered from artifacts instead of `state.json`.
+- Lifecycle and review commands still persist the control-plane fields they
+  own without writing removed cache fields back into state.
+
+#### Execution Notes
+
+Removed cache-style `state.json` writes from `status`, lifecycle, review, and
+evidence mutators. `harness status` now resolves workflow nodes without
+rewriting local state, and archived publish/ci/sync readiness now loads the
+latest evidence directly from append-only evidence records instead of
+state-file pointers.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Runtime writer cleanup and artifact-driven evidence
+reads landed together with the contract/test updates, so finalize review covers
+the cohesive candidate instead of a separate step-closeout round.
+
+Reviewed the runtime readers/writers against lifecycle coverage for execute,
+review, reopen, archive, land, status, review UI, and CLI/e2e flows so the
+remaining state fields are only the ones still used as control-plane inputs.
+
+### Step 3: Lock the model with regression coverage and cleanup docs
+
+- Done: [x]
+
+#### Objective
+
+Prove the control-plane-only model end to end and remove stale references to
+the old cache semantics.
+
+#### Details
+
+Add focused regression tests that fail if status reintroduces no-op
+`state.json` rewrites, if archived readiness still secretly depends on
+state-held evidence pointers, or if retained review/reopen/land flows regress
+after the field removal. Sweep the touched docs and tests for outdated
+descriptions of `state.json` as a thin latest-node cache so future agents do
+not rediscover the old mental model.
+
+#### Expected Files
+
+- `internal/status/service_test.go`
+- `internal/evidence/service_test.go`
+- `internal/lifecycle/service_test.go`
+- `internal/review/service_test.go`
+- `internal/reviewui/service_test.go`
+- `README.md`
+
+#### Validation
+
+- New and updated package tests cover the removal of cache-field writes and the
+  artifact-driven evidence resolution path.
+- `go test ./...` passes once the slice is complete.
+
+#### Execution Notes
+
+Updated regression coverage across status, evidence, lifecycle, review UI,
+runstate, timeline, UI, CLI, and E2E tests so the suite now locks in the
+control-plane-only state model. The tracked specs were also rewritten to stop
+describing `state.json` as a latest-node/evidence cache. Follow-up finalize
+review repairs then tightened the removed-key assertions to include
+`plan_path`/`plan_stem`, added multi-record latest-evidence regression tests,
+updated generated contract wording that still called local state a cache, and
+scoped artifact-driven evidence lookup to the current revision so reopen does
+not reuse stale publish/ci/sync records. A later review follow-up also added
+raw on-disk `state.json` assertions on mutating unit/e2e paths so writer
+commands cannot silently reintroduce removed cache keys.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Regression-locking this slice depended on the integrated
+repo-wide change set, so finalize review covers the resulting candidate rather
+than a separate step-closeout round.
+
+Validated the regression net with focused package runs and a full `go test ./...`
+pass after the state-contract cleanup, including the review workflow E2E that
+reads the persisted local state artifact directly. Finalize review rounds
+`review-001-full` and `review-002-full` surfaced and drove fixes for residual
+docs/test gaps plus reopen revision scoping in artifact-backed evidence lookup.
+`review-003-full` then tightened writer-path raw-state assertions for removed
+cache keys on archive/e2e mutating paths.
+
+## Validation Strategy
+
+- Start with focused package tests around the runstate readers/writers because
+  the main risk is accidentally removing a control-plane dependency that a
+  later command still needs.
+- Add a direct regression that proves consecutive `harness status` reads stop
+  mutating `state.json` when nothing else changes.
+- Re-run the broader Go test suite once the targeted status/evidence/lifecycle
+  flows are green.
+
+## Risks
+
+- Risk: Removing fields that look like cache may accidentally drop a hidden
+  control-plane dependency in review, reopen, or land flows.
+  - Mitigation: Keep the retained-field list explicit in Step 1 and add
+    package-level regression coverage for each retained command path in Step 3.
+- Risk: Direct evidence discovery could pick the wrong record if the selection
+  rules are underspecified.
+  - Mitigation: Define and test one deterministic “latest evidence” rule in
+    code and specs before deleting the old state-pointer path.
+
+## Validation Summary
+
+- `go build ./...`
+- `scripts/sync-contract-artifacts --check`
+- `go test ./internal/evidence ./internal/reviewui ./internal/review ./internal/lifecycle ./internal/status -count=1`
+- `go test ./internal/cli ./internal/runstate ./internal/timeline ./internal/ui -count=1`
+- `go test ./tests/e2e -count=1`
+- `go test ./... -count=1`
+- `go test ./internal/evidence ./internal/status ./internal/lifecycle -count=1`
+- `go test ./internal/cli ./internal/runstate ./internal/timeline ./internal/ui ./tests/e2e -count=1`
+- `scripts/sync-contract-artifacts`
+- `scripts/sync-contract-artifacts --check`
+
+## Review Summary
+
+Finalize review `review-004-full` passed after iterative repair rounds
+`review-001-full` through `review-003-full` surfaced and drove the remaining
+docs/test/revision-scoping fixes. The final reviewer pass found no remaining
+correctness, test-coverage, or docs-consistency blockers for the
+control-plane-only `state.json` model.
+
+## Archive Summary
+
+- Archived At: 2026-04-09T10:21:51+08:00
+- Revision: 1
+- PR: NONE
+- Ready: The candidate has a passing finalize review and is ready to archive,
+  then move through publish evidence toward merge approval.
+- Merge Handoff: Archive the plan, record publish/CI/sync evidence for the
+  archived candidate, and wait for explicit human merge approval before land.
+
+## Outcome Summary
+
+### Delivered
+
+- Reframed `state.json` as a control-plane-only artifact and removed cached
+  node/path/evidence pointer fields from contracts, schemas, and runtime
+  writers.
+- Stopped `harness status` from mutating `state.json` on read-only resolution
+  and switched publish/CI/sync lookup to artifact-driven discovery.
+- Locked the new model with package, CLI, UI, timeline, lifecycle, and E2E
+  regression coverage, including reopen revision scoping and raw on-disk
+  `state.json` assertions for mutating paths.
+
+### Not Delivered
+
+NONE.
+
+### Follow-Up Issues
+
+- Consider whether `execution_started_at` should move into its own durable
+  execution-start artifact once the control-plane-only `state.json` slice is
+  stable.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -405,8 +405,8 @@ Contract:
   `handoff_state`
 - surface aggregated review failures as a concrete repair signal rather than
   falling back to a generic step summary
-- if review metadata cannot be recovered safely, degrade conservatively and do
-  not refresh the cached `current_node`
+- if review metadata cannot be recovered safely, degrade conservatively rather
+  than writing a fallback cache answer into local state
 - once all steps and acceptance criteria are complete, surface archive blockers
   early through a structured `blockers` list plus repair-first next actions
   instead of making the controller learn them only from `harness archive`
@@ -427,10 +427,8 @@ Contract:
   step, keep the current node stable, preserve a conservative warning, and
   steer the controller toward repairing artifacts or rerunning the relevant
   step-closeout review instead of silently trusting older clean passes
-- when refreshing the cached `current_node`, acquire the shared per-plan state
-  lock before loading and rewriting `state.json`; if another command is already
-  mutating local state, return a clear contention error instead of risking a
-  stale cache overwrite
+- treat `state.json` as a control-plane artifact for cross-command runtime
+  state, not as a cache of the latest resolved node or evidence pointers
 
 Recommended next action examples:
 
@@ -731,8 +729,7 @@ Contract:
   - `docs/plans/active/` -> `docs/plans/archived/` for `standard`
   - `docs/plans/active/` ->
     `.local/harness/plans/archived/<plan-stem>.md` for `lightweight`
-- update `.local/harness/current-plan.json` and any existing plan-local
-  `state.json` pointers to the archived path
+- update `.local/harness/current-plan.json` to the archived plan path
 - keep publish, CI, and sync follow-up out of the archive gate; those belong to
   `execution/finalize/publish`
 - return the shared v0.2 envelope with `state.current_node` set to the
@@ -782,10 +779,9 @@ Contract:
 - increment command-owned revision state
 - require an explicit mode such as `finalize-fix` or `new-step`
 - preserve archive audit history via explicit update-required placeholders
-- clear stale review, evidence, and handoff cache signals from the prior
-  archived candidate
-- update `.local/harness/current-plan.json` and any existing plan-local
-  `state.json` pointers back to the active path
+- clear stale review and land control-plane signals from the prior archived
+  candidate
+- update `.local/harness/current-plan.json` back to the active path
 - return the shared v0.2 envelope with the reopened post-command node,
   `facts.revision`, `facts.reopen_mode`, transition artifacts, and actionable
   `next_actions`
@@ -812,7 +808,9 @@ Contract:
   `--help`
 - write a timestamped evidence artifact under
   `.local/harness/plans/<plan-stem>/evidence/<kind>/`
-- update the thin `state.json` cache with the latest pointer for that kind
+- let later status and land-readiness checks discover the latest evidence
+  directly from append-only evidence artifacts instead of storing a pointer in
+  `state.json`
 - preserve trajectory by never editing older evidence artifacts in place
 - accept explicit `not_applied` payloads when a domain truly does not apply
 

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -46,8 +46,10 @@ plus the latest relevant artifacts.
 ### CLI-Owned Resolution
 
 Agents do not set `current_node` directly. The CLI resolves it from the
-current plan artifact plus command-owned artifacts and may cache the latest
-answer in a thin CLI-owned `state.json`.
+current plan artifact plus command-owned artifacts. The plan-local
+`state.json` remains a CLI-owned control artifact for runtime facts that must
+persist across commands, but it is not the storage location for a cached
+latest `current_node`.
 
 ### Safe Local Persistence
 
@@ -127,8 +129,9 @@ For active work in both profiles, this plan artifact is a tracked file under
 - archive milestones
 - reopen milestones, including the explicit reopen mode
 - land entry and land completion milestones
-- the thin `state.json` cache containing the latest resolved `current_node`
-  plus latest artifact pointers
+- the plan-local `state.json` control artifact containing only cross-command
+  runtime facts that are not otherwise reconstructed directly from plans or
+  append-only artifacts
 
 These CLI-owned JSON artifacts are disposable runtime state, but they still
 need crash-safe persistence so the controller can trust `harness status` after
@@ -173,6 +176,15 @@ Resolution rules:
 - append-only `ci`, `publish`, and `sync` evidence
 - archive, reopen, and land milestones
 - worktree-level last-landed context when no current work remains
+
+The plan-local `state.json` carries only the control-plane subset of those
+inputs that do not already live in a more specific artifact:
+
+- `execution_started_at`
+- `revision`
+- `active_review_round`
+- `reopen`
+- `land`
 
 ## High-Level Resolution Order
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -478,7 +478,7 @@ func TestExecuteStartRollsBackWhenTimelineAppendFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state after rollback: %v", err)
 	}
-	if state == nil || state.ExecutionStartedAt != "" || state.CurrentNode != "plan" {
+	if state == nil || state.ExecutionStartedAt != "" {
 		t.Fatalf("expected execute start rollback to restore pre-start state, got %#v", state)
 	}
 	current, err := runstate.LoadCurrentPlan(root)
@@ -868,8 +868,6 @@ func TestArchiveCommandAppendsTimelineEvent(t *testing.T) {
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-ready", &runstate.State{
-		PlanPath:           relPlanPath,
-		PlanStem:           "2026-03-18-archive-ready",
 		ExecutionStartedAt: "2026-03-18T15:00:00Z",
 		Revision:           1,
 		ActiveReviewRound: &runstate.ReviewRound{

--- a/internal/contracts/evidence.go
+++ b/internal/contracts/evidence.go
@@ -28,7 +28,7 @@ type EvidenceArtifacts struct {
 	// PlanPath is the archived plan path associated with the evidence record.
 	PlanPath string `json:"plan_path"`
 
-	// LocalStatePath is the plan-local state cache path when one exists.
+	// LocalStatePath is the plan-local control-plane state path when one exists.
 	LocalStatePath string `json:"local_state_path,omitempty"`
 
 	// RecordID is the stable identifier of the created evidence record.

--- a/internal/contracts/lifecycle.go
+++ b/internal/contracts/lifecycle.go
@@ -65,7 +65,7 @@ type LifecycleArtifacts struct {
 	// a plan artifact.
 	ToPlanPath string `json:"to_plan_path"`
 
-	// LocalStatePath is the plan-local state cache path when one exists.
+	// LocalStatePath is the plan-local control-plane state path when one exists.
 	LocalStatePath string `json:"local_state_path,omitempty"`
 
 	// CurrentPlanPath is the worktree-level current-plan pointer path when the

--- a/internal/contracts/review.go
+++ b/internal/contracts/review.go
@@ -377,7 +377,7 @@ type ReviewStartArtifacts struct {
 	// PlanPath is the current plan path associated with the review round.
 	PlanPath string `json:"plan_path"`
 
-	// LocalStatePath is the plan-local state cache path.
+	// LocalStatePath is the plan-local control-plane state path.
 	LocalStatePath string `json:"local_state_path"`
 
 	// RoundID is the stable identifier for the review round.
@@ -466,6 +466,6 @@ type ReviewAggregateArtifacts struct {
 	// AggregatePath is the path to the updated aggregate artifact.
 	AggregatePath string `json:"aggregate_path"`
 
-	// LocalStatePath is the plan-local state cache path.
+	// LocalStatePath is the plan-local control-plane state path.
 	LocalStatePath string `json:"local_state_path"`
 }

--- a/internal/contracts/review_ui.go
+++ b/internal/contracts/review_ui.go
@@ -34,7 +34,7 @@ type ReviewArtifacts struct {
 	// PlanPath is the current plan path associated with the review data.
 	PlanPath string `json:"plan_path,omitempty"`
 
-	// LocalStatePath is the plan-local state cache path when one exists.
+	// LocalStatePath is the plan-local control-plane state path when one exists.
 	LocalStatePath string `json:"local_state_path,omitempty"`
 
 	// ReviewsDir is the current-plan review rounds directory.

--- a/internal/contracts/runstate.go
+++ b/internal/contracts/runstate.go
@@ -15,22 +15,11 @@ type CurrentPlanFile struct {
 	LastLandedAt string `json:"last_landed_at,omitempty"`
 }
 
-// LocalStateFile is the plan-local runtime state cache under
+// LocalStateFile is the plan-local runtime control artifact under
 // `.local/harness/plans/<plan-stem>/state.json`.
 type LocalStateFile struct {
 	// ExecutionStartedAt is the execution-start timestamp for the plan.
 	ExecutionStartedAt string `json:"execution_started_at,omitempty"`
-
-	// CurrentNode is the cached canonical workflow node when one has been
-	// resolved.
-	CurrentNode string `json:"current_node,omitempty"`
-
-	// PlanPath is the current tracked or archived plan path associated with this
-	// state file.
-	PlanPath string `json:"plan_path,omitempty"`
-
-	// PlanStem is the durable plan stem associated with this state file.
-	PlanStem string `json:"plan_stem,omitempty"`
 
 	// Revision is the current plan-local revision number.
 	Revision int `json:"revision,omitempty"`
@@ -42,24 +31,8 @@ type LocalStateFile struct {
 	// flight.
 	ActiveReviewRound *ReviewRoundState `json:"active_review_round,omitempty"`
 
-	// LatestEvidence records the latest evidence pointers tracked in the state
-	// file.
-	LatestEvidence *EvidenceSetState `json:"latest_evidence,omitempty"`
-
 	// Land records the current land state when merge cleanup is in flight.
 	Land *LandState `json:"land,omitempty"`
-
-	// LatestCI is the transitional cached CI state retained while status still
-	// reads legacy evidence hints directly from state.json.
-	LatestCI *LegacyCIState `json:"latest_ci,omitempty"`
-
-	// Sync is the transitional cached sync state retained while status still
-	// reads legacy hints directly from state.json.
-	Sync *LegacySyncState `json:"sync,omitempty"`
-
-	// LatestPublish is the transitional cached publish state retained while
-	// status still reads legacy hints directly from state.json.
-	LatestPublish *LegacyPublishState `json:"latest_publish,omitempty"`
 }
 
 // ReopenState records the active reopen repair state.
@@ -96,34 +69,6 @@ type ReviewRoundState struct {
 	Decision string `json:"decision,omitempty"`
 }
 
-// EvidenceSetState records the latest evidence pointers tracked in the local
-// state file.
-type EvidenceSetState struct {
-	// CI points to the latest CI evidence record when one exists.
-	CI *EvidencePointerState `json:"ci,omitempty"`
-
-	// Publish points to the latest publish evidence record when one exists.
-	Publish *EvidencePointerState `json:"publish,omitempty"`
-
-	// Sync points to the latest sync evidence record when one exists.
-	Sync *EvidencePointerState `json:"sync,omitempty"`
-}
-
-// EvidencePointerState points to one evidence record from the local state file.
-type EvidencePointerState struct {
-	// Kind is the evidence kind.
-	Kind string `json:"kind"`
-
-	// RecordID is the stable identifier of the evidence record.
-	RecordID string `json:"record_id"`
-
-	// Path is the path to the evidence record artifact.
-	Path string `json:"path"`
-
-	// RecordedAt is the evidence record timestamp when one is tracked.
-	RecordedAt string `json:"recorded_at,omitempty"`
-}
-
 // LandState records the current land state in the local state file.
 type LandState struct {
 	// PRURL is the pull request URL recorded for the land phase.
@@ -137,34 +82,4 @@ type LandState struct {
 
 	// CompletedAt is the timestamp when land cleanup completed.
 	CompletedAt string `json:"completed_at,omitempty"`
-}
-
-// LegacyCIState is the transitional CI cache retained in the local state file
-// while status still reads legacy evidence hints directly.
-type LegacyCIState struct {
-	// SnapshotID is the legacy CI snapshot identifier.
-	SnapshotID string `json:"snapshot_id"`
-
-	// Status is the cached legacy CI status.
-	Status string `json:"status"`
-}
-
-// LegacySyncState is the transitional sync cache retained in the local state
-// file while status still reads legacy hints directly.
-type LegacySyncState struct {
-	// Freshness is the cached sync freshness label.
-	Freshness string `json:"freshness"`
-
-	// Conflicts reports whether the cached sync state observed conflicts.
-	Conflicts bool `json:"conflicts"`
-}
-
-// LegacyPublishState is the transitional publish cache retained in the local
-// state file while status still reads legacy hints directly.
-type LegacyPublishState struct {
-	// AttemptID is the legacy publish attempt identifier.
-	AttemptID string `json:"attempt_id"`
-
-	// PRURL is the cached publish pull request URL.
-	PRURL string `json:"pr_url"`
 }

--- a/internal/contracts/status.go
+++ b/internal/contracts/status.go
@@ -98,7 +98,7 @@ type StatusArtifacts struct {
 	// current status resolution.
 	PlanPath string `json:"plan_path,omitempty" jsonschema:"example=docs/plans/active/2026-03-31-centralize-contract-schemas-and-generated-reference-docs.md"`
 
-	// LocalStatePath is the plan-local state cache path when one exists.
+	// LocalStatePath is the plan-local control-plane state path when one exists.
 	LocalStatePath string `json:"local_state_path,omitempty" jsonschema:"example=.local/harness/plans/2026-03-31-centralize-contract-schemas-and-generated-reference-docs/state.json"`
 
 	// ReviewRoundID is the active review round identifier when review is in

--- a/internal/contracts/timeline.go
+++ b/internal/contracts/timeline.go
@@ -120,7 +120,7 @@ type TimelineArtifacts struct {
 	// timeline.
 	PlanPath string `json:"plan_path,omitempty"`
 
-	// LocalStatePath is the plan-local state cache path when one exists.
+	// LocalStatePath is the plan-local control-plane state path when one exists.
 	LocalStatePath string `json:"local_state_path,omitempty"`
 
 	// EventIndexPath is the append-only event index path.

--- a/internal/evidence/service.go
+++ b/internal/evidence/service.go
@@ -74,17 +74,8 @@ func (s Service) Submit(kind string, inputBytes []byte) Result {
 		if err := writeJSONFile(recordPath, record); err != nil {
 			return errorResult("evidence submit", "Unable to persist the evidence artifact.", []CommandError{{Path: "record", Message: err.Error()}})
 		}
-		originalState := cloneState(state)
-		statePath, err = updateStateAfterEvidence(s.Workdir, planStem, relPlanPath, state, statePath, kind, recordID, recordPath, now, func(next *runstate.State) {
-			next.LatestCI = &runstate.CIState{SnapshotID: recordID, Status: record.Status}
-		})
-		if err != nil {
-			issues := rollbackEvidenceMutation(s.Workdir, planStem, originalState, statePath, recordPath)
-			issues = append([]CommandError{{Path: "state", Message: err.Error()}}, issues...)
-			return errorResult("evidence submit", "Unable to update local harness state.", issues)
-		}
 		return s.finalizeMutation(successResult(planPath, statePath, kind, recordID, recordPath, "Recorded CI evidence for the current archived candidate."), func() []CommandError {
-			return rollbackEvidenceMutation(s.Workdir, planStem, originalState, statePath, recordPath)
+			return rollbackEvidenceMutation(recordPath)
 		})
 	case "publish":
 		var input PublishInput
@@ -115,21 +106,8 @@ func (s Service) Submit(kind string, inputBytes []byte) Result {
 		if err := writeJSONFile(recordPath, record); err != nil {
 			return errorResult("evidence submit", "Unable to persist the evidence artifact.", []CommandError{{Path: "record", Message: err.Error()}})
 		}
-		originalState := cloneState(state)
-		statePath, err = updateStateAfterEvidence(s.Workdir, planStem, relPlanPath, state, statePath, kind, recordID, recordPath, now, func(next *runstate.State) {
-			if record.Status == "recorded" {
-				next.LatestPublish = &runstate.Publish{AttemptID: recordID, PRURL: record.PRURL}
-				return
-			}
-			next.LatestPublish = nil
-		})
-		if err != nil {
-			issues := rollbackEvidenceMutation(s.Workdir, planStem, originalState, statePath, recordPath)
-			issues = append([]CommandError{{Path: "state", Message: err.Error()}}, issues...)
-			return errorResult("evidence submit", "Unable to update local harness state.", issues)
-		}
 		return s.finalizeMutation(successResult(planPath, statePath, kind, recordID, recordPath, "Recorded publish evidence for the current archived candidate."), func() []CommandError {
-			return rollbackEvidenceMutation(s.Workdir, planStem, originalState, statePath, recordPath)
+			return rollbackEvidenceMutation(recordPath)
 		})
 	case "sync":
 		var input SyncInput
@@ -158,26 +136,8 @@ func (s Service) Submit(kind string, inputBytes []byte) Result {
 		if err := writeJSONFile(recordPath, record); err != nil {
 			return errorResult("evidence submit", "Unable to persist the evidence artifact.", []CommandError{{Path: "record", Message: err.Error()}})
 		}
-		originalState := cloneState(state)
-		statePath, err = updateStateAfterEvidence(s.Workdir, planStem, relPlanPath, state, statePath, kind, recordID, recordPath, now, func(next *runstate.State) {
-			switch record.Status {
-			case "fresh":
-				next.Sync = &runstate.SyncState{Freshness: "fresh", Conflicts: false}
-			case "stale":
-				next.Sync = &runstate.SyncState{Freshness: "stale", Conflicts: false}
-			case "conflicted":
-				next.Sync = &runstate.SyncState{Freshness: "stale", Conflicts: true}
-			default:
-				next.Sync = nil
-			}
-		})
-		if err != nil {
-			issues := rollbackEvidenceMutation(s.Workdir, planStem, originalState, statePath, recordPath)
-			issues = append([]CommandError{{Path: "state", Message: err.Error()}}, issues...)
-			return errorResult("evidence submit", "Unable to update local harness state.", issues)
-		}
 		return s.finalizeMutation(successResult(planPath, statePath, kind, recordID, recordPath, "Recorded sync evidence for the current archived candidate."), func() []CommandError {
-			return rollbackEvidenceMutation(s.Workdir, planStem, originalState, statePath, recordPath)
+			return rollbackEvidenceMutation(recordPath)
 		})
 	default:
 		return errorResult("evidence submit", "Evidence kind is invalid.", []CommandError{{
@@ -187,60 +147,16 @@ func (s Service) Submit(kind string, inputBytes []byte) Result {
 	}
 }
 
-func LoadLatestCI(workdir string, state *runstate.State) (*CIRecord, error) {
-	if state == nil {
-		return nil, nil
-	}
-	if state.LatestEvidence != nil && state.LatestEvidence.CI != nil {
-		return loadRecord[CIRecord](workdir, state.LatestEvidence.CI.Path)
-	}
-	if state.LatestCI != nil {
-		return &CIRecord{
-			RecordID: state.LatestCI.SnapshotID,
-			Kind:     "ci",
-			Status:   strings.ToLower(strings.TrimSpace(state.LatestCI.Status)),
-		}, nil
-	}
-	return nil, nil
+func LoadLatestCI(workdir, planStem string, revision int) (*CIRecord, error) {
+	return loadLatestRecord[CIRecord](workdir, planStem, "ci", revision)
 }
 
-func LoadLatestPublish(workdir string, state *runstate.State) (*PublishRecord, error) {
-	if state == nil {
-		return nil, nil
-	}
-	if state.LatestEvidence != nil && state.LatestEvidence.Publish != nil {
-		return loadRecord[PublishRecord](workdir, state.LatestEvidence.Publish.Path)
-	}
-	if state.LatestPublish != nil {
-		return &PublishRecord{
-			RecordID: state.LatestPublish.AttemptID,
-			Kind:     "publish",
-			Status:   "recorded",
-			PRURL:    strings.TrimSpace(state.LatestPublish.PRURL),
-		}, nil
-	}
-	return nil, nil
+func LoadLatestPublish(workdir, planStem string, revision int) (*PublishRecord, error) {
+	return loadLatestRecord[PublishRecord](workdir, planStem, "publish", revision)
 }
 
-func LoadLatestSync(workdir string, state *runstate.State) (*SyncRecord, error) {
-	if state == nil {
-		return nil, nil
-	}
-	if state.LatestEvidence != nil && state.LatestEvidence.Sync != nil {
-		return loadRecord[SyncRecord](workdir, state.LatestEvidence.Sync.Path)
-	}
-	if state.Sync != nil {
-		status := strings.ToLower(strings.TrimSpace(state.Sync.Freshness))
-		if state.Sync.Conflicts {
-			status = "conflicted"
-		}
-		return &SyncRecord{
-			RecordID: "legacy-sync",
-			Kind:     "sync",
-			Status:   status,
-		}, nil
-	}
-	return nil, nil
+func LoadLatestSync(workdir, planStem string, revision int) (*SyncRecord, error) {
+	return loadLatestRecord[SyncRecord](workdir, planStem, "sync", revision)
 }
 
 func loadRecord[T any](workdir, relPath string) (*T, error) {
@@ -257,6 +173,57 @@ func loadRecord[T any](workdir, relPath string) (*T, error) {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
 	return &record, nil
+}
+
+func loadLatestRecord[T any](workdir, planStem, kind string, revision int) (*T, error) {
+	if strings.TrimSpace(planStem) == "" {
+		return nil, nil
+	}
+	dir := filepath.Join(workdir, ".local", "harness", "plans", planStem, "evidence", kind)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	maxID := 0
+	var latestRecord *T
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		matches := recordIDPattern.FindStringSubmatch(entry.Name())
+		if matches == nil || matches[1] != kind {
+			continue
+		}
+		n, err := strconv.Atoi(matches[2])
+		if err != nil || n <= maxID {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		var header struct {
+			Revision int `json:"revision"`
+		}
+		if err := json.Unmarshal(data, &header); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		if revision > 0 && header.Revision != revision {
+			continue
+		}
+		var record T
+		if err := json.Unmarshal(data, &record); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		maxID = n
+		latestRecord = &record
+	}
+	return latestRecord, nil
 }
 
 func validateCIInput(input CIInput) []CommandError {
@@ -336,40 +303,6 @@ func nextRecordLocation(workdir, planStem, kind string) (string, string, error) 
 	}
 	recordID := fmt.Sprintf("%s-%03d", kind, maxID+1)
 	return recordID, filepath.Join(dir, recordID+".json"), nil
-}
-
-func updateStateAfterEvidence(workdir, planStem, relPlanPath string, state *runstate.State, statePath, kind, recordID, recordPath, recordedAt string, mutate func(next *runstate.State)) (string, error) {
-	if state == nil {
-		state = &runstate.State{}
-	}
-	state.PlanPath = relPlanPath
-	state.PlanStem = planStem
-	if state.Revision <= 0 {
-		state.Revision = 1
-	}
-	if state.LatestEvidence == nil {
-		state.LatestEvidence = &runstate.EvidenceSet{}
-	}
-	relRecordPath, err := filepath.Rel(workdir, recordPath)
-	if err != nil {
-		return statePath, err
-	}
-	pointer := &runstate.EvidencePointer{
-		Kind:       kind,
-		RecordID:   recordID,
-		Path:       filepath.ToSlash(relRecordPath),
-		RecordedAt: recordedAt,
-	}
-	switch kind {
-	case "ci":
-		state.LatestEvidence.CI = pointer
-	case "publish":
-		state.LatestEvidence.Publish = pointer
-	case "sync":
-		state.LatestEvidence.Sync = pointer
-	}
-	mutate(state)
-	return saveState(workdir, planStem, state)
 }
 
 func successResult(planPath, statePath, kind, recordID, recordPath, summary string) Result {
@@ -505,16 +438,15 @@ func (s Service) loadCurrentArchivedPlan() (string, string, string, *runstate.St
 			}},
 		}
 	}
-	if state != nil && (strings.TrimSpace(state.CurrentNode) == "land" ||
-		(state.Land != nil &&
-			strings.TrimSpace(state.Land.LandedAt) != "" &&
-			strings.TrimSpace(state.Land.CompletedAt) == "")) {
+	if state != nil && state.Land != nil &&
+		strings.TrimSpace(state.Land.LandedAt) != "" &&
+		strings.TrimSpace(state.Land.CompletedAt) == "" {
 		release()
 		return "", "", "", nil, "", func() {}, &Result{
 			OK:      false,
 			Summary: "Evidence commands are not allowed after merge confirmation enters required post-merge bookkeeping.",
 			Errors: []CommandError{{
-				Path:    "state.current_node",
+				Path:    "state.land",
 				Message: "current archived candidate is already in required post-merge bookkeeping",
 			}},
 		}
@@ -542,52 +474,15 @@ func cloneState(state *runstate.State) *runstate.State {
 		reopen := *state.Reopen
 		cloned.Reopen = &reopen
 	}
-	if state.LatestEvidence != nil {
-		evidenceSet := *state.LatestEvidence
-		cloned.LatestEvidence = &evidenceSet
-		if state.LatestEvidence.CI != nil {
-			ciPtr := *state.LatestEvidence.CI
-			cloned.LatestEvidence.CI = &ciPtr
-		}
-		if state.LatestEvidence.Publish != nil {
-			publishPtr := *state.LatestEvidence.Publish
-			cloned.LatestEvidence.Publish = &publishPtr
-		}
-		if state.LatestEvidence.Sync != nil {
-			syncPtr := *state.LatestEvidence.Sync
-			cloned.LatestEvidence.Sync = &syncPtr
-		}
-	}
 	if state.Land != nil {
 		land := *state.Land
 		cloned.Land = &land
 	}
-	if state.LatestCI != nil {
-		ci := *state.LatestCI
-		cloned.LatestCI = &ci
-	}
-	if state.Sync != nil {
-		sync := *state.Sync
-		cloned.Sync = &sync
-	}
-	if state.LatestPublish != nil {
-		publish := *state.LatestPublish
-		cloned.LatestPublish = &publish
-	}
 	return &cloned
 }
 
-func rollbackEvidenceMutation(workdir, planStem string, originalState *runstate.State, statePath, recordPath string) []CommandError {
-	issues := make([]CommandError, 0, 2)
-	if originalState != nil {
-		if _, err := runstate.SaveState(workdir, planStem, originalState); err != nil {
-			issues = append(issues, CommandError{Path: "state", Message: fmt.Sprintf("rollback local state: %v", err)})
-		}
-	} else if statePath != "" {
-		if err := os.Remove(statePath); err != nil && !os.IsNotExist(err) {
-			issues = append(issues, CommandError{Path: "state", Message: fmt.Sprintf("rollback local state: %v", err)})
-		}
-	}
+func rollbackEvidenceMutation(recordPath string) []CommandError {
+	issues := make([]CommandError, 0, 1)
 	if err := os.Remove(recordPath); err != nil && !os.IsNotExist(err) {
 		issues = append(issues, CommandError{Path: "record", Message: fmt.Sprintf("rollback evidence artifact: %v", err)})
 	}

--- a/internal/evidence/service_internal_test.go
+++ b/internal/evidence/service_internal_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/runstate"
 )
 
-func TestSubmitRemovesRecordArtifactWhenStateSaveFails(t *testing.T) {
+func TestSubmitIgnoresStateSaveFailuresAndKeepsRecordArtifact(t *testing.T) {
 	testCases := []struct {
 		name       string
 		kind       string
@@ -60,13 +60,13 @@ func TestSubmitRemovesRecordArtifactWhenStateSaveFails(t *testing.T) {
 					return time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC)
 				},
 			}.Submit(tc.kind, []byte(tc.input))
-			if result.OK {
-				t.Fatalf("expected evidence submit failure, got %#v", result)
+			if !result.OK {
+				t.Fatalf("expected evidence submit success, got %#v", result)
 			}
 
 			recordPath := filepath.Join(root, tc.recordPath)
-			if _, err := os.Stat(recordPath); !os.IsNotExist(err) {
-				t.Fatalf("expected evidence record to be removed on rollback, got %v", err)
+			if _, err := os.Stat(recordPath); err != nil {
+				t.Fatalf("expected evidence record to remain on disk, got %v", err)
 			}
 
 			state, statePath, err := runstate.LoadState(root, "2026-04-01-evidence-rollback")
@@ -74,11 +74,11 @@ func TestSubmitRemovesRecordArtifactWhenStateSaveFails(t *testing.T) {
 				t.Fatalf("load state: %v", err)
 			}
 			if state != nil {
-				t.Fatalf("expected no persisted state after rollback, got %#v", state)
+				t.Fatalf("expected no persisted state cache writes, got %#v", state)
 			}
 			if statePath != "" {
 				if _, err := os.Stat(statePath); !os.IsNotExist(err) {
-					t.Fatalf("expected no state file after rollback, got %v", err)
+					t.Fatalf("expected no state file to be written, got %v", err)
 				}
 			}
 		})

--- a/internal/evidence/service_test.go
+++ b/internal/evidence/service_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/runstate"
 )
 
-func TestSubmitCIEvidenceWritesArtifactAndUpdatesStatePointer(t *testing.T) {
+func TestSubmitCIEvidenceWritesArtifactWithoutStateCache(t *testing.T) {
 	root := t.TempDir()
 	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
 	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
@@ -35,14 +35,12 @@ func TestSubmitCIEvidenceWritesArtifactAndUpdatesStatePointer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.LatestEvidence == nil || state.LatestEvidence.CI == nil {
-		t.Fatalf("expected ci evidence pointer in state, got %#v", state)
+	if state != nil {
+		t.Fatalf("expected CI submit to avoid state cache writes, got %#v", state)
 	}
-	if state.LatestCI == nil || state.LatestCI.Status != "success" {
-		t.Fatalf("expected transitional CI cache, got %#v", state)
-	}
+	assertStateFileAbsent(t, root, "2026-03-21-evidence-plan")
 
-	record, err := evidence.LoadLatestCI(root, state)
+	record, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 1)
 	if err != nil {
 		t.Fatalf("load latest CI record: %v", err)
 	}
@@ -130,7 +128,7 @@ func TestSubmitCIRejectsWrongStatusType(t *testing.T) {
 	assertEvidenceError(t, result, "input.status")
 }
 
-func TestSubmitPublishWritesArtifactAndUpdatesStatePointer(t *testing.T) {
+func TestSubmitPublishWritesArtifactWithoutStateCache(t *testing.T) {
 	root := t.TempDir()
 	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
 	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
@@ -151,14 +149,12 @@ func TestSubmitPublishWritesArtifactAndUpdatesStatePointer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.LatestEvidence == nil || state.LatestEvidence.Publish == nil {
-		t.Fatalf("expected publish evidence pointer in state, got %#v", state)
+	if state != nil {
+		t.Fatalf("expected publish submit to avoid state cache writes, got %#v", state)
 	}
-	if state.LatestPublish == nil || state.LatestPublish.PRURL == "" {
-		t.Fatalf("expected transitional publish cache, got %#v", state)
-	}
+	assertStateFileAbsent(t, root, "2026-03-21-evidence-plan")
 
-	record, err := evidence.LoadLatestPublish(root, state)
+	record, err := evidence.LoadLatestPublish(root, "2026-03-21-evidence-plan", 1)
 	if err != nil {
 		t.Fatalf("load latest publish record: %v", err)
 	}
@@ -188,15 +184,16 @@ func TestSubmitSyncSupportsExplicitNotApplied(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	record, err := evidence.LoadLatestSync(root, state)
+	if state != nil {
+		t.Fatalf("expected sync submit to avoid state cache writes, got %#v", state)
+	}
+	assertStateFileAbsent(t, root, "2026-03-21-evidence-plan")
+	record, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1)
 	if err != nil {
 		t.Fatalf("load latest sync record: %v", err)
 	}
 	if record == nil || record.Status != "not_applied" {
 		t.Fatalf("unexpected sync record: %#v", record)
-	}
-	if state.Sync != nil {
-		t.Fatalf("expected transitional sync cache to stay nil for not_applied, got %#v", state.Sync)
 	}
 }
 
@@ -217,7 +214,7 @@ func TestSubmitSyncRejectsWrongHeadRefType(t *testing.T) {
 	assertEvidenceError(t, result, "input.head_ref")
 }
 
-func TestSubmitSyncFreshWritesArtifactAndUpdatesStatePointer(t *testing.T) {
+func TestSubmitSyncFreshWritesArtifactWithoutStateCache(t *testing.T) {
 	root := t.TempDir()
 	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
 	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
@@ -238,14 +235,12 @@ func TestSubmitSyncFreshWritesArtifactAndUpdatesStatePointer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.LatestEvidence == nil || state.LatestEvidence.Sync == nil {
-		t.Fatalf("expected sync evidence pointer in state, got %#v", state)
+	if state != nil {
+		t.Fatalf("expected sync submit to avoid state cache writes, got %#v", state)
 	}
-	if state.Sync == nil || state.Sync.Freshness != "fresh" || state.Sync.Conflicts {
-		t.Fatalf("expected transitional sync cache, got %#v", state.Sync)
-	}
+	assertStateFileAbsent(t, root, "2026-03-21-evidence-plan")
 
-	record, err := evidence.LoadLatestSync(root, state)
+	record, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1)
 	if err != nil {
 		t.Fatalf("load latest sync record: %v", err)
 	}
@@ -274,9 +269,6 @@ func TestSubmitEvidenceRejectsLandInProgress(t *testing.T) {
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(root, "2026-03-21-evidence-plan", &runstate.State{
-		PlanPath:    relPlanPath,
-		PlanStem:    "2026-03-21-evidence-plan",
-		CurrentNode: "land",
 		Land: &runstate.LandState{
 			PRURL:    "https://github.com/catu-ai/easyharness/pull/99",
 			LandedAt: "2026-03-21T11:00:00Z",
@@ -316,6 +308,140 @@ func TestSubmitEvidenceRejectsWhenStateMutationLockIsHeld(t *testing.T) {
 	}
 }
 
+func TestLoadLatestCIPrefersNewestRecord(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	first := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 21, 10, 0, 0, 0, time.UTC)
+		},
+	}.Submit("ci", []byte(`{"status":"pending","provider":"buildkite","url":"https://ci.example/1"}`))
+	if !first.OK {
+		t.Fatalf("expected first CI submit success, got %#v", first)
+	}
+	second := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 21, 10, 3, 0, 0, time.UTC)
+		},
+	}.Submit("ci", []byte(`{"status":"success","provider":"buildkite","url":"https://ci.example/2"}`))
+	if !second.OK {
+		t.Fatalf("expected second CI submit success, got %#v", second)
+	}
+
+	record, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 1)
+	if err != nil {
+		t.Fatalf("load latest CI record: %v", err)
+	}
+	if record == nil || record.RecordID != "ci-002" || record.Status != "success" || record.URL != "https://ci.example/2" {
+		t.Fatalf("expected newest CI record to win, got %#v", record)
+	}
+}
+
+func TestLoadLatestPublishPrefersNewestRecord(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	first := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 21, 10, 0, 0, 0, time.UTC)
+		},
+	}.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99","branch":"codex/test","base":"main","commit":"abc123"}`))
+	if !first.OK {
+		t.Fatalf("expected first publish submit success, got %#v", first)
+	}
+	second := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 21, 10, 3, 0, 0, time.UTC)
+		},
+	}.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/100","branch":"codex/test-2","base":"main","commit":"def456"}`))
+	if !second.OK {
+		t.Fatalf("expected second publish submit success, got %#v", second)
+	}
+
+	record, err := evidence.LoadLatestPublish(root, "2026-03-21-evidence-plan", 1)
+	if err != nil {
+		t.Fatalf("load latest publish record: %v", err)
+	}
+	if record == nil || record.RecordID != "publish-002" || record.PRURL != "https://github.com/catu-ai/easyharness/pull/100" || record.Commit != "def456" {
+		t.Fatalf("expected newest publish record to win, got %#v", record)
+	}
+}
+
+func TestLoadLatestSyncPrefersNewestRecord(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	first := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 21, 10, 0, 0, 0, time.UTC)
+		},
+	}.Submit("sync", []byte(`{"status":"stale","base_ref":"main","head_ref":"codex/test"}`))
+	if !first.OK {
+		t.Fatalf("expected first sync submit success, got %#v", first)
+	}
+	second := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 21, 10, 3, 0, 0, time.UTC)
+		},
+	}.Submit("sync", []byte(`{"status":"fresh","base_ref":"main","head_ref":"codex/test-2"}`))
+	if !second.OK {
+		t.Fatalf("expected second sync submit success, got %#v", second)
+	}
+
+	record, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1)
+	if err != nil {
+		t.Fatalf("load latest sync record: %v", err)
+	}
+	if record == nil || record.RecordID != "sync-002" || record.Status != "fresh" || record.HeadRef != "codex/test-2" {
+		t.Fatalf("expected newest sync record to win, got %#v", record)
+	}
+}
+
+func TestLoadLatestRecordIgnoresOlderRevisionEvidence(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	first := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 21, 10, 0, 0, 0, time.UTC)
+		},
+	}.Submit("ci", []byte(`{"status":"success","provider":"buildkite","url":"https://ci.example/1"}`))
+	if !first.OK {
+		t.Fatalf("expected first CI submit success, got %#v", first)
+	}
+	if _, err := runstate.SaveState(root, "2026-03-21-evidence-plan", &runstate.State{Revision: 2}); err != nil {
+		t.Fatalf("save reopened revision state: %v", err)
+	}
+
+	record, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 2)
+	if err != nil {
+		t.Fatalf("load latest CI record: %v", err)
+	}
+	if record != nil {
+		t.Fatalf("expected older revision evidence to be ignored, got %#v", record)
+	}
+}
+
 func assertEvidenceError(t *testing.T, result evidence.Result, path string) {
 	t.Helper()
 	for _, issue := range result.Errors {
@@ -324,6 +450,14 @@ func assertEvidenceError(t *testing.T, result evidence.Result, path string) {
 		}
 	}
 	t.Fatalf("expected evidence error for %s, got %#v", path, result.Errors)
+}
+
+func assertStateFileAbsent(t *testing.T, root, planStem string) {
+	t.Helper()
+	path := filepath.Join(root, ".local", "harness", "plans", planStem, "state.json")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected state.json to stay absent, got %v", err)
+	}
 }
 
 func writeArchivedPlan(t *testing.T, root, relPath string) string {

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -62,13 +62,10 @@ func (s Service) ExecuteStart() Result {
 	if state.Revision <= 0 {
 		state.Revision = 1
 	}
-	state.PlanPath = relCurrentPath
-	state.PlanStem = planStem
 
 	if strings.TrimSpace(state.ExecutionStartedAt) == "" {
 		state.ExecutionStartedAt = now.Format(time.RFC3339)
 	}
-	state.CurrentNode = ""
 
 	savedStatePath, err := runstate.SaveState(s.Workdir, planStem, state)
 	if err != nil {
@@ -181,9 +178,6 @@ func (s Service) Archive() Result {
 	originalState := cloneState(state)
 	nextState := cloneState(state)
 	if nextState != nil {
-		nextState.PlanPath = relTargetPath
-		nextState.PlanStem = planStem
-		nextState.CurrentNode = ""
 		nextState.Reopen = nil
 		nextState.Land = nil
 		statePath, err = runstate.SaveState(s.Workdir, planStem, nextState)
@@ -255,9 +249,9 @@ func (s Service) Reopen(mode string) Result {
 			Message: fmt.Sprintf("reopen requires status=archived and lifecycle=awaiting_merge_approval, got status=%q lifecycle=%q", doc.DerivedPlanStatus(), doc.DerivedLifecycle(state)),
 		}})
 	}
-	if state != nil && (state.CurrentNode == "land" || (state.Land != nil && strings.TrimSpace(state.Land.LandedAt) != "" && strings.TrimSpace(state.Land.CompletedAt) == "")) {
+	if state != nil && state.Land != nil && strings.TrimSpace(state.Land.LandedAt) != "" && strings.TrimSpace(state.Land.CompletedAt) == "" {
 		return errorResult("reopen", "Archived candidate is already in required post-merge bookkeeping.", []CommandError{{
-			Path:    "state.current_node",
+			Path:    "state.land",
 			Message: "required post-merge bookkeeping must finish with `harness land complete` before reopen is allowed",
 		}})
 	}
@@ -318,8 +312,6 @@ func (s Service) Reopen(mode string) Result {
 	if nextState == nil {
 		nextState = &runstate.State{}
 	}
-	nextState.PlanPath = relTargetPath
-	nextState.PlanStem = planStem
 	nextState.ExecutionStartedAt = now.Format(time.RFC3339)
 	nextState.Revision = runstate.CurrentRevision(state) + 1
 	nextState.Reopen = &runstate.ReopenState{
@@ -328,12 +320,7 @@ func (s Service) Reopen(mode string) Result {
 		BaseStepCount: len(doc.Steps),
 	}
 	nextState.ActiveReviewRound = nil
-	nextState.CurrentNode = ""
-	nextState.LatestEvidence = nil
 	nextState.Land = nil
-	nextState.LatestCI = nil
-	nextState.Sync = nil
-	nextState.LatestPublish = nil
 	statePath, err = runstate.SaveState(s.Workdir, planStem, nextState)
 	if err != nil {
 		_ = os.Remove(targetPath)
@@ -465,19 +452,16 @@ func (s Service) Land(prURL, commit string) Result {
 			},
 		}, nil)
 	}
-	if issues := s.landReadinessIssues(state, prURL); len(issues) > 0 {
+	if issues := s.landReadinessIssues(planStem, state, prURL); len(issues) > 0 {
 		return errorResult("land", "Archived candidate is not ready to enter required post-merge bookkeeping.", issues)
 	}
 	originalState := cloneState(state)
 	if state == nil {
 		state = &runstate.State{}
 	}
-	state.PlanPath = relCurrentPath
-	state.PlanStem = planStem
 	if state.Revision <= 0 {
 		state.Revision = 1
 	}
-	state.CurrentNode = "land"
 	state.Land = &runstate.LandState{
 		PRURL:    prURL,
 		Commit:   strings.TrimSpace(commit),
@@ -539,7 +523,6 @@ func (s Service) LandComplete() Result {
 	if err != nil {
 		return errorResult("land complete", "Unable to read the current-plan pointer before land completion.", []CommandError{{Path: "state", Message: err.Error()}})
 	}
-	state.CurrentNode = "idle"
 	state.Land.CompletedAt = now.Format(time.RFC3339)
 	statePath, err = runstate.SaveState(s.Workdir, planStem, state)
 	if err != nil {
@@ -872,37 +855,9 @@ func cloneState(state *runstate.State) *runstate.State {
 		reopen := *state.Reopen
 		cloned.Reopen = &reopen
 	}
-	if state.LatestEvidence != nil {
-		evidenceSet := *state.LatestEvidence
-		cloned.LatestEvidence = &evidenceSet
-		if state.LatestEvidence.CI != nil {
-			ciPtr := *state.LatestEvidence.CI
-			cloned.LatestEvidence.CI = &ciPtr
-		}
-		if state.LatestEvidence.Publish != nil {
-			publishPtr := *state.LatestEvidence.Publish
-			cloned.LatestEvidence.Publish = &publishPtr
-		}
-		if state.LatestEvidence.Sync != nil {
-			syncPtr := *state.LatestEvidence.Sync
-			cloned.LatestEvidence.Sync = &syncPtr
-		}
-	}
 	if state.Land != nil {
 		land := *state.Land
 		cloned.Land = &land
-	}
-	if state.LatestCI != nil {
-		ci := *state.LatestCI
-		cloned.LatestCI = &ci
-	}
-	if state.Sync != nil {
-		sync := *state.Sync
-		cloned.Sync = &sync
-	}
-	if state.LatestPublish != nil {
-		publish := *state.LatestPublish
-		cloned.LatestPublish = &publish
 	}
 	return &cloned
 }
@@ -1065,16 +1020,16 @@ func requiredReviewMessage(revision int) string {
 	return "archive requires a passing aggregated finalize review before archive"
 }
 
-func (s Service) landReadinessIssues(state *runstate.State, prURL string) []CommandError {
+func (s Service) landReadinessIssues(planStem string, state *runstate.State, prURL string) []CommandError {
 	issues := make([]CommandError, 0)
 
-	publish, err := evidence.LoadLatestPublish(s.Workdir, state)
+	publish, err := evidence.LoadLatestPublish(s.Workdir, planStem, runstate.CurrentRevision(state))
 	if err != nil {
-		return []CommandError{{Path: "state.latest_evidence.publish", Message: err.Error()}}
+		return []CommandError{{Path: "evidence.publish", Message: err.Error()}}
 	}
 	if publish == nil || publish.Status != "recorded" || strings.TrimSpace(publish.PRURL) == "" {
 		issues = append(issues, CommandError{
-			Path:    "state.latest_evidence.publish",
+			Path:    "evidence.publish",
 			Message: "record publish evidence with a PR URL before entering required post-merge bookkeeping",
 		})
 	} else if strings.TrimSpace(publish.PRURL) != prURL {
@@ -1084,24 +1039,24 @@ func (s Service) landReadinessIssues(state *runstate.State, prURL string) []Comm
 		})
 	}
 
-	ciRecord, err := evidence.LoadLatestCI(s.Workdir, state)
+	ciRecord, err := evidence.LoadLatestCI(s.Workdir, planStem, runstate.CurrentRevision(state))
 	if err != nil {
-		return []CommandError{{Path: "state.latest_evidence.ci", Message: err.Error()}}
+		return []CommandError{{Path: "evidence.ci", Message: err.Error()}}
 	}
 	if ciRecord == nil || (ciRecord.Status != "success" && ciRecord.Status != "not_applied") {
 		issues = append(issues, CommandError{
-			Path:    "state.latest_evidence.ci",
+			Path:    "evidence.ci",
 			Message: "record passing or explicit not_applied CI evidence before entering required post-merge bookkeeping",
 		})
 	}
 
-	syncRecord, err := evidence.LoadLatestSync(s.Workdir, state)
+	syncRecord, err := evidence.LoadLatestSync(s.Workdir, planStem, runstate.CurrentRevision(state))
 	if err != nil {
-		return []CommandError{{Path: "state.latest_evidence.sync", Message: err.Error()}}
+		return []CommandError{{Path: "evidence.sync", Message: err.Error()}}
 	}
 	if syncRecord == nil || (syncRecord.Status != "fresh" && syncRecord.Status != "not_applied") {
 		issues = append(issues, CommandError{
-			Path:    "state.latest_evidence.sync",
+			Path:    "evidence.sync",
 			Message: "record fresh or explicit not_applied sync evidence before entering required post-merge bookkeeping",
 		})
 	}

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/catu-ai/easyharness/internal/evidence"
 	"github.com/catu-ai/easyharness/internal/lifecycle"
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/runstate"
@@ -21,8 +20,6 @@ func TestArchiveMovesPlanAndUpdatesPointers(t *testing.T) {
 	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 	activePath := writeActiveArchiveCandidate(t, root, activeRelPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -67,9 +64,10 @@ func TestArchiveMovesPlanAndUpdatesPointers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.PlanPath != "docs/plans/archived/2026-03-18-archive-smoke.md" {
+	if state == nil {
 		t.Fatalf("unexpected state: %#v", state)
 	}
+	assertRawStateJSONOmitsKeys(t, filepath.Join(root, ".local", "harness", "plans", "2026-03-18-archive-smoke", "state.json"), "current_node", "plan_path", "plan_stem")
 }
 
 func TestArchiveLightweightMovesLocalPlanAndPromptsBreadcrumb(t *testing.T) {
@@ -77,8 +75,6 @@ func TestArchiveLightweightMovesLocalPlanAndPromptsBreadcrumb(t *testing.T) {
 	activeRelPath := "docs/plans/active/2026-03-18-lightweight.md"
 	activePath := writeLightweightActiveArchiveCandidate(t, root, activeRelPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-lightweight", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-lightweight",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -150,9 +146,6 @@ func TestExecuteStartPersistsMilestoneAndPointer(t *testing.T) {
 	if state == nil || state.ExecutionStartedAt != "2026-03-18T01:00:00Z" {
 		t.Fatalf("expected execution-start milestone, got %#v", state)
 	}
-	if state.PlanPath != activeRelPath {
-		t.Fatalf("unexpected plan path in state: %#v", state)
-	}
 }
 
 func TestExecuteStartBackfillsLegacyExecutingPlan(t *testing.T) {
@@ -160,10 +153,7 @@ func TestExecuteStartBackfillsLegacyExecutingPlan(t *testing.T) {
 	activeRelPath := "docs/plans/active/2026-03-18-execute-start-legacy.md"
 	writeFile(t, filepath.Join(root, activeRelPath), buildAwaitingPlan(t, "Legacy Execute Start"))
 	if _, err := runstate.SaveState(root, "2026-03-18-execute-start-legacy", &runstate.State{
-		PlanPath:    activeRelPath,
-		PlanStem:    "2026-03-18-execute-start-legacy",
-		Revision:    2,
-		CurrentNode: "execution/step-1/implement",
+		Revision: 2,
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-legacy-delta",
 			Kind:       "delta",
@@ -294,8 +284,6 @@ func TestArchiveRejectsMissingArchiveSummaryFields(t *testing.T) {
 	content = strings.Replace(content, "- PR: NONE\n", "", 1)
 	writeFile(t, path, content)
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           "docs/plans/active/2026-03-18-archive-smoke.md",
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -328,8 +316,6 @@ func TestArchivePreflightFailureLeavesPlanAndPointersUntouched(t *testing.T) {
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -366,8 +352,8 @@ func TestArchivePreflightFailureLeavesPlanAndPointersUntouched(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.PlanPath != activeRelPath {
-		t.Fatalf("expected state pointer to remain on active plan, got %#v", state)
+	if state == nil {
+		t.Fatalf("expected state to remain after failed archive, got %#v", state)
 	}
 }
 
@@ -376,8 +362,6 @@ func TestArchiveRollsBackWhenCurrentPlanWriteFails(t *testing.T) {
 	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 	activePath := writeActiveArchiveCandidate(t, root, activeRelPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -408,8 +392,8 @@ func TestArchiveRollsBackWhenCurrentPlanWriteFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.PlanPath != activeRelPath {
-		t.Fatalf("expected state to roll back to active path, got %#v", state)
+	if state == nil {
+		t.Fatalf("expected state rollback to preserve local state, got %#v", state)
 	}
 }
 
@@ -418,8 +402,6 @@ func TestArchiveRestoresActivePlanWhenTimelineAppendFailsAfterCleanup(t *testing
 	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 	activePath := writeActiveArchiveCandidate(t, root, activeRelPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -458,8 +440,8 @@ func TestArchiveRestoresActivePlanWhenTimelineAppendFailsAfterCleanup(t *testing
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.PlanPath != activeRelPath {
-		t.Fatalf("expected state to roll back to active path, got %#v", state)
+	if state == nil {
+		t.Fatalf("expected state to roll back to active state, got %#v", state)
 	}
 }
 
@@ -485,8 +467,6 @@ func TestArchiveRejectsUnresolvedLocalState(t *testing.T) {
 			root := t.TempDir()
 			activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 			writeActiveArchiveCandidate(t, root, activeRelPath)
-			tc.state.PlanPath = activeRelPath
-			tc.state.PlanStem = "2026-03-18-archive-smoke"
 			tc.state.ExecutionStartedAt = "2026-03-18T03:30:00Z"
 			if tc.state.ActiveReviewRound == nil && tc.errorPath != "state.active_review_round" {
 				tc.state.ActiveReviewRound = &runstate.ReviewRound{
@@ -555,8 +535,6 @@ func TestArchiveRequiresPassingReviewForRevisionOne(t *testing.T) {
 			root := t.TempDir()
 			activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 			writeActiveArchiveCandidate(t, root, activeRelPath)
-			tc.state.PlanPath = activeRelPath
-			tc.state.PlanStem = "2026-03-18-archive-smoke"
 			tc.state.ExecutionStartedAt = "2026-03-18T03:30:00Z"
 			if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", tc.state); err != nil {
 				t.Fatalf("save state: %v", err)
@@ -578,8 +556,6 @@ func TestArchiveRejectsEarlierStepCloseoutDebtEvenAfterPassingFinalizeReview(t *
 	writeActiveArchiveCandidateWithCloseoutDebt(t, root, activeRelPath)
 
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T03:35:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -607,8 +583,6 @@ func TestArchiveAllowsPassingDeltaReviewForReopenedRevision(t *testing.T) {
 	writeActiveArchiveCandidate(t, root, activeRelPath)
 
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T03:55:00Z",
 		Revision:           2,
 		ActiveReviewRound: &runstate.ReviewRound{
@@ -633,14 +607,13 @@ func TestArchiveAllowsPassingDeltaReviewForReopenedRevision(t *testing.T) {
 	}
 }
 
-func TestArchiveIgnoresCIPublishSyncSignalsOnceFinalizeReviewPasses(t *testing.T) {
+func TestArchiveIgnoresEvidenceArtifactsOnceFinalizeReviewPasses(t *testing.T) {
 	root := t.TempDir()
 	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 	writeActiveArchiveCandidate(t, root, activeRelPath)
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-archive-smoke", "docs/plans/archived/2026-03-18-archive-smoke.md")
 
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T04:05:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -649,8 +622,6 @@ func TestArchiveIgnoresCIPublishSyncSignalsOnceFinalizeReviewPasses(t *testing.T
 			Aggregated: true,
 			Decision:   "pass",
 		},
-		LatestCI: &runstate.CIState{SnapshotID: "ci-001", Status: "pending"},
-		Sync:     &runstate.SyncState{Freshness: "stale", Conflicts: true},
 	}); err != nil {
 		t.Fatalf("save state: %v", err)
 	}
@@ -671,8 +642,6 @@ func TestArchiveUsesAggregateArtifactForLegacyReviewDecision(t *testing.T) {
 	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 	writeActiveArchiveCandidate(t, root, activeRelPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T04:25:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -702,8 +671,6 @@ func TestReopenMovesArchivedPlanBackToActiveAndResetsSummaries(t *testing.T) {
 	root := t.TempDir()
 	writeActiveArchiveCandidate(t, root, "docs/plans/active/2026-03-18-archive-smoke.md")
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           "docs/plans/active/2026-03-18-archive-smoke.md",
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -773,8 +740,6 @@ func TestReopenRestoresArchivedPlanWhenTimelineAppendFailsAfterCleanup(t *testin
 	root := t.TempDir()
 	writeActiveArchiveCandidate(t, root, "docs/plans/active/2026-03-18-archive-smoke.md")
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           "docs/plans/active/2026-03-18-archive-smoke.md",
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -821,8 +786,8 @@ func TestReopenRestoresArchivedPlanWhenTimelineAppendFailsAfterCleanup(t *testin
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.PlanPath != archivedRelPath {
-		t.Fatalf("expected state to roll back to archived path, got %#v", state)
+	if state == nil || state.ActiveReviewRound == nil || state.Reopen != nil {
+		t.Fatalf("expected state to roll back to archived review state, got %#v", state)
 	}
 }
 
@@ -831,8 +796,6 @@ func TestReopenRemovesSynthesizedStateWhenTimelineAppendFailsWithoutPriorState(t
 	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 	writeActiveArchiveCandidate(t, root, activeRelPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -897,8 +860,6 @@ func TestReopenLightweightMovesLocalArchiveBackToTrackedActive(t *testing.T) {
 	activeRelPath := "docs/plans/active/2026-03-18-lightweight-reopen.md"
 	writeLightweightActiveArchiveCandidate(t, root, activeRelPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-lightweight-reopen", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-lightweight-reopen",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -949,7 +910,7 @@ func TestReopenLightweightMovesLocalArchiveBackToTrackedActive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load reopened state: %v", err)
 	}
-	if state == nil || state.Reopen == nil || state.Reopen.Mode != "finalize-fix" || state.PlanPath != activeRelPath {
+	if state == nil || state.Reopen == nil || state.Reopen.Mode != "finalize-fix" {
 		t.Fatalf("expected reopened lightweight state to point back to tracked active path, got %#v", state)
 	}
 	current, err := runstate.LoadCurrentPlan(root)
@@ -965,8 +926,6 @@ func TestReopenNewStepRecordsModeAndStatusCue(t *testing.T) {
 	root := t.TempDir()
 	writeActiveArchiveCandidate(t, root, "docs/plans/active/2026-03-18-archive-smoke.md")
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           "docs/plans/active/2026-03-18-archive-smoke.md",
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -1029,8 +988,6 @@ func TestReopenMarkersMustBeClearedBeforeRearchive(t *testing.T) {
 	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 	writeActiveArchiveCandidate(t, root, activeRelPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -1063,8 +1020,6 @@ func TestReopenMarkersMustBeClearedBeforeRearchive(t *testing.T) {
 	}
 
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T03:05:00Z",
 		Revision:           2,
 		Reopen:             &runstate.ReopenState{Mode: "finalize-fix", ReopenedAt: "2026-03-18T03:00:00Z"},
@@ -1105,13 +1060,11 @@ func TestReopenMarkersMustBeClearedBeforeRearchive(t *testing.T) {
 	}
 }
 
-func TestReopenClearsStaleCIAndSyncSignals(t *testing.T) {
+func TestReopenResetsReviewStateAfterArchive(t *testing.T) {
 	root := t.TempDir()
 	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"
 	writeActiveArchiveCandidate(t, root, activeRelPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath:           activeRelPath,
-		PlanStem:           "2026-03-18-archive-smoke",
 		ExecutionStartedAt: "2026-03-18T01:55:00Z",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -1120,8 +1073,6 @@ func TestReopenClearsStaleCIAndSyncSignals(t *testing.T) {
 			Aggregated: true,
 			Decision:   "pass",
 		},
-		LatestCI: &runstate.CIState{SnapshotID: "ci-1", Status: "success"},
-		Sync:     &runstate.SyncState{Freshness: "fresh", Conflicts: false},
 	}); err != nil {
 		t.Fatalf("save initial state: %v", err)
 	}
@@ -1138,8 +1089,6 @@ func TestReopenClearsStaleCIAndSyncSignals(t *testing.T) {
 	}
 
 	if _, err := runstate.SaveState(root, "2026-03-18-archive-smoke", &runstate.State{
-		PlanPath: "docs/plans/archived/2026-03-18-archive-smoke.md",
-		PlanStem: "2026-03-18-archive-smoke",
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
 			Kind:       "full",
@@ -1147,15 +1096,6 @@ func TestReopenClearsStaleCIAndSyncSignals(t *testing.T) {
 			Aggregated: true,
 			Decision:   "pass",
 		},
-		LatestEvidence: &runstate.EvidenceSet{
-			CI:      &runstate.EvidencePointer{Kind: "ci", RecordID: "ci-2", Path: ".local/harness/plans/2026-03-18-archive-smoke/evidence/ci/ci-002.json"},
-			Publish: &runstate.EvidencePointer{Kind: "publish", RecordID: "publish-1", Path: ".local/harness/plans/2026-03-18-archive-smoke/evidence/publish/publish-001.json"},
-			Sync:    &runstate.EvidencePointer{Kind: "sync", RecordID: "sync-2", Path: ".local/harness/plans/2026-03-18-archive-smoke/evidence/sync/sync-002.json"},
-		},
-		CurrentNode:   "execution/finalize/await_merge",
-		LatestCI:      &runstate.CIState{SnapshotID: "ci-2", Status: "failed"},
-		Sync:          &runstate.SyncState{Freshness: "stale", Conflicts: true},
-		LatestPublish: &runstate.Publish{AttemptID: "publish-1", PRURL: "https://github.com/catu-ai/easyharness/pull/99"},
 	}); err != nil {
 		t.Fatalf("save archived state: %v", err)
 	}
@@ -1175,8 +1115,8 @@ func TestReopenClearsStaleCIAndSyncSignals(t *testing.T) {
 	if state == nil {
 		t.Fatalf("expected reopened state")
 	}
-	if state.ActiveReviewRound != nil || state.CurrentNode != "" || state.Land != nil || state.LatestEvidence != nil || state.LatestCI != nil || state.Sync != nil || state.LatestPublish != nil {
-		t.Fatalf("expected reopened state to clear stale review/evidence/cache signals, got %#v", state)
+	if state.ActiveReviewRound != nil || state.Land != nil || state.Reopen == nil || state.Reopen.Mode != "finalize-fix" {
+		t.Fatalf("expected reopened state to preserve only reopen metadata, got %#v", state)
 	}
 }
 
@@ -1186,7 +1126,7 @@ func TestReopenRejectsLandCleanupInProgress(t *testing.T) {
 	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
 		t.Fatalf("save current plan: %v", err)
 	}
-	seedMergeReadyEvidenceForLifecycle(t, root)
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-landed-plan", "docs/plans/archived/2026-03-18-landed-plan.md")
 
 	svc := lifecycle.Service{
 		Workdir: root,
@@ -1203,13 +1143,13 @@ func TestReopenRejectsLandCleanupInProgress(t *testing.T) {
 	if reopen.OK {
 		t.Fatalf("expected reopen to fail during land cleanup, got %#v", reopen)
 	}
-	assertErrorPath(t, reopen.Errors, "state.current_node")
+	assertErrorPath(t, reopen.Errors, "state.land")
 
 	state, _, err := runstate.LoadState(root, "2026-03-18-landed-plan")
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.CurrentNode != "land" || state.Land == nil || state.Land.CompletedAt != "" {
+	if state == nil || state.Land == nil || state.Land.CompletedAt != "" {
 		t.Fatalf("expected land cleanup state to remain intact, got %#v", state)
 	}
 
@@ -1228,7 +1168,7 @@ func TestLandCompleteWritesIdleMarkerForStatus(t *testing.T) {
 	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
 		t.Fatalf("save current plan: %v", err)
 	}
-	seedMergeReadyEvidenceForLifecycle(t, root)
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-landed-plan", "docs/plans/archived/2026-03-18-landed-plan.md")
 
 	svc := lifecycle.Service{
 		Workdir: root,
@@ -1272,7 +1212,7 @@ func TestLandGuidanceRequiresPRAndIssueBookkeeping(t *testing.T) {
 	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
 		t.Fatalf("save current plan: %v", err)
 	}
-	seedMergeReadyEvidenceForLifecycle(t, root)
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-landed-plan", "docs/plans/archived/2026-03-18-landed-plan.md")
 
 	result := lifecycle.Service{
 		Workdir: root,
@@ -1312,7 +1252,7 @@ func TestLandCompleteRejectsMissingLandEntry(t *testing.T) {
 	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
 		t.Fatalf("save current plan: %v", err)
 	}
-	seedMergeReadyEvidenceForLifecycle(t, root)
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-landed-plan", "docs/plans/archived/2026-03-18-landed-plan.md")
 
 	result := lifecycle.Service{
 		Workdir: root,
@@ -1325,23 +1265,18 @@ func TestLandCompleteRejectsMissingLandEntry(t *testing.T) {
 	}
 }
 
-func TestLandUsesLegacyEvidenceCachesWhenPointersAreMissing(t *testing.T) {
+func TestLandReadsEvidenceArtifactsWhenStateIsSparse(t *testing.T) {
 	root := t.TempDir()
 	writeArchivedLandedPlan(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
 	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(root, "2026-03-18-landed-plan", &runstate.State{
-		PlanPath:       "docs/plans/archived/2026-03-18-landed-plan.md",
-		PlanStem:       "2026-03-18-landed-plan",
 		Revision:       3,
-		LatestCI:       &runstate.CIState{SnapshotID: "ci-legacy", Status: "success"},
-		LatestPublish:  &runstate.Publish{AttemptID: "publish-legacy", PRURL: "https://github.com/catu-ai/easyharness/pull/99"},
-		Sync:           &runstate.SyncState{Freshness: "fresh", Conflicts: false},
-		LatestEvidence: nil,
 	}); err != nil {
 		t.Fatalf("save legacy state: %v", err)
 	}
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-landed-plan", "docs/plans/archived/2026-03-18-landed-plan.md")
 
 	result := lifecycle.Service{
 		Workdir: root,
@@ -1350,7 +1285,36 @@ func TestLandUsesLegacyEvidenceCachesWhenPointersAreMissing(t *testing.T) {
 		},
 	}.Land("https://github.com/catu-ai/easyharness/pull/99", "")
 	if !result.OK {
-		t.Fatalf("expected land success from legacy caches, got %#v", result)
+		t.Fatalf("expected land success from evidence artifacts, got %#v", result)
+	}
+}
+
+func TestLandRejectsOlderRevisionEvidenceAfterReopen(t *testing.T) {
+	root := t.TempDir()
+	writeArchivedLandedPlan(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if _, err := runstate.SaveState(root, "2026-03-18-landed-plan", &runstate.State{
+		Revision: 1,
+	}); err != nil {
+		t.Fatalf("save initial state: %v", err)
+	}
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-landed-plan", "docs/plans/archived/2026-03-18-landed-plan.md")
+	if _, err := runstate.SaveState(root, "2026-03-18-landed-plan", &runstate.State{
+		Revision: 2,
+	}); err != nil {
+		t.Fatalf("save reopened state: %v", err)
+	}
+
+	result := lifecycle.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 6, 0, 0, 0, time.UTC)
+		},
+	}.Land("https://github.com/catu-ai/easyharness/pull/99", "")
+	if result.OK {
+		t.Fatalf("expected older revision evidence to block land, got %#v", result)
 	}
 }
 
@@ -1360,7 +1324,7 @@ func TestLandRejectsOverwriteDuringCleanup(t *testing.T) {
 	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
 		t.Fatalf("save current plan: %v", err)
 	}
-	seedMergeReadyEvidenceForLifecycle(t, root)
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-landed-plan", "docs/plans/archived/2026-03-18-landed-plan.md")
 
 	svc := lifecycle.Service{
 		Workdir: root,
@@ -1393,7 +1357,7 @@ func TestLandAllowsCommitEnrichmentDuringCleanup(t *testing.T) {
 	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
 		t.Fatalf("save current plan: %v", err)
 	}
-	seedMergeReadyEvidenceForLifecycle(t, root)
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-landed-plan", "docs/plans/archived/2026-03-18-landed-plan.md")
 
 	svc := lifecycle.Service{
 		Workdir: root,
@@ -1426,7 +1390,7 @@ func TestLandCompleteRollsBackStateWhenCurrentPlanWriteFails(t *testing.T) {
 	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
 		t.Fatalf("save current plan: %v", err)
 	}
-	seedMergeReadyEvidenceForLifecycle(t, root)
+	writeMergeReadyEvidenceArtifacts(t, root, "2026-03-18-landed-plan", "docs/plans/archived/2026-03-18-landed-plan.md")
 
 	svc := lifecycle.Service{
 		Workdir: root,
@@ -1456,27 +1420,79 @@ func TestLandCompleteRollsBackStateWhenCurrentPlanWriteFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.CurrentNode != "land" || state.Land == nil || state.Land.CompletedAt != "" {
+	if state == nil || state.Land == nil || state.Land.CompletedAt != "" {
 		t.Fatalf("expected land state rollback after pointer write failure, got %#v", state)
 	}
 }
 
-func seedMergeReadyEvidenceForLifecycle(t *testing.T, root string) {
+func writeMergeReadyEvidenceArtifacts(t *testing.T, root, planStem, planPath string) {
 	t.Helper()
-	svc := evidence.Service{
-		Workdir: root,
-		Now: func() time.Time {
-			return time.Date(2026, 3, 18, 5, 50, 0, 0, time.UTC)
+	revision := 1
+	if state, _, err := runstate.LoadState(root, planStem); err == nil {
+		revision = runstate.CurrentRevision(state)
+	}
+	type recordFile struct {
+		dir     string
+		name    string
+		payload any
+	}
+	recordedAt := time.Date(2026, 3, 18, 5, 50, 0, 0, time.UTC).Format(time.RFC3339)
+	files := []recordFile{
+		{
+			dir:  filepath.Join(root, ".local", "harness", "plans", planStem, "evidence", "publish"),
+			name: "publish-001.json",
+			payload: map[string]any{
+				"record_id":   "publish-001",
+				"kind":        "publish",
+				"plan_path":   planPath,
+				"plan_stem":   planStem,
+				"revision":    revision,
+				"recorded_at": recordedAt,
+				"status":      "recorded",
+				"pr_url":      "https://github.com/catu-ai/easyharness/pull/99",
+			},
+		},
+		{
+			dir:  filepath.Join(root, ".local", "harness", "plans", planStem, "evidence", "ci"),
+			name: "ci-001.json",
+			payload: map[string]any{
+				"record_id":   "ci-001",
+				"kind":        "ci",
+				"plan_path":   planPath,
+				"plan_stem":   planStem,
+				"revision":    revision,
+				"recorded_at": recordedAt,
+				"status":      "success",
+				"provider":    "github-actions",
+			},
+		},
+		{
+			dir:  filepath.Join(root, ".local", "harness", "plans", planStem, "evidence", "sync"),
+			name: "sync-001.json",
+			payload: map[string]any{
+				"record_id":   "sync-001",
+				"kind":        "sync",
+				"plan_path":   planPath,
+				"plan_stem":   planStem,
+				"revision":    revision,
+				"recorded_at": recordedAt,
+				"status":      "fresh",
+				"base_ref":    "main",
+				"head_ref":    "codex/test",
+			},
 		},
 	}
-	if result := svc.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
-		t.Fatalf("seed publish evidence: %#v", result)
-	}
-	if result := svc.Submit("ci", []byte(`{"status":"success","provider":"github-actions"}`)); !result.OK {
-		t.Fatalf("seed ci evidence: %#v", result)
-	}
-	if result := svc.Submit("sync", []byte(`{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`)); !result.OK {
-		t.Fatalf("seed sync evidence: %#v", result)
+	for _, file := range files {
+		if err := os.MkdirAll(file.dir, 0o755); err != nil {
+			t.Fatalf("mkdir evidence dir: %v", err)
+		}
+		data, err := json.Marshal(file.payload)
+		if err != nil {
+			t.Fatalf("marshal evidence record: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(file.dir, file.name), data, 0o644); err != nil {
+			t.Fatalf("write evidence record: %v", err)
+		}
 	}
 }
 
@@ -1624,4 +1640,21 @@ func assertErrorContains(t *testing.T, issues []lifecycle.CommandError, path, fr
 		}
 	}
 	t.Fatalf("expected error for %s containing %q, got %#v", path, fragment, issues)
+}
+
+func assertRawStateJSONOmitsKeys(t *testing.T, path string, keys ...string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read raw state json: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("parse raw state json: %v", err)
+	}
+	for _, key := range keys {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("expected raw state json to omit %q, got %#v", key, payload)
+		}
+	}
 }

--- a/internal/plan/runtime.go
+++ b/internal/plan/runtime.go
@@ -1,10 +1,6 @@
 package plan
 
-import (
-	"strings"
-
-	"github.com/catu-ai/easyharness/internal/runstate"
-)
+import "github.com/catu-ai/easyharness/internal/runstate"
 
 func (d *Document) DerivedPlanStatus() string {
 	switch d.PathKind {
@@ -33,19 +29,9 @@ func (d *Document) ExecutionStarted(state *runstate.State) bool {
 		return false
 	}
 	return state.ExecutionStartedAt != "" ||
-		currentNodeImpliesExecution(state.CurrentNode) ||
 		state.ActiveReviewRound != nil ||
-		state.LatestEvidence != nil ||
 		state.Land != nil ||
-		state.LatestCI != nil ||
-		state.Sync != nil ||
-		state.LatestPublish != nil ||
 		state.Reopen != nil
-}
-
-func currentNodeImpliesExecution(node string) bool {
-	node = strings.TrimSpace(node)
-	return strings.HasPrefix(node, "execution/") || node == "land"
 }
 
 func (d *Document) DerivedLifecycle(state *runstate.State) string {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -194,8 +194,6 @@ func (s Service) Start(specBytes []byte) StartResult {
 	if state == nil {
 		state = &runstate.State{}
 	}
-	state.PlanPath = relPlanPath
-	state.PlanStem = planStem
 	state.ActiveReviewRound = &runstate.ReviewRound{
 		RoundID:    roundID,
 		Kind:       spec.Kind,
@@ -540,8 +538,6 @@ func (s Service) Aggregate(roundID string) AggregateResult {
 	if state == nil {
 		state = &runstate.State{}
 	}
-	state.PlanPath = manifest.PlanPath
-	state.PlanStem = manifest.PlanStem
 	state.ActiveReviewRound = &runstate.ReviewRound{
 		RoundID:    manifest.RoundID,
 		Kind:       manifest.Kind,
@@ -1054,37 +1050,9 @@ func cloneState(state *runstate.State) *runstate.State {
 		reopen := *state.Reopen
 		cloned.Reopen = &reopen
 	}
-	if state.LatestEvidence != nil {
-		evidenceSet := *state.LatestEvidence
-		cloned.LatestEvidence = &evidenceSet
-		if state.LatestEvidence.CI != nil {
-			ciPtr := *state.LatestEvidence.CI
-			cloned.LatestEvidence.CI = &ciPtr
-		}
-		if state.LatestEvidence.Publish != nil {
-			publishPtr := *state.LatestEvidence.Publish
-			cloned.LatestEvidence.Publish = &publishPtr
-		}
-		if state.LatestEvidence.Sync != nil {
-			syncPtr := *state.LatestEvidence.Sync
-			cloned.LatestEvidence.Sync = &syncPtr
-		}
-	}
 	if state.Land != nil {
 		land := *state.Land
 		cloned.Land = &land
-	}
-	if state.LatestCI != nil {
-		ci := *state.LatestCI
-		cloned.LatestCI = &ci
-	}
-	if state.Sync != nil {
-		sync := *state.Sync
-		cloned.Sync = &sync
-	}
-	if state.LatestPublish != nil {
-		publish := *state.LatestPublish
-		cloned.LatestPublish = &publish
 	}
 	return &cloned
 }

--- a/internal/review/service_internal_test.go
+++ b/internal/review/service_internal_test.go
@@ -241,8 +241,6 @@ func writeExecutingPlanFixture(t *testing.T, root, relPath string) {
 	planStem := strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath))
 	if _, err := runstate.SaveState(root, planStem, &runstate.State{
 		ExecutionStartedAt: "2026-04-01T09:30:00Z",
-		PlanPath:           relPath,
-		PlanStem:           planStem,
 		Revision:           1,
 	}); err != nil {
 		t.Fatalf("save execute-start state: %v", err)

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -113,8 +113,6 @@ func TestStartAcceptsExplicitEarlierStepFromFinalizeContext(t *testing.T) {
 	writeExecutingFinalizePlan(t, root, relPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-review-contract", &runstate.State{
 		ExecutionStartedAt: "2026-03-18T01:00:00Z",
-		PlanPath:           relPath,
-		PlanStem:           "2026-03-18-review-contract",
 		Revision:           1,
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-001-full",
@@ -242,8 +240,6 @@ func TestStartAcceptsExecutionStartMilestoneWithoutLegacyExecutingLifecycle(t *t
 	writePlainReviewPlan(t, root, relPath)
 	if _, err := runstate.SaveState(root, "2026-03-18-review-contract", &runstate.State{
 		ExecutionStartedAt: "2026-03-18T01:01:00Z",
-		PlanPath:           relPath,
-		PlanStem:           "2026-03-18-review-contract",
 	}); err != nil {
 		t.Fatalf("save state: %v", err)
 	}
@@ -1175,8 +1171,6 @@ func writeExecutingPlan(t *testing.T, root, relPath string) string {
 	path := writePlainReviewPlan(t, root, relPath)
 	if _, err := runstate.SaveState(root, strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath)), &runstate.State{
 		ExecutionStartedAt: "2026-03-18T01:00:00Z",
-		PlanPath:           relPath,
-		PlanStem:           strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath)),
 		Revision:           1,
 	}); err != nil {
 		t.Fatalf("save execute-start state: %v", err)
@@ -1197,8 +1191,6 @@ func writeExecutingFinalizePlan(t *testing.T, root, relPath string) string {
 	}
 	if _, err := runstate.SaveState(root, strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath)), &runstate.State{
 		ExecutionStartedAt: "2026-03-18T01:00:00Z",
-		PlanPath:           relPath,
-		PlanStem:           strings.TrimSuffix(filepath.Base(relPath), filepath.Ext(relPath)),
 		Revision:           1,
 	}); err != nil {
 		t.Fatalf("save execute-start state: %v", err)

--- a/internal/reviewui/service.go
+++ b/internal/reviewui/service.go
@@ -149,9 +149,6 @@ func archivedReviewHiddenDuringLand(state *runstate.State) bool {
 	if state == nil {
 		return false
 	}
-	if strings.TrimSpace(state.CurrentNode) == "land" {
-		return true
-	}
 	return state.Land != nil &&
 		strings.TrimSpace(state.Land.LandedAt) != "" &&
 		strings.TrimSpace(state.Land.CompletedAt) == ""

--- a/internal/reviewui/service_test.go
+++ b/internal/reviewui/service_test.go
@@ -287,7 +287,7 @@ func TestServiceReadReturnsArchivedPlanRounds(t *testing.T) {
 func TestServiceReadHidesArchivedRoundsDuringLandCleanup(t *testing.T) {
 	workdir := t.TempDir()
 	relPlanPath, planStem := seedArchivedPlan(t, workdir, "2026-04-02-review-ui-landed.md", "Review UI Landed")
-	saveReviewStateWithNode(t, workdir, planStem, relPlanPath, 1, "", "land")
+	saveReviewStateWithLand(t, workdir, planStem, relPlanPath, 1, "2026-04-03T01:00:00Z", "")
 
 	writeReviewRoundFixture(t, workdir, planStem, "review-001-full", map[string]any{
 		"round_id":        "review-001-full",
@@ -910,8 +910,6 @@ func TestServiceReadKeepsMissingLedgerRoundsDegradedEvenWithAggregateDecision(t 
 		"kind":            "full",
 		"revision":        1,
 		"review_title":    "Finalize review",
-		"plan_path":       relPlanPath,
-		"plan_stem":       planStem,
 		"created_at":      "2026-04-02T12:00:00Z",
 		"ledger_path":     roundArtifactPath(workdir, planStem, "review-001-full", "ledger.json"),
 		"aggregate_path":  roundArtifactPath(workdir, planStem, "review-001-full", "aggregate.json"),
@@ -1006,11 +1004,10 @@ func saveReviewState(t *testing.T, workdir, planStem, relPlanPath string, revisi
 func saveReviewStateWithNode(t *testing.T, workdir, planStem, relPlanPath string, revision int, activeRoundID, currentNode string) {
 	t.Helper()
 	state := &runstate.State{
-		CurrentNode: currentNode,
-		PlanPath:    relPlanPath,
-		PlanStem:    planStem,
-		Revision:    revision,
+		Revision: revision,
 	}
+	_ = relPlanPath
+	_ = currentNode
 	if activeRoundID != "" {
 		state.ActiveReviewRound = &runstate.ReviewRound{
 			RoundID:    activeRoundID,
@@ -1027,14 +1024,13 @@ func saveReviewStateWithNode(t *testing.T, workdir, planStem, relPlanPath string
 func saveReviewStateWithLand(t *testing.T, workdir, planStem, relPlanPath string, revision int, landedAt, completedAt string) {
 	t.Helper()
 	state := &runstate.State{
-		PlanPath: relPlanPath,
-		PlanStem: planStem,
 		Revision: revision,
 		Land: &runstate.LandState{
 			LandedAt:    landedAt,
 			CompletedAt: completedAt,
 		},
 	}
+	_ = relPlanPath
 	if _, err := runstate.SaveState(workdir, planStem, state); err != nil {
 		t.Fatalf("save state: %v", err)
 	}

--- a/internal/runstate/state.go
+++ b/internal/runstate/state.go
@@ -18,12 +18,7 @@ type CurrentPlan = contracts.CurrentPlanFile
 type State = contracts.LocalStateFile
 type ReopenState = contracts.ReopenState
 type ReviewRound = contracts.ReviewRoundState
-type EvidenceSet = contracts.EvidenceSetState
-type EvidencePointer = contracts.EvidencePointerState
 type LandState = contracts.LandState
-type CIState = contracts.LegacyCIState
-type SyncState = contracts.LegacySyncState
-type Publish = contracts.LegacyPublishState
 
 type reviewAggregate struct {
 	Decision string `json:"decision"`

--- a/internal/runstate/state_test.go
+++ b/internal/runstate/state_test.go
@@ -46,15 +46,19 @@ func TestSaveStateWritesExactJSON(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir state dir: %v", err)
 	}
-	if err := os.WriteFile(path, []byte(`{"current_node":"execution/step-999/review","plan_path":"stale","plan_stem":"old","revision":999}`), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(`{"revision":999,"execution_started_at":"stale","land":{"landed_at":"stale"}}`), 0o644); err != nil {
 		t.Fatalf("seed state.json: %v", err)
 	}
 
 	state := &State{
-		CurrentNode: "execution/step-1/implement",
-		PlanPath:    "docs/plans/active/example.md",
-		PlanStem:    planStem,
-		Revision:    1,
+		ExecutionStartedAt: "2026-03-26T10:00:00Z",
+		Revision:           1,
+		ActiveReviewRound: &ReviewRound{
+			RoundID:    "review-001-delta",
+			Kind:       "delta",
+			Revision:   1,
+			Aggregated: false,
+		},
 	}
 	savedPath, err := SaveState(root, planStem, state)
 	if err != nil {
@@ -83,7 +87,13 @@ func TestSaveStateWritesExactJSON(t *testing.T) {
 	if loaded == nil {
 		t.Fatalf("LoadState returned nil state")
 	}
-	if loaded.CurrentNode != state.CurrentNode || loaded.PlanPath != state.PlanPath || loaded.PlanStem != state.PlanStem || loaded.Revision != state.Revision {
+	if loaded.ExecutionStartedAt != state.ExecutionStartedAt || loaded.Revision != state.Revision {
+		t.Fatalf("loaded state = %#v, want %#v", loaded, state)
+	}
+	if loaded.ActiveReviewRound == nil || state.ActiveReviewRound == nil {
+		t.Fatalf("expected active review round to survive save/load, got %#v", loaded)
+	}
+	if loaded.ActiveReviewRound.RoundID != state.ActiveReviewRound.RoundID || loaded.ActiveReviewRound.Kind != state.ActiveReviewRound.Kind || loaded.ActiveReviewRound.Revision != state.ActiveReviewRound.Revision {
 		t.Fatalf("loaded state = %#v, want %#v", loaded, state)
 	}
 }

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -139,21 +139,6 @@ func (s Service) read(acquireLock bool) Result {
 		}
 	}
 
-	relPlanPath, err := filepath.Rel(s.Workdir, planPath)
-	if err != nil {
-		return Result{
-			OK:      false,
-			Command: "status",
-			Summary: "Unable to determine the current plan path.",
-			Artifacts: &Artifacts{
-				PlanPath:       planPath,
-				LocalStatePath: statePath,
-			},
-			Errors: []StatusError{{Path: "plan", Message: err.Error()}},
-		}
-	}
-	relPlanPath = filepath.ToSlash(relPlanPath)
-
 	result := Result{
 		OK:      true,
 		Command: "status",
@@ -212,7 +197,7 @@ func (s Service) read(acquireLock bool) Result {
 			}
 		}
 	case doc.DerivedPlanStatus() == "archived":
-		evidenceCtx, evidenceWarnings := loadEvidenceContext(s.Workdir, state)
+		evidenceCtx, evidenceWarnings := loadEvidenceContext(s.Workdir, planStem, runstate.CurrentRevision(state))
 		result.Warnings = append(result.Warnings, evidenceWarnings...)
 		applyEvidenceFacts(facts, result.Artifacts, evidenceCtx)
 		if archivedCandidateReadyForMerge(evidenceCtx) {
@@ -261,15 +246,6 @@ func (s Service) read(acquireLock bool) Result {
 		result.Facts = nil
 	} else {
 		result.Facts = facts
-	}
-
-	cacheSafe := reviewCtx == nil || !reviewCtx.UnsafeFallback
-	if !cacheSafe {
-		result.Warnings = append(result.Warnings, "Skipping current_node cache refresh because the reviewed step could not be recovered safely from local review metadata.")
-	} else if savedStatePath, err := s.cacheResolvedNode(planStem, relPlanPath, state, result.State.CurrentNode); err != nil {
-		result.Warnings = append(result.Warnings, fmt.Sprintf("Unable to refresh the current_node cache: %v", err))
-	} else if strings.TrimSpace(savedStatePath) != "" {
-		result.Artifacts.LocalStatePath = savedStatePath
 	}
 
 	if result.Artifacts != nil && result.Artifacts.PlanPath == "" && result.Artifacts.LocalStatePath == "" &&
@@ -437,21 +413,21 @@ func loadReviewContext(workdir, planStem string, doc *plan.Document, state *runs
 	return ctx, warnings
 }
 
-func loadEvidenceContext(workdir string, state *runstate.State) (*evidenceContext, []string) {
+func loadEvidenceContext(workdir, planStem string, revision int) (*evidenceContext, []string) {
 	ctx := &evidenceContext{}
 	warnings := make([]string, 0)
 
-	if publish, err := evidence.LoadLatestPublish(workdir, state); err != nil {
+	if publish, err := evidence.LoadLatestPublish(workdir, planStem, revision); err != nil {
 		warnings = append(warnings, fmt.Sprintf("Unable to read publish evidence: %v", err))
 	} else {
 		ctx.Publish = publish
 	}
-	if ci, err := evidence.LoadLatestCI(workdir, state); err != nil {
+	if ci, err := evidence.LoadLatestCI(workdir, planStem, revision); err != nil {
 		warnings = append(warnings, fmt.Sprintf("Unable to read CI evidence: %v", err))
 	} else {
 		ctx.CI = ci
 	}
-	if sync, err := evidence.LoadLatestSync(workdir, state); err != nil {
+	if sync, err := evidence.LoadLatestSync(workdir, planStem, revision); err != nil {
 		warnings = append(warnings, fmt.Sprintf("Unable to read sync evidence: %v", err))
 	} else {
 		ctx.Sync = sync
@@ -989,19 +965,6 @@ func idleResult(currentPlan *runstate.CurrentPlan) Result {
 	return result
 }
 
-func (s Service) cacheResolvedNode(planStem, relPlanPath string, state *runstate.State, currentNode string) (string, error) {
-	if strings.TrimSpace(planStem) == "" {
-		return "", nil
-	}
-	if state == nil {
-		state = &runstate.State{}
-	}
-	state.PlanPath = relPlanPath
-	state.PlanStem = planStem
-	state.CurrentNode = currentNode
-	return runstate.SaveState(s.Workdir, planStem, state)
-}
-
 func currentStepIndex(doc *plan.Document) int {
 	currentStep := doc.CurrentStep()
 	if currentStep == nil {
@@ -1057,24 +1020,6 @@ func activeReviewForStepCloseoutScan(reviewCtx *reviewContext) *stepcloseout.Act
 	}
 }
 
-func fallbackReviewTitleStep(doc *plan.Document, state *runstate.State) (int, bool) {
-	if state != nil {
-		if index, ok := stepIndexFromNode(state.CurrentNode); ok {
-			return index, false
-		}
-	}
-	if index := currentStepIndex(doc); index >= 0 {
-		if index > 0 {
-			return index - 1, true
-		}
-		return index, true
-	}
-	if len(doc.Steps) == 0 {
-		return -1, false
-	}
-	return len(doc.Steps) - 1, true
-}
-
 func landInProgress(state *runstate.State) bool {
 	return state != nil &&
 		state.Land != nil &&
@@ -1084,23 +1029,6 @@ func landInProgress(state *runstate.State) bool {
 
 func stepNode(index int, phase string) string {
 	return fmt.Sprintf("execution/step-%d/%s", index+1, phase)
-}
-
-func stepIndexFromNode(node string) (int, bool) {
-	node = strings.TrimSpace(node)
-	if !strings.HasPrefix(node, "execution/step-") {
-		return -1, false
-	}
-	node = strings.TrimPrefix(node, "execution/step-")
-	parts := strings.SplitN(node, "/", 2)
-	if len(parts) != 2 {
-		return -1, false
-	}
-	var stepNumber int
-	if _, err := fmt.Sscanf(parts[0], "%d", &stepNumber); err != nil || stepNumber <= 0 {
-		return -1, false
-	}
-	return stepNumber - 1, true
 }
 
 func commandErrorsToStatusErrors(errors []lifecycle.CommandError) []StatusError {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -41,16 +41,16 @@ func TestStatusPlanNodeForActivePlan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.CurrentNode != "plan" {
-		t.Fatalf("expected cached plan node, got %#v", state)
+	if state != nil {
+		t.Fatalf("expected status read to avoid caching plan node, got %#v", state)
 	}
 
 	doc, err := plan.LoadFile(filepath.Join(root, "docs/plans/active/2026-03-18-status-plan.md"))
 	if err != nil {
 		t.Fatalf("load plan: %v", err)
 	}
-	if got := doc.DerivedLifecycle(state); got != "awaiting_plan_approval" {
-		t.Fatalf("expected cached plan node to preserve awaiting_plan_approval, got %q", got)
+	if got := doc.DerivedLifecycle(nil); got != "awaiting_plan_approval" {
+		t.Fatalf("expected lifecycle to derive from the plan alone, got %q", got)
 	}
 }
 
@@ -82,9 +82,7 @@ func TestStatusLightweightPublishPromptsForBreadcrumb(t *testing.T) {
 	})
 	writeCurrentPlan(t, root, relPath)
 	writeState(t, root, "2026-03-18-status-lightweight", map[string]any{
-		"plan_path": relPath,
-		"plan_stem": "2026-03-18-status-lightweight",
-		"revision":  1,
+		"revision": 1,
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -130,9 +128,10 @@ func TestStatusExecutionStepImplementNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.CurrentNode != "execution/step-1/implement" {
-		t.Fatalf("expected cached execution node, got %#v", state)
+	if state == nil || state.ExecutionStartedAt != "2026-03-18T10:05:00+08:00" {
+		t.Fatalf("expected execution-start state to remain available, got %#v", state)
 	}
+	assertStateJSONLacksKeys(t, root, "2026-03-18-status-plan", "current_node")
 }
 
 func TestStatusRejectsWhenStateMutationLockIsHeld(t *testing.T) {
@@ -1298,14 +1297,13 @@ func TestStatusFinalizeFixSummaryForUnscopedUnreadableHistory(t *testing.T) {
 	}
 }
 
-func TestStatusFailedStepReviewUsesCachedStepWhenManifestIsMissing(t *testing.T) {
+func TestStatusFailedStepReviewUsesActiveReviewRoundWhenManifestIsMissing(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
 		return completeFirstStep(content)
 	})
 	writeState(t, root, "2026-03-18-status-plan", map[string]any{
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
-		"current_node":         "execution/step-1/implement",
 		"active_review_round": map[string]any{
 			"round_id":   "review-001-delta",
 			"kind":       "delta",
@@ -1324,9 +1322,10 @@ func TestStatusFailedStepReviewUsesCachedStepWhenManifestIsMissing(t *testing.T)
 	if err != nil {
 		t.Fatalf("load state: %v", err)
 	}
-	if state == nil || state.CurrentNode != "execution/step-1/implement" {
-		t.Fatalf("expected cache to stay pinned to the reviewed step, got %#v", state)
+	if state == nil || state.ActiveReviewRound == nil || state.ActiveReviewRound.RoundID != "review-001-delta" {
+		t.Fatalf("expected review control state to remain intact without a node cache, got %#v", state)
 	}
+	assertStateJSONLacksKeys(t, root, "2026-03-18-status-plan", "current_node")
 }
 
 func TestStatusUnknownAggregatedReviewDecisionStaysConservative(t *testing.T) {
@@ -1853,36 +1852,80 @@ func TestStatusWarnsInAwaitMergeWhenCompletedStepStillLacksCloseout(t *testing.T
 	}
 }
 
-func TestStatusArchivedPlanReadyForAwaitMergeFromLegacyEvidenceCache(t *testing.T) {
+func TestStatusArchivedPlanReadyForAwaitMergeFromEvidenceArtifacts(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
 		return completeAllSteps(content, true)
 	})
 	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
 	writeState(t, root, "2026-03-18-status-plan", map[string]any{
-		"latest_publish": map[string]any{
-			"attempt_id": "publish-legacy-001",
-			"pr_url":     "https://github.com/catu-ai/easyharness/pull/13",
-		},
-		"latest_ci": map[string]any{
-			"snapshot_id": "ci-legacy-001",
-			"status":      "success",
-		},
-		"sync": map[string]any{
-			"freshness": "fresh",
-			"conflicts": false,
-		},
+		"revision": 1,
 	})
+
+	svc := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC)
+		},
+	}
+	if result := svc.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+		t.Fatalf("publish evidence: %#v", result)
+	}
+	if result := svc.Submit("ci", []byte(`{"status":"success","provider":"github-actions"}`)); !result.OK {
+		t.Fatalf("ci evidence: %#v", result)
+	}
+	if result := svc.Submit("sync", []byte(`{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`)); !result.OK {
+		t.Fatalf("sync evidence: %#v", result)
+	}
 
 	result := status.Service{Workdir: root}.Read()
 	if result.State.CurrentNode != "execution/finalize/await_merge" {
-		t.Fatalf("expected legacy evidence fallback to reach await_merge, got %#v", result.State)
+		t.Fatalf("expected evidence artifacts to reach await_merge, got %#v", result.State)
 	}
 	if result.Facts == nil || result.Facts.PRURL != "https://github.com/catu-ai/easyharness/pull/13" || result.Facts.CIStatus != "success" || result.Facts.SyncStatus != "fresh" {
 		t.Fatalf("unexpected facts: %#v", result.Facts)
 	}
-	if result.Artifacts == nil || result.Artifacts.PublishRecordID != "publish-legacy-001" || result.Artifacts.CIRecordID != "ci-legacy-001" {
+	if result.Artifacts == nil || result.Artifacts.PublishRecordID == "" || result.Artifacts.CIRecordID == "" || result.Artifacts.SyncRecordID == "" {
 		t.Fatalf("unexpected artifacts: %#v", result.Artifacts)
+	}
+	assertStateJSONLacksKeys(t, root, "2026-03-18-status-plan", "latest_publish", "latest_ci", "latest_evidence")
+}
+
+func TestStatusArchivedPlanIgnoresOlderRevisionEvidenceArtifacts(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		return completeAllSteps(content, true)
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"revision": 1,
+	})
+
+	svc := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC)
+		},
+	}
+	if result := svc.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+		t.Fatalf("publish evidence: %#v", result)
+	}
+	if result := svc.Submit("ci", []byte(`{"status":"success","provider":"github-actions"}`)); !result.OK {
+		t.Fatalf("ci evidence: %#v", result)
+	}
+	if result := svc.Submit("sync", []byte(`{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`)); !result.OK {
+		t.Fatalf("sync evidence: %#v", result)
+	}
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"revision": 2,
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if result.State.CurrentNode != "execution/finalize/publish" {
+		t.Fatalf("expected older revision evidence to keep publish state, got %#v", result.State)
+	}
+	if result.Facts != nil && (result.Facts.PRURL != "" || result.Facts.CIStatus != "" || result.Facts.SyncStatus != "") {
+		t.Fatalf("expected older revision evidence to stay hidden, got %#v", result.Facts)
 	}
 }
 
@@ -1950,30 +1993,35 @@ func TestStatusArchivedPlanReadyForAwaitMergeWhenCIAndSyncAreBothNotApplied(t *t
 	}
 }
 
-func TestStatusArchivedPlanStaysInPublishFromLegacyEvidenceCacheWhenDirty(t *testing.T) {
+func TestStatusArchivedPlanStaysInPublishFromEvidenceArtifactsWhenDirty(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
 		return completeAllSteps(content, true)
 	})
 	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
 	writeState(t, root, "2026-03-18-status-plan", map[string]any{
-		"latest_publish": map[string]any{
-			"attempt_id": "publish-legacy-001",
-			"pr_url":     "https://github.com/catu-ai/easyharness/pull/13",
-		},
-		"latest_ci": map[string]any{
-			"snapshot_id": "ci-legacy-001",
-			"status":      "failed",
-		},
-		"sync": map[string]any{
-			"freshness": "fresh",
-			"conflicts": false,
-		},
+		"revision": 1,
 	})
+
+	svc := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC)
+		},
+	}
+	if result := svc.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+		t.Fatalf("publish evidence: %#v", result)
+	}
+	if result := svc.Submit("ci", []byte(`{"status":"failed","provider":"github-actions"}`)); !result.OK {
+		t.Fatalf("ci evidence: %#v", result)
+	}
+	if result := svc.Submit("sync", []byte(`{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`)); !result.OK {
+		t.Fatalf("sync evidence: %#v", result)
+	}
 
 	result := status.Service{Workdir: root}.Read()
 	if result.State.CurrentNode != "execution/finalize/publish" {
-		t.Fatalf("expected dirty legacy evidence fallback to stay in publish, got %#v", result.State)
+		t.Fatalf("expected dirty evidence artifacts to stay in publish, got %#v", result.State)
 	}
 	if result.Facts == nil || result.Facts.CIStatus != "failed" {
 		t.Fatalf("unexpected facts: %#v", result.Facts)
@@ -1988,6 +2036,7 @@ func TestStatusArchivedPlanStaysInPublishFromLegacyEvidenceCacheWhenDirty(t *tes
 	if !foundFixCI {
 		t.Fatalf("unexpected next actions: %#v", result.NextAction)
 	}
+	assertStateJSONLacksKeys(t, root, "2026-03-18-status-plan", "latest_publish", "latest_ci", "latest_evidence")
 }
 
 func TestStatusArchivedPlanStaysInPublishWhenEvidenceIsDirty(t *testing.T) {
@@ -2081,7 +2130,6 @@ func TestStatusLandNode(t *testing.T) {
 	})
 	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
 	writeState(t, root, "2026-03-18-status-plan", map[string]any{
-		"current_node": "land",
 		"land": map[string]any{
 			"pr_url":    "https://github.com/catu-ai/easyharness/pull/99",
 			"commit":    "abc123",
@@ -2600,6 +2648,34 @@ func writeState(t *testing.T, root, planStem string, payload map[string]any) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, "state.json"), data, 0o644); err != nil {
 		t.Fatalf("write state: %v", err)
+	}
+}
+
+func assertStateJSONLacksKeys(t *testing.T, root, planStem string, keys ...string) {
+	t.Helper()
+	path := filepath.Join(root, ".local", "harness", "plans", planStem, "state.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read state json: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("parse state json: %v", err)
+	}
+	requiredAbsent := []string{
+		"current_node",
+		"plan_path",
+		"plan_stem",
+		"latest_evidence",
+		"latest_ci",
+		"sync",
+		"latest_publish",
+	}
+	keys = append(requiredAbsent, keys...)
+	for _, key := range keys {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("expected state.json to omit %q, got %#v", key, payload)
+		}
 	}
 }
 

--- a/internal/timeline/service_test.go
+++ b/internal/timeline/service_test.go
@@ -19,8 +19,6 @@ func TestReadLoadsCurrentPlanTimelineEvents(t *testing.T) {
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(root, "2026-04-01-timeline-plan", &runstate.State{
-		PlanPath:           relPlanPath,
-		PlanStem:           "2026-04-01-timeline-plan",
 		ExecutionStartedAt: "2026-04-01T10:00:00Z",
 		Revision:           1,
 	}); err != nil {
@@ -106,8 +104,6 @@ func TestReadSynthesizesImplementBootstrapWhenExecutionStartedPredatesEventIndex
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(root, "2026-04-01-timeline-plan", &runstate.State{
-		PlanPath:           relPlanPath,
-		PlanStem:           "2026-04-01-timeline-plan",
 		ExecutionStartedAt: "2026-04-01T10:00:00Z",
 		Revision:           1,
 	}); err != nil {

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -107,8 +107,6 @@ func TestNewHandlerServesTimelineJSON(t *testing.T) {
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(workdir, "2026-04-01-ui-timeline-plan", &runstate.State{
-		PlanPath: relPlanPath,
-		PlanStem: "2026-04-01-ui-timeline-plan",
 		Revision: 1,
 	}); err != nil {
 		t.Fatalf("save state: %v", err)
@@ -174,8 +172,6 @@ func TestNewHandlerServesReviewJSON(t *testing.T) {
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(workdir, "2026-04-02-ui-review-plan", &runstate.State{
-		PlanPath: relPlanPath,
-		PlanStem: "2026-04-02-ui-review-plan",
 		Revision: 2,
 		ActiveReviewRound: &runstate.ReviewRound{
 			RoundID:    "review-002-full",
@@ -265,8 +261,6 @@ func TestNewHandlerServesReviewJSONFailureAs503(t *testing.T) {
 	}
 	planStem := "2026-04-02-ui-review-error"
 	if _, err := runstate.SaveState(workdir, planStem, &runstate.State{
-		PlanPath: relPlanPath,
-		PlanStem: planStem,
 		Revision: 1,
 	}); err != nil {
 		t.Fatalf("save state: %v", err)
@@ -333,8 +327,6 @@ func TestNewHandlerServesLargeTimelinePayloadWithoutTruncation(t *testing.T) {
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(workdir, "2026-04-01-ui-timeline-large", &runstate.State{
-		PlanPath: relPlanPath,
-		PlanStem: "2026-04-01-ui-timeline-large",
 		Revision: 1,
 	}); err != nil {
 		t.Fatalf("save state: %v", err)

--- a/schema/artifacts/local-state.schema.json
+++ b/schema/artifacts/local-state.schema.json
@@ -3,53 +3,6 @@
   "$id": "https://github.com/catu-ai/easyharness/tree/main/schema/artifacts/local-state.schema.json",
   "$ref": "#/$defs/LocalStateFile",
   "$defs": {
-    "EvidencePointerState": {
-      "properties": {
-        "kind": {
-          "type": "string",
-          "description": "Kind is the evidence kind."
-        },
-        "record_id": {
-          "type": "string",
-          "description": "RecordID is the stable identifier of the evidence record."
-        },
-        "path": {
-          "type": "string",
-          "description": "Path is the path to the evidence record artifact."
-        },
-        "recorded_at": {
-          "type": "string",
-          "description": "RecordedAt is the evidence record timestamp when one is tracked."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "kind",
-        "record_id",
-        "path"
-      ],
-      "description": "EvidencePointerState points to one evidence record from the local state file."
-    },
-    "EvidenceSetState": {
-      "properties": {
-        "ci": {
-          "$ref": "#/$defs/EvidencePointerState",
-          "description": "CI points to the latest CI evidence record when one exists."
-        },
-        "publish": {
-          "$ref": "#/$defs/EvidencePointerState",
-          "description": "Publish points to the latest publish evidence record when one exists."
-        },
-        "sync": {
-          "$ref": "#/$defs/EvidencePointerState",
-          "description": "Sync points to the latest sync evidence record when one exists."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "description": "EvidenceSetState records the latest evidence pointers tracked in the local state file."
-    },
     "LandState": {
       "properties": {
         "pr_url": {
@@ -73,80 +26,11 @@
       "type": "object",
       "description": "LandState records the current land state in the local state file."
     },
-    "LegacyCIState": {
-      "properties": {
-        "snapshot_id": {
-          "type": "string",
-          "description": "SnapshotID is the legacy CI snapshot identifier."
-        },
-        "status": {
-          "type": "string",
-          "description": "Status is the cached legacy CI status."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "snapshot_id",
-        "status"
-      ],
-      "description": "LegacyCIState is the transitional CI cache retained in the local state file while status still reads legacy evidence hints directly."
-    },
-    "LegacyPublishState": {
-      "properties": {
-        "attempt_id": {
-          "type": "string",
-          "description": "AttemptID is the legacy publish attempt identifier."
-        },
-        "pr_url": {
-          "type": "string",
-          "description": "PRURL is the cached publish pull request URL."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "attempt_id",
-        "pr_url"
-      ],
-      "description": "LegacyPublishState is the transitional publish cache retained in the local state file while status still reads legacy hints directly."
-    },
-    "LegacySyncState": {
-      "properties": {
-        "freshness": {
-          "type": "string",
-          "description": "Freshness is the cached sync freshness label."
-        },
-        "conflicts": {
-          "type": "boolean",
-          "description": "Conflicts reports whether the cached sync state observed conflicts."
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "freshness",
-        "conflicts"
-      ],
-      "description": "LegacySyncState is the transitional sync cache retained in the local state file while status still reads legacy hints directly."
-    },
     "LocalStateFile": {
       "properties": {
         "execution_started_at": {
           "type": "string",
           "description": "ExecutionStartedAt is the execution-start timestamp for the plan."
-        },
-        "current_node": {
-          "type": "string",
-          "description": "CurrentNode is the cached canonical workflow node when one has been resolved."
-        },
-        "plan_path": {
-          "type": "string",
-          "description": "PlanPath is the current tracked or archived plan path associated with this state file."
-        },
-        "plan_stem": {
-          "type": "string",
-          "description": "PlanStem is the durable plan stem associated with this state file."
         },
         "revision": {
           "type": "integer",
@@ -160,30 +44,14 @@
           "$ref": "#/$defs/ReviewRoundState",
           "description": "ActiveReviewRound records the current active review round when review is in flight."
         },
-        "latest_evidence": {
-          "$ref": "#/$defs/EvidenceSetState",
-          "description": "LatestEvidence records the latest evidence pointers tracked in the state file."
-        },
         "land": {
           "$ref": "#/$defs/LandState",
           "description": "Land records the current land state when merge cleanup is in flight."
-        },
-        "latest_ci": {
-          "$ref": "#/$defs/LegacyCIState",
-          "description": "LatestCI is the transitional cached CI state retained while status still reads legacy evidence hints directly from state.json."
-        },
-        "sync": {
-          "$ref": "#/$defs/LegacySyncState",
-          "description": "Sync is the transitional cached sync state retained while status still reads legacy hints directly from state.json."
-        },
-        "latest_publish": {
-          "$ref": "#/$defs/LegacyPublishState",
-          "description": "LatestPublish is the transitional cached publish state retained while status still reads legacy hints directly from state.json."
         }
       },
       "additionalProperties": false,
       "type": "object",
-      "description": "LocalStateFile is the plan-local runtime state cache under `.local/harness/plans/\u003cplan-stem\u003e/state.json`."
+      "description": "LocalStateFile is the plan-local runtime control artifact under `.local/harness/plans/\u003cplan-stem\u003e/state.json`."
     },
     "ReopenState": {
       "properties": {

--- a/schema/commands/evidence.submit.result.schema.json
+++ b/schema/commands/evidence.submit.result.schema.json
@@ -30,7 +30,7 @@
         },
         "local_state_path": {
           "type": "string",
-          "description": "LocalStatePath is the plan-local state cache path when one exists."
+          "description": "LocalStatePath is the plan-local control-plane state path when one exists."
         },
         "record_id": {
           "type": "string",

--- a/schema/commands/lifecycle.result.schema.json
+++ b/schema/commands/lifecycle.result.schema.json
@@ -34,7 +34,7 @@
         },
         "local_state_path": {
           "type": "string",
-          "description": "LocalStatePath is the plan-local state cache path when one exists."
+          "description": "LocalStatePath is the plan-local control-plane state path when one exists."
         },
         "current_plan_path": {
           "type": "string",

--- a/schema/commands/review.aggregate.result.schema.json
+++ b/schema/commands/review.aggregate.result.schema.json
@@ -135,7 +135,7 @@
         },
         "local_state_path": {
           "type": "string",
-          "description": "LocalStatePath is the plan-local state cache path."
+          "description": "LocalStatePath is the plan-local control-plane state path."
         }
       },
       "additionalProperties": false,

--- a/schema/commands/review.start.result.schema.json
+++ b/schema/commands/review.start.result.schema.json
@@ -86,7 +86,7 @@
         },
         "local_state_path": {
           "type": "string",
-          "description": "LocalStatePath is the plan-local state cache path."
+          "description": "LocalStatePath is the plan-local control-plane state path."
         },
         "round_id": {
           "type": "string",

--- a/schema/commands/status.result.schema.json
+++ b/schema/commands/status.result.schema.json
@@ -60,7 +60,7 @@
         },
         "local_state_path": {
           "type": "string",
-          "description": "LocalStatePath is the plan-local state cache path when one exists.",
+          "description": "LocalStatePath is the plan-local control-plane state path when one exists.",
           "examples": [
             ".local/harness/plans/2026-03-31-centralize-contract-schemas-and-generated-reference-docs/state.json"
           ]

--- a/schema/ui-resources/review.schema.json
+++ b/schema/ui-resources/review.schema.json
@@ -104,7 +104,7 @@
         },
         "local_state_path": {
           "type": "string",
-          "description": "LocalStatePath is the plan-local state cache path when one exists."
+          "description": "LocalStatePath is the plan-local control-plane state path when one exists."
         },
         "reviews_dir": {
           "type": "string",

--- a/schema/ui-resources/timeline.schema.json
+++ b/schema/ui-resources/timeline.schema.json
@@ -60,7 +60,7 @@
         },
         "local_state_path": {
           "type": "string",
-          "description": "LocalStatePath is the plan-local state cache path when one exists."
+          "description": "LocalStatePath is the plan-local control-plane state path when one exists."
         },
         "event_index_path": {
           "type": "string",

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -207,9 +208,7 @@ type statusResult struct {
 
 type runState struct {
 	ExecutionStartedAt string `json:"execution_started_at"`
-	PlanPath           string `json:"plan_path"`
 	Revision           int    `json:"revision"`
-	CurrentNode        string `json:"current_node"`
 	ActiveReviewRound  struct {
 		RoundID    string `json:"round_id"`
 		Aggregated bool   `json:"aggregated"`
@@ -284,6 +283,23 @@ func assertNode(t *testing.T, status statusResult, want string) {
 	t.Helper()
 	if status.State.CurrentNode != want {
 		t.Fatalf("expected current node %q, got %#v", want, status)
+	}
+}
+
+func assertRawStateJSONOmitsKeys(t *testing.T, path string, keys ...string) {
+	t.Helper()
+	var payload map[string]any
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read raw state json: %v", err)
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("parse raw state json: %v", err)
+	}
+	for _, key := range keys {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("expected raw state json to omit %q, got %#v", key, payload)
+		}
 	}
 }
 

--- a/tests/e2e/review_workflow_test.go
+++ b/tests/e2e/review_workflow_test.go
@@ -345,9 +345,10 @@ func TestReviewWorkflowWithBuiltBinary(t *testing.T) {
 	})
 
 	state := support.ReadJSONFile[runState](t, aggregatePayload.Artifacts.LocalStatePath)
-	if state.ExecutionStartedAt == "" || state.PlanPath != planRelPath {
+	if state.ExecutionStartedAt == "" || state.Revision != 1 {
 		t.Fatalf("unexpected runstate: %#v", state)
 	}
+	assertRawStateJSONOmitsKeys(t, aggregatePayload.Artifacts.LocalStatePath, "current_node", "plan_path", "plan_stem")
 	if state.ActiveReviewRound.RoundID != startPayload.Artifacts.RoundID {
 		t.Fatalf("expected active review round %q, got %#v", startPayload.Artifacts.RoundID, state)
 	}


### PR DESCRIPTION
## What changed

- shrink `state.json` down to control-plane-only fields and remove cached node/path/evidence pointer fields from contracts, runtime writers, and schemas
- stop `harness status` from rewriting `state.json` on read-only resolution and switch archived evidence lookup to artifact-driven discovery
- tighten regression coverage across status, lifecycle, evidence, CLI/UI/timeline, and e2e flows, including reopen revision scoping and raw on-disk `state.json` assertions for mutating paths
- archive the tracked plan for this slice under `docs/plans/archived/2026-04-09-shrink-state-json-to-control-plane-only.md`

## Why

Issue #58 called out that `harness status` was still rewriting `state.json` even when the resolved node had not changed. The deeper cleanup here is to stop treating `state.json` as a mixed cache-and-control artifact at all: only persist the control-plane state we actually need across commands, and derive the rest from tracked plans plus append-only local artifacts.

## Impact

- `state.json` now only carries control-plane runtime state
- status/evidence readiness no longer depends on cached path/node/evidence pointer fields
- reopen/revision flows now scope evidence lookup to the current revision so stale artifacts cannot make a reopened candidate look merge-ready
- the tracked contract surface now teaches the same model as the runtime implementation

## Validation

- `go build ./...`
- `scripts/sync-contract-artifacts --check`
- `go test ./internal/evidence ./internal/reviewui ./internal/review ./internal/lifecycle ./internal/status -count=1`
- `go test ./internal/cli ./internal/runstate ./internal/timeline ./internal/ui -count=1`
- `go test ./tests/e2e -count=1`
- `go test ./... -count=1`
