### PR TITLE
[codex] Close issue 36 with focused parsing coverage

### DIFF
--- a/docs/plans/active/2026-04-11-close-issue-36-parsing-coverage.md
+++ b/docs/plans/active/2026-04-11-close-issue-36-parsing-coverage.md
@@ -82,7 +82,7 @@ available from a first fuzzing pass.
 
 ### Step 1: Add focused fuzz coverage for plan markdown parsing
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -121,10 +121,18 @@ target asserting `LintFile` success implies `LoadFile` success while document
 helper methods stay panic-free on arbitrary inputs. Validated with
 `go test ./internal/plan` and
 `go test -run=^$ -fuzz=FuzzLintFileAndLoadFileAgreement -fuzztime=2s ./internal/plan`.
+After `review-001-delta`, tightened the fuzz baseline so exact canonical seeds
+must continue linting and loading cleanly, closing the one-way alignment gap
+the reviewer called out.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` passed with one non-blocking correctness finding: the
+original fuzz target only asserted `LintFile` success implied `LoadFile`
+success. Fixed that gap by requiring exact canonical seeds in the fuzz baseline
+to continue linting and loading cleanly, then reran
+`go test ./internal/plan` and
+`go test -run=^$ -fuzz=FuzzLintFileAndLoadFileAgreement -fuzztime=2s ./internal/plan`.
 
 ### Step 2: Cover schema-driven input decoding and keep issue closeout bounded
 
@@ -163,7 +171,20 @@ target needed to close `#36`.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added `internal/inputschema/fuzz_test.go` in the package-under-test so the
+slice can exercise unexported normalization helpers directly. The new coverage
+adds deterministic helper properties for JSON-pointer rendering,
+quoted-property splitting, and parent-issue pruning, plus a schema-backed fuzz
+target that checks `Validate` never returns empty or de-normalized issue paths
+and never leaks parent-child path pairs after pruning. Kept `internal/evidence`
+unchanged and revalidated it only as a command-boundary consumer of the schema
+layer. This step intentionally did not deepen `internal/reviewui` or
+historical evidence-record fuzzing because existing deterministic malformed and
+partial-artifact tests already cover that recovery path more strongly than a
+first bounded fuzz pass would. Validated with
+`go test ./internal/inputschema`,
+`go test -run=^$ -fuzz=FuzzValidateNormalizesIssuePaths -fuzztime=2s ./internal/inputschema`,
+and `go test ./internal/inputschema ./internal/evidence`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-04-11-close-issue-36-parsing-coverage.md
+++ b/docs/plans/active/2026-04-11-close-issue-36-parsing-coverage.md
@@ -136,7 +136,7 @@ to continue linting and loading cleanly, then reran
 
 ### Step 2: Cover schema-driven input decoding and keep issue closeout bounded
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -188,7 +188,11 @@ and `go test ./internal/inputschema ./internal/evidence`.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-002-delta` passed cleanly with no findings after inspecting the new
+`internal/inputschema` helper properties, schema-backed fuzz target, generated
+schemas, and the command-boundary evidence consumers. The round confirmed this
+step materially advances `#36` while staying bounded away from `reviewui`,
+`tests/resilience`, `tests/support`, and historical evidence-reader hardening.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-04-11-close-issue-36-parsing-coverage.md
+++ b/docs/plans/active/2026-04-11-close-issue-36-parsing-coverage.md
@@ -1,0 +1,224 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-11T21:38:59+08:00"
+source_type: issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/36
+size: S
+---
+
+# Close Issue 36 With Focused Parsing Coverage
+
+## Goal
+
+Close `#36` by adding focused fuzz or property-style coverage for the
+highest-value parsing-heavy harness paths without expanding into deterministic
+resilience work, repo-level lifecycle E2E, or broader concurrency hardening.
+
+This slice should make a clear repository-level judgment about which candidate
+paths deserve fuzz/property investment now. The expected closeout is: plan
+markdown parsing and command-input schema decoding gain meaningful new
+coverage, while review artifact readers and historical evidence-record readers
+are explicitly judged out of scope for this issue because their current
+deterministic coverage is already stronger than the remaining risk reduction
+available from a first fuzzing pass.
+
+## Scope
+
+### In Scope
+
+- Add package-level Go fuzz tests for the plan markdown parsing surface in
+  `internal/plan`, centered on `LintFile`, `LoadFile`, and the shared parsing
+  helpers they exercise.
+- Add property-style or seed-based invariants in `internal/plan` that check
+  stable relationships between linting and document loading on canonical plan
+  inputs.
+- Add focused fuzz or property-style coverage for `internal/inputschema`
+  normalization logic, especially JSON-pointer rendering, quoted-property
+  extraction, and parent-issue pruning.
+- Keep evidence command coverage aligned with the schema layer where that helps
+  prove schema-derived error paths still surface correctly through a real
+  command entrypoint.
+- Leave an execution trail strong enough that archive or issue closeout can say
+  `#36` was intentionally closed after evaluating plan lint, review artifacts,
+  and evidence payload decoding rather than only touching one of them.
+
+### Out of Scope
+
+- `tests/resilience/`, deterministic failure-path coverage, or any work owned
+  by `#37`.
+- Repo-level lifecycle E2E coverage, fixture expansion, or changes under
+  `tests/support/`.
+- Broader concurrency or lock-behavior coverage owned by `#56`.
+- Deep fuzzing of `internal/reviewui` artifact recovery or `internal/evidence`
+  historical record loading beyond what is needed to justify why those readers
+  are not the primary targets for closing `#36`.
+- Schema redesigns, command-shape changes, or new issue/follow-up creation.
+
+## Acceptance Criteria
+
+- [ ] `internal/plan` has new package-level fuzz or property-style coverage for
+      parsing-heavy plan inputs, and the targeted surfaces do not panic when
+      fed arbitrary data plus seeded canonical plan examples.
+- [ ] Canonical valid-plan seeds assert at least one stable plan invariant such
+      as: lint success and document loading stay aligned, current-step
+      detection remains deterministic, or archive-readiness helpers stay
+      coherent after successful parsing.
+- [ ] `internal/inputschema` has new fuzz or property-style coverage for path
+      rendering and validation-error normalization, including nested-array
+      paths, quoted-property extraction, and parent-issue pruning behavior.
+- [ ] Any touched `internal/evidence` regression coverage stays narrowly tied
+      to schema-decoding behavior and does not expand into resilience-style
+      malformed-artifact recovery.
+- [ ] The slice documents, through plan execution notes and closeout, that
+      review artifact readers and historical evidence-record readers were
+      evaluated but were not required additions for closing `#36`.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Add focused fuzz coverage for plan markdown parsing
+
+- Done: [ ]
+
+#### Objective
+
+Introduce high-signal fuzz or property-style tests in `internal/plan` that
+exercise the mixed YAML and Markdown parsing surface without widening into
+repo-level fixtures or resilience infrastructure.
+
+#### Details
+
+Target the shared parser surface behind `LintFile` and `LoadFile`, not a new
+parallel helper API. Seed the fuzz corpus with valid rendered plans plus a
+small number of invalid structured variants so the engine learns both success
+and failure shapes. Prefer invariants that stay useful under future template
+evolution, such as no panic, stable error/result shape expectations for seeded
+examples, and coherence between successful lint and successful document load
+for canonical valid plans.
+
+#### Expected Files
+
+- `internal/plan/lint_test.go`
+- `internal/plan/document_test.go`
+- `internal/plan/*_test.go`
+
+#### Validation
+
+- `go test ./internal/plan`
+- `go test -fuzz=Fuzz -run=^$ ./internal/plan` for a bounded fuzz pass
+
+#### Execution Notes
+
+Added `internal/plan/fuzz_test.go` with canonical seed properties that keep
+`LintFile` and `LoadFile` aligned across active, archived, and archived
+lightweight plans; added a tracked-plan corpus check that every repository plan
+that lints cleanly also loads cleanly; and added a bounded file-based fuzz
+target asserting `LintFile` success implies `LoadFile` success while document
+helper methods stay panic-free on arbitrary inputs. Validated with
+`go test ./internal/plan` and
+`go test -run=^$ -fuzz=FuzzLintFileAndLoadFileAgreement -fuzztime=2s ./internal/plan`.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Cover schema-driven input decoding and keep issue closeout bounded
+
+- Done: [ ]
+
+#### Objective
+
+Add focused fuzz or property-style coverage for command-input schema
+normalization in `internal/inputschema`, then keep any supporting evidence
+tests tightly limited to proving those normalized errors still reach a real
+command surface.
+
+#### Details
+
+Concentrate on the path-shaping logic that easyharness owns locally:
+`renderInstanceLocation`, `propertiesFromValidationMessage`,
+`renderIssueDetails`, and `pruneParentIssues`. Use schema-backed seeds so the
+tests stay grounded in real command inputs instead of arbitrary generated
+structures. If `internal/evidence/service_test.go` needs small updates, keep
+them at the command-boundary level and do not broaden into malformed historical
+record loading or status-side conservative behavior. During execution, record
+the explicit judgment that `internal/reviewui` already has strong deterministic
+coverage for malformed and partial artifacts, so it is not the first fuzzing
+target needed to close `#36`.
+
+#### Expected Files
+
+- `internal/inputschema/validator_test.go`
+- `internal/inputschema/*_test.go`
+- `internal/evidence/service_test.go`
+
+#### Validation
+
+- `go test ./internal/inputschema ./internal/evidence`
+- `go test -fuzz=Fuzz -run=^$ ./internal/inputschema` for a bounded fuzz pass
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Use package-level `go test` runs for the touched units instead of repo-level
+  E2E suites.
+- Run bounded Go fuzz passes only in `internal/plan` and `internal/inputschema`
+  so the work stays isolated from `tests/resilience/`, `tests/support/`, and
+  other worktrees handling `#37` plus `#56`.
+- Treat closeout as incomplete unless the final validation record can explain
+  why review artifact readers and historical evidence readers were evaluated
+  but not made primary fuzz targets for this issue.
+
+## Risks
+
+- Risk: Fuzz targets around file-based plan parsing can become flaky or too
+  coupled to temporary filesystem setup.
+  - Mitigation: Seed from deterministic tempdir fixtures and keep invariants
+    focused on no-panic and stable parser relationships rather than brittle
+    exact-error text for random inputs.
+- Risk: The slice could drift into resilience or malformed-artifact hardening
+  already separated into `#37`.
+  - Mitigation: Keep all new work inside package tests for `internal/plan`,
+    `internal/inputschema`, and narrowly scoped evidence regressions.
+- Risk: Closing `#36` could look premature if the plan does not explicitly
+  justify why review artifact readers were not fuzzed.
+  - Mitigation: Make that judgment explicit in execution and archive summaries
+    and only archive once the added coverage plus rationale would let a cold
+    reviewer understand the decision.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/archived/2026-04-11-close-issue-36-parsing-coverage.md
+++ b/docs/plans/archived/2026-04-11-close-issue-36-parsing-coverage.md
@@ -57,20 +57,20 @@ available from a first fuzzing pass.
 
 ## Acceptance Criteria
 
