### PR TITLE
Stabilize review/state lock coordination

### DIFF
--- a/docs/plans/active/2026-04-11-stabilize-review-state-lock-coordination.md
+++ b/docs/plans/active/2026-04-11-stabilize-review-state-lock-coordination.md
@@ -1,0 +1,280 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-11T23:42:00+08:00"
+source_type: issue
+source_refs:
+    - '#57'
+size: S
+---
+
+# Stabilize review and state lock coordination without widening mutation scope
+
+## Goal
+
+Close `#57` by turning the current review/state locking behavior into an
+explicit, shared contract instead of leaving lock ordering and contention
+handling split across ad hoc review command implementations.
+
+This slice should preserve the current concurrency surface rather than redesign
+it. `state.json` is now a thin control-plane artifact rather than a
+`current_node` cache, so the work should align the code and specs with that
+reality while making it harder for future review-path changes to introduce lock
+ordering regressions or hidden scope creep.
+
+## Scope
+
+### In Scope
+
+- Confirm and codify the current split responsibilities among review mutation
+  locking, state mutation locking, and timeline mutation locking.
+- Refactor the review command paths that mutate both review artifacts and
+  `state.json` so they acquire locks through one shared, review-local
+  orchestration entrypoint with a fixed ordering contract.
+- Keep the ordering contract explicit and centralized for the dual-lock review
+  paths so future commands do not re-decide the sequence independently.
+- Preserve the current behavior boundary where `review start` and
+  `review aggregate` coordinate both review artifacts and `state.json`, while
+  `review submit` remains review-only.
+- Update tracked specs to reflect the current role of `state.json` as a
+  control-plane runtime artifact and to document the review/state lock
+  relationship in the narrowest durable way that future agents can follow.
+- Add focused regression coverage for lock acquisition ordering, contention
+  behavior, and the boundary that keeps `review submit` out of state mutation
+  locking.
+
+### Out of Scope
+
+- Replacing the separate review and state mutation locks with one broader
+  plan-local lock primitive.
+- Expanding `review submit` to acquire the state mutation lock.
+- Broadening lock coverage for unrelated command families beyond the current
+  review start and aggregate paths.
+- Changing the runtime role of `state.json`, reintroducing a persisted
+  `current_node`, or redesigning status resolution.
+- Folding timeline event serialization into this issue or introducing new lock
+  files.
+
+## Acceptance Criteria
+
+- [ ] `#57` is satisfiable through a narrow implementation that keeps distinct
+      review and state mutation semantics while removing duplicated dual-lock
+      orchestration from review command code.
+- [ ] The dual-lock review paths use one shared entrypoint that fixes the
+      acquisition order and keeps contention failures fail-fast and
+      understandable without silently widening lock scope.
+- [ ] `review submit` continues to operate without a state mutation lock, and
+      tests make that boundary explicit so later refactors do not accidentally
+      serialize it behind `state.json` writes.
+- [ ] Tracked specs and nearby code comments describe `state.json` as the
+      plan-local control-plane artifact it is today and explain the narrow
+      review/state coordination contract without implying a future-wide lock
+      merge.
+- [ ] Focused automated tests cover the shared review-path locking contract and
+      prove that the refactor does not introduce new contention failures,
+      deadlock-prone ordering drift, or behavior regressions for normal review
+      flows.
+
+## Deferred Items
+
+- Any future decision to converge review and state serialization into a single
+  broader lock primitive after a separate design discussion.
+- Any later cleanup that generalizes lock orchestration across timeline or
+  other non-review mutation surfaces.
+
+## Work Breakdown
+
+### Step 1: Pin the current mutation surfaces and the narrow lock contract
+
+- Done: [x]
+
+#### Objective
+
+Turn the post-issue-51 implementation reality into an explicit contract for
+this slice so execution can close `#57` without accidentally broadening what is
+serialized.
+
+#### Details
+
+Start by grounding the plan in the current code, not the older assumption that
+`state.json` caches workflow nodes. The intended outcome is a clear written
+boundary: `review start` and `review aggregate` are the only review commands in
+scope for shared review-plus-state coordination, `review submit` stays
+review-only, and timeline locking remains a separate concern. Any spec wording
+that still sounds like "state mutation" means "all workflow state" should be
+tightened so future agents can tell that this issue is about lock orchestration
+discipline, not a broad concurrency redesign.
+
+#### Expected Files
+
+- `docs/specs/state-model.md`
+- `docs/specs/cli-contract.md`
+- optional nearby docs if one additional tracked note is needed to keep the
+  contract honest
+
+#### Validation
+
+- The tracked plan and touched specs make it clear why this slice is standard
+  rather than lightweight and why timeline and lock unification remain outside
+  scope.
+- A future agent reading only the plan plus the updated specs can explain which
+  commands are supposed to take which locks and why `review submit` is
+  intentionally excluded from state locking.
+
+#### Execution Notes
+
+Documented the narrowed runtime model in `docs/specs/state-model.md` and
+`docs/specs/cli-contract.md`: `state.json` remains a control-plane artifact,
+timeline locking stays separate, `review start` and `review aggregate` are the
+dual-lock review paths, and `review submit` stays review-only.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 was tightly coupled to the Step 2 helper
+extraction and Step 3 regression coverage, so a separate step-bound review
+would have duplicated the later branch-level finalize review.
+
+### Step 2: Centralize dual-lock review-path orchestration without changing lock coverage
+
+- Done: [x]
+
+#### Objective
+
+Refactor the review service so the commands that mutate both review artifacts
+and `state.json` share one explicit locking helper with fixed ordering and
+stable contention behavior.
+
+#### Details
+
+Keep the change narrow and behavior-preserving. The goal is not to invent a new
+global locking abstraction; it is to remove duplicated sequencing logic from
+`review start` and `review aggregate` so later edits cannot drift in lock
+ordering or error wording. If a small helper in `internal/review/` or
+`internal/runstate/` improves clarity, use it, but do not leak this slice into
+other command families or change the existing mutation surfaces. Normal review
+flows should continue to produce the same durable artifacts and summaries after
+the refactor.
+
+#### Expected Files
+
+- `internal/review/service.go`
+- optional supporting review-local helper files if that makes the orchestration
+  clearer
+- optional `internal/runstate/state.go` only if a tiny shared helper is the
+  cleanest narrow seam
+
+#### Validation
+
+- `review start` and `review aggregate` no longer hand-roll separate dual-lock
+  orchestration.
+- The central helper keeps the lock order explicit and does not widen locking
+  for `review submit` or unrelated command families.
+- Normal review-path behavior and artifact persistence remain unchanged aside
+  from the intended implementation consolidation.
+
+#### Execution Notes
+
+Added a shared review-local helper in `internal/review/service.go` so
+`review start` and `review aggregate` now acquire review and state locks
+through one fixed-order entrypoint instead of hand-rolling the sequencing in
+two places. This was a behavior-preserving refactor, so strict red/green TDD
+was not practical; the safety proof comes from the new focused regression
+coverage added alongside the refactor.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: The helper extraction is only trustworthy when read
+together with the spec updates and regression tests, so finalize review is the
+right review surface for this step.
+
+### Step 3: Lock the contract in with focused regression coverage
+
+- Done: [x]
+
+#### Objective
+
+Prove that the narrower shared review-path orchestration closes `#57` without
+introducing new issues in contention handling or mutation scope.
+
+#### Details
+
+Favor deterministic tests over broad concurrency infrastructure. Cover at least
+the shared dual-lock entrypoint behavior for the review paths that touch
+`state.json`, a contention scenario that proves fail-fast behavior still
+surfaces cleanly, and the boundary that leaves `review submit` outside state
+locking. If the refactor exposes the need for tiny test seams, keep them local
+to the touched review or runstate code and back them with package-level tests
+rather than widening into repository-level orchestration work.
+
+#### Expected Files
+
+- `internal/review/service_test.go`
+- optional focused tests in `internal/runstate/state_test.go`
+- optional nearby spec or comment touch-ups if the tests reveal an ambiguity
+
+#### Validation
+
+- Focused automated tests for the touched packages pass.
+- The new assertions would catch accidental lock-order drift, accidental state
+  locking of `review submit`, or confusing contention behavior in the shared
+  review-path helper.
+- Closeout can honestly say `#57` is resolved by codifying the current dual-lock
+  model rather than deferring the real risk to another hidden follow-up.
+
+#### Execution Notes
+
+Extended `internal/review/service_test.go` with focused lock-contract tests:
+`review start` and `review aggregate` now prove they prefer the review lock
+when both locks are held, and `review submit` now proves it still succeeds
+while the state mutation lock is held.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: The added regression coverage exists to support the same
+small integrated slice reviewed at finalize time, so a separate step-closeout
+round would be redundant.
+
+## Validation Strategy
+
+- Run `harness plan lint` on this plan before approval.
+- During execution, run targeted Go tests for the touched review and runstate
+  packages, adding any narrow spec or comment checks needed to keep the
+  lock-contract wording aligned with the code.
+- Prefer deterministic lock-contention tests over timing-sensitive concurrent
+  stress.
+
+## Risks
+
+- Risk: A refactor intended to centralize ordering could accidentally widen lock
+  scope or change the user-visible contention behavior.
+  - Mitigation: Keep the helper narrowly owned by the review paths that already
+    take both locks and pin the current boundaries with focused tests.
+- Risk: Spec cleanup could overstate the contract and imply broader lock
+  unification than the code actually delivers.
+  - Mitigation: Phrase the docs around the current review/state coordination
+    behavior and explicitly list lock unification as deferred work.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-04-11-stabilize-review-state-lock-coordination.md
+++ b/docs/plans/active/2026-04-11-stabilize-review-state-lock-coordination.md
@@ -208,6 +208,8 @@ rather than widening into repository-level orchestration work.
 #### Expected Files
 
 - `internal/review/service_test.go`
