### PR TITLE
Add plan size frontmatter and relax lightweight eligibility

### DIFF
--- a/.agents/skills/harness-plan/SKILL.md
+++ b/.agents/skills/harness-plan/SKILL.md
@@ -18,13 +18,24 @@ Use this skill to create or update the tracked plan that will drive execution.
 ## Workflow
 
 1. Start from `harness plan template` when creating a new plan.
+   - choose the plan `size` early and keep the estimate explicit in the
+     frontmatter
    - use `harness plan template --lightweight` only for explicitly approved,
-     tiny bounded low-risk work such as README/docs/comments/copy cleanup
+     `XXS` bounded low-risk work such as README/docs/comments/copy cleanup, a
+     very small CI condition tweak, or another tiny fix whose blast radius is
+     easy to explain
    - even in lightweight mode, keep the active plan under `docs/plans/active/`
      and use the field plus archive behavior to distinguish the profile
-   - if the slice touches behavior, normative contract meaning, release flow,
-     or another non-trivial risk surface, stay on the standard tracked-plan
-     path
+   - if the slice touches normative contract meaning, core runtime state,
+     review/archive/evidence semantics, release safety, security-sensitive
+     logic, or another non-trivial risk surface, stay on the standard
+     tracked-plan path
+   - if the initial estimate is `XXL`, stop and confirm with the human whether
+     the work should be split before approval; if the split is unclear, return
+     to discovery to decide how to split it
+   - if a human still approves `XXL`, move obvious spillover into
+     `Deferred Items` or follow-up issues instead of letting the oversized plan
+     quietly absorb extra scope
 2. Name the file with the plan-schema convention:
    `YYYY-MM-DD-clear-topic.md`.
 3. Make the topic meaningful and specific. It should tell a cold reader what is
@@ -34,6 +45,8 @@ Use this skill to create or update the tracked plan that will drive execution.
    - explicit scope and out-of-scope
    - acceptance criteria
    - reviewable work breakdown
+   - a `size` choice that matches the documented ladder and is explainable from
+     the plan itself
 5. Make the plan self-contained. Fold in decisions from discovery or prior
    discussion so another agent can execute from the plan plus repository state
    alone.
@@ -76,9 +89,13 @@ The plan is ready when:
 - the resulting tracked plan would resolve to `plan` until
   `harness execute start` is recorded
 - when the plan is lightweight, a future agent could still explain why
-  lightweight was eligible, know that archive snapshots move to
+  lightweight was eligible, know that lightweight is only for `XXS` work, know
+  that archive snapshots move to
   `.local/harness/plans/archived/<plan-stem>.md`, and know that archive-time
   breadcrumb guidance remains required
+- when the plan is sized `XXL`, the plan or approval handoff makes clear that
+  the human explicitly confirmed not splitting it further yet and that obvious
+  spillover moved into `Deferred Items` or follow-up issues where appropriate
 - if supplements exist, a future agent could tell what was absorbed into formal
   tracked locations before archive so the archived supplements are only backup
   context rather than a hidden dependency

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,12 +109,24 @@ requirement to leave a repo-visible breadcrumb such as a PR body note.
 
 Use `lightweight` only when all of these are true:
 
-- the whole slice is one bounded low-risk maintenance change
-- the edits are limited to README/docs/comments/copy or similarly
-  non-behavioral cleanup
-- no `harness` behavior, normative spec, state rule, persistence behavior,
-  release or CI workflow, or security-sensitive logic changes
+- the human explicitly approves using `workflow_profile: lightweight`
+- the plan is sized `XXS`
+- the whole slice is one bounded low-risk change
+- the edits stay within a narrow surface such as README/docs/comments/copy, a
+  small CI condition adjustment, a tiny helper-script fix, or another similarly
+  small change whose blast radius is easy to explain
+- no schema-meaning changes, core state/review/archive/evidence changes,
+  release-safety changes, or security-sensitive logic changes
 - if the boundary is unclear, default to `standard`
+
+When drafting a new plan, estimate `size` early. If the initial estimate is
+`XXL`, stop and confirm with the human whether the work should be split first;
+if the split is unclear, return to discovery to settle a better split before
+execution approval. If the work still proceeds as `XXL`, move obvious spillover
+into `Deferred Items` or follow-up issues instead of letting the oversized plan
+quietly absorb extra scope. `XXL` remains available for truthful historical
+sizing and rare coherent large slices, but it should not be the routine
+starting point for new work.
 
 Use `harness reopen --mode finalize-fix|new-step` when an archived candidate
 is no longer merge-ready because of new feedback, remote changes, or other

--- a/README.md
+++ b/README.md
@@ -319,18 +319,32 @@ available.
 
 Use `lightweight` only when all of these are true:
 
-- the whole slice is one bounded low-risk maintenance change
-- the edits are limited to README/docs/comments/copy or similarly
-  non-behavioral cleanup
-- no `harness` behavior, normative spec, state rule, persistence behavior,
-  release or CI workflow, or security-sensitive logic changes
+- the human explicitly approves using `workflow_profile: lightweight`
+- the plan is sized `XXS`
+- the whole slice is one bounded low-risk change
+- the edits stay within a narrow surface such as README/docs/comments/copy,
+  a small CI condition adjustment, a tiny helper-script fix, or another
+  similarly small change whose blast radius is easy to explain
+- no schema-meaning changes, core state/review/archive/evidence changes,
+  release-safety changes, or security-sensitive logic changes
 - if the boundary is unclear, default to `standard`
 
-In practice, lightweight is for tiny bounded low-risk changes such as README
-wording, doc clarification, comment cleanup, or similarly narrow non-behavioral
-metadata fixes. If the change touches CLI behavior, runtime state, review or
-archive semantics, release flow, or any normative contract meaning, use the
-standard tracked-plan path instead.
+In practice, lightweight is for explicitly approved `XXS` slices: tiny bounded
+low-risk changes such as README wording, doc clarification, comment cleanup, a
+very small CI condition tweak, or another narrowly scoped fix whose risk is
+easy to explain. Small size alone is not enough. If the change touches
+normative contract meaning, core runtime state, review or archive semantics,
+release safety, or another non-trivial risk surface, use the standard
+tracked-plan path instead.
+
+When drafting a new plan, estimate `size` early. If the initial estimate is
+`XXL`, stop and confirm with the human whether the work should be split first;
+if the split is not obvious, go back through discovery to settle the split
+before execution approval. If the work still proceeds as `XXL`, move obvious
+spillover into `Deferred Items` or follow-up issues instead of letting the
+oversized plan quietly absorb extra scope. `XXL` is allowed for historical
+truth and rare coherent large slices, but it should not be the routine
+starting point for new work.
 
 If an archived candidate becomes invalid before merge, reopen it with
 `harness reopen --mode finalize-fix` for narrow repair or

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -42,12 +42,24 @@ requirement to leave a repo-visible breadcrumb such as a PR body note.
 
 Use `lightweight` only when all of these are true:
 
-- the whole slice is one bounded low-risk maintenance change
-- the edits are limited to README/docs/comments/copy or similarly
-  non-behavioral cleanup
-- no `harness` behavior, normative spec, state rule, persistence behavior,
-  release or CI workflow, or security-sensitive logic changes
+- the human explicitly approves using `workflow_profile: lightweight`
+- the plan is sized `XXS`
+- the whole slice is one bounded low-risk change
+- the edits stay within a narrow surface such as README/docs/comments/copy, a
+  small CI condition adjustment, a tiny helper-script fix, or another similarly
+  small change whose blast radius is easy to explain
+- no schema-meaning changes, core state/review/archive/evidence changes,
+  release-safety changes, or security-sensitive logic changes
 - if the boundary is unclear, default to `standard`
+
+When drafting a new plan, estimate `size` early. If the initial estimate is
+`XXL`, stop and confirm with the human whether the work should be split first;
+if the split is unclear, return to discovery to settle a better split before
+execution approval. If the work still proceeds as `XXL`, move obvious spillover
+into `Deferred Items` or follow-up issues instead of letting the oversized plan
+quietly absorb extra scope. `XXL` remains available for truthful historical
+sizing and rare coherent large slices, but it should not be the routine
+starting point for new work.
 
 Use `harness reopen --mode finalize-fix|new-step` when an archived candidate
 is no longer merge-ready because of new feedback, remote changes, or other

--- a/assets/bootstrap/skills/harness-plan/SKILL.md
+++ b/assets/bootstrap/skills/harness-plan/SKILL.md
@@ -18,13 +18,24 @@ Use this skill to create or update the tracked plan that will drive execution.
 ## Workflow
 
 1. Start from `harness plan template` when creating a new plan.
+   - choose the plan `size` early and keep the estimate explicit in the
+     frontmatter
    - use `harness plan template --lightweight` only for explicitly approved,
-     tiny bounded low-risk work such as README/docs/comments/copy cleanup
+     `XXS` bounded low-risk work such as README/docs/comments/copy cleanup, a
+     very small CI condition tweak, or another tiny fix whose blast radius is
+     easy to explain
    - even in lightweight mode, keep the active plan under `docs/plans/active/`
      and use the field plus archive behavior to distinguish the profile
-   - if the slice touches behavior, normative contract meaning, release flow,
-     or another non-trivial risk surface, stay on the standard tracked-plan
-     path
+   - if the slice touches normative contract meaning, core runtime state,
+     review/archive/evidence semantics, release safety, security-sensitive
+     logic, or another non-trivial risk surface, stay on the standard
+     tracked-plan path
+   - if the initial estimate is `XXL`, stop and confirm with the human whether
+     the work should be split before approval; if the split is unclear, return
+     to discovery to decide how to split it
+   - if a human still approves `XXL`, move obvious spillover into
+     `Deferred Items` or follow-up issues instead of letting the oversized plan
+     quietly absorb extra scope
 2. Name the file with the plan-schema convention:
    `YYYY-MM-DD-clear-topic.md`.
 3. Make the topic meaningful and specific. It should tell a cold reader what is
@@ -34,6 +45,8 @@ Use this skill to create or update the tracked plan that will drive execution.
    - explicit scope and out-of-scope
    - acceptance criteria
    - reviewable work breakdown
+   - a `size` choice that matches the documented ladder and is explainable from
+     the plan itself
 5. Make the plan self-contained. Fold in decisions from discovery or prior
    discussion so another agent can execute from the plan plus repository state
    alone.
@@ -76,9 +89,13 @@ The plan is ready when:
 - the resulting tracked plan would resolve to `plan` until
   `harness execute start` is recorded
 - when the plan is lightweight, a future agent could still explain why
-  lightweight was eligible, know that archive snapshots move to
+  lightweight was eligible, know that lightweight is only for `XXS` work, know
+  that archive snapshots move to
   `.local/harness/plans/archived/<plan-stem>.md`, and know that archive-time
   breadcrumb guidance remains required
+- when the plan is sized `XXL`, the plan or approval handoff makes clear that
+  the human explicitly confirmed not splitting it further yet and that obvious
+  spillover moved into `Deferred Items` or follow-up issues where appropriate
 - if supplements exist, a future agent could tell what was absorbed into formal
   tracked locations before archive so the archived supplements are only backup
   context rather than a hidden dependency

--- a/assets/templates/plan-template.md
+++ b/assets/templates/plan-template.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: REPLACE_WITH_RFC3339_TIMESTAMP
 source_type: direct_request
 source_refs: []
+size: REPLACE_WITH_PLAN_SIZE
 ---
 
 # Replace With Plan Title

--- a/docs/plans/active/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md
+++ b/docs/plans/active/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-10T23:19:20+08:00"
 source_type: direct_request
 source_refs: []
+size: L
 ---
 
 # Add plan size frontmatter and relax lightweight eligibility
@@ -341,6 +342,8 @@ with the schema, template, and lint changes in the final candidate review.
 
 ## Validation Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - Ran `scripts/sync-bootstrap-assets` after the bootstrap guidance edits so
   `.agents/skills/harness-plan/SKILL.md` and the managed block in `AGENTS.md`
   stayed aligned with `assets/bootstrap/`.
@@ -360,6 +363,8 @@ with the schema, template, and lint changes in the final candidate review.
   `COUNT=0` failures.
 
 ## Review Summary
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Finalize review `review-001-full` found a blocking tests gap around missing
   negative coverage for invalid size handling and the lack of a durable
@@ -381,6 +386,8 @@ with the schema, template, and lint changes in the final candidate review.
 
 ## Archive Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - Archived At: 2026-04-11T00:13:20+08:00
 - Revision: 1
 - PR: `#138` (`https://github.com/catu-ai/easyharness/pull/138`)
@@ -396,6 +403,8 @@ with the schema, template, and lint changes in the final candidate review.
 ## Outcome Summary
 
 ### Delivered
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Added required tracked-plan frontmatter `size` support with the initial
   ladder `XXS`, `XS`, `S`, `M`, `L`, `XL`, and `XXL`.
@@ -414,6 +423,8 @@ with the schema, template, and lint changes in the final candidate review.
 
 ### Not Delivered
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - This slice did not remove `workflow_profile: lightweight` as a separate
   planning surface.
 - This slice did not add automatic size suggestion or inference to
@@ -421,7 +432,10 @@ with the schema, template, and lint changes in the final candidate review.
 
 ### Follow-Up Issues
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - #136 Revisit whether lightweight should remain a distinct workflow profile
   after size backfill (`https://github.com/catu-ai/easyharness/issues/136`)
 - #137 Consider suggesting candidate plan sizes from plan structure and the
   backfilled corpus (`https://github.com/catu-ai/easyharness/issues/137`)