-- [ ] `internal/plan` has new package-level fuzz or property-style coverage for
+- [x] `internal/plan` has new package-level fuzz or property-style coverage for
       parsing-heavy plan inputs, and the targeted surfaces do not panic when
       fed arbitrary data plus seeded canonical plan examples.
-- [ ] Canonical valid-plan seeds assert at least one stable plan invariant such
+- [x] Canonical valid-plan seeds assert at least one stable plan invariant such
       as: lint success and document loading stay aligned, current-step
       detection remains deterministic, or archive-readiness helpers stay
       coherent after successful parsing.
-- [ ] `internal/inputschema` has new fuzz or property-style coverage for path
+- [x] `internal/inputschema` has new fuzz or property-style coverage for path
       rendering and validation-error normalization, including nested-array
       paths, quoted-property extraction, and parent-issue pruning behavior.
-- [ ] Any touched `internal/evidence` regression coverage stays narrowly tied
+- [x] Any touched `internal/evidence` regression coverage stays narrowly tied
       to schema-decoding behavior and does not expand into resilience-style
       malformed-artifact recovery.
-- [ ] The slice documents, through plan execution notes and closeout, that
+- [x] The slice documents, through plan execution notes and closeout, that
       review artifact readers and historical evidence-record readers were
       evaluated but were not required additions for closing `#36`.
 