+- `internal/cli/app.go`
+- `internal/cli/app_test.go`
 - optional focused tests in `internal/runstate/state_test.go`
 - optional nearby spec or comment touch-ups if the tests reveal an ambiguity
 
@@ -224,8 +226,12 @@ rather than widening into repository-level orchestration work.
 
 Extended `internal/review/service_test.go` with focused lock-contract tests:
 `review start` and `review aggregate` now prove they prefer the review lock
-when both locks are held, and `review submit` now proves it still succeeds
-while the state mutation lock is held.
+when both locks are held, and the initial service-level `review submit` test
+proved the intended lock boundary. Finalize review then caught a real CLI-layer
+gap in `internal/cli/app.go`: the wrapper was still taking a locked pre-submit
+status snapshot. The repair switched that snapshot to the unlocked status path
+and added a CLI regression test in `internal/cli/app_test.go` so the runtime
+boundary now matches the documented contract.
 
 #### Review Notes
 

--- a/docs/plans/archived/2026-04-11-stabilize-review-state-lock-coordination.md
+++ b/docs/plans/archived/2026-04-11-stabilize-review-state-lock-coordination.md
@@ -56,20 +56,20 @@ ordering regressions or hidden scope creep.
 
 ## Acceptance Criteria
 
-- [ ] `#57` is satisfiable through a narrow implementation that keeps distinct
+- [x] `#57` is satisfiable through a narrow implementation that keeps distinct
       review and state mutation semantics while removing duplicated dual-lock
       orchestration from review command code.
