### PR TITLE
Add resilience and runstate concurrency coverage

### DIFF
--- a/docs/plans/active/2026-04-11-add-resilience-and-runstate-concurrency-coverage.md
+++ b/docs/plans/active/2026-04-11-add-resilience-and-runstate-concurrency-coverage.md
@@ -1,0 +1,324 @@
+---
+template_version: 0.2.0
+created_at: 2026-04-11T21:26:48+08:00
+source_type: issue
+source_refs:
+    - '#37'
+    - '#56'
+size: L
+---
+
+# Add resilience and runstate concurrency coverage for archive, reopen, evidence, and status
+
+## Goal
+
+Close `#37` and `#56` with targeted test coverage that proves the repository
+fails safely under malformed local state and remains coherent under realistic
+overlapping runstate command flows.
+
+This slice should not devolve into "more tests" in the abstract. It should add
+the missing repo-level evidence that the harness handles deterministic failure
+cases in `tests/resilience/` and that archive, reopen, evidence submission, and
+status still honor the runstate contract under deterministic command
+interleavings. If implementation reveals that the current production seams do
+not support those tests cleanly, make the smallest behavior-preserving changes
+needed to expose the intended contracts rather than widening the scope into a
+state-model redesign.
+
+## Scope
+
+### In Scope
+
+- Add a dedicated `tests/resilience/` package with deterministic repository-level
+  coverage for the highest-value failure cases called out by `#37`.
+- Cover corrupted or malformed `.local/harness/current-plan.json` and confirm
+  the affected commands fail safely with conservative summaries and no
+  accidental state mutation.
+- Cover missing or malformed review and evidence artifacts that `status` or
+  adjacent read paths must treat conservatively rather than silently accepting
+  as clean state.
+- Cover at least one archive or reopen rollback-family failure at the
+  repository level when local state or path moves are incomplete or invalid.
+- Add one or more deterministic integration-style tests for realistic command
+  interleavings around archive, reopen, evidence submission, and status, aimed
+  at the broader concurrency contract described by `#56`.
+- Extend `tests/support/` only where shared repo-level helpers materially
+  improve readability or determinism for the new resilience and concurrency
+  scenarios.
+- Update tracked coverage notes if needed so the repository makes it clear that
+  resilience coverage is no longer an open broad gap after this slice.
+- If execution uncovers leftover scope that prevents honest issue closure,
+  record it explicitly as a follow-up issue instead of leaving the gap implicit.
+
+### Out of Scope
+
+- Fuzzing or property-style parser coverage from `#36`.
+- Broad new happy-path lifecycle E2E scenarios beyond the deterministic
+  resilience and concurrency cases needed for `#37` and `#56`.
+- Redesigning state-lock semantics, cache policy, archive semantics, or the
+  evidence model unless a narrow behavior-preserving seam is required to make
+  the new tests deterministic.
+- Nondeterministic stress, long-running race harnesses, or flaky timing-based
+  concurrency infrastructure.
+- Rewriting existing package-local rollback tests merely to mirror them at the
+  repo level when they do not add new contract evidence.
+
+## Acceptance Criteria
+
+- [ ] `tests/resilience/` exists and `go test ./tests/resilience -count=1`
+      passes with deterministic repository-level cases that directly satisfy the
+      failure-path intent of `#37`.
+- [ ] The resilience suite covers malformed or corrupted
+      `.local/harness/current-plan.json`, missing or malformed review/evidence
+      artifacts, and at least one archive or reopen rollback-family safety
+      case where the command must fail conservatively without leaving the
+      worktree in a misleading state.
+- [ ] The new resilience assertions prove safe failure behavior, not only that
+      a command returns non-zero; the tests pin summaries, warnings, pointer or
+      artifact preservation, and any required rollback outcomes that define the
+      contract.
+- [ ] `go test ./tests/e2e -count=1` passes with at least one deterministic
+      integration-style scenario that exercises realistic overlapping command
+      patterns around archive, reopen, evidence submission, and status for the
+      same plan, satisfying the broader contract requested by `#56`.
+- [ ] The concurrency-focused assertions prove CLI-level runstate coherence:
+      overlapping commands either serialize or fail clearly, status stays
+      conservative, and no stale or cross-revision evidence is mistaken for the
+      current archived candidate during the tested interleavings.
+- [ ] Any minimal production or helper changes introduced for testability stay
+      behavior-preserving and are covered by the new repo-level scenarios plus
+      any focused package-level regression tests needed for the touched code.
+- [ ] The resulting tracked docs or closeout notes make it defensible to close
+      `#37` and `#56` without a hidden "more resilience/concurrency coverage
+      later" bucket; if anything material remains, it is moved into an explicit
+      follow-up issue before archive.
+
+## Deferred Items
+
+- `#36`: evaluate and, if warranted, add fuzz or property-style coverage for
+  parsing-heavy harness paths such as plan linting, review artifacts, and
+  evidence payload decoding.
+- Any later expansion into broader stress or race-style infrastructure beyond
+  the deterministic command interleavings needed to close `#56`.
+
+## Work Breakdown
+
+### Step 1: Define the repo-level gap targets and fixture strategy
+
+- Done: [ ]
+
+#### Objective
+
+Turn `#37` and `#56` into a concrete repo-level test matrix, then add only the
+shared helpers or coverage-note updates needed to keep the new scenarios
+deterministic and reviewable.
+
+#### Details
+
+Start by mapping the issue text against what the repository already covers in
+package-local tests so execution does not waste time re-proving the same
+rollback branches at a different layer. The outcome of this step should be a
+small explicit matrix of repo-level gaps: malformed current-plan pointer,
+degraded artifact reads, one rollback-family scenario, and one or more
+realistic command interleavings around archive/reopen/evidence/status. If the
+existing `docs/testing/e2e-transition-coverage.md` wording still presents
+resilience work as an unresolved broad follow-up after this slice lands, update
+ that tracked note as part of this step or the final step so repository-visible
+coverage expectations stay honest. Keep helper changes narrow and transparent;
+the test bodies should still read like real command transcripts.
+
+#### Expected Files
+
+- `docs/testing/e2e-transition-coverage.md`
+- `tests/support/repo.go`
+- `tests/support/run.go`
+- `tests/support/assert.go`
+- optional new `tests/support/*` helper files if shared deterministic fixture
+  setup is needed for the resilience suite
+
+#### Validation
+
+- The planned repo-level scenarios are explicitly narrower than the package-level
+  rollback matrix and clearly tied to the issue closure goals.
+- Any helper additions reduce duplication without hiding which CLI commands or
+  files the new tests are asserting against.
+- If tracked coverage docs are touched, they continue to describe the source of
+  truth accurately and no longer leave resilience coverage as an ambiguous
+  future bucket once the rest of this plan is complete.
+
+#### Execution Notes
+
+Mapped the repo-level closure targets against existing package-local coverage,
+then kept the shared fixture expansion narrow: `tests/support/repo.go` now adds
+`Workspace.WriteFile`, and `docs/testing/e2e-transition-coverage.md` now records
+that the earlier resilience/concurrency follow-up is covered by the new suites
+instead of remaining an ambiguous deferred bucket.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Add deterministic resilience coverage for malformed local state
+
+- Done: [ ]
+
+#### Objective
+
+Create `tests/resilience/` and prove the CLI fails safely when core local
+workflow state or artifacts are corrupted, missing, or semantically invalid.
+
+#### Details
+
+Favor generated temporary repositories and small targeted malformed payloads
+over large checked-in fixtures. At minimum, cover a corrupted
+`current-plan.json` case that affects `status` or another current-plan consumer,
+one missing or malformed review/evidence artifact case that must surface a
+warning or degraded summary instead of a false clean state, and one
+archive/reopen rollback-family case whose safety property is easier to trust
+when exercised through the real binary. The assertions need to prove more than
+"command failed": pin the conservative user-facing summary, any warning or
+error paths that matter, and the persisted file or pointer state that must
+remain intact after the failure.
+
+#### Expected Files
+
+- `tests/resilience/current_plan_test.go`
+- `tests/resilience/artifact_failures_test.go`
+- `tests/resilience/archive_reopen_rollback_test.go`
+- `tests/support/repo.go`
+- `tests/support/assert.go`
+- optional focused package-level tests if a small seam or fallback path must be
+  tightened in production code
+
+#### Validation
+
+- `go test ./tests/resilience -count=1` passes.
+- The resilience suite proves conservative failure behavior for malformed local
+  state and artifact degradation without relying on flaky timing or global test
+  ordering.
+- Any touched production fallback paths remain covered by focused package-level
+  tests in addition to the repo-level binary assertions.
+
+#### Execution Notes
+
+Added `tests/resilience/` with deterministic real-binary coverage for malformed
+`current-plan.json`, malformed historical review/evidence artifacts that must
+keep `status` conservative, and archive/reopen rollback-family failures where
+the current plan pointer and on-disk plan paths must recover cleanly.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Add deterministic integration-style concurrency coverage for runstate-dense workflows
+
+- Done: [ ]
+
+#### Objective
+
+Prove the broader concurrency contract behind `#56` with realistic overlapping
+command patterns around archive, reopen, evidence submission, and status.
+
+#### Details
+
+These tests should sit above the existing package-level lock-contention checks
+by exercising real command sequences against the same plan and asserting
+end-to-end coherence. Favor deterministic orchestration such as explicit lock
+ownership, staged command ordering, or injected overlap points rather than
+timing races. Good target patterns include: status attempting to refresh while
+another command owns the state-mutation lock; evidence submission plus status
+or reopen against an archived candidate; or archive/reopen transitions whose
+revision-sensitive evidence lookup must remain coherent across the interleaving.
+If a minimal behavior-preserving seam is needed to expose a deterministic hook,
+keep it local to the touched service and back it with focused package tests.
+This step should also finish any coverage-note updates needed so closeout can
+honestly say that the remaining open follow-up is parser fuzz/property work,
+not a vague concurrency bucket.
+
+#### Expected Files
+
+- `tests/e2e/runstate_concurrency_test.go`
+- `tests/e2e/helpers_test.go`
+- `tests/support/run.go`
+- `internal/status/service_test.go`
+- `internal/evidence/service_test.go`
+- `internal/lifecycle/service_test.go`
+- optional touched production files such as `internal/status/service.go`,
+  `internal/evidence/service.go`, or `internal/lifecycle/service.go` if a
+  deterministic test seam is required
+- `docs/testing/e2e-transition-coverage.md`
+
+#### Validation
+
+- `go test ./tests/e2e -count=1` passes with the new deterministic concurrency
+  scenario coverage.
+- Targeted package tests for any seam or touched service continue to pass.
+- The resulting repo-level assertions demonstrate CLI-level coherence under the
+  tested interleavings and do not merely restate helper-level lock behavior.
+
+#### Execution Notes
+
+Added `tests/e2e/runstate_concurrency_test.go` to prove a real archive ->
+await-merge -> reopen -> re-archive -> evidence handoff loop at revision 2.
+The scenario explicitly proves stale revision-1 evidence stays ignored after
+reopen and that `status` plus `evidence submit` fail clearly while the shared
+state lock is held.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run `go test ./tests/resilience -count=1` throughout development because the
+  new suite is the main closure evidence for `#37`.
+- Run `go test ./tests/e2e -count=1` while building the deterministic
+  concurrency scenarios so the broader contract behind `#56` is exercised
+  through the real binary.
+- If execution adds or tightens any deterministic hooks in production code, run
+  the focused package suites for the touched services in addition to the repo-level
+  tests.
+- Run `go test ./...` before archive so the added resilience and concurrency
+  coverage is validated against the full repository.
+
+## Risks
+
+- Risk: The repo-level scenarios could duplicate existing package-local
+  rollback coverage without adding new issue-closing evidence.
+  - Mitigation: Keep Step 1 explicit about the repo-level gap matrix and prefer
+    degraded-read, pointer-integrity, and command-interleaving contracts that
+    package-local tests do not already prove.
+- Risk: Deterministic concurrency tests could drift into flaky timing-based
+  orchestration.
+  - Mitigation: Use explicit lock ownership or staged overlap points instead of
+    sleeps or racey goroutine timing.
+- Risk: A real issue-closing gap may appear only after implementation starts,
+  leaving hidden residual scope.
+  - Mitigation: Record any remaining material gap as an explicit follow-up issue
+    before archive rather than quietly weakening the issue-closure claim.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-04-11-add-resilience-and-runstate-concurrency-coverage.md
+++ b/docs/plans/active/2026-04-11-add-resilience-and-runstate-concurrency-coverage.md
@@ -65,30 +65,30 @@ state-model redesign.
 
 ## Acceptance Criteria
 
