### PR TITLE
Add controller truth-surface checklist guidance

### DIFF
--- a/.agents/skills/harness-execute/SKILL.md
+++ b/.agents/skills/harness-execute/SKILL.md
@@ -34,6 +34,16 @@ Routine review progression is controller-owned. Once the approved plan reaches
 an ordinary step-closeout or finalize-review boundary, the controller should
 start that review flow without asking the human to micromanage it.
 
+Before high-risk transitions, run a short controller self-check instead of
+trusting momentum. Use the phase-based checklist in
+[controller-truth-surfaces.md](references/controller-truth-surfaces.md) at
+these moments:
+
+- before starting a review round
+- before aggregating a review round
+- before archiving
+- before merge-sensitive publish or land handoff work
+
 For `delta` review, use a real git commit anchor. The detailed controller
 dispatch fields, anchor guidance, and reviewer-resume rules live in
 [review-orchestration.md](references/review-orchestration.md).
@@ -109,6 +119,8 @@ when it is genuinely impractical, and record the reason in the step's
   remote-sync work becomes relevant.
 - Read [closeout-and-archive.md](references/closeout-and-archive.md) before any
   archive attempt.
+- Read [controller-truth-surfaces.md](references/controller-truth-surfaces.md)
+  whenever you are about to cross a high-risk controller boundary.
 
 ## Exit Criteria
 

--- a/.agents/skills/harness-execute/references/closeout-and-archive.md
+++ b/.agents/skills/harness-execute/references/closeout-and-archive.md
@@ -4,30 +4,32 @@ Archive is a freeze-and-summarize step, not just a file move.
 
 ## Before Archive
 
-1. Run `harness status` and confirm the plan is actually archive-ready.
+1. Run the `Pre-Archive` scan from
+   [controller-truth-surfaces.md](controller-truth-surfaces.md).
+2. Run `harness status` and confirm the plan is actually archive-ready.
    - If `status` returns `blockers`, fix those first instead of learning them
      from a failing `harness archive`.
-2. Make sure acceptance criteria are checked and steps are completed.
-3. Read the latest finalize review artifacts under `.local` and confirm the
+3. Make sure acceptance criteria are checked and steps are completed.
+4. Read the latest finalize review artifacts under `.local` and confirm the
    branch really is in `execution/finalize/archive` rather than still needing
    review or repair.
-4. Update the tracked plan's durable summaries from those artifacts:
+5. Update the tracked plan's durable summaries from those artifacts:
    - `Validation Summary`
    - `Review Summary`
    - `Archive Summary`
    - `Outcome Summary`
    - for lightweight work, the active plan is still tracked before archive,
      while the archived snapshot later moves to `.local/harness/plans/archived/`
-5. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
+6. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
    with durable handoff details before archive. Issue links are fine, but the
    main rule is that it must not stay `NONE`.
-6. Run:
+7. Run:
 
    ```bash
    harness plan lint <plan-path>
    ```
 