-- [ ] The dual-lock review paths use one shared entrypoint that fixes the
+- [x] The dual-lock review paths use one shared entrypoint that fixes the
       acquisition order and keeps contention failures fail-fast and
       understandable without silently widening lock scope.
-- [ ] `review submit` continues to operate without a state mutation lock, and
+- [x] `review submit` continues to operate without a state mutation lock, and
       tests make that boundary explicit so later refactors do not accidentally
       serialize it behind `state.json` writes.
-- [ ] Tracked specs and nearby code comments describe `state.json` as the
+- [x] Tracked specs and nearby code comments describe `state.json` as the
       plan-local control-plane artifact it is today and explain the narrow
       review/state coordination contract without implying a future-wide lock
       merge.
-- [ ] Focused automated tests cover the shared review-path locking contract and
+- [x] Focused automated tests cover the shared review-path locking contract and
       prove that the refactor does not introduce new contention failures,
       deadlock-prone ordering drift, or behavior regressions for normal review
       flows.
@@ -261,26 +261,74 @@ round would be redundant.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+Validated the narrowed lock contract with focused package tests:
+`go test ./internal/review ./internal/cli -count=1`.
+
+The review-focused suite now covers review-versus-state lock preference when
+both locks are held, plus the boundary that keeps `review submit` off
+state-mutation locking at both the service and CLI wrapper layers.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Finalize review proceeded in three rounds:
+
+- `review-001-full` found one important docs/runtime mismatch: `review submit`
+  still acquired the state lock indirectly through a locked pre-submit status
+  snapshot in the CLI wrapper.
+- `review-002-delta` rechecked the narrow repair that switched that snapshot to
+  the unlocked status path and passed with no findings.
+- `review-003-full` reran full finalize review for revision `1` and passed with
+  no findings, restoring archive readiness for the candidate.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-04-12T00:00:34+08:00
+- Revision: 1
+The archived candidate closes `#57` by keeping the existing split between
+review, state, and timeline mutation surfaces while making the review/state
+interaction explicit and harder to regress.
+
+Durable closeout now lives in tracked specs plus focused regression tests:
+
+- `docs/specs/state-model.md` and `docs/specs/cli-contract.md` explain the
+  current control-plane role of `state.json`, the separate timeline lock, and
+  the fixed review-then-state acquisition order for dual-lock review paths.
+- `internal/review/service.go` centralizes the dual-lock orchestration for
+  `review start` and `review aggregate`.
+- `internal/review/service_test.go` and `internal/cli/app_test.go` pin the
+  intended lock boundaries, including the repaired CLI `review submit` path.
+- PR: NONE. The candidate has not been pushed or opened as a PR yet.
+- Ready: The branch is archive-ready locally after the repaired CLI boundary,
+  the clean `review-003-full` finalize review, and focused
+  `go test ./internal/review ./internal/cli -count=1` validation.
+- Merge Handoff: Archive the plan, commit the archive move and closeout notes,
+  push `codex/issue-57-lock-coordination`, open or update the PR, and record
+  publish, CI, and sync evidence before treating the candidate as waiting for
+  merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Closed `#57` with a narrow implementation instead of a broader lock-model
+  redesign.
+- Kept `review submit` outside the plan-local state lock path in actual runtime
+  behavior, not just in service-level code or docs wording.
+- Added focused regression coverage for lock-order preference, state-lock
+  contention, and the repaired CLI wrapper behavior.
+- Left the review/state/timeline split explicit and documented so future work
+  can evolve from a truthful baseline.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No broader convergence to a single plan-local mutation lock primitive.
+- No general lock-orchestration cleanup outside the current review start,
+  review submit, and review aggregate surfaces.
 
 ### Follow-Up Issues
 