-- [ ] `tests/resilience/` exists and `go test ./tests/resilience -count=1`
+- [x] `tests/resilience/` exists and `go test ./tests/resilience -count=1`
       passes with deterministic repository-level cases that directly satisfy the
       failure-path intent of `#37`.
-- [ ] The resilience suite covers malformed or corrupted
+- [x] The resilience suite covers malformed or corrupted
       `.local/harness/current-plan.json`, missing or malformed review/evidence
       artifacts, and at least one archive or reopen rollback-family safety
       case where the command must fail conservatively without leaving the
       worktree in a misleading state.
-- [ ] The new resilience assertions prove safe failure behavior, not only that
+- [x] The new resilience assertions prove safe failure behavior, not only that
       a command returns non-zero; the tests pin summaries, warnings, pointer or
       artifact preservation, and any required rollback outcomes that define the
       contract.
-- [ ] `go test ./tests/e2e -count=1` passes with at least one deterministic
+- [x] `go test ./tests/e2e -count=1` passes with at least one deterministic
       integration-style scenario that exercises realistic overlapping command
       patterns around archive, reopen, evidence submission, and status for the
       same plan, satisfying the broader contract requested by `#56`.
-- [ ] The concurrency-focused assertions prove CLI-level runstate coherence:
+- [x] The concurrency-focused assertions prove CLI-level runstate coherence:
       overlapping commands either serialize or fail clearly, status stays
       conservative, and no stale or cross-revision evidence is mistaken for the
       current archived candidate during the tested interleavings.
