### PR TITLE
[codex] Repair global fallback replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ By default the installer:
 - uses `~/.local/bin` by default
 - keeps parallel worktrees isolated by dispatching to the current worktree's
   `.local/bin/harness`
-- only updates the outside-source-tree fallback when you install with
+- only refreshes a healthy outside-source-tree fallback when you install with
   `--global`
+- self-heals an invalid outside-source-tree fallback during a normal install so
+  unrelated repositories stop dispatching to a broken fallback binary
 
 Useful options:
 

--- a/docs/plans/active/2026-04-10-repair-global-fallback-file-replacement.md
+++ b/docs/plans/active/2026-04-10-repair-global-fallback-file-replacement.md
@@ -151,8 +151,9 @@ repairs passed
 `go test ./tests/smoke -run TestInstallDevHarnessRepairsBrokenSymlinkGlobalFallback -count=1`,
 `go test ./tests/smoke -run TestInstallDevHarnessRepairsDirectorySymlinkGlobalFallback -count=1`,
 and a focused regression run over the fallback-repair smoke subset.
-No README change was needed because the user-facing install contract stayed the
-same; the repair only changes how the fallback file is replaced and validated.
+Updated `README.md` to clarify the final contract: healthy outside-source-tree
+fallbacks still only refresh on `--global`, while ordinary installs now
+self-heal invalid fallback paths.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-04-10-repair-global-fallback-file-replacement.md
+++ b/docs/plans/active/2026-04-10-repair-global-fallback-file-replacement.md
@@ -1,0 +1,201 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-10T09:43:51+08:00"
+source_type: direct_request
+source_refs:
+  - chat://current-session
+---
+
+# Repair Global Fallback Replacement And Health Checks
+
+## Goal
+
+Fix the dev installer so `scripts/install-dev-harness --global` truly replaces
+the global fallback binary used outside easyharness source trees instead of
+rewriting bytes in place on top of an existing file object that may remain
+unhealthy.
+
+This slice addresses the observed failure where
+`~/.local/share/easyharness/dev/harness` was byte-identical to a healthy
+worktree-local binary but still got killed when executed from an unrelated
+repository until the old path was removed and recreated with a new inode. The
+installer should replace the fallback atomically, verify that the final target
+is runnable, and repair an invalid existing fallback even during ordinary
+non-`--global` installs without regressing the explicit global ownership model
+introduced on 2026-04-08.
+
+## Scope
+
+### In Scope
+
+- Change global fallback writes in `scripts/install-dev-harness` from in-place
+  overwrite to same-directory temp-file replacement with an atomic rename.
+- Add a health check for the final fallback path so the installer validates the
+  executable it just installed, not only the worktree-local build output.
+- Repair an invalid existing global fallback during ordinary installs while
+  preserving the existing rule that healthy fallbacks are not refreshed unless
+  `--global` is requested.
+- Add smoke coverage for atomic replacement, invalid-fallback self-healing, and
+  continued preservation of healthy fallbacks.
+
+### Out of Scope
+
+- Changing wrapper dispatch rules between easyharness source trees and unrelated
+  repositories.
+- Broad redesign of development installation locations or fallback discovery.
+- Release-binary, Homebrew, or hosted distribution changes.
+
+## Acceptance Criteria
+
+- [ ] `scripts/install-dev-harness --global` replaces the global fallback via a
+      new file object rather than an in-place overwrite, and the final fallback
+      path passes a direct runnable health check.
+- [ ] Ordinary `scripts/install-dev-harness` keeps an existing healthy global
+      fallback untouched.
+- [ ] Ordinary `scripts/install-dev-harness` repairs an existing invalid global
+      fallback so the wrapper works again from a non-easyharness repository.
+- [ ] Installer smoke coverage demonstrates the atomic replacement path, the
+      invalid-fallback self-heal path, and the healthy-fallback preservation
+      path.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Make fallback refresh replace the final file object
+
+- Done: [x]
+
+#### Objective
+
+Refactor installer fallback writes so `--global` installs a newly created final
+file object and validates the resulting executable path after replacement.
+
+#### Details
+
+The current installer copies the worktree-local binary directly onto the global
+fallback path, which preserves the existing file object and was shown to leave
+an apparently unhealthy executable in place even when its bytes match a healthy
+binary. Write the fallback into a temp path inside the destination directory,
+set executable permissions there, atomically rename it into place, then run the
+health check against the final target path. If validation fails, the installer
+should exit with a clear error instead of silently reporting success.
+
+#### Expected Files
+
+- `scripts/install-dev-harness`
+
+#### Validation
+
+- `bash -n scripts/install-dev-harness`
+- Manual or automated proof that `--global` replaces the existing fallback with
+  a new file object and leaves the final path directly runnable.
+
+#### Execution Notes
+
+Changed `scripts/install-dev-harness` so global fallback refresh now writes to a
+same-directory temp file and atomically renames it into place, then validates
+the final fallback path with `--version` before reporting success. Focused
+validation passed with `bash -n scripts/install-dev-harness`,
+`go test ./tests/smoke -run TestInstallDevHarnessGlobalRefreshReplacesFallbackFileObject -count=1`,
+and a real reinstall plus `harness --version` from
+`/Users/yaozhang/Workspace/HEJI`, which now succeeds against
+`~/.local/share/easyharness/dev/harness`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This installer slice is reviewable only as the combined
+Step 1 + Step 2 candidate, so closeout review is deferred to Step 2.
+
+### Step 2: Cover self-healing and preserved healthy fallback behavior
+
+- Done: [x]
+
+#### Objective
+
+Extend smoke coverage so the installer contract explicitly covers invalid
+fallback repair without regressing the existing healthy-fallback preservation
+rule.
+
+#### Details
+
+Add a smoke test that seeds an invalid global fallback, runs ordinary
+`scripts/install-dev-harness`, and proves the wrapper works from an unrelated
+repository afterward. Keep or expand the existing preservation coverage so a
+healthy fallback still remains untouched without `--global`. If the execution
+flow or user-facing output changes materially, update README/help text to match
+the repaired installer semantics.
+
+#### Expected Files
+
+- `tests/smoke/install_dev_harness_test.go`
+- `README.md`
+
+#### Validation
+
+- `go test ./tests/smoke -run InstallDevHarness -count=1`
+- Review any updated install guidance for consistency with the actual script
+  behavior.
+
+#### Execution Notes
+
+Expanded installer smoke coverage with a new inode-replacement assertion for
+`--global` refresh and an invalid-fallback self-heal case for ordinary installs.
+The repair path passed
+`go test ./tests/smoke -run TestInstallDevHarnessRepairsInvalidExistingGlobalFallback -count=1`.
+No README change was needed because the user-facing install contract stayed the
+same; the repair only changes how the fallback file is replaced and validated.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run shell validation for the installer script after the fallback-write
+  changes.
+- Run the installer-focused smoke suite covering fallback refresh, fallback
+  preservation, and invalid-fallback repair.
+- Re-run `scripts/install-dev-harness` after Go or installer changes before
+  relying on direct `harness` invocations in this worktree.
+
+## Risks
+
+- Risk: The replacement flow could accidentally break the explicit 2026-04-08
+  contract that healthy global fallbacks are preserved unless `--global` is
+  used.
+  - Mitigation: Keep the refresh gate unchanged for healthy fallbacks and add
+    smoke coverage for preservation.
+- Risk: A temp-file-and-rename flow could leave partial artifacts behind or
+  validate the wrong path.
+  - Mitigation: Create the temp file in the destination directory, chmod before
+    rename, and run the health check against the final fallback path after the
+    rename.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-04-10-repair-global-fallback-file-replacement.md
+++ b/docs/plans/active/2026-04-10-repair-global-fallback-file-replacement.md
@@ -145,12 +145,27 @@ Expanded installer smoke coverage with a new inode-replacement assertion for
 `--global` refresh and an invalid-fallback self-heal case for ordinary installs.
 The repair path passed
 `go test ./tests/smoke -run TestInstallDevHarnessRepairsInvalidExistingGlobalFallback -count=1`.