-NONE
+- No new GitHub follow-up issue was created in this slice. Any future decision
+  to unify review and state locking should begin as a separate design request
+  rather than being treated as unresolved debt inside `#57`.
+- Timeline-lock cleanup likewise remains intentionally out of scope unless a
+  later request broadens the concurrency model beyond this issue.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -475,6 +475,9 @@ Contract:
 - when `step` is omitted and the inferred binding would be finalize review,
   reject the request if earlier completed steps still lack review-complete
   closeout and direct the controller toward explicit `step=<i>` repair instead
+- when mutating both review artifacts and local state, acquire the review
+  mutation lock before the state mutation lock instead of inventing a separate
+  acquisition order for this command
 - update local `state.json` so `harness status` can surface the active round
 - return round metadata plus next actions for the controller agent
 
@@ -621,6 +624,8 @@ Contract:
   - `path/to/file.go#L1-L3`
 - store the structured reviewer artifact in the round's owned location
 - update the dispatch or audit ledger
+- stay on the review-artifact mutation path only; reviewer submission should
+  not acquire the plan-local state mutation lock
 - return a submission receipt plus clear next actions
 
 Recommended next action:
@@ -653,6 +658,9 @@ Contract:
   decision surface
 - write an aggregate artifact that captures the review decision surface and
   preserves any finding `locations` verbatim