-- [ ] Any minimal production or helper changes introduced for testability stay
+- [x] Any minimal production or helper changes introduced for testability stay
       behavior-preserving and are covered by the new repo-level scenarios plus
       any focused package-level regression tests needed for the touched code.
-- [ ] The resulting tracked docs or closeout notes make it defensible to close
+- [x] The resulting tracked docs or closeout notes make it defensible to close
       `#37` and `#56` without a hidden "more resilience/concurrency coverage
       later" bucket; if anything material remains, it is moved into an explicit
       follow-up issue before archive.
@@ -105,7 +105,7 @@ state-model redesign.
 
 ### Step 1: Define the repo-level gap targets and fixture strategy
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -156,11 +156,13 @@ instead of remaining an ambiguous deferred bucket.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Fixture strategy, helper scope, and coverage-note
+updates are tightly coupled to the implemented resilience and concurrency
+scenarios, so a separate Step 1 delta review would be misleading duplication.
 
 ### Step 2: Add deterministic resilience coverage for malformed local state
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -208,11 +210,13 @@ the current plan pointer and on-disk plan paths must recover cleanly.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: The resilience suite is part of the same integrated
+repo-level closure slice as Step 1 and Step 3, so branch-level finalize review
+is the trustworthy review surface.
 
 ### Step 3: Add deterministic integration-style concurrency coverage for runstate-dense workflows
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -266,7 +270,9 @@ state lock is held.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: The deterministic concurrency scenario depends on the
+same fixture strategy and documentation closeout as the resilience suite, so
+branch-level finalize review is the trustworthy review surface.
 
 ## Validation Strategy
 

--- a/docs/plans/archived/2026-04-11-add-resilience-and-runstate-concurrency-coverage.md
+++ b/docs/plans/archived/2026-04-11-add-resilience-and-runstate-concurrency-coverage.md
@@ -1,6 +1,6 @@
 ---
 template_version: 0.2.0
-created_at: 2026-04-11T21:26:48+08:00
+created_at: "2026-04-11T21:26:48+08:00"
 source_type: issue
 source_refs:
     - '#37'
@@ -305,26 +305,53 @@ branch-level finalize review is the trustworthy review surface.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- Added deterministic repo-level resilience coverage in
+  `tests/resilience/` for malformed current-plan pointers, malformed
+  review/evidence artifacts, and archive/reopen rollback-family failures.
+- Added deterministic repo-level concurrency coverage in
+  `tests/e2e/runstate_concurrency_test.go` for archive, reopen, evidence, and
+  status interleavings across revisions.
+- Validated with `go test ./tests/resilience -count=1`,
+  `go test ./tests/e2e -count=1`, and `go test ./... -count=1`.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Finalize review `review-001-full` passed with no blocking or non-blocking
+  findings across the `correctness`, `tests`, and `docs_consistency` slots.
+- Reviewer submissions confirmed that the new repo-level tests, coverage note,
+  and tracked plan state agree on the intended issue-closure scope for `#37`
+  and `#56`.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-04-11T21:51:24+08:00
+- Revision: 1
+- PR: NONE
+- Ready: The candidate now covers the deterministic resilience and runstate
+  interleavings needed to close `#37` and `#56`, and the full repository test
+  suite passed before archive.
+- Merge Handoff: Commit and push the archived plan move, then record publish,
+  CI, and sync evidence for the archived candidate before treating it as truly
+  waiting for merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added `tests/resilience/` coverage for malformed current-plan pointers,
+  degraded artifact reads, and archive/reopen rollback-family safety cases.
+- Added a deterministic `tests/e2e/runstate_concurrency_test.go` scenario that
+  proves stale evidence stays revision-scoped after reopen and that lock
+  contention fails clearly for `status` and `evidence submit`.
+- Updated `docs/testing/e2e-transition-coverage.md` so resilience and broader
+  runstate follow-up no longer appear as an ambiguous deferred gap.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+NONE.
 
 ### Follow-Up Issues
 
-NONE
+- `#36` remains the explicit follow-up for fuzz or property-style coverage on
+  parsing-heavy paths such as plan linting, review artifacts, and evidence
+  payload decoding.

--- a/docs/testing/e2e-transition-coverage.md
+++ b/docs/testing/e2e-transition-coverage.md
@@ -141,9 +141,18 @@ real-binary scenario:
 There are no remaining gaps at the bounded transition-family level for the
 repo-level E2E suite.
 