-7. Archive the plan:
+8. Archive the plan:
 
    ```bash
    harness archive
@@ -43,11 +45,12 @@ Archive still needs an explicit handoff flow:
 4. If the profile is `lightweight`, update the agreed repo-visible breadcrumb
    such as the PR body note before treating the candidate as ready to wait for
    merge approval.
-5. Run `harness status` again to confirm the archived candidate now reports the
-   expected `execution/finalize/publish` or
-   `execution/finalize/await_merge` node for this worktree.
+5. Run `harness status` again to confirm the archived candidate entered
+   `execution/finalize/publish` for this worktree.
 6. Record publish, CI, and sync facts through `harness evidence submit`.
-7. Wait for human merge approval or switch to `harness-land` only when asked
+7. Run `harness status` again after that handoff work and confirm the candidate
+   is now genuinely ready to report `execution/finalize/await_merge`.
+8. Wait for human merge approval or switch to `harness-land` only when asked
    once status reaches `execution/finalize/await_merge`.
 
 If new feedback or remote changes invalidate the archived candidate, use:

--- a/.agents/skills/harness-execute/references/controller-truth-surfaces.md
+++ b/.agents/skills/harness-execute/references/controller-truth-surfaces.md
@@ -1,0 +1,60 @@
+# Controller Truth Surfaces
+
+Use this checklist at high-risk controller transitions. It is a short
+self-check for the controller, not a second reviewer protocol.
+
+## Pre-Review
+
+- scope truth
+  - decide whether this round is really `delta` or `full`, and say why a
+    narrower or broader pass would be less trustworthy
+- anchor and diff truth
+  - for `delta`, verify the review anchor is a real git commit and the current
+    change boundary still matches the intended review slice
+- contract scan
+  - scan the active plan, touched contracts, docs wording, and focused
+    validation so the controller does not outsource all completeness checking
+    to reviewers
+- dispatch sanity
+  - make sure the review spec and reviewer prompt carry the actual round
+    context, anchor, and bounded change summary instead of forcing reviewers to
+    guess
+
+## Pre-Aggregate
+
+- submission truth
+  - verify every expected slot submitted a real result rather than a missing,
+    invalid, or still-skeleton artifact
+- round-state truth
+  - verify you are aggregating the current active round and not mixing older
+    findings, newer repairs, or the wrong revision
+- synthesis sanity
+  - read the submitted findings once before aggregation so obvious duplicates,
+    missing severities, or malformed claims do not slide through by inertia
+
+## Pre-Archive
+
+- placeholder debt
+  - replace placeholder summaries, unchecked acceptance criteria, and step
+    markers before archive instead of letting `archive` discover them late
+- narrative debt
+  - make sure the tracked plan tells a durable story of what changed, how it
+    was validated, what review concluded, and what follow-up remains
+- publish-readiness sanity
+  - confirm the branch is truly in archive closeout rather than still needing
+    review, repair, or unresolved handoff work
+
+## Pre-Land
+
+- PR truth
+  - refresh the actual PR state instead of trusting a stale local impression of
+    readiness
+- CI truth
+  - verify the latest relevant runs and distinguish `success` from cancelled,
+    stale, superseded, or still-running checks
+- sync truth
+  - refresh branch freshness against the remote base before merge-sensitive
+    handoff or merge work
+- merge and bookkeeping truth
+  - confirm the remaining PR comment, issue follow-up, evidence, and land
+    bookkeeping work rather than assuming merge-ready means done

--- a/.agents/skills/harness-execute/references/publish-ci-sync.md
+++ b/.agents/skills/harness-execute/references/publish-ci-sync.md
@@ -24,7 +24,10 @@ but record the observed external facts through `harness evidence submit`:
    `harness evidence submit --kind ci`
 6. refresh remote readiness and record it with
    `harness evidence submit --kind sync`
-7. only then treat the candidate as ready to enter
+7. once those remote facts exist, run the `Pre-Land` scan from
+   [controller-truth-surfaces.md](controller-truth-surfaces.md) before treating
+   the archived candidate as genuinely merge-ready
+8. only then treat the candidate as ready to enter
    `execution/finalize/await_merge`
 
 ## Remote Freshness

--- a/.agents/skills/harness-execute/references/review-orchestration.md
+++ b/.agents/skills/harness-execute/references/review-orchestration.md
@@ -44,6 +44,8 @@ plan intent, or contract meaning warrants it.
 
 ## Routine Start Rules
 
+- Before starting a review round, run the `Pre-Review` scan from
+  [controller-truth-surfaces.md](controller-truth-surfaces.md).
 - After a completed step becomes reviewable, start a step-bound review before
   treating the step as durably done, unless the step will instead record
   `NO_STEP_REVIEW_NEEDED: <reason>` in `Review Notes`.
@@ -152,7 +154,9 @@ round to use the same set.
    might be useful later.
 8. If a reviewer finished without a valid submission, respawn a clean reviewer
    for that slot immediately.
-9. Only after every expected reviewer slot has a valid submission and every
+9. Before aggregation, run the `Pre-Aggregate` scan from
+   [controller-truth-surfaces.md](controller-truth-surfaces.md).
+10. Only after every expected reviewer slot has a valid submission and every
    reviewer agent is closed, run:
 
    ```bash

--- a/.agents/skills/harness-execute/references/step-inner-loop.md
+++ b/.agents/skills/harness-execute/references/step-inner-loop.md
@@ -17,9 +17,11 @@ The inner loop is how you finish one plan step cleanly.
    later `delta` review has a real git anchor.
 7. Run `harness status` before step closeout so the next action reflects the
    current step, any active review, and any warning-driven follow-up.
-8. If the slice is ready for review, run step-closeout review now. Use `delta`
-   by default from the latest anchor commit, but use `full` when a narrower
-   review would be misleading or the slice needs a broader pass.
+8. If the slice is ready for review, first run the `Pre-Review` scan in
+   [controller-truth-surfaces.md](controller-truth-surfaces.md), then start
+   step-closeout review. Use `delta` by default from the latest anchor commit,
+   but use `full` when a narrower review would be misleading or the slice
+   needs a broader pass.
 9. If no step-closeout review is needed, record
    `NO_STEP_REVIEW_NEEDED: <reason>` in `Review Notes` before marking the step
    done.

--- a/.agents/skills/harness-land/SKILL.md
+++ b/.agents/skills/harness-land/SKILL.md
@@ -19,18 +19,21 @@ merge.
      `harness reopen --mode new-step` when the change deserves a new step, and
      then return to `harness-execute`.
    - If the plan is still executing, stay in `harness-execute`.
-3. Verify the PR still looks merge-ready.
-4. Merge the PR.
-5. Prefer `Merge commit` unless the human explicitly asks for a different
+3. Re-read the `Pre-Land` scan in
+   [../harness-execute/references/controller-truth-surfaces.md](../harness-execute/references/controller-truth-surfaces.md)
+   so merge readiness, CI truth, and required bookkeeping are freshly checked.
+4. Verify the PR still looks merge-ready.
+5. Merge the PR.
+6. Prefer `Merge commit` unless the human explicitly asks for a different
    strategy.
-6. Run:
+7. Run:
 
    ```bash
    harness land --pr <url> [--commit <sha>]
    ```
 
    This records merge confirmation and enters required post-merge bookkeeping.
-7. Finish the required post-merge bookkeeping before leaving `land`.
+8. Finish the required post-merge bookkeeping before leaving `land`.
    - Add a final PR comment when the permanent PR record still needs a durable
      merge closeout note or follow-up handoff after the merge.
    - The minimum PR comment content is:
@@ -42,8 +45,8 @@ merge.
    - If a linked issue is only partially addressed, intentionally deferred, or
      still needs later work, do not close it silently; add or update the issue
      with a follow-up reference to the merged PR and the remaining work.