+

--- a/docs/plans/archived/2026-03-17-superharness-cli-and-plan-foundations.md
+++ b/docs/plans/archived/2026-03-17-superharness-cli-and-plan-foundations.md
@@ -1,12 +1,9 @@
 ---
-status: archived
-lifecycle: awaiting_merge_approval
-revision: 3
 template_version: 0.1.0
 created_at: "2026-03-17T10:12:01+08:00"
-updated_at: "2026-03-18T22:13:16+08:00"
 source_type: direct_request
 source_refs: []
+size: XXL
 ---
 
 # Superharness v0.1 Foundations
@@ -85,7 +82,7 @@ core workflow.
 
 ### Step 1: Lock the planning and CLI contracts
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -124,7 +121,7 @@ review-round scope ownership, and step-local note placement.
 
 ### Step 2: Implement `harness plan template` and `harness plan lint`
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -187,7 +184,7 @@ follow-up negative tests and lint guards now cover those cases.
 
 ### Step 3: Implement local state and `harness status`
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -241,7 +238,7 @@ archiving instead of pointing back to already-written closeout summaries.
 
 ### Step 4: Implement the review-round contract
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -290,7 +287,7 @@ intended local-state contract.
 
 ### Step 5: Implement archive and reopen
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -342,7 +339,7 @@ plan pointer updates, and a clean active-plan lint result after reopen.
 
 ### Step 6: Address archive and reopen review feedback
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -387,7 +384,7 @@ stale-state cleanup on reopen.
 
 ### Step 7: Simplify review round identifiers
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -428,7 +425,7 @@ compact ID format.
 
 ### Step 8: Make archive review gating revision-aware
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 

--- a/docs/plans/archived/2026-03-18-readme-agents-and-skill-pack.md
+++ b/docs/plans/archived/2026-03-18-readme-agents-and-skill-pack.md
@@ -1,14 +1,11 @@
 ---
-status: archived
-lifecycle: awaiting_merge_approval
-revision: 3
 template_version: 0.1.0
 created_at: "2026-03-18T22:25:00+08:00"
-updated_at: "2026-03-19T23:26:43+08:00"
 source_type: issue
 source_refs:
     - '#5'
     - https://github.com/yzhang1918/superharness/pull/10
+size: L
 ---
 
 # Bootstrap README, AGENTS, and skill pack
@@ -91,7 +88,7 @@ contracts it is trying to establish.
 
 ### Step 1: Define the dogfoodable repository entrypoints
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -135,7 +132,7 @@ binary, and then confirms the repo build is the one the shell will run.
 
 ### Step 2: Add human-facing repository docs
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -174,7 +171,7 @@ reviewer skill boundary is explicit instead of only inferable from
 
 ### Step 3: Add the first repo-local skill pack
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -231,7 +228,7 @@ passed cleanly.
 
 ### Step 4: Dogfood the docs and skills against this repository
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -291,7 +288,7 @@ from this slice.
 
 ### Step 5: Address revision-2 review feedback for distribution-ready skills
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -361,7 +358,7 @@ to `harness review submit` only. That inconsistency was also fixed locally, and
 
 ### Step 6: Address revision-3 review feedback on skill wording and metadata
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 

--- a/docs/plans/archived/2026-03-19-review-round-sequence-allocation.md
+++ b/docs/plans/archived/2026-03-19-review-round-sequence-allocation.md
@@ -1,13 +1,10 @@
 ---
-status: archived
-lifecycle: awaiting_merge_approval
-revision: 1
 template_version: 0.1.0
 created_at: "2026-03-19T23:40:00+08:00"
-updated_at: "2026-03-19T23:51:41+08:00"
 source_type: issue
 source_refs:
     - '#9'
+size: S
 ---
 
 # Allocate review round IDs from the max existing sequence
@@ -63,7 +60,7 @@ hardening only the sequence allocator and the tests that define its behavior.
 
 ### Step 1: Harden compact review round sequence discovery
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -104,7 +101,7 @@ this plan's `Review Summary`.
 
 ### Step 2: Lock behavior with sparse-history tests
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -142,7 +139,7 @@ coverage in place.
 
 ### Step 3: Clarify mandatory reviewer-subagent orchestration
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 

--- a/docs/plans/archived/2026-03-20-archive-readiness-landed-status-and-execute-tdd.md
+++ b/docs/plans/archived/2026-03-20-archive-readiness-landed-status-and-execute-tdd.md
@@ -1,13 +1,10 @@
 ---
-status: archived
-lifecycle: awaiting_merge_approval
-revision: 3
 template_version: 0.1.0
 created_at: "2026-03-20T00:00:00+08:00"
-updated_at: "2026-03-20T23:30:31+08:00"
 source_type: issue
 source_refs:
     - '#13'
+size: XL
 ---
 
 # Surface archive blockers, archive handoff, landed status, and execute TDD discipline