-The intentionally deferred follow-up after this slice is:
+The earlier lifecycle-expansion slice intentionally deferred resilience and
+broader runstate-interleaving follow-up. Those adjacent gaps are now covered by:
 
-- resilience coverage in `tests/resilience/`
+- `tests/resilience/` for malformed current-plan pointers, degraded
+  review/evidence artifact reads, and archive/reopen rollback-family safety
+  cases
+- `tests/e2e/runstate_concurrency_test.go` for deterministic archive, reopen,
+  evidence, and status interleavings around revision-scoped archived evidence
+  and fail-fast lock contention
+
+The remaining follow-up after those adjacent suites is:
+
 - fuzzing or property-style coverage for parsing-heavy paths
 - unbounded route enumeration beyond the documented loop budgets
 

--- a/tests/e2e/runstate_concurrency_test.go
+++ b/tests/e2e/runstate_concurrency_test.go
@@ -1,0 +1,291 @@
+package e2e_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/catu-ai/easyharness/internal/runstate"
+	"github.com/catu-ai/easyharness/tests/support"
+)
+
+const (
+	runstateConcurrencyPlanTitle = "Runstate Concurrency Coverage Plan"
+	runstateConcurrencyStepOne   = "Prepare the first archived candidate"
+	runstateConcurrencyStepTwo   = "Reach merge-ready handoff before reopen"
+)
+
+func TestArchivedRunstateInterleavingsIgnoreStaleEvidenceAndFailClearlyUnderLock(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	planRelPath := "docs/plans/active/2026-04-11-runstate-concurrency-coverage.md"
+	planPath := workspace.Path(planRelPath)
+
+	template := support.Run(
+		t,
+		workspace.Root,
+		"plan", "template",
+		"--title", runstateConcurrencyPlanTitle,
+		"--timestamp", "2026-04-11T00:00:00Z",
+		"--source-type", "issue",
+		"--source-ref", "#56",
+		"--output", planRelPath,
+	)
+	support.RequireSuccess(t, template)
+	support.RequireNoStderr(t, template)
+	support.RewritePlanPreservingFrontmatter(t, planPath, runstateConcurrencyPlanTitle, runstateConcurrencyPlanBody())
+
+	lint := support.Run(t, workspace.Root, "plan", "lint", planRelPath)
+	support.RequireSuccess(t, lint)
+	support.RequireNoStderr(t, lint)
+
+	drivePlanToAwaitMergeNode(t, workspace, planPath, runstateConcurrencyStepOne, runstateConcurrencyStepTwo)
+
+	mergeReadyStatus := runStatus(t, workspace.Root)
+	assertNode(t, mergeReadyStatus, "execution/finalize/await_merge")
+
+	reopen := support.Run(t, workspace.Root, "reopen", "--mode", "finalize-fix")
+	support.RequireSuccess(t, reopen)
+	support.RequireNoStderr(t, reopen)
+	reopenPayload := requireLifecycleResult(t, reopen)
+	if !reopenPayload.OK || reopenPayload.Command != "reopen" {
+		t.Fatalf("unexpected reopen payload: %#v", reopenPayload)
+	}
+	if reopenPayload.State.CurrentNode != "execution/finalize/fix" || reopenPayload.Facts.Revision != 2 || reopenPayload.Facts.ReopenMode != "finalize-fix" {
+		t.Fatalf("expected finalize-fix reopen to bump revision to 2, got %#v", reopenPayload)
+	}
+
+	support.RewritePlanPreservingFrontmatter(t, planPath, runstateConcurrencyPlanTitle, runstateConcurrencyPlanBody())
+	support.CompleteStep(
+		t,
+		planPath,
+		1,
+		"Re-established the first completed step after reopen.",
+		"NO_STEP_REVIEW_NEEDED: Rehydrated reopen fixture keeps the original closeout intent.",
+	)
+	support.CompleteStep(
+		t,
+		planPath,
+		2,
+		"Re-established the second completed step after reopen.",
+		"NO_STEP_REVIEW_NEEDED: Rehydrated reopen fixture keeps the original closeout intent.",
+	)
+	support.CheckAllAcceptanceCriteria(t, planPath)
+
+	preFinalizeStatus := runStatus(t, workspace.Root)
+	assertNode(t, preFinalizeStatus, "execution/finalize/fix")
+	if preFinalizeStatus.Facts.ReopenMode != "finalize-fix" {
+		t.Fatalf("expected finalize-fix repair cue before the fresh finalize review, got %#v", preFinalizeStatus)
+	}
+
+	runPassingFinalizeReview(t, workspace)
+
+	postFinalizeStatus := runStatus(t, workspace.Root)
+	assertNode(t, postFinalizeStatus, "execution/finalize/archive")
+
+	archive := support.Run(t, workspace.Root, "archive")
+	support.RequireSuccess(t, archive)
+	support.RequireNoStderr(t, archive)
+	archivePayload := requireLifecycleResult(t, archive)
+	if !archivePayload.OK || archivePayload.Command != "archive" || archivePayload.Facts.Revision != 2 {
+		t.Fatalf("expected second archive to preserve revision 2, got %#v", archivePayload)
+	}
+
+	postRearchiveStatus := runStatus(t, workspace.Root)
+	assertNode(t, postRearchiveStatus, "execution/finalize/publish")
+	if postRearchiveStatus.Artifacts.PublishRecordID != "" || postRearchiveStatus.Artifacts.CIRecordID != "" || postRearchiveStatus.Artifacts.SyncRecordID != "" {
+		t.Fatalf("expected revision-1 evidence to stay ignored after reopen, got %#v", postRearchiveStatus.Artifacts)
+	}
+
+	release, err := runstate.AcquireStateMutationLock(workspace.Root, "2026-04-11-runstate-concurrency-coverage")
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+
+	lockedStatus := support.Run(t, workspace.Root, "status")
+	support.RequireExitCode(t, lockedStatus, 1)
+	support.RequireNoStderr(t, lockedStatus)
+	lockedStatusPayload := support.RequireJSONResult[statusResult](t, lockedStatus)
+	if lockedStatusPayload.OK || lockedStatusPayload.Summary != "Another local state mutation is already in progress." {
+		t.Fatalf("expected locked status failure, got %#v", lockedStatusPayload)
+	}
+
+	lockedCIInput := workspace.WriteJSON(t, "tmp/locked-ci.json", map[string]any{
+		"status":   "success",
+		"provider": "github-actions",
+		"url":      "https://ci.example/build/rev2-locked",
+	})
+	lockedEvidence := support.Run(t, workspace.Root, "evidence", "submit", "--kind", "ci", "--input", lockedCIInput)
+	support.RequireExitCode(t, lockedEvidence, 1)
+	support.RequireNoStderr(t, lockedEvidence)
+	lockedEvidencePayload := support.RequireJSONResult[evidenceSubmitResult](t, lockedEvidence)
+	if lockedEvidencePayload.OK || lockedEvidencePayload.Summary != "Another local state mutation is already in progress." {
+		t.Fatalf("expected locked evidence-submit failure, got %#v", lockedEvidencePayload)
+	}
+	support.RequireFileMissing(t, workspace.Path(".local/harness/plans/2026-04-11-runstate-concurrency-coverage/evidence/ci/ci-002.json"))
+
+	release()
+
+	submitEvidence(t, workspace, "publish", "tmp/rev2-publish.json", map[string]any{
+		"status": "recorded",
+		"pr_url": "https://github.com/catu-ai/easyharness/pull/156",
+		"branch": "codex/runstate-concurrency-coverage",
+		"base":   "main",
+		"commit": "def456abc789",
+	})
+	submitEvidence(t, workspace, "ci", "tmp/rev2-ci.json", map[string]any{
+		"status":   "success",
+		"provider": "github-actions",
+		"url":      "https://ci.example/build/rev2",
+	})
+	submitEvidence(t, workspace, "sync", "tmp/rev2-sync.json", map[string]any{
+		"status":   "fresh",
+		"base_ref": "main",
+		"head_ref": "codex/runstate-concurrency-coverage",
+	})
+
+	finalStatus := runStatus(t, workspace.Root)
+	assertNode(t, finalStatus, "execution/finalize/await_merge")
+	if finalStatus.Artifacts.PublishRecordID != "publish-002" || finalStatus.Artifacts.CIRecordID != "ci-002" || finalStatus.Artifacts.SyncRecordID != "sync-002" {
+		t.Fatalf("expected revision-2 evidence to drive merge-ready status, got %#v", finalStatus.Artifacts)
+	}
+}
+
+func runstateConcurrencyPlanBody() string {
+	return strings.TrimSpace(`
+## Goal
+
+Exercise deterministic archive, reopen, evidence, and status interleavings so
+stale archived evidence never masquerades as the current candidate and lock
+contention fails clearly.
+
+## Scope
+
+### In Scope
+
+- Reach ` + "`" + `execution/finalize/await_merge` + "`" + ` with real evidence records.
+- Reopen the archived candidate and archive it again at a new revision.
+- Prove older revision evidence stays ignored until the new revision records its
+  own publish, CI, and sync evidence.
+- Hold the shared state lock while ` + "`" + `status` + "`" + ` and
+  ` + "`" + `evidence submit` + "`" + ` run so the user-facing failure remains
+  clear and deterministic.
+
+### Out of Scope
+
+- Nondeterministic race harnesses.
+- New-step reopen semantics.
+
+## Acceptance Criteria
+
+- [ ] Revision 1 reaches ` + "`" + `execution/finalize/await_merge` + "`" + ` through real publish, CI, and sync evidence.
+- [ ] After ` + "`" + `reopen --mode finalize-fix` + "`" + ` and re-archive, stale revision-1 evidence does not advance revision 2 past ` + "`" + `execution/finalize/publish` + "`" + `.
+- [ ] While the shared state lock is held, ` + "`" + `status` + "`" + ` and
+  ` + "`" + `evidence submit` + "`" + ` fail clearly without creating new evidence records.
+- [ ] Fresh revision-2 evidence advances the candidate back to ` + "`" + `execution/finalize/await_merge` + "`" + `.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Prepare the first archived candidate
+
+- Done: [ ]
+
+#### Objective
+
+Close out the initial tracked step before the first archive.
+
+#### Details
+
+NONE
+
+#### Expected Files
+
+- tests/e2e/runstate_concurrency_test.go
+
+#### Validation
+
+- Run a clean delta review before advancing.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Reach merge-ready handoff before reopen
+
+- Done: [ ]
+
+#### Objective
+
+Archive the initial candidate, record merge-ready evidence, then reopen for a
+new revision of finalize-scope repair.
+
+#### Details
+
+The scenario should use the same plan stem across both archived revisions so the
+test can prove stale evidence stays revision-scoped rather than bleeding into
+the reopened candidate.
+
+#### Expected Files
+
+- tests/e2e/runstate_concurrency_test.go
+
+#### Validation
+
+- Run a clean finalize review before each archive point.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run ` + "`" + `go test ./tests/e2e -count=1` + "`" + `.
+
+## Risks
+
+- Risk: The test could accidentally re-prove only helper-level lock behavior.
+  - Mitigation: Assert node progression and revision-sensitive evidence
+    selection through the real binary before and after the lock-contention
+    checks.
+
+## Validation Summary
+
+Validated the deterministic archive, reopen, evidence, and status interleaving.
+
+## Review Summary
+
+No unresolved blocking review findings remain in the candidate used for
+concurrency coverage.
+
+## Archive Summary
+
+- PR: NONE
+- Ready: The candidate is ready for archive and later merge handoff.
+- Merge Handoff: Commit and push the archive move before treating the candidate
+  as waiting for merge approval.
+
+## Outcome Summary
+
+### Delivered
+
+Delivered deterministic runstate concurrency coverage.
+
+### Not Delivered
+
+NONE.
+
+### Follow-Up Issues
+
+NONE
+`)
+}