@@ -224,25 +224,68 @@ step materially advances `#36` while staying bounded away from `reviewui`,
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- Added `internal/plan/fuzz_test.go` with canonical active, archived, and
+  archived lightweight plan seeds; a tracked-plan corpus lint/load agreement
+  property; and a bounded fuzz target covering arbitrary plan-file inputs.
+- Added `internal/inputschema/fuzz_test.go` with helper-level path
+  normalization properties plus a schema-backed fuzz target for `Validate`.
+- Validation runs:
+  - `go test ./internal/plan`
+  - `go test -run=^$ -fuzz=FuzzLintFileAndLoadFileAgreement -fuzztime=2s ./internal/plan`
+  - `go test ./internal/inputschema`
+  - `go test -run=^$ -fuzz=FuzzValidateNormalizesIssuePaths -fuzztime=2s ./internal/inputschema`
+  - `go test ./internal/plan ./internal/inputschema ./internal/evidence`
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- `review-001-delta`
+  - passed with one non-blocking correctness finding about one-way lint/load
+    agreement in the initial fuzz target
+  - repaired by requiring exact canonical seeds in the fuzz baseline to
+    continue linting and loading cleanly
+- `review-002-delta`
+  - passed clean with no findings on the `internal/inputschema` coverage and
+    bounded issue-closure rationale
+- `review-003-full`
+  - passed clean with no findings across correctness, tests, and docs
+    consistency for the full candidate
+- The final candidate is archive-ready after the clean full review and green
+  validation runs.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-04-11T21:55:34+08:00
+- Revision: 1
+- PR: NONE. The candidate has not been pushed or opened as a PR yet.
+- Ready: The branch is archive-ready locally after the clean finalize review
+  and focused parsing-coverage validation runs.
+- Merge Handoff: Archive the plan, commit the archive move, push
+  `codex/close-issue-36-parsing-coverage`, open or update the PR, and record
+  publish, CI, and sync evidence before treating the candidate as waiting for
+  merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added focused parsing-heavy fuzz/property coverage in `internal/plan` that
+  exercises plan-file parsing across canonical seeds, tracked-plan corpus
+  inputs, and bounded arbitrary plan content.
+- Added focused parsing-heavy fuzz/property coverage in `internal/inputschema`
+  for JSON-pointer rendering, quoted-property extraction, parent-issue
+  pruning, and schema-backed validation-error normalization.
+- Documented and validated the bounded closure rationale for `#36`: keep
+  `internal/evidence` at the command-boundary consumer level and rely on the
+  repository's existing deterministic malformed-artifact tests in
+  `internal/reviewui` rather than widening this slice into resilience work.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No new fuzz target was added for `internal/reviewui` artifact recovery.
+- No new fuzz target was added for historical evidence-record loading in
+  `internal/evidence`.
+- No deterministic resilience coverage, repo-level lifecycle E2E expansion, or
+  `tests/support/` work was added in this slice.
 
 ### Follow-Up Issues
 