-8. Finish local cleanup, branch sync, and any final remote follow-up.
-9. Run:
+9. Finish local cleanup, branch sync, and any final remote follow-up.
+10. Run:
 
    ```bash
    harness land complete
@@ -54,7 +57,7 @@ merge.
    candidate pointer, and
    records the last landed archived plan so `harness status` returns to `idle`
    with the landed context preserved in artifacts.
-10. Sync local `main`, delete the feature branch if appropriate, and leave the
+11. Sync local `main`, delete the feature branch if appropriate, and leave the
     worktree clean.
 
 ## Do Not

--- a/assets/bootstrap/skills/harness-execute/SKILL.md
+++ b/assets/bootstrap/skills/harness-execute/SKILL.md
@@ -34,6 +34,16 @@ Routine review progression is controller-owned. Once the approved plan reaches
 an ordinary step-closeout or finalize-review boundary, the controller should
 start that review flow without asking the human to micromanage it.
 
+Before high-risk transitions, run a short controller self-check instead of
+trusting momentum. Use the phase-based checklist in
+[controller-truth-surfaces.md](references/controller-truth-surfaces.md) at
+these moments:
+
+- before starting a review round
+- before aggregating a review round
+- before archiving
+- before merge-sensitive publish or land handoff work
+
 For `delta` review, use a real git commit anchor. The detailed controller
 dispatch fields, anchor guidance, and reviewer-resume rules live in
 [review-orchestration.md](references/review-orchestration.md).
@@ -109,6 +119,8 @@ when it is genuinely impractical, and record the reason in the step's
   remote-sync work becomes relevant.
 - Read [closeout-and-archive.md](references/closeout-and-archive.md) before any
   archive attempt.
+- Read [controller-truth-surfaces.md](references/controller-truth-surfaces.md)
+  whenever you are about to cross a high-risk controller boundary.
 
 ## Exit Criteria
 

--- a/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
+++ b/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
@@ -4,30 +4,32 @@ Archive is a freeze-and-summarize step, not just a file move.
 
 ## Before Archive
 
-1. Run `harness status` and confirm the plan is actually archive-ready.
+1. Run the `Pre-Archive` scan from
+   [controller-truth-surfaces.md](controller-truth-surfaces.md).
+2. Run `harness status` and confirm the plan is actually archive-ready.
    - If `status` returns `blockers`, fix those first instead of learning them
      from a failing `harness archive`.
-2. Make sure acceptance criteria are checked and steps are completed.
-3. Read the latest finalize review artifacts under `.local` and confirm the
+3. Make sure acceptance criteria are checked and steps are completed.
+4. Read the latest finalize review artifacts under `.local` and confirm the
    branch really is in `execution/finalize/archive` rather than still needing
    review or repair.
-4. Update the tracked plan's durable summaries from those artifacts:
+5. Update the tracked plan's durable summaries from those artifacts:
    - `Validation Summary`
    - `Review Summary`
    - `Archive Summary`
    - `Outcome Summary`
    - for lightweight work, the active plan is still tracked before archive,
      while the archived snapshot later moves to `.local/harness/plans/archived/`
-5. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
+6. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
    with durable handoff details before archive. Issue links are fine, but the
    main rule is that it must not stay `NONE`.
-6. Run:
+7. Run:
 
    ```bash
    harness plan lint <plan-path>
    ```
 
-7. Archive the plan:
+8. Archive the plan:
 
    ```bash
    harness archive
@@ -43,11 +45,12 @@ Archive still needs an explicit handoff flow:
 4. If the profile is `lightweight`, update the agreed repo-visible breadcrumb
    such as the PR body note before treating the candidate as ready to wait for
    merge approval.
-5. Run `harness status` again to confirm the archived candidate now reports the
-   expected `execution/finalize/publish` or
-   `execution/finalize/await_merge` node for this worktree.
+5. Run `harness status` again to confirm the archived candidate entered
+   `execution/finalize/publish` for this worktree.
 6. Record publish, CI, and sync facts through `harness evidence submit`.
-7. Wait for human merge approval or switch to `harness-land` only when asked
+7. Run `harness status` again after that handoff work and confirm the candidate
+   is now genuinely ready to report `execution/finalize/await_merge`.
+8. Wait for human merge approval or switch to `harness-land` only when asked
    once status reaches `execution/finalize/await_merge`.
 
 If new feedback or remote changes invalidate the archived candidate, use:

--- a/assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md
+++ b/assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md
@@ -1,0 +1,60 @@
+# Controller Truth Surfaces
+
+Use this checklist at high-risk controller transitions. It is a short
+self-check for the controller, not a second reviewer protocol.
+
+## Pre-Review
+
+- scope truth
+  - decide whether this round is really `delta` or `full`, and say why a
+    narrower or broader pass would be less trustworthy
+- anchor and diff truth
+  - for `delta`, verify the review anchor is a real git commit and the current
+    change boundary still matches the intended review slice
+- contract scan
+  - scan the active plan, touched contracts, docs wording, and focused
+    validation so the controller does not outsource all completeness checking
+    to reviewers
+- dispatch sanity
+  - make sure the review spec and reviewer prompt carry the actual round
+    context, anchor, and bounded change summary instead of forcing reviewers to
+    guess
+
+## Pre-Aggregate
+
+- submission truth
+  - verify every expected slot submitted a real result rather than a missing,
+    invalid, or still-skeleton artifact
+- round-state truth
+  - verify you are aggregating the current active round and not mixing older
+    findings, newer repairs, or the wrong revision
+- synthesis sanity
+  - read the submitted findings once before aggregation so obvious duplicates,
+    missing severities, or malformed claims do not slide through by inertia
+
+## Pre-Archive
+
+- placeholder debt
+  - replace placeholder summaries, unchecked acceptance criteria, and step
+    markers before archive instead of letting `archive` discover them late
+- narrative debt
+  - make sure the tracked plan tells a durable story of what changed, how it
+    was validated, what review concluded, and what follow-up remains
+- publish-readiness sanity
+  - confirm the branch is truly in archive closeout rather than still needing
+    review, repair, or unresolved handoff work
+
+## Pre-Land
+
+- PR truth
+  - refresh the actual PR state instead of trusting a stale local impression of
+    readiness
+- CI truth
+  - verify the latest relevant runs and distinguish `success` from cancelled,
+    stale, superseded, or still-running checks
+- sync truth
+  - refresh branch freshness against the remote base before merge-sensitive
+    handoff or merge work
+- merge and bookkeeping truth
+  - confirm the remaining PR comment, issue follow-up, evidence, and land
+    bookkeeping work rather than assuming merge-ready means done

--- a/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
+++ b/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
@@ -24,7 +24,10 @@ but record the observed external facts through `harness evidence submit`:
    `harness evidence submit --kind ci`
 6. refresh remote readiness and record it with
    `harness evidence submit --kind sync`
-7. only then treat the candidate as ready to enter
+7. once those remote facts exist, run the `Pre-Land` scan from
+   [controller-truth-surfaces.md](controller-truth-surfaces.md) before treating
+   the archived candidate as genuinely merge-ready
+8. only then treat the candidate as ready to enter
    `execution/finalize/await_merge`
 
 ## Remote Freshness

--- a/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
+++ b/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
@@ -44,6 +44,8 @@ plan intent, or contract meaning warrants it.
 
 ## Routine Start Rules
 
+- Before starting a review round, run the `Pre-Review` scan from
+  [controller-truth-surfaces.md](controller-truth-surfaces.md).
 - After a completed step becomes reviewable, start a step-bound review before
   treating the step as durably done, unless the step will instead record
   `NO_STEP_REVIEW_NEEDED: <reason>` in `Review Notes`.
@@ -152,7 +154,9 @@ round to use the same set.
    might be useful later.
 8. If a reviewer finished without a valid submission, respawn a clean reviewer
    for that slot immediately.
-9. Only after every expected reviewer slot has a valid submission and every
+9. Before aggregation, run the `Pre-Aggregate` scan from
+   [controller-truth-surfaces.md](controller-truth-surfaces.md).
+10. Only after every expected reviewer slot has a valid submission and every
    reviewer agent is closed, run:
 
    ```bash

--- a/assets/bootstrap/skills/harness-execute/references/step-inner-loop.md
+++ b/assets/bootstrap/skills/harness-execute/references/step-inner-loop.md
@@ -17,9 +17,11 @@ The inner loop is how you finish one plan step cleanly.
    later `delta` review has a real git anchor.
 7. Run `harness status` before step closeout so the next action reflects the
    current step, any active review, and any warning-driven follow-up.
-8. If the slice is ready for review, run step-closeout review now. Use `delta`
-   by default from the latest anchor commit, but use `full` when a narrower
-   review would be misleading or the slice needs a broader pass.
+8. If the slice is ready for review, first run the `Pre-Review` scan in
+   [controller-truth-surfaces.md](controller-truth-surfaces.md), then start
+   step-closeout review. Use `delta` by default from the latest anchor commit,
+   but use `full` when a narrower review would be misleading or the slice
+   needs a broader pass.
 9. If no step-closeout review is needed, record
    `NO_STEP_REVIEW_NEEDED: <reason>` in `Review Notes` before marking the step
    done.

--- a/assets/bootstrap/skills/harness-land/SKILL.md
+++ b/assets/bootstrap/skills/harness-land/SKILL.md
@@ -19,18 +19,21 @@ merge.
      `harness reopen --mode new-step` when the change deserves a new step, and
      then return to `harness-execute`.
    - If the plan is still executing, stay in `harness-execute`.
-3. Verify the PR still looks merge-ready.
-4. Merge the PR.
-5. Prefer `Merge commit` unless the human explicitly asks for a different
+3. Re-read the `Pre-Land` scan in
+   [../harness-execute/references/controller-truth-surfaces.md](../harness-execute/references/controller-truth-surfaces.md)
+   so merge readiness, CI truth, and required bookkeeping are freshly checked.
+4. Verify the PR still looks merge-ready.
+5. Merge the PR.
+6. Prefer `Merge commit` unless the human explicitly asks for a different
    strategy.
-6. Run:
+7. Run:
 
    ```bash
    harness land --pr <url> [--commit <sha>]
    ```
 
    This records merge confirmation and enters required post-merge bookkeeping.
-7. Finish the required post-merge bookkeeping before leaving `land`.
+8. Finish the required post-merge bookkeeping before leaving `land`.
    - Add a final PR comment when the permanent PR record still needs a durable
      merge closeout note or follow-up handoff after the merge.
    - The minimum PR comment content is:
@@ -42,8 +45,8 @@ merge.
    - If a linked issue is only partially addressed, intentionally deferred, or
      still needs later work, do not close it silently; add or update the issue
      with a follow-up reference to the merged PR and the remaining work.
-8. Finish local cleanup, branch sync, and any final remote follow-up.
-9. Run:
+9. Finish local cleanup, branch sync, and any final remote follow-up.
+10. Run:
 
    ```bash
    harness land complete