--- a/tests/resilience/archive_reopen_rollback_test.go
+++ b/tests/resilience/archive_reopen_rollback_test.go
@@ -1,0 +1,114 @@
+package resilience_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/catu-ai/easyharness/internal/runstate"
+	"github.com/catu-ai/easyharness/tests/support"
+)
+
+func TestArchiveRollsBackWhenActivePlanCannotBeRemoved(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	relPlanPath := "docs/plans/active/2026-04-11-resilience-archive-rollback.md"
+	writeActiveArchiveCandidate(t, workspace, relPlanPath)
+	writeCurrentPlan(t, workspace, relPlanPath)
+	writeState(t, workspace, "2026-04-11-resilience-archive-rollback", &runstate.State{
+		ExecutionStartedAt: "2026-04-11T13:15:00Z",
+		Revision:           1,
+		ActiveReviewRound: &runstate.ReviewRound{
+			RoundID:    "review-001-full",
+			Kind:       "full",
+			Revision:   1,
+			Aggregated: true,
+			Decision:   "pass",
+		},
+	})
+
+	activeDir := workspace.Path("docs/plans/active")
+	if err := os.Chmod(activeDir, 0o555); err != nil {
+		t.Fatalf("chmod active dir: %v", err)
+	}
+
+	result := support.Run(t, workspace.Root, "archive")
+
+	if err := os.Chmod(activeDir, 0o755); err != nil {
+		t.Fatalf("restore active dir perms: %v", err)
+	}
+
+	support.RequireExitCode(t, result, 1)
+	support.RequireNoStderr(t, result)
+
+	parsed := support.RequireJSONResult[lifecycleResult](t, result)
+	if parsed.OK || parsed.Command != "archive" {
+		t.Fatalf("expected archive failure payload, got %#v", parsed)
+	}
+	if parsed.Summary != "Unable to remove the active plan after archiving." {
+		t.Fatalf("unexpected summary: %#v", parsed)
+	}
+	support.RequireFileExists(t, workspace.Path(relPlanPath))
+	support.RequireFileMissing(t, workspace.Path("docs/plans/archived/2026-04-11-resilience-archive-rollback.md"))
+	current := readCurrentPlan(t, workspace)
+	if current["plan_path"] != relPlanPath {
+		t.Fatalf("expected current plan pointer to roll back to active path, got %#v", current)
+	}
+	state, _, err := runstate.LoadState(workspace.Root, "2026-04-11-resilience-archive-rollback")
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if state == nil || state.Reopen != nil || state.ActiveReviewRound == nil {
+		t.Fatalf("expected archived state mutation to roll back cleanly, got %#v", state)
+	}
+}
+
+func TestReopenRollsBackWhenArchivedPlanCannotBeRemoved(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	relPlanPath := "docs/plans/archived/2026-04-11-resilience-reopen-rollback.md"
+	writeArchivedArchiveCandidate(t, workspace, relPlanPath)
+	writeCurrentPlan(t, workspace, relPlanPath)
+	writeState(t, workspace, "2026-04-11-resilience-reopen-rollback", &runstate.State{
+		Revision: 1,
+		ActiveReviewRound: &runstate.ReviewRound{
+			RoundID:    "review-001-full",
+			Kind:       "full",
+			Revision:   1,
+			Aggregated: true,
+			Decision:   "pass",
+		},
+	})
+
+	archivedDir := workspace.Path("docs/plans/archived")
+	if err := os.Chmod(archivedDir, 0o555); err != nil {
+		t.Fatalf("chmod archived dir: %v", err)
+	}
+
+	result := support.Run(t, workspace.Root, "reopen", "--mode", "finalize-fix")
+
+	if err := os.Chmod(archivedDir, 0o755); err != nil {
+		t.Fatalf("restore archived dir perms: %v", err)
+	}
+
+	support.RequireExitCode(t, result, 1)
+	support.RequireNoStderr(t, result)
+
+	parsed := support.RequireJSONResult[lifecycleResult](t, result)
+	if parsed.OK || parsed.Command != "reopen" {
+		t.Fatalf("expected reopen failure payload, got %#v", parsed)
+	}
+	if parsed.Summary != "Unable to remove the archived plan after reopening." {
+		t.Fatalf("unexpected summary: %#v", parsed)
+	}
+	support.RequireFileExists(t, workspace.Path(relPlanPath))
+	support.RequireFileMissing(t, workspace.Path("docs/plans/active/2026-04-11-resilience-reopen-rollback.md"))
+	current := readCurrentPlan(t, workspace)
+	if current["plan_path"] != relPlanPath {
+		t.Fatalf("expected current plan pointer to roll back to archived path, got %#v", current)
+	}
+	state, _, err := runstate.LoadState(workspace.Root, "2026-04-11-resilience-reopen-rollback")
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if state == nil || state.Revision != 1 || state.Reopen != nil {
+		t.Fatalf("expected reopened state mutation to roll back cleanly, got %#v", state)
+	}
+}