@@ -91,7 +88,7 @@ TDD discipline for behavior changes.
 
 ### Step 1: Align archive, land, and execute contracts
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -144,7 +141,7 @@ this slice, then validated by `harness plan lint`, `go test ./internal/plan
 
 ### Step 2: Share archive-readiness evaluation between status and archive
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -195,7 +192,7 @@ both passed.
 
 ### Step 3: Represent landed worktrees as idle local state
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 
@@ -249,7 +246,7 @@ the direct post-install `harness status` smoke check.
 
 ### Step 4: Differentiate archived handoff from true merge-waiting state
 
-- Status: completed
+- Done: [x]
 
 #### Objective
 

--- a/docs/plans/archived/2026-03-21-canonical-node-state-model-cutover.md
+++ b/docs/plans/archived/2026-03-21-canonical-node-state-model-cutover.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-03-21T00:00:00+08:00"
 source_type: direct_request
 source_refs: []
+size: XXL
 ---
 
 # Cut over to the v0.2 canonical-node state model

--- a/docs/plans/archived/2026-03-22-automatic-review-closeout-and-status-reminders.md
+++ b/docs/plans/archived/2026-03-22-automatic-review-closeout-and-status-reminders.md
@@ -5,6 +5,7 @@ source_type: issue
 source_refs:
     - '#22'
     - '#28'
+size: XL
 ---
 
 # Clarify automatic review closeout and status reminders

--- a/docs/plans/archived/2026-03-22-repo-level-smoke-and-review-workflow-tests.md
+++ b/docs/plans/archived/2026-03-22-repo-level-smoke-and-review-workflow-tests.md
@@ -4,6 +4,7 @@ created_at: "2026-03-22T00:00:00+08:00"
 source_type: issue
 source_refs:
     - '#6'
+size: L
 ---
 
 # Add repo-level smoke and review workflow tests

--- a/docs/plans/archived/2026-03-23-alpha-binary-release-readiness.md
+++ b/docs/plans/archived/2026-03-23-alpha-binary-release-readiness.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-03-23T23:28:51+08:00"
 source_type: direct_request
 source_refs: []
+size: XL
 ---
 
 # Prepare the first alpha binary release

--- a/docs/plans/archived/2026-03-23-expand-repo-level-e2e-lifecycle-and-merge-handoff-coverage.md
+++ b/docs/plans/archived/2026-03-23-expand-repo-level-e2e-lifecycle-and-merge-handoff-coverage.md
@@ -5,6 +5,7 @@ source_type: issue
 source_refs:
     - '#6'
     - '#33'
+size: XXL
 ---
 
 # Expand repo-level E2E lifecycle and merge handoff coverage

--- a/docs/plans/archived/2026-03-23-harness-version-command.md
+++ b/docs/plans/archived/2026-03-23-harness-version-command.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-03-23T00:20:00+08:00"
 source_type: direct_request
 source_refs: []
+size: XXS
 ---
 
 # Add harness --version command

--- a/docs/plans/archived/2026-03-23-reject-non-active-review-aggregates.md
+++ b/docs/plans/archived/2026-03-23-reject-non-active-review-aggregates.md
@@ -4,6 +4,7 @@ created_at: "2026-03-23T23:10:00+08:00"
 source_type: issue
 source_refs:
     - '#7'
+size: M
 ---
 
 # Reject non-active review aggregate updates

--- a/docs/plans/archived/2026-03-25-fix-timestamp-fidelity-and-reissue-release.md
+++ b/docs/plans/archived/2026-03-25-fix-timestamp-fidelity-and-reissue-release.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-03-25T00:05:25+08:00"
 source_type: direct_request
 source_refs: []
+size: M
 ---
 
 # Fix timestamp fidelity for release artifacts and plan templates

--- a/docs/plans/archived/2026-03-26-move-repository-to-catu-ai-org.md
+++ b/docs/plans/archived/2026-03-26-move-repository-to-catu-ai-org.md
@@ -4,6 +4,7 @@ created_at: "2026-03-26T11:27:38+08:00"
 source_type: direct_request
 source_refs:
     - 'issue #44'
+size: XL
 ---
 
 # Move the repository into the catu-ai organization

--- a/docs/plans/archived/2026-03-26-protect-runstate-writes-with-atomic-saves-and-locks.md
+++ b/docs/plans/archived/2026-03-26-protect-runstate-writes-with-atomic-saves-and-locks.md
@@ -4,6 +4,7 @@ created_at: "2026-03-26T22:54:50+08:00"
 source_type: issue
 source_refs:
     - '#51'
+size: L
 ---
 
 # Protect runstate writes with atomic saves and state locks

--- a/docs/plans/archived/2026-03-26-rename-project-to-microharness.md
+++ b/docs/plans/archived/2026-03-26-rename-project-to-microharness.md
@@ -4,6 +4,7 @@ created_at: "2026-03-26T09:53:35+08:00"
 source_type: direct_request
 source_refs:
     - 'issue #45'
+size: L
 ---
 
 # Rename the project and repository to microharness

--- a/docs/plans/archived/2026-03-26-simplify-review-metadata-and-inference.md
+++ b/docs/plans/archived/2026-03-26-simplify-review-metadata-and-inference.md
@@ -4,6 +4,7 @@ created_at: "2026-03-26T18:21:04+08:00"
 source_type: direct_request
 source_refs:
     - '#50'
+size: XL
 ---
 
 # Simplify review metadata and infer structural closeout context

--- a/docs/plans/archived/2026-03-26-unify-review-summary-naming.md
+++ b/docs/plans/archived/2026-03-26-unify-review-summary-naming.md
@@ -4,6 +4,7 @@ created_at: "2026-03-26T00:00:00Z"
 source_type: issue
 source_refs:
     - '#52'
+size: XXS
 ---
 
 # Unify human-facing review title naming

--- a/docs/plans/archived/2026-03-29-rename-project-to-easyharness.md
+++ b/docs/plans/archived/2026-03-29-rename-project-to-easyharness.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-03-29T23:59:00+08:00"
 source_type: direct_request
 source_refs: []
+size: XL
 ---
 
 # Rename the project and repository to easyharness

--- a/docs/plans/archived/2026-03-30-add-homebrew-tap-distribution.md
+++ b/docs/plans/archived/2026-03-30-add-homebrew-tap-distribution.md
@@ -4,6 +4,7 @@ created_at: "2026-03-30T14:03:45+08:00"
 source_type: direct_request
 source_refs:
     - '#42'
+size: XL
 ---
 
 # Add Homebrew tap distribution for tagged releases

--- a/docs/plans/archived/2026-03-30-lightweight-workflow-for-low-risk-changes.md
+++ b/docs/plans/archived/2026-03-30-lightweight-workflow-for-low-risk-changes.md
@@ -4,6 +4,7 @@ created_at: "2026-03-30T23:57:22+08:00"
 source_type: issue
 source_refs:
     - '#69'
+size: XXL
 ---
 
 # Add a lightweight workflow for low-risk changes

--- a/docs/plans/archived/2026-03-31-bootstrap-repo-install-contract.md
+++ b/docs/plans/archived/2026-03-31-bootstrap-repo-install-contract.md
@@ -4,6 +4,7 @@ created_at: "2026-03-31T00:08:51+08:00"
 source_type: issue
 source_refs:
     - '#68'
+size: XL
 ---
 
 # Add a repeatable repository install flow for AGENTS delta and skills

--- a/docs/plans/archived/2026-03-31-centralize-contract-schemas-and-generated-reference-docs.md
+++ b/docs/plans/archived/2026-03-31-centralize-contract-schemas-and-generated-reference-docs.md
@@ -4,6 +4,7 @@ created_at: "2026-03-31T15:51:27+08:00"
 source_type: issue
 source_refs:
     - https://github.com/catu-ai/easyharness/issues/72
+size: M
 ---
 
 # Centralize contract schemas and generated reference docs

--- a/docs/plans/archived/2026-03-31-read-only-harness-ui-shell-and-status-foundation.md
+++ b/docs/plans/archived/2026-03-31-read-only-harness-ui-shell-and-status-foundation.md
@@ -6,6 +6,7 @@ source_refs:
     - '#2'
     - '#70'
     - https://github.com/catu-ai/easyharness/pull/86
+size: L
 ---
 
 # Build the read-only harness UI shell and live status foundation

--- a/docs/plans/archived/2026-03-31-unify-bootstrap-skill-source-and-drift-checks.md
+++ b/docs/plans/archived/2026-03-31-unify-bootstrap-skill-source-and-drift-checks.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-03-31T13:25:46+08:00"
 source_type: direct_request
 source_refs: []
+size: S
 ---
 
 # Unify bootstrap skill source and drift checks

--- a/docs/plans/archived/2026-04-01-add-review-finding-locations.md
+++ b/docs/plans/archived/2026-04-01-add-review-finding-locations.md
@@ -4,6 +4,7 @@ created_at: "2026-04-01T21:14:00+08:00"
 source_type: direct_request
 source_refs:
     - '#90'
+size: XS
 ---
 
 # Add location strings to review findings

--- a/docs/plans/archived/2026-04-01-allow-release-dispatch-from-version-tagging.md
+++ b/docs/plans/archived/2026-04-01-allow-release-dispatch-from-version-tagging.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-01T21:24:05+08:00"
 source_type: direct_request
 source_refs: []
+size: XS
 ---
 
 # Allow VERSION Tag Workflow To Dispatch Release

--- a/docs/plans/archived/2026-04-01-harness-ui-timeline-event-index.md
+++ b/docs/plans/archived/2026-04-01-harness-ui-timeline-event-index.md
@@ -4,6 +4,7 @@ created_at: "2026-04-01T21:14:39+08:00"
 source_type: issue
 source_refs:
     - '#93'
+size: XL
 ---
 
 # Hook real timeline data into the harness UI with a command-owned event index

--- a/docs/plans/archived/2026-04-01-version-file-driven-release-tagging.md
+++ b/docs/plans/archived/2026-04-01-version-file-driven-release-tagging.md
@@ -4,6 +4,7 @@ created_at: "2026-04-01T09:37:52+08:00"
 source_type: direct_request
 source_refs:
     - https://github.com/catu-ai/easyharness/issues/87
+size: M
 ---
 
 # Drive releases from a tracked VERSION file

--- a/docs/plans/archived/2026-04-02-hook-review-round-data-into-harness-ui.md
+++ b/docs/plans/archived/2026-04-02-hook-review-round-data-into-harness-ui.md
@@ -4,6 +4,7 @@ created_at: "2026-04-02T23:12:05+08:00"
 source_type: issue
 source_refs:
     - '#95'
+size: L
 ---
 
 # Hook review round data into the harness UI

--- a/docs/plans/archived/2026-04-03-discovery-explorer-subagent-contract.md
+++ b/docs/plans/archived/2026-04-03-discovery-explorer-subagent-contract.md
@@ -4,6 +4,7 @@ created_at: "2026-04-03T23:05:10+08:00"
 source_type: issue
 source_refs:
     - '#88'
+size: S
 ---
 
 # Define the discovery explorer-subagent contract

--- a/docs/plans/archived/2026-04-03-retire-diff-and-files-ui-placeholders.md
+++ b/docs/plans/archived/2026-04-03-retire-diff-and-files-ui-placeholders.md
@@ -4,6 +4,7 @@ created_at: "2026-04-03T23:22:00+08:00"
 source_type: issue
 source_refs:
     - '#91'
+size: S
 ---
 
 # Retire the Diff and Files UI placeholders

--- a/docs/plans/archived/2026-04-06-unify-harness-ui-workbench-and-topbar-status-strip.md
+++ b/docs/plans/archived/2026-04-06-unify-harness-ui-workbench-and-topbar-status-strip.md
@@ -4,6 +4,7 @@ created_at: "2026-04-06T22:24:18+08:00"
 source_type: issue
 source_refs:
     - '#94'
+size: XL
 ---
 
 # Unify the harness UI workbench model and topbar workflow summary

--- a/docs/plans/archived/2026-04-07-adopt-schema-driven-validation-for-command-inputs.md
+++ b/docs/plans/archived/2026-04-07-adopt-schema-driven-validation-for-command-inputs.md
@@ -4,6 +4,7 @@ created_at: "2026-04-07T23:36:44+08:00"
 source_type: issue
 source_refs:
     - https://github.com/catu-ai/easyharness/issues/75
+size: XL
 ---
 
 # Adopt schema-driven validation for structured JSON command inputs

--- a/docs/plans/archived/2026-04-08-add-clean-pass-explicit-repair-fallback-coverage.md
+++ b/docs/plans/archived/2026-04-08-add-clean-pass-explicit-repair-fallback-coverage.md
@@ -4,6 +4,7 @@ created_at: "2026-04-08T13:50:00Z"
 source_type: issue
 source_refs:
     - https://github.com/catu-ai/easyharness/issues/113
+size: XXS
 ---
 
 # Add clean-pass explicit repair fallback coverage

--- a/docs/plans/archived/2026-04-08-clarify-explicit-step-closeout-repair-semantics.md
+++ b/docs/plans/archived/2026-04-08-clarify-explicit-step-closeout-repair-semantics.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-08T20:44:26+08:00"
 source_type: direct_request
 source_refs: []
+size: S
 ---
 
 # Clarify explicit step closeout repair semantics

--- a/docs/plans/archived/2026-04-08-converge-lifecycle-outputs-on-v0-2-shared-envelope.md
+++ b/docs/plans/archived/2026-04-08-converge-lifecycle-outputs-on-v0-2-shared-envelope.md
@@ -4,6 +4,7 @@ created_at: "2026-04-08T10:00:00+08:00"
 source_type: issue
 source_refs:
     - https://github.com/catu-ai/easyharness/issues/110
+size: L
 ---
 
 # Converge lifecycle outputs on the v0.2 shared envelope

--- a/docs/plans/archived/2026-04-08-gate-finalize-on-earlier-step-closeout-debt.md
+++ b/docs/plans/archived/2026-04-08-gate-finalize-on-earlier-step-closeout-debt.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-08T22:47:47+08:00"
 source_type: direct_request
 source_refs: []
+size: M
 ---
 
 # Gate finalize on earlier-step closeout debt

--- a/docs/plans/archived/2026-04-08-global-fallback-dev-wrapper.md
+++ b/docs/plans/archived/2026-04-08-global-fallback-dev-wrapper.md
@@ -4,6 +4,7 @@ created_at: "2026-04-08T22:27:00+08:00"
 source_type: direct_request
 source_refs:
     - chat://current-session
+size: S
 ---
 
 # Add Explicit Global Fallback Control To Dev Wrapper Install

--- a/docs/plans/archived/2026-04-08-make-land-bookkeeping-required.md
+++ b/docs/plans/archived/2026-04-08-make-land-bookkeeping-required.md
@@ -4,6 +4,7 @@ created_at: "2026-04-08T20:43:52+08:00"
 source_type: issue
 source_refs:
     - https://github.com/catu-ai/easyharness/issues/16
+size: S
 ---
 
 # Make Harness-Land Post-Merge Bookkeeping Required

--- a/docs/plans/archived/2026-04-09-delta-review-anchor-and-agent-protocol.md
+++ b/docs/plans/archived/2026-04-09-delta-review-anchor-and-agent-protocol.md
@@ -4,6 +4,7 @@ created_at: "2026-04-09T22:19:30+08:00"
 source_type: direct_request
 source_refs:
     - '#89'
+size: XL
 ---
 
 # Delta review anchor and agent protocol

--- a/docs/plans/archived/2026-04-09-fix-workbench-scroll-boundaries.md
+++ b/docs/plans/archived/2026-04-09-fix-workbench-scroll-boundaries.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-09T21:13:00+08:00"
 source_type: direct_request
 source_refs: []
+size: M
 ---
 
 # Fix harness UI workbench scroll boundaries so panes scroll without moving the whole page

--- a/docs/plans/archived/2026-04-09-shrink-state-json-to-control-plane-only.md
+++ b/docs/plans/archived/2026-04-09-shrink-state-json-to-control-plane-only.md
@@ -4,6 +4,7 @@ created_at: "2026-04-09T09:36:00+08:00"
 source_type: direct_request
 source_refs:
     - '#58'
+size: L
 ---
 
 # Shrink `state.json` to control-plane-only runtime state

--- a/docs/plans/archived/2026-04-09-treat-tracked-plans-as-packages-with-supplements.md
+++ b/docs/plans/archived/2026-04-09-treat-tracked-plans-as-packages-with-supplements.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-09T23:13:09+08:00"
 source_type: direct_request
 source_refs: []
+size: L
 ---
 
 # Treat tracked plans as packages with supplements

--- a/docs/plans/archived/2026-04-10-add-current-plan-browser-page.md
+++ b/docs/plans/archived/2026-04-10-add-current-plan-browser-page.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-10T09:43:25+08:00"
 source_type: direct_request
 source_refs: []
+size: XL
 ---
 
 # Add a current-plan browser page to harness UI

--- a/docs/plans/archived/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md
+++ b/docs/plans/archived/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md
@@ -342,8 +342,6 @@ with the schema, template, and lint changes in the final candidate review.
 
 ## Validation Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 - Ran `scripts/sync-bootstrap-assets` after the bootstrap guidance edits so
   `.agents/skills/harness-plan/SKILL.md` and the managed block in `AGENTS.md`
   stayed aligned with `assets/bootstrap/`.
@@ -361,10 +359,18 @@ UPDATE_REQUIRED_AFTER_REOPEN
   sizes and migrating four legacy archived plans away from obsolete runtime
   frontmatter and `- Status:` markers, the final sweep completed with
   `COUNT=0` failures.
+- After PR `#138` CI failed on revision 1, reinstalled the repo-local
+  `harness` binary with `scripts/install-dev-harness` so later lifecycle
+  commands used the current Go CLI instead of a stale pre-size build.
+- For revision 2 finalize-fix repair, ran
+  `go test ./internal/lifecycle ./internal/plan` to cover the archive/reopen
+  lifecycle path plus tracked-plan lint expectations after restoring size to
+  the reopened candidate.
+- Ran
+  `go test ./tests/smoke -run TestPlanTemplateAndLintRoundTrip -count=1` to
+  prove the smoke round-trip now passes with explicit `--size M`.
 
 ## Review Summary
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Finalize review `review-001-full` found a blocking tests gap around missing
   negative coverage for invalid size handling and the lack of a durable
@@ -383,28 +389,33 @@ UPDATE_REQUIRED_AFTER_REOPEN
   block still only implied that gate.
 - Finalize review `review-005-full` passed cleanly with no blocking or
   non-blocking findings after the last tests and docs repairs.
+- Post-archive PR `#138` CI then failed on two missed test surfaces: the
+  archived revision-1 candidate had been created with a stale pre-size
+  `harness` binary and lost `size` in frontmatter, and
+  `tests/smoke/TestPlanTemplateAndLintRoundTrip` still authored a plan without
+  an explicit `--size` flag.
+- Delta finalize review `review-006-delta`, anchored at commit
+  `86bc0f273483d533748464622f2d7a08a6f2104e`, passed cleanly with no blocking
+  or non-blocking findings after the revision-2 reopen repair added the smoke
+  size fix and archive size-preservation regression coverage.
 
 ## Archive Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
-- Archived At: 2026-04-11T00:13:20+08:00
-- Revision: 1
+- Archived At: 2026-04-11T00:30:51+08:00
+- Revision: 2
 - PR: `#138` (`https://github.com/catu-ai/easyharness/pull/138`)
-- Ready: The archived candidate is published to PR `#138`, has a clean full
-  finalize review (`review-005-full`), active-plan lint is green, focused plus
-  broader validation passed, and the remaining deferred scope is handed off to
-  issues `#136` and `#137`.
-- Merge Handoff: Record publish evidence for PR `#138`, wait for the
-  post-archive checks on branch `codex/plan-size-frontmatter`, refresh sync
-  against `origin/main`, and keep the candidate in publish handoff until
-  `harness status` advances to `execution/finalize/await_merge`.
+- Ready: The archived revision-2 candidate repairs the failed revision-1 CI
+  run by restoring the missing archived-plan size frontmatter, fixing the
+  smoke authoring path to pass an explicit size, and carrying a clean delta
+  finalize review (`review-006-delta`) plus focused local validation.
+- Merge Handoff: Push the refreshed branch to PR `#138`, refresh
+  publish/CI/sync evidence for the new head commit, and keep the candidate in
+  publish handoff until `harness status` advances to
+  `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Added required tracked-plan frontmatter `size` support with the initial
   ladder `XXS`, `XS`, `S`, `M`, `L`, `XL`, and `XXL`.
@@ -420,10 +431,12 @@ UPDATE_REQUIRED_AFTER_REOPEN
 - Backfilled `size` across the tracked plan corpus and migrated four legacy
   archived plans off obsolete runtime frontmatter so the whole tracked plan set
   is lint-clean under the new schema.
+- Reopened the archived candidate after CI failure, restored `size: L` to the
+  revision-2 candidate, fixed the smoke template round-trip to pass an
+  explicit size, and added lifecycle regression coverage that archive
+  preserves size frontmatter.
 
 ### Not Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - This slice did not remove `workflow_profile: lightweight` as a separate
   planning surface.
@@ -432,10 +445,7 @@ UPDATE_REQUIRED_AFTER_REOPEN
 
 ### Follow-Up Issues
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 - #136 Revisit whether lightweight should remain a distinct workflow profile
   after size backfill (`https://github.com/catu-ai/easyharness/issues/136`)
 - #137 Consider suggesting candidate plan sizes from plan structure and the
   backfilled corpus (`https://github.com/catu-ai/easyharness/issues/137`)
-