+- when mutating both review artifacts and local state, acquire the review
+  mutation lock before the state mutation lock instead of inventing a separate
+  acquisition order for this command
 - update local `state.json` with the aggregate result, including whether the
   round passed or requested changes
 - allow later commands to recover that decision from the round aggregate

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -186,6 +186,20 @@ inputs that do not already live in a more specific artifact:
 - `reopen`
 - `land`
 
+The mutation surfaces around those runtime artifacts stay split on purpose:
+
+- `.state-mutation.lock` serializes rewrites of plan-local `state.json`
+- `.review-mutation.lock` serializes review-artifact mutation such as round
+  creation, submission, ledger updates, and aggregation
+- `.timeline-mutation.lock` serializes appends to the plan-local
+  `events.jsonl` index
+
+When a review command mutates both review artifacts and `state.json`, it should
+acquire the review mutation lock before the state mutation lock. Commands that
+only submit reviewer output should stay on the review-artifact path and should
+not acquire the state mutation lock just because the round also has local
+state.
+
 ## High-Level Resolution Order
 
 1. If merge has been confirmed and the required post-merge bookkeeping is still

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -756,7 +756,7 @@ func (a *App) runReviewSubmit(args []string) int {
 		return 1
 	}
 	recordedAt := a.Now().Format(time.RFC3339)