+After step-closeout review surfaced symlink edge cases, added focused smoke
+coverage for both broken symlink and directory-symlink global fallbacks. Those
+repairs passed
+`go test ./tests/smoke -run TestInstallDevHarnessRepairsBrokenSymlinkGlobalFallback -count=1`,
+`go test ./tests/smoke -run TestInstallDevHarnessRepairsDirectorySymlinkGlobalFallback -count=1`,
+and a focused regression run over the fallback-repair smoke subset.
 No README change was needed because the user-facing install contract stayed the
 same; the repair only changes how the fallback file is replaced and validated.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` requested one blocking correctness fix because ordinary
+installs still skipped self-healing when the fallback path was a broken symlink.
+The repair broadened the invalid-fallback gate to include symlink paths and
+added `TestInstallDevHarnessRepairsBrokenSymlinkGlobalFallback`.
+`review-002-delta` then requested one blocking correctness fix because a
+directory-symlink fallback still caused `mv -f` to write into the linked
+directory instead of replacing the symlink entry. The repair now removes
+symlink targets before the final rename and adds
+`TestInstallDevHarnessRepairsDirectorySymlinkGlobalFallback`.
+`review-003-delta` passed cleanly after those fixes.
 
 ## Validation Strategy
 

--- a/docs/plans/archived/2026-04-10-repair-global-fallback-file-replacement.md
+++ b/docs/plans/archived/2026-04-10-repair-global-fallback-file-replacement.md
@@ -3,7 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-10T09:43:51+08:00"
 source_type: direct_request
 source_refs:
-  - chat://current-session
+    - chat://current-session
 ---
 
 # Repair Global Fallback Replacement And Health Checks
@@ -47,14 +47,14 @@ introduced on 2026-04-08.
 
 ## Acceptance Criteria
 
-- [ ] `scripts/install-dev-harness --global` replaces the global fallback via a
+- [x] `scripts/install-dev-harness --global` replaces the global fallback via a
       new file object rather than an in-place overwrite, and the final fallback
       path passes a direct runnable health check.
-- [ ] Ordinary `scripts/install-dev-harness` keeps an existing healthy global
+- [x] Ordinary `scripts/install-dev-harness` keeps an existing healthy global
       fallback untouched.
-- [ ] Ordinary `scripts/install-dev-harness` repairs an existing invalid global
+- [x] Ordinary `scripts/install-dev-harness` repairs an existing invalid global
       fallback so the wrapper works again from a non-easyharness repository.
-- [ ] Installer smoke coverage demonstrates the atomic replacement path, the
+- [x] Installer smoke coverage demonstrates the atomic replacement path, the
       invalid-fallback self-heal path, and the healthy-fallback preservation
       path.
 
@@ -192,25 +192,61 @@ symlink targets before the final rename and adds
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `bash -n scripts/install-dev-harness`
+- `go test ./tests/smoke -run TestInstallDevHarnessGlobalRefreshReplacesFallbackFileObject -count=1`
+- `go test ./tests/smoke -run TestInstallDevHarnessRepairsInvalidExistingGlobalFallback -count=1`
+- `go test ./tests/smoke -run TestInstallDevHarnessRepairsBrokenSymlinkGlobalFallback -count=1`
+- `go test ./tests/smoke -run TestInstallDevHarnessRepairsDirectorySymlinkGlobalFallback -count=1`
+- `go test ./tests/smoke -run TestInstallDevHarnessNormalInstallDoesNotReplaceExistingGlobalFallback -count=1`
+- Real repro validation:
+  - `scripts/install-dev-harness --global`
+  - `harness --version` from `/Users/yaozhang/Workspace/HEJI`
+    returned the global fallback path successfully after the replacement fix.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- `review-001-delta` found one blocking correctness issue: ordinary installs
+  skipped self-healing for broken fallback symlinks.
+- `review-002-delta` found one blocking correctness issue: directory-symlink
+  fallbacks were not replaced cleanly.
+- `review-003-delta` passed cleanly after the symlink fixes.
+- `review-004-full` found two blocking finalize issues: stale README/plan
+  wording about fallback updates and missing file-object preservation proof for
+  healthy fallbacks.
+- `review-005-full` passed cleanly after the README/plan clarification and the
+  healthy-fallback inode assertion.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-04-10T10:23:21+08:00
+- Revision: 1
+- PR: to be created immediately after archive from branch
+  `codex/repair-global-fallback-file-replacement`
+- Ready: finalize review `review-005-full` passed cleanly and the candidate is
+  ready to archive, publish, and wait for merge approval once publish/CI/sync
+  evidence is recorded.
+- Merge Handoff: archive the plan, push the branch, open the PR, record
+  publish/CI/sync evidence, and then wait for merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Replaced global fallback refresh with same-directory temp-file replacement,
+  final-path health checking, and direct verification of the installed fallback
+  binary.
+- Added ordinary-install self-healing for invalid fallback paths, including
+  broken symlinks and symlinks to directories.
+- Expanded installer smoke coverage for inode replacement, invalid fallback
+  repair, symlink repair, directory-symlink repair, and healthy-fallback
+  preservation via unchanged inode checks.
+- Updated README guidance and tracked plan notes to distinguish explicit
+  `--global` refresh of healthy fallbacks from ordinary-install repair of
+  invalid ones.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+None.
 
 ### Follow-Up Issues
 

--- a/docs/plans/archived/2026-04-10-repair-global-fallback-file-replacement.md
+++ b/docs/plans/archived/2026-04-10-repair-global-fallback-file-replacement.md
@@ -220,13 +220,13 @@ symlink targets before the final rename and adds
 
 - Archived At: 2026-04-10T10:23:21+08:00
 - Revision: 1
-- PR: to be created immediately after archive from branch
-  `codex/repair-global-fallback-file-replacement`
-- Ready: finalize review `review-005-full` passed cleanly and the candidate is
-  ready to archive, publish, and wait for merge approval once publish/CI/sync
-  evidence is recorded.
-- Merge Handoff: archive the plan, push the branch, open the PR, record
-  publish/CI/sync evidence, and then wait for merge approval.
+- PR: draft PR `https://github.com/catu-ai/easyharness/pull/132`
+- Ready: publish and sync evidence are recorded, CI evidence is `not_applied`
+  because the branch has no required checks, and the archived candidate is
+  ready to wait for merge approval.
+- Merge Handoff: keep the draft PR open on branch
+  `codex/repair-global-fallback-file-replacement` and wait for explicit human
+  merge approval before switching into `harness-land`.
 
 ## Outcome Summary
 