--- a/tests/resilience/artifact_failures_test.go
+++ b/tests/resilience/artifact_failures_test.go
@@ -1,0 +1,79 @@
+package resilience_test
+
+import (
+	"testing"
+
+	"github.com/catu-ai/easyharness/internal/runstate"
+	"github.com/catu-ai/easyharness/tests/support"
+)
+
+func TestStatusWarnsAndStaysConservativeWhenHistoricalReviewArtifactsAreMalformed(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	relPlanPath := "docs/plans/active/2026-04-11-resilience-review-artifacts.md"
+	writePlanFixture(t, workspace, relPlanPath, "Resilience Review Artifacts", func(content string) string {
+		return completeFirstStep(content)
+	})
+	writeCurrentPlan(t, workspace, relPlanPath)
+	writeState(t, workspace, "2026-04-11-resilience-review-artifacts", &runstate.State{
+		ExecutionStartedAt: "2026-04-11T13:10:00Z",
+	})
+	writeReviewManifest(t, workspace, "2026-04-11-resilience-review-artifacts", "review-001-delta", map[string]any{
+		"review_title": "Step 1: Replace with first step title",
+		"step":         1,
+		"revision":     1,
+	})
+	writeReviewAggregate(t, workspace, "2026-04-11-resilience-review-artifacts", "review-001-delta", map[string]any{
+		"decision": "pass",
+	})
+	workspace.WriteFile(t, ".local/harness/plans/2026-04-11-resilience-review-artifacts/reviews/review-002-delta/manifest.json", []byte("{not-json"))
+	writeReviewAggregate(t, workspace, "2026-04-11-resilience-review-artifacts", "review-002-delta", map[string]any{
+		"review_title": "mystery historical target",
+		"revision":     1,
+		"decision":     "changes_requested",
+	})
+
+	result := support.Run(t, workspace.Root, "status")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	parsed := support.RequireJSONResult[statusResult](t, result)
+	if parsed.State.CurrentNode != "execution/step-2/implement" {
+		t.Fatalf("expected step 2 node to remain stable, got %#v", parsed)
+	}
+	if !findWarning(parsed.Warnings, "Unable to read historical review manifest") {
+		t.Fatalf("expected unreadable review-manifest warning, got %#v", parsed.Warnings)
+	}
+	if !findWarning(parsed.Warnings, "review-002-delta") {
+		t.Fatalf("expected conservative unmapped-round warning, got %#v", parsed.Warnings)
+	}
+	for _, action := range parsed.NextAction {
+		if action.Description != "" && action.Command == nil && findWarning([]string{action.Description}, "review-002-delta") {
+			t.Fatalf("did not expect malformed historical review to inject repair guidance, got %#v", parsed.NextAction)
+		}
+	}
+}
+
+func TestStatusDoesNotTreatMalformedEvidenceAsMergeReady(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	relPlanPath := "docs/plans/archived/2026-04-11-resilience-evidence-artifacts.md"
+	writeArchivedArchiveCandidate(t, workspace, relPlanPath)
+	writeCurrentPlan(t, workspace, relPlanPath)
+	writeState(t, workspace, "2026-04-11-resilience-evidence-artifacts", &runstate.State{
+		Revision: 1,
+	})
+	writePublishRecord(t, workspace, "2026-04-11-resilience-evidence-artifacts", relPlanPath, "publish-001", "https://github.com/catu-ai/easyharness/pull/201", 1)
+	writeCIRecord(t, workspace, "2026-04-11-resilience-evidence-artifacts", relPlanPath, "ci-001", "success", 1)
+	workspace.WriteFile(t, ".local/harness/plans/2026-04-11-resilience-evidence-artifacts/evidence/sync/sync-001.json", []byte("{not-json"))
+
+	result := support.Run(t, workspace.Root, "status")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	parsed := support.RequireJSONResult[statusResult](t, result)
+	if parsed.State.CurrentNode != "execution/finalize/publish" {
+		t.Fatalf("expected malformed evidence to keep publish node, got %#v", parsed)
+	}
+	if !findWarning(parsed.Warnings, "Unable to read sync evidence") {
+		t.Fatalf("expected sync-evidence warning, got %#v", parsed.Warnings)
+	}
+}