--- a/docs/plans/archived/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md
+++ b/docs/plans/archived/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md
@@ -1,0 +1,427 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-10T23:19:20+08:00"
+source_type: direct_request
+source_refs: []
+---
+
+# Add plan size frontmatter and relax lightweight eligibility
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Add a required `size` field to tracked plan frontmatter so every plan carries a
+durable t-shirt estimate that future agents and humans can read without
+recovering intent from chat history. The first version should keep the size
+model simple, repository-backed, and backfilled across the tracked plan
+history that already lives in git.
+
+Relax `lightweight` eligibility so the profile is no longer limited to docs or
+copy-only work. `size` must still describe work magnitude rather than risk,
+but `XXS` plans should become eligible to use `lightweight` when the slice is
+truly tiny and bounded. At the same time, very large work should be called out
+explicitly so `XXL` becomes a signal to split scope or defer follow-up issues
+rather than a routine planning default.
+
+## Scope
+
+### In Scope
+
+- Define a required top-level `size` frontmatter field for tracked plans.
+- Define the supported size ladder for the initial rollout:
+  `XXS`, `XS`, `S`, `M`, `L`, `XL`, `XXL`.
+- Document a durable meaning for each size so future agents can size new plans
+  and backfill historical plans consistently.
+- Update `lightweight` guidance so `XXS` plans may use the lightweight profile
+  without making size alone the only risk gate.
+- Add guidance that `XXL` work is discouraged and should normally justify why
+  it was not split further, with explicit human confirmation at plan creation
+  time and deferred follow-up captured explicitly when appropriate.
+- Update plan template, parsing, linting, and related tests so the new field is
+  first-class in the CLI contract.
+- Backfill `size` across tracked plans in `docs/plans/`, including the current
+  active plan created for this slice.
+- Update the harness-managed planning guidance in bootstrap assets and sync the
+  generated `.agents/` and managed `AGENTS.md` materialized output.
+
+### Out of Scope
+
+- Changing workflow choice to be determined by `size` alone.
+- Introducing `XXXL` or a larger ladder unless implementation uncovers a
+  repository-backed need that contradicts current discovery evidence.
+- Automatically splitting existing large historical plans into new plan files.
+- Adding a new archive format or replacing `workflow_profile: lightweight`
+  with a second workflow object.
+- Backfilling disposable local archives under `.local/`.
+
+## Acceptance Criteria
+
+- [x] `docs/specs/plan-schema.md` defines required frontmatter `size`, accepts
+      exactly `XXS`, `XS`, `S`, `M`, `L`, `XL`, and `XXL`, and explains the
+      meaning of each size clearly enough for future agents to classify plans
+      without chat-only context.
+- [x] `harness plan template` and `harness plan lint` treat `size` as a
+      first-class field, and focused automated tests cover valid, invalid, and
+      omitted-size cases.
+- [x] The `lightweight` eligibility docs and planning skill guidance explicitly
+      allow `XXS` plans to use `lightweight` while preserving the rule that
+      small size does not automatically make a change low-risk.
+- [x] Planning guidance documents `XXL` as discouraged by default and explains
+      that large plans should justify why they were not split further, require
+      explicit human confirmation when first sized as `XXL`, and move
+      obviously deferrable scope into `Deferred Items` or follow-up issues.
+- [x] Every tracked plan under `docs/plans/active/` and `docs/plans/archived/`
+      in this repository carries an explicitly chosen `size` value, and the
+      resulting set passes `harness plan lint`.
+
+## Deferred Items
+
+- Revisit whether `lightweight` remains a distinct field once the repository
+  has real history using `size` plus the relaxed `XXS` eligibility rule.
+- Consider whether a future planner-facing command should suggest a candidate
+  `size` automatically from plan structure once the backfilled corpus exists.
+
+## Work Breakdown
+
+### Step 1: Define the size and workflow contract
+
+- Done: [x]
+
+#### Objective
+
+Write the durable repository contract for plan size, the initial size ladder,
+the relaxed `XXS` lightweight rule, and the discouraged-by-default `XXL`
+guidance.
+
+#### Details
+
+This step should encode the discovery decisions explicitly:
+- `size` measures work magnitude, not risk by itself
+- the supported ladder is `XXS` through `XXL`
+- `XXS` plans may use `lightweight`, but small size does not waive risk
+  judgment
+- `XXL` is allowed but should trigger an explicit explanation and serious
+  consideration of deferred follow-up scope
+- if a plan is sized `XXL` at creation time, the planning workflow should stop
+  and confirm with the human whether the slice should be split, potentially
+  returning to discovery to decide how to split it
+- planning guidance should include practical sizing heuristics, not only enum
+  names
+
+Because the repository dogsfoods bootstrap assets, update the bootstrap source
+files rather than hand-editing generated `.agents/skills/` guidance or the
+managed `AGENTS.md` block directly. Keep the normative rules in specs and the
+practical sizing heuristics in the planning skill/docs aligned.
+
+#### Expected Files
+
+- `docs/specs/plan-schema.md`
+- `docs/specs/cli-contract.md`
+- `README.md`
+- `assets/bootstrap/skills/harness-plan/SKILL.md`
+- `assets/bootstrap/agents-managed-block.md`
+- `AGENTS.md`
+- `.agents/skills/harness-plan/SKILL.md`
+
+#### Validation
+
+- The specs define the enum, meanings, `XXS` lightweight eligibility, and
+  `XXL` guidance without relying on discovery chat.
+- The planning skill tells a future agent how to choose a size in practice.
+- The planning workflow makes it explicit that an initial `XXL` estimate
+  requires human confirmation and may send the work back through discovery to
+  settle a better split.
+- `scripts/sync-bootstrap-assets` refreshes the generated skill and managed
+  `AGENTS.md` output cleanly after the bootstrap source changes.
+
+#### Execution Notes
+
+Defined `size` as a required t-shirt field in `docs/specs/plan-schema.md`,
+added the initial `XXS` through `XXL` ladder plus adjacent-size heuristics,
+and updated the lightweight rules so only `XXS` plans may use
+`workflow_profile: lightweight` while keeping explicit low-risk judgment.
+Documented that an initial `XXL` estimate is a planning warning that requires
+human confirmation and may send the work back through discovery to decide how
+to split it. Propagated the same guidance into `docs/specs/cli-contract.md`,
+`README.md`, `assets/bootstrap/skills/harness-plan/SKILL.md`, and
+`assets/bootstrap/agents-managed-block.md`, then ran
+`scripts/sync-bootstrap-assets` so `.agents/skills/harness-plan/SKILL.md` and
+the managed block in `AGENTS.md` stayed in sync with the bootstrap sources.
+Finalize review `review-002-full` later surfaced one remaining planner-facing
+drift: the schema already said `XXL` work should push obvious spillover into
+`Deferred Items` or follow-up issues, but the README and planning guidance
+only mentioned confirming or rediscovering the split. Updated the README,
+bootstrap guidance, and synced managed outputs so that `XXL` plans now carry
+that deferred-scope handoff explicitly wherever planners are likely to look.
+Finalize review `review-004-full` then caught one last operator-facing docs
+drift: the schema and planning skill already required explicit human approval
+for `workflow_profile: lightweight`, but the README and managed `AGENTS.md`
+block only implied approval through `XXS` plus low-risk wording. Added the
+explicit human-approval gate to the README and bootstrap-managed workflow
+guidance, then reran `scripts/sync-bootstrap-assets` so `AGENTS.md` and
+`.agents/skills/harness-plan/SKILL.md` matched the durable contract again.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 establishes the contract that Step 2 implements,
+so review is more meaningful once the template/lint/CLI behavior lands against
+the updated rules.
+
+### Step 2: Implement required size support in plan tooling
+
+- Done: [x]
+
+#### Objective
+
+Teach the plan template, parser, linting, and related tests to require and
+validate `size` as part of the tracked-plan schema.
+
+#### Details
+
+The implementation should make `size` a normal frontmatter field rather than a
+docs-only convention. Generated plans need an explicit way to carry `size`
+from the start, historical files with missing `size` must fail lint after the
+rollout, and invalid values must produce targeted lint errors. Keep the change
+clean: do not add compatibility shims, dual paths, or a hidden default that
+masks omitted sizing decisions.
+
+If command help or template seeding needs an explicit size flag, choose the
+clearest end-state directly and keep tests focused on authoring plus linting
+behavior.
+
+#### Expected Files
+
+- `assets/templates/plan-template.md`
+- `assets/templates/embed.go`
+- `cmd/harness/main.go`
+- `internal/plan/document.go`
+- `internal/plan/document_test.go`
+- `internal/plan/lint.go`
+- `internal/plan/lint_test.go`
+- `internal/plan/template.go`
+- `internal/plan/template_test.go`
+
+#### Validation
+
+- `harness plan template` emits plans with explicit `size` support and clear
+  authoring guidance.
+- `harness plan lint` rejects omitted or unsupported sizes with targeted
+  errors.
+- Focused Go tests cover template rendering, document parsing, and linting for
+  the new field.
+
+#### Execution Notes
+
+Added first-class size support in the plan tooling. `assets/templates/plan-template.md`
+now carries an explicit `size` frontmatter slot, `internal/plan/size.go`
+defines the supported ladder, `internal/plan/lint.go` requires `size` and
+rejects unsupported values, and `internal/plan/template.go` now keeps missing
+size explicit instead of silently defaulting it while making lightweight
+templates render with `size: XXS` and rejecting non-`XXS` lightweight input.
+`internal/cli/app.go` now exposes `--size` for `harness plan template`, and
+the impacted tests/fixtures/scripts were updated so valid plan fixtures seed a
+real size deliberately. Focused validation used `go test ./internal/plan
+./internal/cli`, plus broader impacted-package reruns across `internal/evidence`,
+`internal/lifecycle`, `internal/review`, `internal/status`, `internal/ui`, and
+`tests/e2e`. A `go test ./...` pass printed successful results for every
+package but did not return cleanly in this environment, so the impacted suites
+were rerun explicitly and passed. Finalize review `review-001-full` then asked
+for stronger negative coverage around missing/unsupported size values and the
+`XXS` lightweight rule, plus a durable regression check for the migrated
+archived corpus. Added template, lint, and CLI negative tests for those
+failure modes and a repository-backed archived-plan corpus lint test before
+rerunning the focused and broader suites successfully. Finalize review
+`review-002-full` then caught one remaining correctness gap: size validation
+was still normalizing case and surrounding whitespace instead of enforcing the
+documented enum exactly. Tightened the validator to accept only canonical
+spellings and expanded the repository-backed regression from archived plans to
+the full tracked active-plus-archived plan corpus before rerunning the focused
+and broader suites successfully again. Finalize review `review-003-full` then
+found one remaining tests gap: the lightweight path still was not asserting
+the raw emitted `size: XXS`, because the plan template unit helper could patch
+in the placeholder replacement after rendering and the CLI test only checked
+workflow profile plus step shape. Reworked the lightweight template unit test
+to assert the direct render output and extended the CLI lightweight test to
+assert `size: XXS` explicitly, then reran `go test ./internal/plan
+./internal/cli` and `go test ./tests/e2e` successfully before starting a
+fresh finalize review.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 and Step 3 materially depend on each other, so a
+full-candidate review is more meaningful than isolating tooling changes before
+the tracked corpus is backfilled and lint-clean.
+
+### Step 3: Backfill tracked plans and prove the repository state
+
+- Done: [x]
+
+#### Objective
+
+Assign sizes to the tracked plan corpus, update repository-visible examples,
+and prove the backfilled repository passes plan validation end to end.
+
+#### Details
+
+Use the agreed ladder and heuristics from Step 1 to backfill every tracked plan
+under `docs/plans/`. Preserve the existing historical content and only add the
+minimal frontmatter needed for `size` unless a nearby wording update is
+required to keep guidance consistent. The current active plan for this slice
+must also remain compliant with the new schema.
+
+This step should also backfill any spec or example snippets that show plan
+frontmatter so the docs do not keep teaching the old schema. If any historical
+plan truly looks like `XXL`, keep it valid but leave the durable guidance in
+place that such size should normally push future work toward splitting and
+deferred follow-up. The stronger human-confirmation rule applies to newly
+planned work; historical `XXL` plans only need accurate backfilled sizing plus
+the updated durable guidance.
+
+#### Expected Files
+
+- `docs/plans/active/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md`
+- `docs/plans/archived/*.md`
+- `docs/specs/plan-schema.md`
+- `README.md`
+
+#### Validation
+
+- Every tracked plan in `docs/plans/active/` and `docs/plans/archived/` has a
+  valid `size`.
+- Repository examples and schema snippets match the new frontmatter shape.
+- `harness plan lint` passes on the touched tracked plans, and focused checks
+  make it hard to miss an un-backfilled file.
+
+#### Execution Notes
+
+Backfilled `size` across every tracked archived plan under `docs/plans/archived/`
+and kept those edits minimal to frontmatter. The current active plan already
+carried `size: L`. During full-corpus validation, four early archived v0.1
+plans surfaced pre-existing lint debt because they still carried legacy
+runtime frontmatter fields and `- Status:` step markers. Migrated those four
+plans to the current lint-compatible archived shape by removing the obsolete
+runtime frontmatter keys and converting completed step markers to `- Done: [x]`
+without changing the historical execution notes or summaries. After that
+cleanup, a repository-wide loop over `docs/plans/active/*.md` and
+`docs/plans/archived/*.md` completed with `COUNT=0` lint failures.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: The historical backfill is easiest to assess together
+with the schema, template, and lint changes in the final candidate review.
+
+## Validation Strategy
+
+- Use focused Go tests for template, parsing, and lint behavior while the field
+  is introduced.
+- Rerun bootstrap sync after source-asset edits so generated guidance stays in
+  lockstep with the tracked sources.
+- Run repository-level checks over the tracked plan set so missing backfills or
+  stale examples are caught before approval or archive.
+
+## Risks
+
+- Risk: `size` becomes a vague label rather than a durable planning aid.
+  - Mitigation: keep the ladder small, document concrete adjacent-size
+    heuristics, and backfill the historical corpus consistently in the same
+    slice.
+- Risk: relaxing `lightweight` makes the profile too broad and encourages
+  risky small changes to bypass the standard path.
+  - Mitigation: document that `XXS` may use `lightweight`, but size is not the
+    only gate; keep explicit low-risk judgment and escalation guidance.
+- Risk: the repository ends up partially backfilled, leaving historical plans
+  inconsistent with the new schema.
+  - Mitigation: treat backfill as a required acceptance criterion and lint the
+    tracked plan corpus before closeout.
+
+## Validation Summary
+
+- Ran `scripts/sync-bootstrap-assets` after the bootstrap guidance edits so
+  `.agents/skills/harness-plan/SKILL.md` and the managed block in `AGENTS.md`
+  stayed aligned with `assets/bootstrap/`.
+- Ran focused tooling tests with `go test ./internal/plan ./internal/cli`
+  after the size-contract implementation and again after the finalize repairs
+  for exact enum enforcement and raw lightweight `size: XXS` assertions.
+- Ran broader impacted validation with
+  `go test ./internal/evidence ./internal/lifecycle ./internal/review ./internal/status ./internal/ui ./tests/e2e`.
+- Confirmed the lightweight E2E path still passed after the final test repair
+  with `go test ./tests/e2e`.
+- Linted the active tracked plan with
+  `harness plan lint docs/plans/active/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md`.
+- Ran a repository-wide tracked-plan lint sweep over
+  `docs/plans/active/*.md` and `docs/plans/archived/*.md`; after backfilling
+  sizes and migrating four legacy archived plans away from obsolete runtime
+  frontmatter and `- Status:` markers, the final sweep completed with
+  `COUNT=0` failures.
+
+## Review Summary
+
+- Finalize review `review-001-full` found a blocking tests gap around missing
+  negative coverage for invalid size handling and the lack of a durable
+  repository-backed regression for the migrated archive corpus.
+- Finalize review `review-002-full` found two blocking gaps: size validation
+  still normalized case and whitespace instead of enforcing the documented
+  enum exactly, and planner-facing docs outside the schema had not yet
+  reflected the `XXL` deferred-scope handoff guidance.
+- Finalize review `review-003-full` found one blocking tests gap: the
+  lightweight authoring path was not directly asserting the raw emitted
+  `size: XXS` because helper code could patch size into the rendered output
+  after the fact.
+- Finalize review `review-004-full` found one blocking docs-consistency gap:
+  the schema and planning skill required explicit human approval for
+  `workflow_profile: lightweight`, but README and the managed `AGENTS.md`
+  block still only implied that gate.
+- Finalize review `review-005-full` passed cleanly with no blocking or
+  non-blocking findings after the last tests and docs repairs.
+
+## Archive Summary
+
+- Archived At: 2026-04-11T00:13:20+08:00
+- Revision: 1
+- PR: Not opened yet; publish should create or refresh a PR from branch
+  `codex/plan-size-frontmatter`.
+- Ready: The candidate has a clean full finalize review (`review-005-full`),
+  active-plan lint is green, focused plus broader validation passed, and the
+  remaining deferred scope is handed off to issues `#136` and `#137`.
+- Merge Handoff: Archive the revision-1 candidate, commit the archive move and
+  closeout summaries, push branch `codex/plan-size-frontmatter`, open or
+  update the PR, and record publish, CI, and sync evidence until
+  `harness status` advances to `execution/finalize/await_merge`.
+
+## Outcome Summary
+
+### Delivered
+
+- Added required tracked-plan frontmatter `size` support with the initial
+  ladder `XXS`, `XS`, `S`, `M`, `L`, `XL`, and `XXL`.
+- Updated plan-schema, CLI-contract, README, bootstrap planning guidance, and
+  managed agent guidance so size means work magnitude, `XXS` may use
+  `lightweight` only with explicit human approval, and initial `XXL` sizing
+  now prompts split confirmation plus deferred-scope thinking.
+- Implemented first-class size handling in plan templating and linting, added
+  `harness plan template --size`, and enforced the exact documented enum with
+  targeted negative coverage.
+- Made lightweight template generation emit `size: XXS` directly and covered
+  that behavior in both template and CLI tests.
+- Backfilled `size` across the tracked plan corpus and migrated four legacy
+  archived plans off obsolete runtime frontmatter so the whole tracked plan set
+  is lint-clean under the new schema.
+
+### Not Delivered
+
+- This slice did not remove `workflow_profile: lightweight` as a separate
+  planning surface.
+- This slice did not add automatic size suggestion or inference to
+  `harness plan`.
+
+### Follow-Up Issues
+
+- #136 Revisit whether lightweight should remain a distinct workflow profile
+  after size backfill (`https://github.com/catu-ai/easyharness/issues/136`)
+- #137 Consider suggesting candidate plan sizes from plan structure and the
+  backfilled corpus (`https://github.com/catu-ai/easyharness/issues/137`)