--- a/scripts/install-dev-harness
+++ b/scripts/install-dev-harness
@@ -145,6 +145,9 @@ replace_file_atomically() {
   rm -f "${tmp}"
   cp "${src}" "${tmp}"
   chmod 755 "${tmp}"
+  if [[ -L "${dst}" ]]; then
+    rm -f "${dst}"
+  fi
   mv -f "${tmp}" "${dst}"
 }
 

--- a/scripts/install-dev-harness
+++ b/scripts/install-dev-harness
@@ -322,7 +322,7 @@ global_fallback_repaired=0
 refresh_global_fallback=0
 if [[ "${install_global_fallback}" -eq 1 ]]; then
   refresh_global_fallback=1
-elif [[ -n "${global_fallback_path}" && -e "${global_fallback_path}" ]] && ! global_fallback_healthy "${global_fallback_path}"; then
+elif [[ -n "${global_fallback_path}" && ( -e "${global_fallback_path}" || -L "${global_fallback_path}" ) ]] && ! global_fallback_healthy "${global_fallback_path}"; then
   refresh_global_fallback=1
   global_fallback_repaired=1
 fi

--- a/scripts/install-dev-harness
+++ b/scripts/install-dev-harness
@@ -131,6 +131,23 @@ choose_global_fallback_path() {
   printf '%s\n' ""
 }
 