--- a/tests/resilience/current_plan_test.go
+++ b/tests/resilience/current_plan_test.go
@@ -1,0 +1,34 @@
+package resilience_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/catu-ai/easyharness/tests/support"
+)
+
+func TestStatusFailsSafelyWhenCurrentPlanPointerIsMalformed(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	relPlanPath := "docs/plans/active/2026-04-11-resilience-current-plan.md"
+	writePlanFixture(t, workspace, relPlanPath, "Resilience Current Plan", nil)
+	workspace.WriteFile(t, ".local/harness/current-plan.json", []byte("{not-json"))
+
+	result := support.Run(t, workspace.Root, "status")
+	support.RequireExitCode(t, result, 1)
+	support.RequireNoStderr(t, result)
+
+	parsed := support.RequireJSONResult[statusResult](t, result)
+	if parsed.OK || parsed.Command != "status" {
+		t.Fatalf("expected failing status payload, got %#v", parsed)
+	}
+	if parsed.Summary != "Unable to read current worktree state." {
+		t.Fatalf("unexpected summary: %#v", parsed)
+	}
+	if !findError(parsed.Errors, "state") {
+		t.Fatalf("expected state error, got %#v", parsed.Errors)
+	}
+	if len(parsed.Errors) == 0 || !strings.Contains(parsed.Errors[0].Message, "parse current-plan.json") {
+		t.Fatalf("expected parse-current-plan failure, got %#v", parsed.Errors)
+	}
+	support.RequireFileMissing(t, workspace.Path(".local/harness/plans/2026-04-11-resilience-current-plan/state.json"))
+}