--- a/docs/plans/archived/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md
+++ b/docs/plans/archived/2026-04-10-add-plan-size-frontmatter-and-relax-lightweight-eligibility.md
@@ -383,14 +383,14 @@ with the schema, template, and lint changes in the final candidate review.
 
 - Archived At: 2026-04-11T00:13:20+08:00
 - Revision: 1
-- PR: Not opened yet; publish should create or refresh a PR from branch
-  `codex/plan-size-frontmatter`.
-- Ready: The candidate has a clean full finalize review (`review-005-full`),
-  active-plan lint is green, focused plus broader validation passed, and the
-  remaining deferred scope is handed off to issues `#136` and `#137`.
-- Merge Handoff: Archive the revision-1 candidate, commit the archive move and
-  closeout summaries, push branch `codex/plan-size-frontmatter`, open or
-  update the PR, and record publish, CI, and sync evidence until
+- PR: `#138` (`https://github.com/catu-ai/easyharness/pull/138`)
+- Ready: The archived candidate is published to PR `#138`, has a clean full
+  finalize review (`review-005-full`), active-plan lint is green, focused plus
+  broader validation passed, and the remaining deferred scope is handed off to
+  issues `#136` and `#137`.
+- Merge Handoff: Record publish evidence for PR `#138`, wait for the
+  post-archive checks on branch `codex/plan-size-frontmatter`, refresh sync
+  against `origin/main`, and keep the candidate in publish handoff until
   `harness status` advances to `execution/finalize/await_merge`.
 
 ## Outcome Summary

--- a/docs/plans/archived/2026-04-10-controller-discipline-truth-surface-checklist.md
+++ b/docs/plans/archived/2026-04-10-controller-discipline-truth-surface-checklist.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-10T08:45:00+08:00"
 source_type: direct_request
 source_refs: []
+size: S
 ---
 
 # Controller discipline truth-surface checklist

--- a/docs/plans/archived/2026-04-10-deduplicate-pr-ci-triggers.md
+++ b/docs/plans/archived/2026-04-10-deduplicate-pr-ci-triggers.md
@@ -3,6 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-10T23:05:00+08:00"
 source_type: direct_request
 source_refs: []
+size: XS
 ---
 
 # Deduplicate PR CI triggers

--- a/docs/plans/archived/2026-04-10-repair-global-fallback-file-replacement.md
+++ b/docs/plans/archived/2026-04-10-repair-global-fallback-file-replacement.md
@@ -4,6 +4,7 @@ created_at: "2026-04-10T09:43:51+08:00"
 source_type: direct_request
 source_refs:
     - chat://current-session
+size: M
 ---
 
 # Repair Global Fallback Replacement And Health Checks

--- a/docs/plans/archived/2026-04-10-reviewer-worklog-ui-and-aggregate-provenance.md
+++ b/docs/plans/archived/2026-04-10-reviewer-worklog-ui-and-aggregate-provenance.md
@@ -4,6 +4,7 @@ created_at: "2026-04-10T09:02:00+08:00"
 source_type: issue
 source_refs:
     - '#125'
+size: M
 ---
 
 # Expose reviewer worklog detail and clearer aggregate provenance in the harness UI

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -327,16 +327,23 @@ Contract:
 - print the rendered template to stdout by default
 - optionally support writing directly to a target path
 - support a lightweight authoring mode such as `--lightweight`
-- support enough parameters to seed title, date, and source metadata
+- support enough parameters to seed title, date, source metadata, and the
+  required `size` field
 - when only a date is provided, preserve the current local time-of-day on that
   date instead of silently forcing `created_at` to local midnight
 - seed `template_version` from the packaged asset so generated plans record the
   schema/template version they started from
 - avoid introducing a second handwritten template source of truth inside code
+- when the caller does not provide a size, keep the required `size` field
+  explicit in the rendered template rather than silently defaulting it behind
+  the author's back
 - in lightweight mode, seed `workflow_profile: lightweight`, a shorter
   single-step low-risk authoring shape, and guidance that the active plan
   still lives under `docs/plans/active/` while the archive goes to the local
   lightweight archive path
+- lightweight authoring must only be available for `size: XXS`; command UX may
+  enforce that either by requiring an explicit `XXS` size or by rendering the
+  lightweight template with explicit `size: XXS`
 - in standard mode, preserve current behavior when `workflow_profile` is
   omitted
 

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -132,6 +132,7 @@ template_version: 0.2.0
 created_at: 2026-03-17T10:12:01+08:00
 source_type: direct_request
 source_refs: []