+global_fallback_healthy() {
+  local path="$1"
+  [[ -x "${path}" ]] || return 1
+  "${path}" --version >/dev/null 2>&1
+}
+
+replace_file_atomically() {
+  local src="$1"
+  local dst="$2"
+  local tmp="${dst}.tmp.$$"
+
+  rm -f "${tmp}"
+  cp "${src}" "${tmp}"
+  chmod 755 "${tmp}"
+  mv -f "${tmp}" "${dst}"
+}
+
 target_dir="$(choose_install_dir)"
 command_path="${target_dir}/harness"
 global_fallback_path="$(choose_global_fallback_path)"
@@ -301,7 +318,16 @@ build_args=("-o" "${binary_path}" "-ldflags" "${build_ldflags[*]}" "./cmd/harnes
 "${binary_path}" --help >/dev/null
 
 global_fallback_updated=0
+global_fallback_repaired=0
+refresh_global_fallback=0
 if [[ "${install_global_fallback}" -eq 1 ]]; then
+  refresh_global_fallback=1
+elif [[ -n "${global_fallback_path}" && -e "${global_fallback_path}" ]] && ! global_fallback_healthy "${global_fallback_path}"; then
+  refresh_global_fallback=1
+  global_fallback_repaired=1
+fi
+
+if [[ "${refresh_global_fallback}" -eq 1 ]]; then
   if [[ -z "${global_fallback_path}" ]]; then
     echo "Cannot install a global fallback without HOME set." >&2
     exit 1
@@ -317,8 +343,12 @@ if [[ "${install_global_fallback}" -eq 1 ]]; then
     exit 2
   fi
 
-  cp "${binary_path}" "${global_fallback_path}"
-  chmod 755 "${global_fallback_path}"
+  replace_file_atomically "${binary_path}" "${global_fallback_path}"
+  if ! global_fallback_healthy "${global_fallback_path}"; then
+    echo "Installed global fallback at ${global_fallback_path}, but the final path failed its health check." >&2
+    echo "Remove the file and rerun scripts/install-dev-harness --global if the problem persists." >&2
+    exit 1
+  fi
   global_fallback_updated=1
 fi
 
@@ -350,7 +380,11 @@ echo "Installed harness wrapper at ${command_path}"
 echo "Verified the repo-local binary directly at ${binary_path}"
 if [[ -n "${global_fallback_path}" ]]; then
   if [[ "${global_fallback_updated}" -eq 1 ]]; then
-    echo "Updated global fallback binary at ${global_fallback_path}"
+    if [[ "${global_fallback_repaired}" -eq 1 ]]; then
+      echo "Repaired invalid global fallback binary at ${global_fallback_path}"
+    else
+      echo "Updated global fallback binary at ${global_fallback_path}"
+    fi
   elif [[ -x "${global_fallback_path}" ]]; then
     echo "Global fallback binary remains at ${global_fallback_path}"
   else

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -662,6 +662,7 @@ func TestInstallDevHarnessNormalInstallDoesNotReplaceExistingGlobalFallback(t *t
 
 	globalFallback := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
 	writeFixtureFile(t, globalFallback, "#!/bin/sh\nprintf 'global-from-first\\n'\n", 0o755)
+	initialInode := fileInode(t, globalFallback)
 
 	secondInstall := runCommand(
 		t,
@@ -679,6 +680,9 @@ func TestInstallDevHarnessNormalInstallDoesNotReplaceExistingGlobalFallback(t *t
 	}
 
 	support.RequireContains(t, secondInstall.Stdout, "Global fallback binary remains at "+globalFallback)
+	if refreshedInode := fileInode(t, globalFallback); refreshedInode != initialInode {
+		t.Fatalf("expected healthy global fallback inode to remain %d, got %d", initialInode, refreshedInode)
+	}
 
 	wrapperPath := filepath.Join(installDir, "harness")
 	wrapperResult := runCommand(

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -335,6 +335,71 @@ func TestInstallDevHarnessRepairsBrokenSymlinkGlobalFallback(t *testing.T) {
 	support.RequireContains(t, versionResult.Stdout, "mode: dev")
 }
 
+func TestInstallDevHarnessRepairsDirectorySymlinkGlobalFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	tempHome := t.TempDir()
+	globalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
+	symlinkTargetDir := filepath.Join(tempHome, "fallback-dir")
+	if err := os.MkdirAll(filepath.Dir(globalFallback), 0o755); err != nil {
+		t.Fatalf("mkdir global fallback dir: %v", err)
+	}
+	if err := os.MkdirAll(symlinkTargetDir, 0o755); err != nil {
+		t.Fatalf("mkdir symlink target dir: %v", err)
+	}
+	if err := os.Symlink(symlinkTargetDir, globalFallback); err != nil {
+		t.Fatalf("create directory fallback symlink: %v", err)
+	}
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": tempHome,
+			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+	support.RequireContains(t, result.Stdout, "Repaired invalid global fallback binary at "+globalFallback)
+
+	info, err := os.Lstat(globalFallback)
+	if err != nil {
+		t.Fatalf("lstat repaired directory-symlink fallback: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("expected repaired fallback to replace the directory symlink")
+	}
+
+	targetEntries, err := os.ReadDir(symlinkTargetDir)
+	if err != nil {
+		t.Fatalf("read repaired symlink target dir: %v", err)
+	}
+	if len(targetEntries) != 0 {
+		t.Fatalf("expected repaired directory-symlink target dir to stay empty, found %d entries", len(targetEntries))
+	}
+
+	versionResult := runCommand(
+		t,
+		t.TempDir(),
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t),
+		}),
+		globalFallback,
+		"--version",
+	)
+	if versionResult.ExitCode != 0 {
+		t.Fatalf("repaired directory-symlink fallback version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
+	}
+	support.RequireContains(t, versionResult.Stdout, "mode: dev")
+}
+
 func TestInstallDevHarnessVerifiesPATHResolvedWrapperWhenInstallDirIsAlreadyOnPATH(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -282,6 +282,59 @@ func TestInstallDevHarnessRepairsInvalidExistingGlobalFallback(t *testing.T) {
 	}
 }
 
+func TestInstallDevHarnessRepairsBrokenSymlinkGlobalFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	tempHome := t.TempDir()
+	globalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
+	if err := os.MkdirAll(filepath.Dir(globalFallback), 0o755); err != nil {
+		t.Fatalf("mkdir global fallback dir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(tempHome, "missing-fallback"), globalFallback); err != nil {
+		t.Fatalf("create broken fallback symlink: %v", err)
+	}
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": tempHome,
+			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+	support.RequireContains(t, result.Stdout, "Repaired invalid global fallback binary at "+globalFallback)
+
+	info, err := os.Lstat(globalFallback)
+	if err != nil {
+		t.Fatalf("lstat repaired fallback: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("expected repaired fallback to replace the broken symlink")
+	}
+
+	versionResult := runCommand(
+		t,
+		t.TempDir(),
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t),
+		}),
+		globalFallback,
+		"--version",
+	)
+	if versionResult.ExitCode != 0 {
+		t.Fatalf("repaired broken-symlink fallback version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
+	}
+	support.RequireContains(t, versionResult.Stdout, "mode: dev")
+}
+
 func TestInstallDevHarnessVerifiesPATHResolvedWrapperWhenInstallDirIsAlreadyOnPATH(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/catu-ai/easyharness/tests/support"
@@ -131,6 +132,68 @@ func TestInstallDevHarnessGlobalDefaultsToUserLocalBinAndRefreshesFallback(t *te
 	support.RequireContains(t, refreshResult.Stdout, "Updated global fallback binary at "+expectedGlobalFallback)
 }
 
+func TestInstallDevHarnessGlobalRefreshReplacesFallbackFileObject(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	tempHome := t.TempDir()
+
+	initialResult := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": tempHome,
+			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--global",
+	)
+	if initialResult.ExitCode != 0 {
+		t.Fatalf("initial install-dev-harness --global failed with exit %d\nstdout:\n%s\nstderr:\n%s", initialResult.ExitCode, initialResult.Stdout, initialResult.Stderr)
+	}
+
+	globalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
+	initialInode := fileInode(t, globalFallback)
+	writeFixtureFile(t, globalFallback, "#!/bin/sh\nprintf 'stale-global\\n'\n", 0o755)
+
+	refreshResult := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": tempHome,
+			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--global",
+	)
+	if refreshResult.ExitCode != 0 {
+		t.Fatalf("refresh install-dev-harness --global failed with exit %d\nstdout:\n%s\nstderr:\n%s", refreshResult.ExitCode, refreshResult.Stdout, refreshResult.Stderr)
+	}
+
+	refreshedInode := fileInode(t, globalFallback)
+	if refreshedInode == initialInode {
+		t.Fatalf("expected --global refresh to replace the fallback file object, but inode stayed %d", refreshedInode)
+	}
+
+	versionResult := runCommand(
+		t,
+		t.TempDir(),
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t),
+		}),
+		globalFallback,
+		"--version",
+	)
+	if versionResult.ExitCode != 0 {
+		t.Fatalf("refreshed fallback version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
+	}
+	support.RequireContains(t, versionResult.Stdout, "mode: dev")
+}
+
 func TestInstallDevHarnessGlobalRejectsWrapperInstallDirConflict(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
@@ -168,6 +231,54 @@ func TestInstallDevHarnessGlobalRejectsWrapperInstallDirConflict(t *testing.T) {
 	}
 	if string(fallbackContents) != "#!/bin/sh\nprintf 'old-global\\n'\n" {
 		t.Fatalf("expected failed install to leave existing fallback untouched, got:\n%s", string(fallbackContents))
+	}
+}
+
+func TestInstallDevHarnessRepairsInvalidExistingGlobalFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	tempHome := t.TempDir()
+	globalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
+	if err := os.MkdirAll(filepath.Dir(globalFallback), 0o755); err != nil {
+		t.Fatalf("mkdir global fallback dir: %v", err)
+	}
+	writeFixtureFile(t, globalFallback, "#!/bin/sh\nkill -9 $$\n", 0o755)
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": tempHome,
+			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	wrapperPath := filepath.Join(tempHome, ".local", "bin", "harness")
+	support.RequireContains(t, result.Stdout, "Repaired invalid global fallback binary at "+globalFallback)
+
+	versionResult := runCommand(
+		t,
+		t.TempDir(),
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t),
+		}),
+		wrapperPath,
+		"--version",
+	)
+	if versionResult.ExitCode != 0 {
+		t.Fatalf("wrapper version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
+	}
+	support.RequireContains(t, versionResult.Stdout, "mode: dev")
+	if strings.Contains(versionResult.CombinedOutput(), "killed") {
+		t.Fatalf("expected repaired fallback to avoid killed output\nstdout:\n%s\nstderr:\n%s", versionResult.Stdout, versionResult.Stderr)
 	}
 }
 