--- a/tests/resilience/helpers_test.go
+++ b/tests/resilience/helpers_test.go
@@ -1,0 +1,189 @@
+package resilience_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/catu-ai/easyharness/internal/plan"
+	"github.com/catu-ai/easyharness/internal/runstate"
+	"github.com/catu-ai/easyharness/tests/support"
+)
+
+type commandError struct {
+	Path    string `json:"path"`
+	Message string `json:"message"`
+}
+
+type statusResult struct {
+	OK      bool           `json:"ok"`
+	Command string         `json:"command"`
+	Summary string         `json:"summary"`
+	Warnings []string      `json:"warnings"`
+	Errors  []commandError `json:"errors"`
+	State   struct {
+		CurrentNode string `json:"current_node"`
+	} `json:"state"`
+	NextAction []struct {
+		Command     *string `json:"command"`
+		Description string  `json:"description"`
+	} `json:"next_actions"`
+}
+
+type lifecycleResult struct {
+	OK      bool           `json:"ok"`
+	Command string         `json:"command"`
+	Summary string         `json:"summary"`
+	Errors  []commandError `json:"errors"`
+	Artifacts struct {
+		FromPlanPath    string `json:"from_plan_path"`
+		ToPlanPath      string `json:"to_plan_path"`
+		LocalStatePath  string `json:"local_state_path"`
+		CurrentPlanPath string `json:"current_plan_path"`
+	} `json:"artifacts"`
+}
+
+func writePlanFixture(t *testing.T, workspace *support.Workspace, relPath, title string, mutate func(string) string) string {
+	t.Helper()
+
+	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title:      title,
+		Timestamp:  time.Date(2026, 4, 11, 13, 0, 0, 0, time.UTC),
+		SourceType: "issue",
+		SourceRefs: []string{"#37"},
+	})
+	if err != nil {
+		t.Fatalf("render template: %v", err)
+	}
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
+	if mutate != nil {
+		rendered = mutate(rendered)
+	}
+	return workspace.WriteFile(t, relPath, []byte(rendered))
+}
+
+func writeCurrentPlan(t *testing.T, workspace *support.Workspace, relPath string) {
+	t.Helper()
+	if _, err := runstate.SaveCurrentPlan(workspace.Root, relPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+}
+
+func writeState(t *testing.T, workspace *support.Workspace, planStem string, state *runstate.State) {
+	t.Helper()
+	if _, err := runstate.SaveState(workspace.Root, planStem, state); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+}
+
+func writeReviewManifest(t *testing.T, workspace *support.Workspace, planStem, roundID string, payload map[string]any) string {
+	t.Helper()
+	return workspace.WriteJSON(t, filepath.ToSlash(filepath.Join(".local", "harness", "plans", planStem, "reviews", roundID, "manifest.json")), payload)
+}
+
+func writeReviewAggregate(t *testing.T, workspace *support.Workspace, planStem, roundID string, payload map[string]any) string {
+	t.Helper()
+	return workspace.WriteJSON(t, filepath.ToSlash(filepath.Join(".local", "harness", "plans", planStem, "reviews", roundID, "aggregate.json")), payload)
+}
+
+func writePublishRecord(t *testing.T, workspace *support.Workspace, planStem, relPlanPath, recordID, prURL string, revision int) string {
+	t.Helper()
+	return workspace.WriteJSON(t, filepath.ToSlash(filepath.Join(".local", "harness", "plans", planStem, "evidence", "publish", recordID+".json")), map[string]any{
+		"record_id":   recordID,
+		"kind":        "publish",
+		"plan_path":   relPlanPath,
+		"plan_stem":   planStem,
+		"revision":    revision,
+		"recorded_at": "2026-04-11T13:05:00Z",
+		"status":      "recorded",
+		"pr_url":      prURL,
+		"branch":      "codex/resilience-fixture",
+		"base":        "main",
+		"commit":      "abc123def456",
+	})
+}
+
+func writeCIRecord(t *testing.T, workspace *support.Workspace, planStem, relPlanPath, recordID, status string, revision int) string {
+	t.Helper()
+	return workspace.WriteJSON(t, filepath.ToSlash(filepath.Join(".local", "harness", "plans", planStem, "evidence", "ci", recordID+".json")), map[string]any{
+		"record_id":   recordID,
+		"kind":        "ci",
+		"plan_path":   relPlanPath,
+		"plan_stem":   planStem,
+		"revision":    revision,
+		"recorded_at": "2026-04-11T13:06:00Z",
+		"status":      status,
+		"provider":    "github-actions",
+		"url":         "https://ci.example/build/42",
+	})
+}
+
+func writeArchivedArchiveCandidate(t *testing.T, workspace *support.Workspace, relPath string) string {
+	t.Helper()
+	return writePlanFixture(t, workspace, relPath, "Resilience Archived Candidate", func(content string) string {
+		return completeAllSteps(content, true)
+	})
+}
+
+func writeActiveArchiveCandidate(t *testing.T, workspace *support.Workspace, relPath string) string {
+	t.Helper()
+	return writePlanFixture(t, workspace, relPath, "Resilience Active Candidate", func(content string) string {
+		return completeAllSteps(content, true)
+	})
+}
+
+func completeFirstStep(content string) string {
+	content = strings.Replace(content, "- Done: [ ]", "- Done: [x]", 1)
+	content = strings.Replace(content, "PENDING_STEP_EXECUTION", "Done.", 1)
+	content = strings.Replace(content, "PENDING_STEP_REVIEW", "Reviewed.", 1)
+	return content
+}
+
+func completeAllSteps(content string, archiveReady bool) string {
+	content = strings.ReplaceAll(content, "- Done: [ ]", "- Done: [x]")
+	content = strings.ReplaceAll(content, "- [ ]", "- [x]")
+	content = strings.ReplaceAll(content, "PENDING_STEP_EXECUTION", "Done.")
+	content = strings.ReplaceAll(content, "PENDING_STEP_REVIEW", "NO_STEP_REVIEW_NEEDED: Fixture relies on explicit review artifacts.")
+	if archiveReady {
+		content = strings.Replace(content, "## Validation Summary\n\nPENDING_UNTIL_ARCHIVE", "## Validation Summary\n\nValidated the candidate through deterministic repository-level fixtures.", 1)
+		content = strings.Replace(content, "## Review Summary\n\nPENDING_UNTIL_ARCHIVE", "## Review Summary\n\nNo unresolved blocking review findings remain.", 1)
+		content = strings.Replace(content, "## Archive Summary\n\nPENDING_UNTIL_ARCHIVE", "## Archive Summary\n\n- PR: NONE\n- Ready: The candidate is ready for archive.\n- Merge Handoff: Commit and push the archive move before merge approval.", 1)
+		content = strings.Replace(content, "### Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Delivered\n\nDelivered the planned resilience fixture.", 1)
+		content = strings.Replace(content, "### Not Delivered\n\nPENDING_UNTIL_ARCHIVE", "### Not Delivered\n\nNONE.", 1)
+	}
+	return content
+}
+
+func findError(errors []commandError, path string) bool {
+	for _, issue := range errors {
+		if issue.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func findWarning(warnings []string, fragment string) bool {
+	for _, warning := range warnings {
+		if strings.Contains(warning, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func readCurrentPlan(t *testing.T, workspace *support.Workspace) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(workspace.Path(".local/harness/current-plan.json"))
+	if err != nil {
+		t.Fatalf("read current-plan.json: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decode current-plan.json: %v", err)
+	}
+	return payload
+}

--- a/tests/support/repo.go
+++ b/tests/support/repo.go
@@ -40,3 +40,16 @@ func (w *Workspace) WriteJSON(t *testing.T, rel string, value any) string {
 	}
 	return path
 }
+
+func (w *Workspace) WriteFile(t *testing.T, rel string, data []byte) string {
+	t.Helper()
+
+	path := w.Path(rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary
- add `tests/resilience` coverage for malformed current-plan pointers, degraded review/evidence reads, and archive/reopen rollback-family failures
- add deterministic `tests/e2e` coverage for archive/reopen/evidence/status interleavings across revisions and lock contention
- update the tracked plan archive and adjacent coverage note so `#37` and `#56` have repo-visible closeout context, while leaving `#36` explicit as follow-up

## Testing
- go test ./tests/resilience -count=1
- go test ./tests/e2e -count=1
- go test ./... -count=1