--- a/internal/inputschema/fuzz_test.go
+++ b/internal/inputschema/fuzz_test.go
@@ -1,0 +1,136 @@
+package inputschema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/catu-ai/easyharness/internal/contracts"
+)
+
+func TestRenderInstanceLocationDecodesPointerTokensAndArrays(t *testing.T) {
+	got := renderInstanceLocation("/findings/0/locations/1/file~1path/~0anchor")
+	want := ".findings[0].locations[1].file/path.~anchor"
+	if got != want {
+		t.Fatalf("renderInstanceLocation mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestRenderIssueDetailsSplitsQuotedPropertiesWithoutDuplicates(t *testing.T) {
+	issues := renderIssueDetails("input", "/findings/0", "missing properties 'severity', 'details', 'severity'")
+	if len(issues) != 2 {
+		t.Fatalf("expected two issues, got %#v", issues)
+	}
+	if issues[0].Path != "input.findings[0].severity" || issues[1].Path != "input.findings[0].details" {
+		t.Fatalf("unexpected issue paths: %#v", issues)
+	}
+}
+
+func TestPruneParentIssuesDropsOnlyStrictParents(t *testing.T) {
+	issues := []contracts.ErrorDetail{
+		{Path: "input.findings[0]", Message: "parent"},
+		{Path: "input.findings[0].severity", Message: "child"},
+		{Path: "input.summary", Message: "summary"},
+		{Path: "input.summary_text", Message: "sibling"},
+	}
+
+	filtered := pruneParentIssues(issues)
+	if len(filtered) != 3 {
+		t.Fatalf("expected three filtered issues, got %#v", filtered)
+	}
+	if filtered[0].Path != "input.findings[0].severity" {
+		t.Fatalf("expected child issue to survive, got %#v", filtered)
+	}
+	if filtered[1].Path != "input.summary" || filtered[2].Path != "input.summary_text" {
+		t.Fatalf("expected non-parent prefixes to survive, got %#v", filtered)
+	}
+}
+
+func FuzzValidateNormalizesIssuePaths(f *testing.F) {
+	for _, seed := range []struct {
+		schemaKey string
+		rootLabel string
+		payload   string
+	}{
+		{
+			schemaKey: SchemaReviewSpec,
+			rootLabel: "spec",
+			payload:   `{"kind":"delta","dimensions":[{"name":"correctness","instructions":"Check correctness."}]}`,
+		},
+		{
+			schemaKey: SchemaReviewSpec,
+			rootLabel: "spec",
+			payload:   `{"kind":"delta","dimensions":[{"name":"correctness","instructions":"Check correctness."}],"unexpected":true}`,
+		},
+		{
+			schemaKey: SchemaReviewSubmission,
+			rootLabel: "submission",
+			payload:   `{"summary":"Missing fields.","findings":[{"title":"Missing metadata"}]}`,
+		},
+		{
+			schemaKey: SchemaEvidenceCI,
+			rootLabel: "input",
+			payload:   `{}`,
+		},
+		{
+			schemaKey: SchemaEvidencePublish,
+			rootLabel: "input",
+			payload:   `{"status":"recorded","pr_url":"https://example.invalid/pr/1","unexpected":true}`,
+		},
+		{
+			schemaKey: SchemaEvidenceSync,
+			rootLabel: "input",
+			payload:   `{"status":"fresh","head_ref":true}`,
+		},
+		{
+			schemaKey: SchemaEvidenceCI,
+			rootLabel: "input",
+			payload:   `{not-json`,
+		},
+	} {
+		f.Add(seed.schemaKey, seed.rootLabel, seed.payload)
+	}
+
+	f.Fuzz(func(t *testing.T, schemaKey, rootLabel, payload string) {
+		if len(payload) > 1<<14 {
+			t.Skip()
+		}
+		if schemaKey != SchemaReviewSpec &&
+			schemaKey != SchemaReviewSubmission &&
+			schemaKey != SchemaEvidenceCI &&
+			schemaKey != SchemaEvidencePublish &&
+			schemaKey != SchemaEvidenceSync {
+			t.Skip()
+		}
+		rootLabel = strings.TrimSpace(rootLabel)
+		if rootLabel == "" {
+			t.Skip()
+		}
+
+		issues := Validate(schemaKey, rootLabel, []byte(payload))
+		assertNormalizedIssueSet(t, rootLabel, issues)
+	})
+}
+
+func assertNormalizedIssueSet(t *testing.T, rootLabel string, issues []contracts.ErrorDetail) {
+	t.Helper()
+
+	for i, issue := range issues {
+		if strings.TrimSpace(issue.Path) == "" {
+			t.Fatalf("issue %d had empty path: %#v", i, issues)
+		}
+		if issue.Path != rootLabel && !strings.HasPrefix(issue.Path, rootLabel+".") && !strings.HasPrefix(issue.Path, rootLabel+"[") {
+			t.Fatalf("issue path %q did not stay under root %q: %#v", issue.Path, rootLabel, issues)
+		}
+	}
+
+	for i, issue := range issues {
+		for j, other := range issues {
+			if i == j {
+				continue
+			}
+			if strings.HasPrefix(other.Path, issue.Path+".") || strings.HasPrefix(other.Path, issue.Path+"[") {
+				t.Fatalf("issue set still contained parent-child pair %#v", issues)
+			}
+		}
+	}
+}

--- a/internal/plan/fuzz_test.go
+++ b/internal/plan/fuzz_test.go
@@ -1,0 +1,221 @@
+package plan_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/catu-ai/easyharness/internal/plan"
+)
+
+type canonicalPlanSeed struct {
+	name                 string
+	relPath              string
+	content              string
+	wantCurrentStepTitle string
+	wantAllChecked       bool
+	wantAllCompleted     bool
+	wantArchiveReady     bool
+}
+
+func TestCanonicalPlanSeedsKeepLintAndLoadAligned(t *testing.T) {
+	for _, seed := range canonicalPlanSeeds(t) {
+		t.Run(seed.name, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, filepath.FromSlash(seed.relPath))
+			writeFile(t, path, seed.content)
+
+			result := plan.LintFile(path)
+			if !result.OK {
+				t.Fatalf("expected canonical seed to lint clean, got %#v", result)
+			}
+
+			doc, err := plan.LoadFile(path)
+			if err != nil {
+				t.Fatalf("expected canonical seed to load, got %v", err)
+			}
+			if doc == nil {
+				t.Fatal("expected document")
+			}
+
+			current := doc.CurrentStep()
+			if seed.wantCurrentStepTitle == "" {
+				if current != nil {
+					t.Fatalf("expected no current step, got %#v", current)
+				}
+			} else {
+				if current == nil || current.Title != seed.wantCurrentStepTitle {
+					t.Fatalf("unexpected current step: %#v", current)
+				}
+			}
+
+			if got := doc.AllAcceptanceChecked(); got != seed.wantAllChecked {
+				t.Fatalf("AllAcceptanceChecked mismatch: got %v want %v", got, seed.wantAllChecked)
+			}
+			if got := doc.AllStepsCompleted(); got != seed.wantAllCompleted {
+				t.Fatalf("AllStepsCompleted mismatch: got %v want %v", got, seed.wantAllCompleted)
+			}
+
+			archiveReady := !doc.HasPendingArchivePlaceholders() && !doc.CompletedStepsHavePendingPlaceholders()
+			if archiveReady != seed.wantArchiveReady {
+				t.Fatalf("archive readiness mismatch: got %v want %v", archiveReady, seed.wantArchiveReady)
+			}
+		})
+	}
+}
+
+func TestTrackedPlanCorpusKeepsLintAndLoadAligned(t *testing.T) {
+	paths, err := filepath.Glob(filepath.Join("..", "..", "docs", "plans", "*", "*.md"))
+	if err != nil {
+		t.Fatalf("glob tracked plans: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("expected tracked plans in repository")
+	}
+
+	for _, path := range paths {
+		result := plan.LintFile(path)
+		if !result.OK {
+			t.Fatalf("expected tracked plan %s to lint clean, got %#v", path, result)
+		}
+		if _, err := plan.LoadFile(path); err != nil {
+			t.Fatalf("expected tracked plan %s to load cleanly after lint success, got %v", path, err)
+		}
+	}
+}
+
+func FuzzLintFileAndLoadFileAgreement(f *testing.F) {
+	for _, seed := range canonicalPlanSeeds(f) {
+		f.Add(uint8(modeFromPlanPath(seed.relPath)), seed.content)
+	}
+	f.Add(uint8(0), "not a plan")
+	f.Add(uint8(1), "---\ncreated_at: nope\n")
+	f.Add(uint8(2), strings.Repeat("### Step 1: fuzz\n", 32))
+
+	f.Fuzz(func(t *testing.T, mode uint8, content string) {
+		if len(content) > 1<<16 {
+			t.Skip()
+		}
+
+		root := t.TempDir()
+		path := filepath.Join(root, filepath.FromSlash(relPathForMode(mode)))
+		writeFile(t, path, content)
+
+		result := plan.LintFile(path)
+		doc, err := plan.LoadFile(path)
+
+		if result.OK && err != nil {
+			t.Fatalf("lint succeeded but load failed: %v (result=%#v)", err, result)
+		}
+		if err != nil {
+			return
+		}
+		if doc == nil {
+			t.Fatal("expected non-nil document when load succeeds")
+		}
+
+		current := doc.CurrentStep()
+		if current != nil && !documentContainsStep(doc, current.Title) {
+			t.Fatalf("current step %q was not found in document steps %#v", current.Title, doc.Steps)
+		}
+		if doc.AllStepsCompleted() && current != nil {
+			t.Fatalf("expected no current step once all steps are completed, got %#v", current)
+		}
+
+		_ = doc.AllAcceptanceChecked()
+		_ = doc.HasPendingArchivePlaceholders()
+		_ = doc.CompletedStepsHavePendingPlaceholders()
+	})
+}
+
+func canonicalPlanSeeds(tb testing.TB) []canonicalPlanSeed {
+	tb.Helper()
+
+	active := renderCanonicalTemplate(tb, "Canonical Active Plan")
+	archived := makeArchiveReady(checkAllBoxes(strings.ReplaceAll(renderCanonicalTemplate(tb, "Canonical Archived Plan"), "- Done: [ ]", "- Done: [x]")))
+	lightweight := renderCanonicalTemplate(tb, "Canonical Lightweight Archived Plan")
+	lightweight = strings.Replace(lightweight, "size: M", "size: XXS", 1)
+	lightweight = strings.Replace(lightweight, "source_refs: []", "source_refs: []\nworkflow_profile: lightweight", 1)
+	lightweight = strings.ReplaceAll(lightweight, "- Done: [ ]", "- Done: [x]")
+	lightweight = checkAllBoxes(lightweight)
+	lightweight = strings.ReplaceAll(lightweight, "PENDING_STEP_EXECUTION", "Completed lightweight execution notes.")
+	lightweight = strings.ReplaceAll(lightweight, "PENDING_STEP_REVIEW", "NO_STEP_REVIEW_NEEDED: lightweight canonical seed.")
+	lightweight = strings.ReplaceAll(lightweight, "PENDING_UNTIL_ARCHIVE", "Archived lightweight seed summary.")
+	lightweight = strings.Replace(lightweight, "## Archive Summary\n\nArchived lightweight seed summary.", "## Archive Summary\n\n- Archived At: 2026-03-17T12:00:00Z\n- Revision: 1\n- PR: NONE\n- Ready: Archived lightweight canonical seed is complete.\n- Merge Handoff: None for this lightweight canonical seed.", 1)
+
+	return []canonicalPlanSeed{
+		{
+			name:                 "active",
+			relPath:              "docs/plans/active/2026-03-17-canonical-plan.md",
+			content:              active,
+			wantCurrentStepTitle: "Step 1: Replace with first step title",
+			wantAllChecked:       false,
+			wantAllCompleted:     false,
+			wantArchiveReady:     false,
+		},
+		{
+			name:                 "archived",
+			relPath:              "docs/plans/archived/2026-03-17-canonical-plan.md",
+			content:              archived,
+			wantCurrentStepTitle: "",
+			wantAllChecked:       true,
+			wantAllCompleted:     true,
+			wantArchiveReady:     true,
+		},
+		{
+			name:                 "archived_lightweight",
+			relPath:              ".local/harness/plans/archived/2026-03-17-canonical-lightweight-plan.md",
+			content:              lightweight,
+			wantCurrentStepTitle: "",
+			wantAllChecked:       true,
+			wantAllCompleted:     true,
+			wantArchiveReady:     true,
+		},
+	}
+}
+
+func renderCanonicalTemplate(tb testing.TB, title string) string {
+	tb.Helper()
+	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title:      title,
+		Timestamp:  time.Date(2026, 3, 17, 14, 0, 0, 0, time.FixedZone("CST", 8*60*60)),
+		SourceType: "direct_request",
+		Size:       "M",
+	})
+	if err != nil {
+		tb.Fatalf("render template: %v", err)
+	}
+	return rendered
+}
+
+func modeFromPlanPath(relPath string) int {
+	switch {
+	case strings.HasPrefix(relPath, ".local/harness/plans/archived/"):
+		return 2
+	case strings.Contains(relPath, "/archived/"):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func relPathForMode(mode uint8) string {
+	switch mode % 3 {
+	case 1:
+		return "docs/plans/archived/2026-03-17-fuzz-plan.md"
+	case 2:
+		return ".local/harness/plans/archived/2026-03-17-fuzz-plan.md"
+	default:
+		return "docs/plans/active/2026-03-17-fuzz-plan.md"
+	}
+}
+
+func documentContainsStep(doc *plan.Document, title string) bool {
+	for _, step := range doc.Steps {
+		if step.Title == title {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plan/fuzz_test.go
+++ b/internal/plan/fuzz_test.go
@@ -86,7 +86,13 @@ func TestTrackedPlanCorpusKeepsLintAndLoadAligned(t *testing.T) {
 }
 
 func FuzzLintFileAndLoadFileAgreement(f *testing.F) {
+	canonicalByKey := map[canonicalFuzzKey]canonicalPlanSeed{}
 	for _, seed := range canonicalPlanSeeds(f) {
+		key := canonicalFuzzKey{
+			mode:    uint8(modeFromPlanPath(seed.relPath)),
+			content: seed.content,
+		}
+		canonicalByKey[key] = seed
 		f.Add(uint8(modeFromPlanPath(seed.relPath)), seed.content)
 	}
 	f.Add(uint8(0), "not a plan")
@@ -104,6 +110,14 @@ func FuzzLintFileAndLoadFileAgreement(f *testing.F) {
 
 		result := plan.LintFile(path)
 		doc, err := plan.LoadFile(path)
+		if seed, ok := canonicalByKey[canonicalFuzzKey{mode: mode % 3, content: content}]; ok {
+			if !result.OK {
+				t.Fatalf("canonical seed %q stopped linting cleanly: %#v", seed.name, result)
+			}
+			if err != nil {
+				t.Fatalf("canonical seed %q stopped loading cleanly: %v", seed.name, err)
+			}
+		}
 
 		if result.OK && err != nil {
 			t.Fatalf("lint succeeded but load failed: %v (result=%#v)", err, result)
@@ -127,6 +141,11 @@ func FuzzLintFileAndLoadFileAgreement(f *testing.F) {
 		_ = doc.HasPendingArchivePlaceholders()
 		_ = doc.CompletedStepsHavePendingPlaceholders()
 	})
+}
+
+type canonicalFuzzKey struct {
+	mode    uint8
+	content string
 }
 
 func canonicalPlanSeeds(tb testing.TB) []canonicalPlanSeed {


### PR DESCRIPTION
## What changed

This PR closes issue #36 with a focused parsing-coverage slice instead of widening into resilience or repo-level E2E work.

It adds:
- `internal/plan` fuzz/property coverage for plan-file parsing across canonical active, archived, and archived lightweight seeds
- a tracked-plan corpus property that every repository plan that lints cleanly also loads cleanly
- a bounded file-based fuzz target for `LintFile` / `LoadFile` agreement on arbitrary plan content
- `internal/inputschema` helper properties for JSON-pointer rendering, quoted-property extraction, and parent-issue pruning
- a schema-backed fuzz target for `Validate` path normalization

## Why it changed

Issue #36 called for evaluating and, where warranted, adding fuzz or property-style coverage for parsing-heavy harness paths.

This branch intentionally focuses on the highest-value surfaces needed to close that issue:
- plan markdown parsing
- command-input schema decoding and error-path normalization

It does not widen into:
- deterministic resilience work in `tests/resilience/`
- repo-level lifecycle E2E fixture work
- `tests/support/` changes
- broader concurrency coverage tracked elsewhere

It also explicitly evaluates, but does not add, new fuzz targets for `internal/reviewui` artifact recovery and historical evidence-record loading. The rationale is that those paths already have stronger deterministic malformed/partial-artifact coverage than the remaining value from a first bounded fuzz pass in this slice.

## Impact

The candidate gives `#36` a durable closure story:
- high-value parsing-heavy paths now have real fuzz/property coverage
- lower-priority candidate paths were explicitly evaluated and intentionally left out of this slice
- no new follow-up issue is needed to explain the bounded choice

## Validation

- `go test ./internal/plan`
- `go test -run=^$ -fuzz=FuzzLintFileAndLoadFileAgreement -fuzztime=2s ./internal/plan`
- `go test ./internal/inputschema`
- `go test -run=^$ -fuzz=FuzzValidateNormalizesIssuePaths -fuzztime=2s ./internal/inputschema`
- `go test ./internal/plan ./internal/inputschema ./internal/evidence`