@@ -54,7 +57,7 @@ merge.
    candidate pointer, and
    records the last landed archived plan so `harness status` returns to `idle`
    with the landed context preserved in artifacts.
-10. Sync local `main`, delete the feature branch if appropriate, and leave the
+11. Sync local `main`, delete the feature branch if appropriate, and leave the
     worktree clean.
 
 ## Do Not

--- a/docs/plans/archived/2026-04-10-controller-discipline-truth-surface-checklist.md
+++ b/docs/plans/archived/2026-04-10-controller-discipline-truth-surface-checklist.md
@@ -1,0 +1,344 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-10T08:45:00+08:00"
+source_type: direct_request
+source_refs: []
+---
+
+# Controller discipline truth-surface checklist
+
+## Goal
+
+Codify the controller-side lessons from the delta-review anchor slice so strong
+agents miss fewer pre-existing problems and make fewer stateful or remote
+operation mistakes during execution. The accepted direction is a two-layer
+design: keep a small set of stable controller rules in `harness-execute`, then
+add one lightweight phase-based checklist artifact the controller consults at
+high-risk transitions instead of bloating the skill into a long playbook.
+
+This slice should make controller self-check moments explicit across the whole
+execution loop. The checklist is for controllers, not reviewers. Reviewer
+behavior should continue to live primarily in `harness-reviewer`, while the new
+controller artifact focuses on truth surfaces that were easy to skip in the
+recent retrospective: review completeness, submission/round truth, archive
+closeout truth, and PR/CI/sync truth.
+
+## Scope
+
+### In Scope
+
+- Define a two-layer controller discipline model:
+  - stable controller defaults in `harness-execute`
+  - one lightweight controller checklist artifact for high-risk transitions
+- Add explicit controller self-check guidance for four phases:
+  - `pre-review`
+  - `pre-aggregate`
+  - `pre-archive`
+  - `pre-land`
+- Keep the checklist focused on the two failure classes accepted in discovery:
+  - `漏看型`: pre-existing issues not caught at the right self-check/review moment
+  - `误操作型`: lock collisions, CI misreads, stale remote assumptions, or noisy run handling
+- Clarify which controller checks are stable defaults that belong in the skill
+  contract versus which are runtime self-check prompts that belong in the
+  checklist artifact.
+- Sync bootstrap outputs so the repo-local `.agents` copy matches the source
+  controller discipline guidance.
+
+### Out of Scope
+
+- Adding a separate reviewer checklist
+- Turning `harness-execute` into a long exhaustive SOP or workflow engine
+- Reworking `harness-reviewer` beyond any minimal cross-reference needed for
+  controller/reviewer alignment
+- Changing review/state/archive semantics that already landed in the previous
+  delta-review anchor slice
+- Adding CLI-enforced hard gates for every checklist item
+
+## Acceptance Criteria
+
+- [x] The resulting design clearly separates stable controller defaults from the
+      lightweight controller checklist, so a cold reader can see what belongs
+      in `harness-execute` versus the checklist artifact.
+- [x] `harness-execute` guidance adds strong-default controller self-check
+      moments without turning the skill into a long operational wall of text.
+- [x] The controller checklist is organized by the four accepted phases:
+      `pre-review`, `pre-aggregate`, `pre-archive`, and `pre-land`.
+- [x] Each phase stays lean, with only the highest-signal truth-surface checks
+      rather than a long compliance-style list.
+- [x] `pre-review` guidance explicitly covers scope truth, anchor/diff truth,
+      contract scan, and dispatch sanity.
+- [x] `pre-aggregate` guidance explicitly covers submission truth, round-state
+      truth, and a light synthesis sanity check before aggregation.
+- [x] `pre-archive` guidance explicitly covers placeholder debt and narrative
+      debt before the controller archives a candidate.
+- [x] `pre-land` guidance explicitly covers PR truth, CI truth, sync truth, and
+      merge/bookkeeping truth before or during land.
+- [x] Reviewer behavior remains primarily owned by `harness-reviewer`; the new
+      artifact is clearly controller-primary rather than a second reviewer
+      protocol.
+- [x] `scripts/sync-bootstrap-assets` refreshes the materialized `.agents`
+      outputs and `scripts/sync-bootstrap-assets --check` passes afterward.
+
+## Deferred Items
+
+- Consider later whether any checklist item has proved important enough in
+  practice to justify a CLI-enforced hard gate instead of skill-level guidance.
+
+## Work Breakdown
+
+### Step 1: Define the two-layer controller discipline contract
+
+- Done: [x]
+
+#### Objective
+
+Decide exactly which controller truths belong in the stable `harness-execute`
+ contract and which belong in the lightweight checklist artifact.
+
+#### Details
+
+Use the accepted discovery framing rather than reopening it during execution:
+
+- the checklist is controller-primary, not shared equally with reviewers
+- the main goal is to reduce both completeness misses and operation mistakes
+- the checklist should be phase-based, with risk-focused bullets inside each
+  phase
+- language strength should be strong-default guidance, not soft suggestions and
+  not a hard gate engine
+
+This step should leave behind a crisp split that future agents can reuse:
+`harness-execute` owns the stable defaults and when to pause for self-checks;
+the checklist artifact owns the concise per-phase scan content.
+
+#### Expected Files
+
+- `assets/bootstrap/skills/harness-execute/SKILL.md`
+- `assets/bootstrap/skills/harness-execute/references/`
+
+#### Validation
+
+- A cold controller agent could explain the difference between the stable skill
+  contract and the lightweight checklist artifact without relying on discovery
+  chat.
+- The resulting split stays lean enough that `AGENTS.md` does not need to grow
+  and `harness-execute` does not become an exhaustive SOP.
+
+#### Execution Notes
+
+Defined the split in the bootstrap source instead of expanding the managed
+`AGENTS.md` block: `assets/bootstrap/skills/harness-execute/SKILL.md` now owns
+the stable controller defaults and points cold controllers at a dedicated
+truth-surface checklist reference, while the phase-by-phase scan content lives
+outside the core skill body. Updated the execute references that actually own
+review, archive, and publish transitions so the new self-check moments are
+discoverable where controllers already look.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 and Step 2 landed as one tightly coupled
+guidance slice, so a separate step-bound review here would have duplicated the
+later candidate-level finalize review.
+
+### Step 2: Add the phase-based truth-surface checklist
+
+- Done: [x]
+
+#### Objective
+
+Create the lightweight controller checklist artifact that covers the four
+accepted high-risk phases.
+
+#### Details
+
+The checklist should be phase-based and intentionally short. Each phase should
+carry only the checks that matter most:
+
+- `pre-review`
+  - scope truth
+  - anchor/diff truth
+  - contract scan
+  - dispatch sanity
+- `pre-aggregate`
+  - submission truth
+  - round-state truth
+  - synthesis sanity
+- `pre-archive`
+  - placeholder debt
+  - narrative debt
+  - light publish-readiness confirmation
+- `pre-land`
+  - PR truth
+  - CI truth
+  - sync truth
+  - merge/bookkeeping truth
+
+Write it so another strong agent would actually use it during execution instead
+of skimming past it as filler. Keep it decisional and concrete rather than
+turning it into a generic essay about being careful.
+
+#### Expected Files
+
+- `assets/bootstrap/skills/harness-execute/references/`
+- `.agents/skills/harness-execute/references/`
+
+#### Validation
+
+- Each phase fits on a short scan and clearly targets one of the two accepted
+  failure classes from discovery.
+- The checklist is controller-primary and does not silently morph into a second
+  reviewer protocol.
+
+#### Execution Notes
+
+Added `controller-truth-surfaces.md` under the bootstrap execute references and
+kept each phase intentionally short: `pre-review`, `pre-aggregate`,
+`pre-archive`, and `pre-land` each now carry only the accepted truth-surface
+checks from discovery. The checklist is written as controller-facing decisional
+prompts, not as reviewer instructions or a compliance wall.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: The checklist content is inseparable from Step 1's
+contract split, so the final packaged candidate is reviewed as one bounded
+controller-discipline change.
+
+### Step 3: Sync the controller workflow guidance and validate the packaged result
+
+- Done: [x]
+
+#### Objective
+
+Materialize the new controller discipline guidance into the dogfood outputs and
+prove the packaged guidance remains in sync.
+
+#### Details
+
+After editing the bootstrap source files, sync the bootstrap outputs so the
+rooted `.agents` copy reflects the new controller guidance. Validate the final
+result with the bootstrap sync checks and any focused tests needed if the
+controller references or packaging logic require updates.
+
+Keep execution detail concise. The point of this step is not to add runtime
+behavior changes; it is to make sure the packaged guidance a future agent sees
+actually matches the source and the accepted discovery direction.
+
+#### Expected Files
+
+- `assets/bootstrap/skills/harness-execute/SKILL.md`
+- `assets/bootstrap/skills/harness-execute/references/`
+- `.agents/skills/harness-execute/SKILL.md`
+- `.agents/skills/harness-execute/references/`
+
+#### Validation
+
+- `scripts/sync-bootstrap-assets`
+- `scripts/sync-bootstrap-assets --check`
+- `harness plan lint docs/plans/active/2026-04-10-controller-discipline-truth-surface-checklist.md`
+
+#### Execution Notes
+
+Ran `scripts/sync-bootstrap-assets` to materialize the updated execute and land
+guidance into `.agents/`, then verified the package remained clean with
+`scripts/sync-bootstrap-assets --check` and `harness plan lint
+docs/plans/active/2026-04-10-controller-discipline-truth-surface-checklist.md`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 3 only materialized and validated the same
+controller-guidance slice, so separate step review would add little beyond the
+finalize review of the packaged result.
+
+## Validation Strategy
+
+- Keep the validation centered on guidance quality and packaged sync fidelity,
+  not on introducing new runtime mechanics unless execution genuinely requires
+  them.
+- Re-read the resulting skill plus checklist as a cold controller agent and
+  verify that the four high-risk transitions each have a concise truth-surface
+  scan.
+- Use bootstrap sync checks to ensure the repo-local `.agents` materialization
+  stays aligned with the edited bootstrap source.
+
+## Risks
+
+- Risk: The controller checklist could grow into another long SOP that agents
+  skim instead of use.
+  - Mitigation: Keep each phase lean and focused on a few truth-surface checks
+    rather than exhaustive prose.
+- Risk: Stable defaults and checklist prompts could duplicate each other and
+  blur the intended two-layer split.
+  - Mitigation: Decide the split explicitly in Step 1 before filling in the
+    checklist details.
+- Risk: Reviewer behavior could accidentally get redefined in controller docs,
+  causing drift between `harness-execute` and `harness-reviewer`.
+  - Mitigation: Keep the checklist controller-primary and leave reviewer
+    behavior in `harness-reviewer` except for minimal alignment references.
+
+## Validation Summary
+
+- Re-read the edited bootstrap and materialized `.agents` guidance as a cold
+  controller path and confirmed the stable-default vs checklist split stays in
+  `harness-execute` while phase-specific scans stay in
+  `controller-truth-surfaces.md`.
+- Ran `scripts/sync-bootstrap-assets` after the initial implementation and
+  after both finalize-review follow-up fixes so the packaged `.agents` output
+  stayed aligned with `assets/bootstrap/`.
+- Verified packaged sync with `scripts/sync-bootstrap-assets --check`.
+- Verified the tracked plan remained valid with `harness plan lint
+  docs/plans/active/2026-04-10-controller-discipline-truth-surface-checklist.md`.
+
+## Review Summary
+
+- `review-001-full` found one important workflow-semantics issue: the new
+  `Pre-Land` scan was wired before the archived candidate had publish/CI/sync
+  truth available. The fix moved that scan later in the archived-candidate
+  handoff, after publish, CI, and sync evidence exist.
+- `review-002-full` found one important docs-consistency issue: the archive
+  handoff still implied `execution/finalize/await_merge` could appear before
+  publish/CI/sync evidence. The fix rewrote `closeout-and-archive.md` so the
+  post-archive flow explicitly reaches `execution/finalize/publish` first, then
+  evidence submission, then a later `await_merge` status check.
+- `review-003-full` passed clean with no blocking or non-blocking findings
+  after those two follow-up fixes.
+
+## Archive Summary
+
+- Archived At: 2026-04-10T09:19:51+08:00
+- Revision: 1
+- PR: NONE
+- Ready: The candidate now packages a lean controller-only truth-surface
+  checklist, matching execute/land guidance, synchronized `.agents` outputs,
+  clean finalize review, and validation proving the review/archive/publish
+  sequence is internally consistent.
+- Merge Handoff: Archive this candidate, commit and push the archive move, open
+  or update the PR, record publish/CI/sync evidence for the archived
+  candidate, and then wait for explicit human merge approval before land.
+
+## Outcome Summary
+
+### Delivered
+
+- Added a dedicated controller-only `controller-truth-surfaces.md` reference
+  that keeps `pre-review`, `pre-aggregate`, `pre-archive`, and `pre-land`
+  checks concise and phase-based instead of bloating `harness-execute`.
+- Updated `harness-execute` bootstrap guidance to add strong-default
+  controller self-check moments and linked those moments from the review,
+  archive, and publish handoff references.
+- Updated `harness-land` to re-read the `Pre-Land` scan at merge time so land
+  still refreshes PR, CI, sync, and bookkeeping truth before merge-sensitive
+  work.
+- Synced the packaged `.agents` outputs and iterated through three finalize
+  review rounds until the controller-discipline story was internally
+  consistent.
+
+### Not Delivered
+
+- [#128](https://github.com/catu-ai/easyharness/issues/128): Decide later which
+  controller truth-surface checks have proved important enough to promote from
+  skill guidance to CLI hard gates.
+
+### Follow-Up Issues
+
+- [#128](https://github.com/catu-ai/easyharness/issues/128): Track whether any
+  controller truth-surface checks should graduate from workflow guidance to
+  CLI-enforced hard gates.

--- a/docs/plans/archived/2026-04-10-controller-discipline-truth-surface-checklist.md
+++ b/docs/plans/archived/2026-04-10-controller-discipline-truth-surface-checklist.md
@@ -226,8 +226,10 @@ actually matches the source and the accepted discovery direction.
 
 - `assets/bootstrap/skills/harness-execute/SKILL.md`
 - `assets/bootstrap/skills/harness-execute/references/`
+- `assets/bootstrap/skills/harness-land/SKILL.md`
 - `.agents/skills/harness-execute/SKILL.md`
 - `.agents/skills/harness-execute/references/`
+- `.agents/skills/harness-land/SKILL.md`
 
 #### Validation
 
@@ -286,6 +288,9 @@ finalize review of the packaged result.
 - Verified packaged sync with `scripts/sync-bootstrap-assets --check`.
 - Verified the tracked plan remained valid with `harness plan lint
   docs/plans/active/2026-04-10-controller-discipline-truth-surface-checklist.md`.
+- After reopening for revision 2 because `origin/main` advanced, merged
+  `origin/main` into the branch and reran focused validation with `go test
+  ./internal/lifecycle ./internal/plan ./internal/status`.
 
 ## Review Summary
 
@@ -300,19 +305,33 @@ finalize review of the packaged result.
   evidence submission, then a later `await_merge` status check.
 - `review-003-full` passed clean with no blocking or non-blocking findings
   after those two follow-up fixes.
+- Revision 2 reopened the archived candidate after `origin/main` advanced by
+  four commits and overlapped this slice's bootstrap and plan files.
+  `review-004-full` then found three blocking drift issues: stale revision-1
+  archive facts still left in the reopened active plan, a runtime archive next
+  action that still permitted merge before explicit human approval, and a small
+  Step 3 expected-files mismatch around the touched `harness-land` files.
+- `review-005-full` found two remaining revision-2 correctness drifts: the
+  reopened active plan still exposed archive-era facts as current state, and
+  the archive runtime next actions still skipped the publish-phase
+  publish/CI/sync evidence handoff.
+- `review-006-full` passed clean with no blocking or non-blocking findings
+  after those revision-2 plan and runtime truth-surface fixes.
 
 ## Archive Summary
 
-- Archived At: 2026-04-10T09:19:51+08:00
-- Revision: 1
-- PR: NONE
-- Ready: The candidate now packages a lean controller-only truth-surface
-  checklist, matching execute/land guidance, synchronized `.agents` outputs,
-  clean finalize review, and validation proving the review/archive/publish
-  sequence is internally consistent.
-- Merge Handoff: Archive this candidate, commit and push the archive move, open
-  or update the PR, record publish/CI/sync evidence for the archived
-  candidate, and then wait for explicit human merge approval before land.
+- Archived At: 2026-04-10T09:36:35+08:00
+- Revision: 2
+- Reopen History: Revision 1 was archived at `2026-04-10T09:19:51+08:00`, then
+  invalidated by remote drift from `origin/main` and reopened into revision 2.
+- PR: [#129](https://github.com/catu-ai/easyharness/pull/129)
+- Ready: Revision 2 now has a clean finalize full review after merging
+  `origin/main`, refreshing the active plan truth surfaces, tightening the
+  archive runtime next actions, and rerunning focused validation plus bootstrap
+  sync checks.
+- Merge Handoff: Commit and push the refreshed revision-2 archive plus
+  runtime/test updates, update PR #129, then record fresh publish, CI, and
+  sync evidence before waiting for explicit human merge approval.
 
 ## Outcome Summary
 
@@ -330,6 +349,9 @@ finalize review of the packaged result.
 - Synced the packaged `.agents` outputs and iterated through three finalize
   review rounds until the controller-discipline story was internally
   consistent.
+- Reopened the candidate for revision 2 after remote drift from `origin/main`,
+  merged the latest mainline changes, and completed the runtime and plan
+  truth-surface refresh needed for a clean re-archive.
 
 ### Not Delivered
 

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -209,7 +209,9 @@ func (s Service) Archive() Result {
 
 	nextActions := []NextAction{
 		{Command: nil, Description: "Commit and push the tracked plan change created by archiving before treating the candidate as truly waiting for merge approval."},
-		{Command: nil, Description: "Wait for human merge approval or merge manually from the PR once checks are green."},
+		{Command: nil, Description: "Open or update the PR and record publish evidence for the archived candidate while it remains in `execution/finalize/publish`."},
+		{Command: nil, Description: "Record CI and sync evidence before expecting the candidate to advance to `execution/finalize/await_merge`."},
+		{Command: nil, Description: "Wait for explicit human merge approval only after status reaches `execution/finalize/await_merge`; green checks alone do not authorize merge."},
 		{Command: nil, Description: "If new feedback or remote changes invalidate the archived candidate, reopen with `harness reopen --mode finalize-fix` for narrow repair or `harness reopen --mode new-step` when the change deserves a new unfinished step."},
 	}
 	if doc.UsesLightweightProfile() {

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -63,6 +63,18 @@ func TestArchiveMovesPlanAndUpdatesPointers(t *testing.T) {
 	if result.Artifacts == nil || result.Artifacts.FromSupplementsPath != "" || result.Artifacts.ToSupplementsPath != "" {
 		t.Fatalf("expected no supplements artifacts for markdown-only archive, got %#v", result.Artifacts)
 	}
+	if !containsActionDescription(result.NextAction, "Wait for explicit human merge approval only after status reaches `execution/finalize/await_merge`") {
+		t.Fatalf("expected explicit human-approval archive guidance, got %#v", result.NextAction)
+	}
+	if !containsActionDescription(result.NextAction, "record publish evidence for the archived candidate while it remains in `execution/finalize/publish`") {
+		t.Fatalf("expected publish-phase archive guidance, got %#v", result.NextAction)
+	}
+	if !containsActionDescription(result.NextAction, "Record CI and sync evidence before expecting the candidate to advance to `execution/finalize/await_merge`") {
+		t.Fatalf("expected CI/sync archive guidance, got %#v", result.NextAction)
+	}
+	if containsActionDescription(result.NextAction, "merge manually from the PR once checks are green") {
+		t.Fatalf("unexpected archive guidance that permits merge before approval: %#v", result.NextAction)
+	}
 	state, _, err := runstate.LoadState(root, "2026-03-18-archive-smoke")
 	if err != nil {
 		t.Fatalf("load state: %v", err)


### PR DESCRIPTION
## Summary
- add a controller-only `controller-truth-surfaces.md` checklist for `pre-review`, `pre-aggregate`, `pre-archive`, and `pre-land`
- wire the stable self-check moments into `harness-execute` review/archive/publish references and re-check `Pre-Land` from `harness-land`
- archive the tracked plan for this slice and record follow-up issue #128 for any future CLI hard-gate promotion work

## Validation
- `scripts/sync-bootstrap-assets`
- `scripts/sync-bootstrap-assets --check`
- `harness plan lint docs/plans/active/2026-04-10-controller-discipline-truth-surface-checklist.md`
- finalize reviews: `review-001-full`, `review-002-full`, `review-003-full`

## Follow-Up
- Closes none
- Related: #128