-	beforeStatus := readStatusSnapshot(workdir)
+	beforeStatus := readUnlockedStatusSnapshot(workdir)
 	result := review.Service{
 		Workdir:     workdir,
 		Now:         a.Now,

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -750,6 +750,45 @@ func TestReviewSubmitCommandAppendsTimelineEvent(t *testing.T) {
 	assertLastTimelineEventCommand(t, root, "review submit")
 }
 
+func TestReviewSubmitCommandDoesNotFailWhenStateMutationLockIsHeld(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 15, 0, 0, 0, time.FixedZone("CST", 8*60*60))
+	}
+
+	outputPath := filepath.Join(root, "docs/plans/active/2026-03-18-test-plan.md")
+	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Review Submit Lock Plan", "--output", outputPath}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	if exitCode := app.Run([]string{"execute", "start"}); exitCode != 0 {
+		t.Fatalf("execute start failed with %d: %s", exitCode, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	app.Stdin = bytes.NewBufferString(`{"kind":"delta","anchor_sha":"anchor-sha","dimensions":[{"name":"correctness","instructions":"Check the status and contracts."}]}`)
+	if exitCode := app.Run([]string{"review", "start"}); exitCode != 0 {
+		t.Fatalf("review start failed with %d: %s", exitCode, stderr.String())
+	}
+
+	release, err := runstate.AcquireStateMutationLock(root, "2026-03-18-test-plan")
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	stdout.Reset()
+	stderr.Reset()
+	app.Stdin = bytes.NewBufferString(`{"summary":"Looks good","findings":[]}`)
+	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness"}); exitCode != 0 {
+		t.Fatalf("expected review submit success while state lock is held, got %d: %s", exitCode, stderr.String())
+	}
+}
+
 func TestReviewSubmitCommandReturnsSchemaValidationErrors(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -54,32 +54,30 @@ type SubmitArtifacts = contracts.ReviewSubmitArtifacts
 type AggregateResult = contracts.ReviewAggregateResult
 type AggregateArtifacts = contracts.ReviewAggregateArtifacts
 
+type reviewDualMutationLocks struct {
+	PlanPath string
+	release  func()
+}
+
+type reviewMutationLockFailure struct {
+	Summary string
+	Issue   CommandError
+}
+
 func (s Service) Start(specBytes []byte) StartResult {
-	lockedPlanPath, release, err := s.acquireReviewMutationLock()
-	if err == nil {
-		defer release()
-	} else {
+	locks, failure := s.acquireReviewAndStateMutationLocks()
+	if failure != nil {
 		return StartResult{
 			OK:      false,
 			Command: "review start",
-			Summary: "Another review state mutation is already in progress.",
-			Errors:  []CommandError{{Path: "review", Message: err.Error()}},
+			Summary: failure.Summary,
+			Errors:  []CommandError{failure.Issue},
 		}
 	}
-	planStem := strings.TrimSuffix(filepath.Base(lockedPlanPath), filepath.Ext(lockedPlanPath))
-	releaseState, err := runstate.AcquireStateMutationLock(s.Workdir, planStem)
-	if err != nil {
-		return StartResult{
-			OK:      false,
-			Command: "review start",
-			Summary: "Another local state mutation is already in progress.",
-			Errors:  []CommandError{{Path: "state", Message: err.Error()}},
-		}
-	}
-	defer releaseState()
+	defer locks.release()
 
 	now := s.now()
-	planPath, doc, planStem, relPlanPath, state, statePath, errResult := s.loadCurrentExecutingPlan(lockedPlanPath)
+	planPath, doc, planStem, relPlanPath, state, statePath, errResult := s.loadCurrentExecutingPlan(locks.PlanPath)
 	if errResult != nil {
 		return *errResult
 	}
@@ -420,30 +418,18 @@ func (s Service) Submit(roundID, slot string, inputBytes []byte) SubmitResult {
 }
 
 func (s Service) Aggregate(roundID string) AggregateResult {
-	lockedPlanPath, release, err := s.acquireReviewMutationLock()
-	if err == nil {
-		defer release()
-	} else {
+	locks, failure := s.acquireReviewAndStateMutationLocks()
+	if failure != nil {
 		return AggregateResult{
 			OK:      false,
 			Command: "review aggregate",
-			Summary: "Another review state mutation is already in progress.",
-			Errors:  []CommandError{{Path: "review", Message: err.Error()}},
+			Summary: failure.Summary,
+			Errors:  []CommandError{failure.Issue},
 		}
 	}
-	planStem := strings.TrimSuffix(filepath.Base(lockedPlanPath), filepath.Ext(lockedPlanPath))
-	releaseState, err := runstate.AcquireStateMutationLock(s.Workdir, planStem)
-	if err != nil {
-		return AggregateResult{
-			OK:      false,
-			Command: "review aggregate",
-			Summary: "Another local state mutation is already in progress.",
-			Errors:  []CommandError{{Path: "state", Message: err.Error()}},
-		}
-	}
-	defer releaseState()
+	defer locks.release()
 
-	_, _, planStem, _, state, statePath, errResult := s.loadCurrentExecutingPlan(lockedPlanPath)
+	_, _, planStem, _, state, statePath, errResult := s.loadCurrentExecutingPlan(locks.PlanPath)
 	if errResult != nil {
 		return AggregateResult{
 			OK:      false,
@@ -624,6 +610,35 @@ func (s Service) Aggregate(roundID string) AggregateResult {
 		issues = append(issues, restoreJSONFileSnapshot(manifest.Aggregate, previousAggregate, previousAggregateExists, "aggregate")...)
 		return issues
 	})
+}
+
+// review start and review aggregate both mutate review artifacts plus state.json.
+// Keep the review lock outermost so future edits cannot drift into a different
+// acquisition order than the rest of the review command family expects.
+func (s Service) acquireReviewAndStateMutationLocks() (*reviewDualMutationLocks, *reviewMutationLockFailure) {
+	planPath, releaseReview, err := s.acquireReviewMutationLock()
+	if err != nil {
+		return nil, &reviewMutationLockFailure{
+			Summary: "Another review state mutation is already in progress.",
+			Issue:   CommandError{Path: "review", Message: err.Error()},
+		}
+	}
+	planStem := strings.TrimSuffix(filepath.Base(planPath), filepath.Ext(planPath))
+	releaseState, err := runstate.AcquireStateMutationLock(s.Workdir, planStem)
+	if err != nil {
+		releaseReview()
+		return nil, &reviewMutationLockFailure{
+			Summary: "Another local state mutation is already in progress.",
+			Issue:   CommandError{Path: "state", Message: err.Error()},
+		}
+	}
+	return &reviewDualMutationLocks{
+		PlanPath: planPath,
+		release: func() {
+			releaseState()
+			releaseReview()
+		},
+	}, nil
 }
 
 func activeAggregateRoundError(state *runstate.State, roundID string) *AggregateResult {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -536,6 +536,42 @@ func TestSubmitStoresSubmissionAndUpdatesLedger(t *testing.T) {
 	}
 }
 
+func TestSubmitDoesNotRequireStateMutationLock(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-03-18-review-contract"
+	writeExecutingPlan(t, root, "docs/plans/active/"+planStem+".md")
+
+	svc := review.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 1, 0, 0, 0, time.UTC)
+		},
+	}
+	start := svc.Start(mustJSON(t, review.Spec{
+		Kind:      "delta",
+		AnchorSHA: "anchor-sha",
+		Dimensions: []review.Dimension{
+			{Name: "correctness", Instructions: "Check correctness."},
+		},
+	}))
+	if !start.OK {
+		t.Fatalf("start failed: %#v", start)
+	}
+
+	release, err := runstate.AcquireStateMutationLock(root, planStem)
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+		Summary: "Looks good.",
+	}))
+	if !result.OK {
+		t.Fatalf("expected submit success while state lock is held, got %#v", result)
+	}
+}
+
 func TestSubmitRejectsUnknownFindingProperty(t *testing.T) {
 	root := t.TempDir()
 	writeExecutingPlan(t, root, "docs/plans/active/2026-03-18-review-contract.md")
@@ -1101,6 +1137,36 @@ func TestStartRejectsWhenStateMutationLockIsHeld(t *testing.T) {
 	assertStartError(t, result, "state")
 }
 
+func TestStartPrefersReviewMutationLockWhenBothLocksAreHeld(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-03-18-review-contract"
+	writeExecutingPlan(t, root, "docs/plans/active/"+planStem+".md")
+	holdReviewMutationLock(t, root, planStem)
+	release, err := runstate.AcquireStateMutationLock(root, planStem)
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	svc := review.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 1, 0, 0, 0, time.UTC)
+		},
+	}
+	result := svc.Start(mustJSON(t, review.Spec{
+		Kind:      "delta",
+		AnchorSHA: "anchor-sha",
+		Dimensions: []review.Dimension{
+			{Name: "correctness", Instructions: "Check correctness."},
+		},
+	}))
+	if result.OK {
+		t.Fatalf("expected start failure while both locks are held, got %#v", result)
+	}
+	assertStartError(t, result, "review")
+}
+
 func TestAggregateRejectsWhenReviewMutationLockIsHeld(t *testing.T) {
 	root := t.TempDir()
 	planStem := "2026-03-18-review-contract"
@@ -1183,6 +1249,48 @@ func TestAggregateRejectsWhenStateMutationLockIsHeld(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(root, ".local", "harness", "plans", planStem, "reviews", start.Artifacts.RoundID, "aggregate.json")); !os.IsNotExist(err) {
 		t.Fatalf("expected no aggregate artifact while state lock is held, got %v", err)
 	}
+}
+
+func TestAggregatePrefersReviewMutationLockWhenBothLocksAreHeld(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-03-18-review-contract"
+	writeExecutingPlan(t, root, "docs/plans/active/"+planStem+".md")
+
+	svc := review.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 1, 0, 0, 0, time.UTC)
+		},
+	}
+	start := svc.Start(mustJSON(t, review.Spec{
+		Kind:      "delta",
+		AnchorSHA: "anchor-sha",
+		Dimensions: []review.Dimension{
+			{Name: "correctness", Instructions: "Check correctness."},
+		},
+	}))
+	if !start.OK {
+		t.Fatalf("start failed: %#v", start)
+	}
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+		Summary: "Looks good.",
+	}))
+	if !submit.OK {
+		t.Fatalf("submit failed: %#v", submit)
+	}
+
+	holdReviewMutationLock(t, root, planStem)
+	release, err := runstate.AcquireStateMutationLock(root, planStem)
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	result := svc.Aggregate(start.Artifacts.RoundID)
+	if result.OK {
+		t.Fatalf("expected aggregate failure while both locks are held, got %#v", result)
+	}
+	assertAggregateError(t, result, "review")
 }
 
 func TestAggregateFullWithBlockingFindings(t *testing.T) {


### PR DESCRIPTION
## Summary
- centralize the review start/aggregate dual-lock orchestration behind one fixed review-then-state helper
- document the current review/state/timeline lock split and the control-plane role of `state.json`
- add regression coverage for lock preference and repair the CLI `review submit` snapshot so it stays off the state lock path

## Testing
- go test ./internal/review ./internal/cli -count=1

Closes #57