+size: M
 ---
 ```
 
@@ -156,6 +157,44 @@ source_refs: []
 - `source_refs`
   - array of external references such as issue IDs or URLs
   - use `[]` when there are none
+- `size`
+  - required t-shirt estimate for the whole planned slice
+  - supported values are `XXS`, `XS`, `S`, `M`, `L`, `XL`, and `XXL`
+  - size describes magnitude, coordination weight, and review load; it does
+    not by itself prove the work is low-risk
+  - `XXS` is the only size that may use `workflow_profile: lightweight`
+  - an initial `XXL` estimate is a planning warning, not a routine default:
+    before execution approval, the controller should stop, confirm the size
+    with the human, and seriously consider returning to discovery to split the
+    slice or move deferred follow-up into issues
+
+### Size Meanings
+
+- `XXS`
+  - the smallest bounded slice the repository still wants to plan
+  - one narrow intent with limited coordination, such as a tiny command tweak,
+    focused CI condition change, very small helper-script fix, narrow wording
+    adjustment, or regression-coverage backfill
+- `XS`
+  - one clearly scoped change that still stays small, but already needs a bit
+    of propagation such as code plus tests, contract plus docs, or one narrow
+    behavior fix across a couple of nearby surfaces
+- `S`
+  - a small coherent subsystem slice with limited blast radius, often touching
+    a few related files or one focused workflow edge
+- `M`
+  - a medium slice that changes one meaningful subsystem or workflow and needs
+    multiple coordinated edits to keep behavior, docs, and tests aligned
+- `L`
+  - a broad but still localizable change that spans several surfaces or
+    packages while remaining one coherent project
+- `XL`
+  - a very broad coordinated slice with obvious regression risk across several
+    surfaces, integrations, or workflow layers
+- `XXL`
+  - an unusually large slice that is still coherent enough to describe as one
+    plan, but should normally prompt an explicit split discussion before the
+    plan is approved
 
 ### Optional Fields
 
@@ -175,14 +214,17 @@ source_refs: []
 
 `workflow_profile: lightweight` is allowed only when every rule below is true:
 
+- the plan carries `size: XXS`
 - the whole slice is one intentionally narrow low-risk change that can be
   planned, implemented, and validated as a single bounded step
-- the expected edits are limited to non-behavioral repository maintenance such
-  as README wording, documentation copy, comments, or similarly narrow
-  explanatory cleanup
-- no `harness` CLI behavior, state resolution rule, review/archive contract,
-  persistence behavior, release or CI automation, security-sensitive logic, or
-  other user-visible product behavior changes
+- the expected edits stay within a low-risk narrow surface such as README or
+  docs wording, comment cleanup, a small CI condition adjustment, a tiny
+  helper-script fix, or another similarly small change whose blast radius is
+  easy to explain
+- the change does not alter schema meaning, core state resolution,
+  review/archive/evidence contracts, release safety, security-sensitive logic,
+  or another risk surface that would make reviewers reasonably want the
+  standard path
 - if the boundary is unclear, the risk is disputed, or the slice stops looking
   obviously lightweight, it must use `standard`
 
@@ -191,12 +233,16 @@ Examples that may use `lightweight`:
 - fixing a broken README link
 - correcting narrow documentation wording
 - cleaning up comments without changing behavior
+- adjusting one narrowly scoped CI condition with easy-to-explain blast radius
+- making a tiny helper or wrapper fix that stays far away from core workflow
+  semantics
 
 Examples that must stay `standard`:
 
+- any change sized above `XXS`
 - any change under `docs/specs/` that changes the product contract
-- any change to Go code, tests that prove new behavior, or release/CI workflow
-  logic
+- any change to core Go/runtime behavior, review/archive logic, or release
+  safety logic
 - any change that needs more than one meaningful implementation step or a
   broader review posture than bounded low-risk maintenance
 
@@ -375,12 +421,16 @@ human steering but does not justify a tracked archived plan artifact.
 The lightweight profile is eligible only when all of these are true:
 
 - the human explicitly approves using the lightweight profile
+- the plan carries `size: XXS`
 - the plan still describes a small bounded slice that one short plan can steer
 - the expected change is limited to low-risk repository surfaces such as:
   - README or docs wording
   - comments or other non-behavioral text cleanup
-  - similarly narrow metadata or wording fixes that do not change product
-    behavior, state transitions, or command semantics
+  - a small CI condition or workflow-glue adjustment whose blast radius is
+    easy to explain
+  - a tiny helper-script or narrowly scoped code fix that does not change
+    schema meaning, state transitions, review/archive/evidence semantics,
+    release safety, or security-sensitive behavior
 - the controller can explain the lightweight choice in one small repo-visible
   breadcrumb such as a PR body note
 - the plan can stay clear and reviewable without depending on supplements as a
@@ -388,8 +438,9 @@ The lightweight profile is eligible only when all of these are true:
 
 The lightweight profile is not eligible when any of these are true:
 
+- the plan is sized above `XXS`
 - the change affects CLI, runtime, release, review, archive, evidence, or
-  state-machine behavior
+  state-machine behavior in a way that is not obviously tiny and low-risk
 - the change modifies normative product contracts, schema meaning, or command
   semantics
 - the change spans multiple risk areas or would make a reviewer reasonably ask

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -389,11 +389,12 @@ func (a *App) runPlanTemplate(args []string) int {
 	dateValue := fs.String("date", "", "Seed timestamps using this YYYY-MM-DD date with the current local time-of-day.")
 	timestampValue := fs.String("timestamp", "", "Seed timestamps using this RFC3339 timestamp.")
 	sourceType := fs.String("source-type", "direct_request", "Seed the frontmatter source_type field.")
+	size := fs.String("size", "", "Seed the required frontmatter size field (XXS, XS, S, M, L, XL, or XXL).")
 	fs.Var(&refs, "source-ref", "Seed one source_refs entry. Repeat to add multiple refs.")
 	fs.Usage = func() {
 		fmt.Fprintln(a.Stderr, "Usage: harness plan template [flags]")
 		fmt.Fprintln(a.Stderr)
-		fmt.Fprintln(a.Stderr, "Render the packaged plan template with seeded title, timestamp, and source metadata.")
+		fmt.Fprintln(a.Stderr, "Render the packaged plan template with seeded title, timestamp, source metadata, and size.")
 		fmt.Fprintln(a.Stderr)
 		fs.PrintDefaults()
 	}
@@ -420,6 +421,7 @@ func (a *App) runPlanTemplate(args []string) int {
 		Timestamp:  ts,
 		SourceType: *sourceType,
 		SourceRefs: refs,
+		Size:       *size,
 		WorkflowProfile: func() string {
 			if *lightweight {
 				return plan.WorkflowProfileLightweight

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -38,6 +38,7 @@ func TestPlanTemplateWritesOutputFile(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("unexpected exit code %d, stderr=%s", exitCode, stderr.String())
 	}
+	ensurePlanSizeInFile(t, outputPath, "M")
 
 	data, err := os.ReadFile(outputPath)
 	if err != nil {
@@ -69,6 +70,24 @@ func TestPlanTemplateDateSeedsCurrentLocalTimeOfDay(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "created_at: 2026-03-20T14:15:16+08:00") {
 		t.Fatalf("expected date-seeded template to preserve current local time-of-day, got:\n%s", stdout.String())
+	}
+}
+
+func TestPlanTemplateSizeFlagSeedsExplicitSize(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{
+		"plan", "template",
+		"--title", "Sized Plan",
+		"--size", "XL",
+	})
+	if exitCode != 0 {
+		t.Fatalf("expected explicit size template success, got %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "size: XL") {
+		t.Fatalf("expected explicit size in template, got:\n%s", stdout.String())
 	}
 }
 
@@ -162,6 +181,7 @@ func TestPlanLintCommandReturnsJSON(t *testing.T) {
 	}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	ensurePlanSizeInFile(t, outputPath, "M")
 
 	stdout.Reset()
 	stderr.Reset()
@@ -206,8 +226,33 @@ func TestPlanTemplateLightweightFlagSeedsLocalVariant(t *testing.T) {
 	if !strings.Contains(stdout.String(), "workflow_profile: lightweight") {
 		t.Fatalf("expected workflow_profile in template, got %s", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "size: XXS") {
+		t.Fatalf("expected lightweight template to emit size XXS, got %s", stdout.String())
+	}
 	if strings.Contains(stdout.String(), "### Step 2:") {
 		t.Fatalf("expected lightweight template to collapse to one step, got %s", stdout.String())
+	}
+}
+
+func TestPlanTemplateLightweightRejectsNonXXSSize(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{
+		"plan", "template",
+		"--title", "Bad Lightweight Plan",
+		"--lightweight",
+		"--size", "XS",
+	})
+	if exitCode != 1 {
+		t.Fatalf("expected lightweight/non-XXS mismatch to fail with exit code 1, got %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `lightweight templates must use size "XXS"`) {
+		t.Fatalf("expected size mismatch error, got %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout on error, got %q", stdout.String())
 	}
 }
 
@@ -1387,6 +1432,7 @@ func writeArchiveReadyPlanForCLI(t *testing.T, root, relPath string) string {
 	if err != nil {
 		t.Fatalf("RenderTemplate: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 	content := rendered
 	content = replaceCLIAll(content, "- Done: [ ]", "- Done: [x]")
 	content = replaceCLIAll(content, "- Status: pending", "- Status: completed")
@@ -1491,6 +1537,7 @@ func writeArchivedPlanForCLI(t *testing.T, root, relPath string) string {
 	if err != nil {
 		t.Fatalf("RenderTemplate: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 	content := rendered
 	content = bytes.NewBufferString(content).String()
 	content = replaceCLI(content, "status: active", "status: archived")
@@ -1523,4 +1570,16 @@ func replaceCLI(content, old, new string) string {
 func replaceCLIAll(content, old, new string) string {
 	tuned := bytes.ReplaceAll([]byte(content), []byte(old), []byte(new))
 	return string(tuned)
+}
+
+func ensurePlanSizeInFile(t *testing.T, path, size string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read plan file: %v", err)
+	}
+	content := strings.Replace(string(data), "size: REPLACE_WITH_PLAN_SIZE", "size: "+size, 1)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write plan file: %v", err)
+	}
 }

--- a/internal/evidence/service_internal_test.go
+++ b/internal/evidence/service_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -95,6 +96,7 @@ func writeArchivedPlanFixture(t *testing.T, root, relPath string) string {
 	if err != nil {
 		t.Fatalf("render template: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 
 	path := filepath.Join(root, relPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/evidence/service_test.go
+++ b/internal/evidence/service_test.go
@@ -3,6 +3,7 @@ package evidence_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -480,6 +481,7 @@ func writePlan(t *testing.T, root, relPath, title string) string {
 	if err != nil {
 		t.Fatalf("render template: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 	path := filepath.Join(root, relPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir plan dir: %v", err)

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -53,6 +53,13 @@ func TestArchiveMovesPlanAndUpdatesPointers(t *testing.T) {
 	if lint := plan.LintFile(archivedPath); !lint.OK {
 		t.Fatalf("archived plan should lint, got %#v", lint)
 	}
+	archivedBytes, err := os.ReadFile(archivedPath)
+	if err != nil {
+		t.Fatalf("read archived plan: %v", err)
+	}
+	if !strings.Contains(string(archivedBytes), "size: M") {
+		t.Fatalf("expected archived plan to preserve size frontmatter, got:\n%s", archivedBytes)
+	}
 	current, err := runstate.LoadCurrentPlan(root)
 	if err != nil {
 		t.Fatalf("load current-plan: %v", err)

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -1753,6 +1753,7 @@ func writeLightweightActiveArchiveCandidate(t *testing.T, root, relPath string) 
 	t.Helper()
 	path := filepath.Join(root, relPath)
 	content := strings.Replace(buildActiveArchiveCandidate(t), "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
+	content = strings.Replace(content, "size: M", "size: XXS", 1)
 	writeFile(t, path, content)
 	return path
 }
@@ -1768,6 +1769,7 @@ func writeArchivedLandedPlan(t *testing.T, root, relPath string) string {
 	if err != nil {
 		t.Fatalf("render template: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 	rendered = strings.ReplaceAll(rendered, "- Done: [ ]", "- Done: [x]")
 	rendered = strings.ReplaceAll(rendered, "- [ ]", "- [x]")
 	rendered = strings.ReplaceAll(rendered, "PENDING_STEP_EXECUTION", "Done.")
@@ -1831,7 +1833,7 @@ func buildAwaitingPlan(t *testing.T, title string) string {
 	if err != nil {
 		t.Fatalf("render template: %v", err)
 	}
-	return rendered
+	return strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/internal/plan/lint.go
+++ b/internal/plan/lint.go
@@ -63,6 +63,7 @@ type Frontmatter struct {
 	CreatedAt       string   `yaml:"created_at"`
 	SourceType      string   `yaml:"source_type"`
 	SourceRefs      []string `yaml:"source_refs"`
+	Size            string   `yaml:"size"`
 	WorkflowProfile string   `yaml:"workflow_profile,omitempty"`
 }
 
@@ -240,6 +241,7 @@ func validateFrontmatter(ctx *lintContext) []LintIssue {
 		"created_at",
 		"source_type",
 		"source_refs",
+		"size",
 	}
 	for _, key := range requiredKeys {
 		if _, ok := ctx.rawFrontmatter[key]; !ok {
@@ -255,6 +257,11 @@ func validateFrontmatter(ctx *lintContext) []LintIssue {
 	}
 	if strings.TrimSpace(ctx.frontmatter.SourceType) == "" {
 		issues = append(issues, LintIssue{Path: "frontmatter.source_type", Message: "must not be empty"})
+	}
+	if strings.TrimSpace(ctx.frontmatter.Size) == "" {
+		issues = append(issues, LintIssue{Path: "frontmatter.size", Message: "must not be empty"})
+	} else if !isSupportedPlanSize(ctx.frontmatter.Size) {
+		issues = append(issues, LintIssue{Path: "frontmatter.size", Message: fmt.Sprintf("must be one of %s", strings.Join(supportedPlanSizes, ", "))})
 	}
 	for _, legacyKey := range []string{"status", "lifecycle", "revision", "updated_at"} {
 		if _, ok := ctx.rawFrontmatter[legacyKey]; ok {
@@ -272,6 +279,12 @@ func validateFrontmatter(ctx *lintContext) []LintIssue {
 				Message: "must be standard or lightweight when provided",
 			})
 		}
+	}
+	if normalizeWorkflowProfile(ctx.frontmatter.WorkflowProfile) == WorkflowProfileLightweight && ctx.frontmatter.Size != PlanSizeXXS {
+		issues = append(issues, LintIssue{
+			Path:    "frontmatter.size",
+			Message: "lightweight plans must use size XXS",
+		})
 	}
 	supportedVersion, err := templateassets.PlanTemplateVersion()
 	if err != nil {

--- a/internal/plan/lint_test.go
+++ b/internal/plan/lint_test.go
@@ -53,6 +53,48 @@ func TestLintFileRejectsLegacyRuntimeFrontmatter(t *testing.T) {
 	assertHasError(t, result, "frontmatter.updated_at")
 }
 
+func TestLintFileRejectsMissingSize(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "docs/plans/active/2026-03-17-missing-size-plan.md")
+	content := mustRenderTemplate(t, "Missing Size")
+	content = strings.Replace(content, "size: M\n", "", 1)
+	writeFile(t, path, content)
+
+	result := plan.LintFile(path)
+	if result.OK {
+		t.Fatalf("expected missing size to fail, got %#v", result)
+	}
+	assertHasError(t, result, "frontmatter.size")
+}
+
+func TestLintFileRejectsUnsupportedSize(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "docs/plans/active/2026-03-17-unsupported-size-plan.md")
+	content := mustRenderTemplate(t, "Unsupported Size")
+	content = strings.Replace(content, "size: M", "size: HUGE", 1)
+	writeFile(t, path, content)
+
+	result := plan.LintFile(path)
+	if result.OK {
+		t.Fatalf("expected unsupported size to fail, got %#v", result)
+	}
+	assertHasError(t, result, "frontmatter.size")
+}
+
+func TestLintFileRejectsNonCanonicalSizeSpelling(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "docs/plans/active/2026-03-17-lowercase-size-plan.md")
+	content := mustRenderTemplate(t, "Lowercase Size")
+	content = strings.Replace(content, "size: M", "size: xxs", 1)
+	writeFile(t, path, content)
+
+	result := plan.LintFile(path)
+	if result.OK {
+		t.Fatalf("expected lowercase size to fail, got %#v", result)
+	}
+	assertHasError(t, result, "frontmatter.size")
+}
+
 func TestLintFileRejectsMissingDeferredItemsSection(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "docs/plans/active/2026-03-17-easyharness-cli-and-plan-foundations.md")
@@ -337,6 +379,7 @@ func TestLintFileAcceptsTrackedActiveLightweightPlan(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "docs/plans/active/2026-03-17-lightweight-plan.md")
 	content := mustRenderTemplate(t, "Lightweight Tracked Plan")
+	content = strings.Replace(content, "size: M", "size: XXS", 1)
 	content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
 	writeFile(t, path, content)
 
@@ -350,6 +393,7 @@ func TestLintFileAcceptsArchivedLightweightLocalPlan(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".local/harness/plans/archived/2026-03-17-lightweight-plan.md")
 	content := mustRenderTemplate(t, "Archived Lightweight Plan")
+	content = strings.Replace(content, "size: M", "size: XXS", 1)
 	content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
 	content = strings.Replace(content, "- Done: [ ]", "- Done: [x]", 3)
 	content = strings.ReplaceAll(content, "- [ ]", "- [x]")
@@ -365,10 +409,26 @@ func TestLintFileAcceptsArchivedLightweightLocalPlan(t *testing.T) {
 	}
 }
 
+func TestLintFileRejectsNonXXSLightweightPlan(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "docs/plans/active/2026-03-17-bad-lightweight-plan.md")
+	content := mustRenderTemplate(t, "Bad Lightweight Plan")
+	content = strings.Replace(content, "size: M", "size: XS", 1)
+	content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
+	writeFile(t, path, content)
+
+	result := plan.LintFile(path)
+	if result.OK {
+		t.Fatalf("expected non-XXS lightweight plan to fail, got %#v", result)
+	}
+	assertHasError(t, result, "frontmatter.size")
+}
+
 func TestLintFileRejectsLightweightActivePlanUnderLocalPath(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".local/harness/plans/2026-03-17-lightweight-plan/active/2026-03-17-lightweight-plan.md")
 	content := mustRenderTemplate(t, "Bad Local Active Plan")
+	content = strings.Replace(content, "size: M", "size: XXS", 1)
 	content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
 	writeFile(t, path, content)
 
@@ -418,12 +478,29 @@ func TestLintResultJSONRoundTrip(t *testing.T) {
 	}
 }
 
+func TestTrackedPlanCorpusRemainsLintClean(t *testing.T) {
+	paths, err := filepath.Glob(filepath.Join("..", "..", "docs", "plans", "*", "*.md"))
+	if err != nil {
+		t.Fatalf("glob tracked plans: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("expected tracked plans in repository")
+	}
+	for _, path := range paths {
+		result := plan.LintFile(path)
+		if !result.OK {
+			t.Fatalf("expected tracked plan %s to lint clean, got %#v", path, result)
+		}
+	}
+}
+
 func mustRenderTemplate(t *testing.T, title string) string {
 	t.Helper()
 	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
 		Title:      title,
 		Timestamp:  time.Date(2026, 3, 17, 14, 0, 0, 0, time.FixedZone("CST", 8*60*60)),
 		SourceType: "direct_request",
+		Size:       "M",
 	})
 	if err != nil {
 		t.Fatalf("render template: %v", err)

--- a/internal/plan/size.go
+++ b/internal/plan/size.go
@@ -1,0 +1,31 @@
+package plan
+
+const (
+	PlanSizeXXS         = "XXS"
+	PlanSizeXS          = "XS"
+	PlanSizeS           = "S"
+	PlanSizeM           = "M"
+	PlanSizeL           = "L"
+	PlanSizeXL          = "XL"
+	PlanSizeXXL         = "XXL"
+	placeholderPlanSize = "REPLACE_WITH_PLAN_SIZE"
+)
+
+var supportedPlanSizes = []string{
+	PlanSizeXXS,
+	PlanSizeXS,
+	PlanSizeS,
+	PlanSizeM,
+	PlanSizeL,
+	PlanSizeXL,
+	PlanSizeXXL,
+}
+
+func isSupportedPlanSize(value string) bool {
+	switch value {
+	case PlanSizeXXS, PlanSizeXS, PlanSizeS, PlanSizeM, PlanSizeL, PlanSizeXL, PlanSizeXXL:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/plan/template.go
+++ b/internal/plan/template.go
@@ -19,6 +19,7 @@ type TemplateOptions struct {
 	Timestamp       time.Time
 	SourceType      string
 	SourceRefs      []string
+	Size            string
 	WorkflowProfile string
 }
 
@@ -44,9 +45,24 @@ func RenderTemplate(opts TemplateOptions) (string, error) {
 	if opts.SourceRefs == nil {
 		opts.SourceRefs = []string{}
 	}
+	size := opts.Size
 	workflowProfile := normalizeWorkflowProfile(opts.WorkflowProfile)
 	if workflowProfile != WorkflowProfileStandard && workflowProfile != WorkflowProfileLightweight {
 		return "", fmt.Errorf("workflow profile must be %q or %q", WorkflowProfileStandard, WorkflowProfileLightweight)
+	}
+	if workflowProfile == WorkflowProfileLightweight {
+		if size == "" {
+			size = PlanSizeXXS
+		}
+		if size != PlanSizeXXS {
+			return "", fmt.Errorf("lightweight templates must use size %q", PlanSizeXXS)
+		}
+	}
+	if size == "" {
+		size = placeholderPlanSize
+	}
+	if size != placeholderPlanSize && !isSupportedPlanSize(size) {
+		return "", fmt.Errorf("size must be one of %s", strings.Join(supportedPlanSizes, ", "))
 	}
 
 	sourceRefsJSON, err := json.Marshal(opts.SourceRefs)
@@ -61,8 +77,9 @@ func RenderTemplate(opts TemplateOptions) (string, error) {
 	rendered = strings.ReplaceAll(rendered, placeholderTimestamp, timestamp)
 	rendered = strings.Replace(rendered, "source_type: direct_request", "source_type: "+sourceType, 1)
 	rendered = strings.Replace(rendered, "source_refs: []", "source_refs: "+string(sourceRefsJSON), 1)
+	rendered = strings.Replace(rendered, "size: "+placeholderPlanSize, "size: "+size, 1)
 	if workflowProfile == WorkflowProfileLightweight {
-		rendered = strings.Replace(rendered, "source_refs: "+string(sourceRefsJSON), "source_refs: "+string(sourceRefsJSON)+"\nworkflow_profile: lightweight", 1)
+		rendered = strings.Replace(rendered, "size: "+size, "size: "+size+"\nworkflow_profile: lightweight", 1)
 		rendered = strings.Replace(rendered, "### Step 1: Replace with first step title", "### Step 1: Describe the low-risk change", 1)
 		rendered = strings.Replace(rendered, "Describe the concrete outcome for this step.", "Describe the narrow low-risk change to make.", 1)
 		rendered = strings.Replace(rendered, "Describe the step-specific details, tradeoffs, or constraints that do not fit\nin the one-line objective. Write `NONE` if the objective is already enough.", "Explain why this change qualifies for the lightweight path and note any constraints. Write `NONE` if the objective already says enough.", 1)

--- a/internal/plan/template_test.go
+++ b/internal/plan/template_test.go
@@ -10,21 +10,19 @@ import (
 
 func TestRenderTemplateSeedsFields(t *testing.T) {
 	timestamp := time.Date(2026, 3, 17, 13, 50, 0, 0, time.FixedZone("CST", 8*60*60))
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
+	rendered := renderTemplateWithSize(t, plan.TemplateOptions{
 		Title:      "Superharness Test Plan",
 		Timestamp:  timestamp,
 		SourceType: "issue",
 		SourceRefs: []string{"#12", "https://example.com/item"},
-	})
-	if err != nil {
-		t.Fatalf("RenderTemplate returned error: %v", err)
-	}
+	}, "M")
 
 	for _, want := range []string{
 		"# Superharness Test Plan",
 		"created_at: 2026-03-17T13:50:00+08:00",
 		"source_type: issue",
 		`source_refs: ["#12","https://example.com/item"]`,
+		"size: M",
 		"template_version: 0.2.0",
 		"- Done: [ ]",
 	} {
@@ -43,15 +41,47 @@ func TestRenderTemplateRejectsMultilineTitle(t *testing.T) {
 	}
 }
 
-func TestRenderTemplateUsesEmptyArrayForMissingSourceRefs(t *testing.T) {
+func TestRenderTemplateLeavesSizePlaceholderWhenOmitted(t *testing.T) {
 	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
-		Title: "Nil Refs Plan",
+		Title: "Missing Size Plan",
 	})
 	if err != nil {
 		t.Fatalf("RenderTemplate returned error: %v", err)
 	}
+	if !strings.Contains(rendered, "size: REPLACE_WITH_PLAN_SIZE") {
+		t.Fatalf("expected explicit size placeholder, got:\n%s", rendered)
+	}
+}
+
+func TestRenderTemplateRejectsUnsupportedSize(t *testing.T) {
+	_, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title: "Bad Size Plan",
+		Size:  "huge",
+	})
+	if err == nil {
+		t.Fatal("expected unsupported size to fail")
+	}
+}
+
+func TestRenderTemplateRejectsNonCanonicalSizeSpelling(t *testing.T) {
+	_, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title: "Lowercase Size Plan",
+		Size:  "xxs",
+	})
+	if err == nil {
+		t.Fatal("expected non-canonical size spelling to fail")
+	}
+}
+
+func TestRenderTemplateUsesEmptyArrayForMissingSourceRefs(t *testing.T) {
+	rendered := renderTemplateWithSize(t, plan.TemplateOptions{
+		Title: "Nil Refs Plan",
+	}, "M")
 	if !strings.Contains(rendered, "source_refs: []") {
 		t.Fatalf("expected empty source_refs array, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "size: M") {
+		t.Fatalf("expected default plan size, got:\n%s", rendered)
 	}
 }
 
@@ -65,6 +95,7 @@ func TestRenderTemplateLightweightSeedsWorkflowProfileAndSingleStep(t *testing.T
 	}
 	for _, want := range []string{
 		"workflow_profile: lightweight",
+		"size: XXS",
 		"### Step 1: Describe the low-risk change",
 		"Describe the narrow low-risk change to make.",
 	} {
@@ -77,13 +108,32 @@ func TestRenderTemplateLightweightSeedsWorkflowProfileAndSingleStep(t *testing.T
 	}
 }
 
-func TestRenderTemplateIncludesSupplementsArchiveGuidance(t *testing.T) {
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
-		Title: "Supplements Guidance Plan",
+func TestRenderTemplateRejectsLightweightNonXXSSize(t *testing.T) {
+	_, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title:           "Bad Lightweight Plan",
+		Size:            "XS",
+		WorkflowProfile: plan.WorkflowProfileLightweight,
 	})
-	if err != nil {
-		t.Fatalf("RenderTemplate returned error: %v", err)
+	if err == nil {
+		t.Fatal("expected non-XXS lightweight template to fail")
 	}
+}
+
+func TestRenderTemplateRejectsLightweightSizeWithWhitespace(t *testing.T) {
+	_, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title:           "Whitespace Lightweight Plan",
+		Size:            "XXS ",
+		WorkflowProfile: plan.WorkflowProfileLightweight,
+	})
+	if err == nil {
+		t.Fatal("expected whitespace-padded lightweight size to fail")
+	}
+}
+
+func TestRenderTemplateIncludesSupplementsArchiveGuidance(t *testing.T) {
+	rendered := renderTemplateWithSize(t, plan.TemplateOptions{
+		Title: "Supplements Guidance Plan",
+	}, "M")
 	for _, want := range []string{
 		"supplements/<plan-stem>/",
 		"supplement absorption in Archive",
@@ -95,4 +145,20 @@ func TestRenderTemplateIncludesSupplementsArchiveGuidance(t *testing.T) {
 			t.Fatalf("expected supplements archive guidance %q in rendered template, got:\n%s", want, rendered)
 		}
 	}
+}
+
+func renderTemplateWithSize(t *testing.T, opts plan.TemplateOptions, size string) string {
+	t.Helper()
+	rendered, err := plan.RenderTemplate(opts)
+	if err != nil {
+		t.Fatalf("RenderTemplate returned error: %v", err)
+	}
+	if strings.Contains(rendered, "size: "+size) {
+		return rendered
+	}
+	updated := strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: "+size, 1)
+	if updated == rendered {
+		t.Fatalf("expected rendered template to contain size frontmatter for replacement")
+	}
+	return updated
 }

--- a/internal/planui/service_test.go
+++ b/internal/planui/service_test.go
@@ -34,10 +34,7 @@ func TestServiceReadLoadsActivePlanPackageAndPreviewStates(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(planPath), 0o755); err != nil {
 		t.Fatalf("mkdir plan dir: %v", err)
 	}
-	content, err := plan.RenderTemplate(plan.TemplateOptions{Title: "Plan Browser Demo"})
-	if err != nil {
-		t.Fatalf("render plan template: %v", err)
-	}
+	content := renderPlanFixture(t, "Plan Browser Demo")
 	content = strings.Replace(
 		content,
 		"Describe the intended outcome in one or two short paragraphs.",
@@ -148,10 +145,7 @@ func TestServiceReadLoadsArchivedCurrentPlanPackage(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(planPath), 0o755); err != nil {
 		t.Fatalf("mkdir archived dir: %v", err)
 	}
-	content, err := plan.RenderTemplate(plan.TemplateOptions{Title: "Archived"})
-	if err != nil {
-		t.Fatalf("render archived template: %v", err)
-	}
+	content := renderPlanFixture(t, "Archived")
 	mustWriteFile(t, planPath, []byte(content))
 	if _, err := runstate.SaveCurrentPlan(workdir, relPlanPath); err != nil {
 		t.Fatalf("save current plan: %v", err)
@@ -241,4 +235,14 @@ func findHeading(headings []Heading, label string) *Heading {
 		}
 	}
 	return nil
+}
+
+func renderPlanFixture(t *testing.T, title string) string {
+	t.Helper()
+	content, err := plan.RenderTemplate(plan.TemplateOptions{Title: title})
+	if err != nil {
+		t.Fatalf("render plan template: %v", err)
+	}
+	content = strings.Replace(content, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
+	return content
 }

--- a/internal/review/service_internal_test.go
+++ b/internal/review/service_internal_test.go
@@ -251,6 +251,7 @@ func writeExecutingPlanFixture(t *testing.T, root, relPath string) {
 	if err != nil {
 		t.Fatalf("render template: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 
 	path := filepath.Join(root, relPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -1348,6 +1348,7 @@ func writePlainReviewPlan(t *testing.T, root, relPath string) string {
 	if err != nil {
 		t.Fatalf("render template: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 
 	path := filepath.Join(root, relPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/reviewui/service_test.go
+++ b/internal/reviewui/service_test.go
@@ -1169,10 +1169,15 @@ func seedArchivedPlan(t *testing.T, workdir, filename, title string) (string, st
 
 func seedLocalArchivedPlan(t *testing.T, workdir, filename, title string) (string, string) {
 	t.Helper()
-	return seedPlan(t, workdir, filepath.Join(".local/harness/plans/archived", filename), title)
+	return seedPlanWithSize(t, workdir, filepath.Join(".local/harness/plans/archived", filename), title, "XXS")
 }
 
 func seedPlan(t *testing.T, workdir, relPlanPath, title string) (string, string) {
+	t.Helper()
+	return seedPlanWithSize(t, workdir, relPlanPath, title, "M")
+}
+
+func seedPlanWithSize(t *testing.T, workdir, relPlanPath, title, size string) (string, string) {
 	t.Helper()
 	path := filepath.Join(workdir, filepath.FromSlash(relPlanPath))
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -1182,6 +1187,7 @@ func seedPlan(t *testing.T, workdir, relPlanPath, title string) (string, string)
 	if err != nil {
 		t.Fatalf("render plan: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: "+size, 1)
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -58,7 +58,8 @@ func TestStatusPlanNodeForTrackedLightweightPlan(t *testing.T) {
 	root := t.TempDir()
 	relPath := "docs/plans/active/2026-03-18-status-lightweight.md"
 	writePlan(t, root, relPath, func(content string) string {
-		return strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
+		content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
+		return strings.Replace(content, "size: M", "size: XXS", 1)
 	})
 
 	result := status.Service{Workdir: root}.Read()
@@ -131,6 +132,7 @@ func TestStatusLightweightPublishPromptsForBreadcrumb(t *testing.T) {
 	relPath := ".local/harness/plans/archived/2026-03-18-status-lightweight.md"
 	writePlan(t, root, relPath, func(content string) string {
 		content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
+		content = strings.Replace(content, "size: M", "size: XXS", 1)
 		return completeAllSteps(content, true)
 	})
 	writeCurrentPlan(t, root, relPath)
@@ -168,6 +170,7 @@ func TestStatusLightweightArchivedPlanSurfacesSupplementsDirectory(t *testing.T)
 	relPath := ".local/harness/plans/archived/2026-03-18-status-lightweight.md"
 	writePlan(t, root, relPath, func(content string) string {
 		content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
+		content = strings.Replace(content, "size: M", "size: XXS", 1)
 		return completeAllSteps(content, true)
 	})
 	writeCurrentPlan(t, root, relPath)
@@ -1705,6 +1708,7 @@ func TestStatusLightweightPublishPrioritizesRepairDebtBeforeBreadcrumb(t *testin
 	relPath := ".local/harness/plans/archived/2026-03-18-status-lightweight.md"
 	writePlan(t, root, relPath, func(content string) string {
 		content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
+		content = strings.Replace(content, "size: M", "size: XXS", 1)
 		return completeAllStepsWithoutCloseout(content, true)
 	})
 	writeCurrentPlan(t, root, relPath)
@@ -2689,6 +2693,7 @@ func writePlan(t *testing.T, root, relPath string, mutate func(string) string) s
 	if err != nil {
 		t.Fatalf("RenderTemplate: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 	content := mutate(rendered)
 	path := filepath.Join(root, relPath)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/timeline/service_test.go
+++ b/internal/timeline/service_test.go
@@ -238,6 +238,7 @@ func writeActivePlanForTimeline(t *testing.T, root, relPath string) string {
 	if err != nil {
 		t.Fatalf("render plan template: %v", err)
 	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -96,10 +96,7 @@ func TestNewHandlerServesPlanJSON(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir plan dir: %v", err)
 	}
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{Title: "UI Plan"})
-	if err != nil {
-		t.Fatalf("render plan: %v", err)
-	}
+	rendered := renderPlanFixture(t, "UI Plan")
 	rendered = strings.Replace(rendered, "Describe the intended outcome in one or two short paragraphs.", "Read the plan.\n", 1)
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write plan: %v", err)
@@ -182,10 +179,7 @@ func TestNewHandlerServesArchivedCurrentPlanJSON(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir archived dir: %v", err)
 	}
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{Title: "Archived UI Plan"})
-	if err != nil {
-		t.Fatalf("render archived plan: %v", err)
-	}
+	rendered := renderPlanFixture(t, "Archived UI Plan")
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write archived plan: %v", err)
 	}
@@ -253,10 +247,7 @@ func TestNewHandlerServesTimelineJSON(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir plan dir: %v", err)
 	}
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{Title: "UI Timeline Plan"})
-	if err != nil {
-		t.Fatalf("render plan: %v", err)
-	}
+	rendered := renderPlanFixture(t, "UI Timeline Plan")
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}
@@ -318,10 +309,7 @@ func TestNewHandlerServesReviewJSON(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir plan dir: %v", err)
 	}
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{Title: "UI Review Plan"})
-	if err != nil {
-		t.Fatalf("render plan: %v", err)
-	}
+	rendered := renderPlanFixture(t, "UI Review Plan")
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}
@@ -425,10 +413,7 @@ func TestNewHandlerServesReviewJSONWithMalformedWorklogWarnings(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir plan dir: %v", err)
 	}
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{Title: "UI Review Malformed Worklog"})
-	if err != nil {
-		t.Fatalf("render plan: %v", err)
-	}
+	rendered := renderPlanFixture(t, "UI Review Malformed Worklog")
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}
@@ -515,10 +500,7 @@ func TestNewHandlerServesReviewJSONFailureAs503(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir plan dir: %v", err)
 	}
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{Title: "UI Review Error"})
-	if err != nil {
-		t.Fatalf("render plan: %v", err)
-	}
+	rendered := renderPlanFixture(t, "UI Review Error")
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}
@@ -582,10 +564,7 @@ func TestNewHandlerServesLargeTimelinePayloadWithoutTruncation(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir plan dir: %v", err)
 	}
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{Title: "UI Timeline Large Payload"})
-	if err != nil {
-		t.Fatalf("render plan: %v", err)
-	}
+	rendered := renderPlanFixture(t, "UI Timeline Large Payload")
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}
@@ -659,10 +638,7 @@ func TestNewHandlerServesResolvedArtifactFileContents(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir plan dir: %v", err)
 	}
-	rendered, err := plan.RenderTemplate(plan.TemplateOptions{Title: "UI Timeline Artifact Tabs"})
-	if err != nil {
-		t.Fatalf("render plan: %v", err)
-	}
+	rendered := renderPlanFixture(t, "UI Timeline Artifact Tabs")
 	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
 		t.Fatalf("write plan: %v", err)
 	}
@@ -844,6 +820,15 @@ func TestServerRunPrintsListeningURLWithoutOpeningBrowser(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for server shutdown")
 	}
+}
+
+func renderPlanFixture(t *testing.T, title string) string {
+	t.Helper()
+	rendered, err := plan.RenderTemplate(plan.TemplateOptions{Title: title})
+	if err != nil {
+		t.Fatalf("render plan: %v", err)
+	}
+	return strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
 }
 
 type lockedBuffer struct {

--- a/scripts/ui-playwright-review-smoke
+++ b/scripts/ui-playwright-review-smoke
@@ -914,6 +914,16 @@ assert_not_has_text() {
   fi
 }
 
+ensure_plan_size() {
+  local file="$1"
+  local size="$2"
+  if grep -q '^size:' "$file"; then
+    perl -0pi -e 's/^size: .*/size: '"$size"'/m' "$file"
+  else
+    perl -0pi -e 's/source_refs: \[\]/source_refs: []\nsize: '"$size"'/m' "$file"
+  fi
+}
+
 run_empty_review_smoke() {
   local empty_tmp_dir
   local empty_runtime_workdir
@@ -931,6 +941,7 @@ run_empty_review_smoke() {
   mkdir -p "$empty_runtime_workdir" "$empty_session_dir"
 
   "$harness_bin" plan template -title "Review UI Empty" -output "$empty_runtime_workdir/docs/plans/active/2026-04-02-review-ui-empty.md" >/dev/null
+  ensure_plan_size "$empty_runtime_workdir/docs/plans/active/2026-04-02-review-ui-empty.md" "M"
   mkdir -p "$empty_runtime_workdir/.local/harness"
   printf '%s' '{"plan_path":"docs/plans/active/2026-04-02-review-ui-empty.md"}' >"$empty_runtime_workdir/.local/harness/current-plan.json"
 
@@ -1009,6 +1020,7 @@ mkdir -p "$session_dir"
 clear_pwcli_socket "$session_name"
 
 "$harness_bin" plan template -title "Review UI Smoke Fixture" -output "$runtime_workdir/docs/plans/active/2026-04-02-review-ui-smoke.md" >/dev/null
+ensure_plan_size "$runtime_workdir/docs/plans/active/2026-04-02-review-ui-smoke.md" "M"
 
 button_ref_from_snapshot() {
   local label="$1"

--- a/tests/e2e/lightweight_workflow_test.go
+++ b/tests/e2e/lightweight_workflow_test.go
@@ -33,6 +33,7 @@ func TestLightweightWorkflowWithBuiltBinary(t *testing.T) {
 	support.RequireFileExists(t, planPath)
 
 	support.RewritePlanPreservingFrontmatter(t, planPath, lightweightWorkflowTitle, lightweightWorkflowPlanBody())
+	support.EnsurePlanSize(t, planPath, "XXS")
 
 	lint := support.Run(t, workspace.Root, "plan", "lint", planRelPath)
 	support.RequireSuccess(t, lint)

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -459,6 +459,7 @@ func TestPlanTemplateAndLintRoundTrip(t *testing.T) {
 		workspace.Root,
 		"plan", "template",
 		"--title", "Smoke Plan",
+		"--size", "M",
 		"--timestamp", "2026-03-22T00:00:00Z",
 		"--source-type", "issue",
 		"--source-ref", "#6",
@@ -477,6 +478,7 @@ func TestPlanTemplateAndLintRoundTrip(t *testing.T) {
 	support.RequireContains(t, string(data), "created_at: 2026-03-22T00:00:00Z")
 	support.RequireContains(t, string(data), "source_type: issue")
 	support.RequireContains(t, string(data), "source_refs: [\"#6\"]")
+	support.RequireContains(t, string(data), "size: M")
 
 	lint := support.Run(t, workspace.Root, "plan", "lint", planRelPath)
 	support.RequireSuccess(t, lint)

--- a/tests/support/plan.go
+++ b/tests/support/plan.go
@@ -14,6 +14,45 @@ func RewritePlanPreservingFrontmatter(t *testing.T, path, title, body string) {
 	frontmatter := extractFrontmatter(t, content)
 	rewritten := frontmatter + "\n\n# " + strings.TrimSpace(title) + "\n\n" + strings.TrimSpace(body) + "\n"
 	writePlanFile(t, path, rewritten)
+	EnsurePlanSize(t, path, "M")
+}
+
+func RewritePlanPreservingFrontmatterWithSize(t *testing.T, path, title, body, size string) {
+	t.Helper()
+
+	RewritePlanPreservingFrontmatter(t, path, title, body)
+	EnsurePlanSize(t, path, size)
+}
+
+func EnsurePlanSize(t *testing.T, path, size string) {
+	t.Helper()
+
+	content := readPlanFile(t, path)
+	if strings.Contains(content, "size: "+size) {
+		return
+	}
+	updated := InsertPlanSize(content, size)
+	if updated == content {
+		t.Fatalf("expected to update plan size in %s", path)
+	}
+	writePlanFile(t, path, updated)
+}
+
+func InsertPlanSize(content, size string) string {
+	lines := strings.Split(content, "\n")
+	replaced := false
+	for i, line := range lines {
+		if strings.HasPrefix(line, "size:") {
+			lines[i] = "size: " + size
+			replaced = true
+			break
+		}
+	}
+	if replaced {
+		return strings.Join(lines, "\n")
+	}
+	updated := strings.Replace(content, "source_refs: []", "source_refs: []\nsize: "+size, 1)
+	return updated
 }
 
 func CheckAllAcceptanceCriteria(t *testing.T, path string) {


### PR DESCRIPTION
## Summary
- add required tracked-plan `size` frontmatter plus exact XXS-XXL validation in plan tooling
- relax lightweight eligibility so explicitly approved `XXS` slices can use it, and add `XXL` split/defer guidance
- backfill `size` across the tracked plan corpus and update tests/docs/bootstrap guidance accordingly

## Validation
- `scripts/sync-bootstrap-assets`
- `go test ./internal/plan ./internal/cli`
- `go test ./internal/evidence ./internal/lifecycle ./internal/review ./internal/status ./internal/ui ./tests/e2e`
- `go test ./tests/e2e`
- tracked active+archived plan lint sweep (`COUNT=0`)

## Follow-Up
- #136
- #137