@@ -789,6 +900,20 @@ func writeFixtureFile(t *testing.T, path, contents string, mode os.FileMode) {
 	if err := os.WriteFile(path, []byte(contents), mode); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
+}
+
+func fileInode(t *testing.T, path string) uint64 {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("expected syscall.Stat_t for %s, got %T", path, info.Sys())
+	}
+	return stat.Ino
 }
 
 func envWithOverrides(t *testing.T, overrides map[string]string) []string {


### PR DESCRIPTION
## What Changed

- switched global fallback refresh in `scripts/install-dev-harness` from in-place overwrite to temp-file replacement plus final-path health checking
- taught ordinary installs to self-heal invalid outside-source-tree fallbacks, including broken symlinks and symlinks to directories
- expanded installer smoke coverage for inode replacement, invalid-fallback repair, symlink repair, directory-symlink repair, and healthy-fallback preservation
- updated README and the archived plan notes to clarify that healthy fallbacks still only refresh on `--global`, while ordinary installs now repair invalid fallback paths

## Why

A real repro showed that `harness --version` in a non-easyharness repository could be killed even after rerunning `scripts/install-dev-harness --global` from the main worktree. The root cause was that the installer rewrote bytes in place on the existing global fallback path, preserving a bad file object instead of replacing it. Subsequent review rounds also uncovered symlink-shaped invalid fallback cases and a stale doc/test contract around healthy-fallback preservation.

## Impact

- non-easyharness repositories now recover cleanly when the global fallback path is invalid
- healthy global fallbacks remain untouched during ordinary installs
- installer behavior is covered by focused smoke tests that assert both replacement and preservation semantics

## Validation

- `bash -n scripts/install-dev-harness`
- `go test ./tests/smoke -run TestInstallDevHarnessGlobalRefreshReplacesFallbackFileObject -count=1`
- `go test ./tests/smoke -run TestInstallDevHarnessRepairsInvalidExistingGlobalFallback -count=1`
- `go test ./tests/smoke -run TestInstallDevHarnessRepairsBrokenSymlinkGlobalFallback -count=1`
- `go test ./tests/smoke -run TestInstallDevHarnessRepairsDirectorySymlinkGlobalFallback -count=1`
- `go test ./tests/smoke -run TestInstallDevHarnessNormalInstallDoesNotReplaceExistingGlobalFallback -count=1`
- real repro: `scripts/install-dev-harness --global` then `harness --version` from `/Users/yaozhang/Workspace/HEJI`
