### PR TITLE
Retire dev global fallback in install-dev-harness

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -21,16 +21,13 @@ By default the installer:
 - uses `~/.local/bin` by default
 - keeps parallel worktrees isolated by dispatching to the current worktree's
   `.local/bin/harness`
-- only refreshes a healthy outside-source-tree fallback when you install with
-  `--global`
-- self-heals an invalid outside-source-tree fallback during a normal install so
-  unrelated repositories stop dispatching to a broken fallback binary
+- dispatches outside easyharness source trees to a stable `harness` already on
+  `PATH`, such as a Homebrew install
 
 Useful options:
 
 ```bash
 scripts/install-dev-harness --help
-scripts/install-dev-harness --global
 scripts/install-dev-harness --install-dir "$HOME/.local/bin"
 scripts/install-dev-harness --force
 ```
@@ -42,17 +39,13 @@ be called directly:
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-When you want a checkout to provide the fallback used outside easyharness
-source trees, refresh it explicitly:
-
-```bash
-cd /path/to/your-easyharness-checkout
-scripts/install-dev-harness --global
-```
-
 Inside any easyharness source tree, the wrapper still dispatches to that
-checkout's local `.local/bin/harness` and does not silently fall back to the
-global binary.
+checkout's local `.local/bin/harness` and does not silently fall back to a
+stable Homebrew or other PATH-installed binary.
+
+Outside easyharness source trees, the wrapper expects a stable `harness`
+installation to already be available on `PATH`. The normal release path is the
+Homebrew install shown in the root [`README.md`](../README.md).
 
 Verify the command is available:
 

--- a/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
+++ b/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
@@ -116,7 +116,7 @@ review boundary is the integrated Step 2 candidate.
 
 ### Step 2: Rebaseline docs and smoke coverage
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -173,7 +173,8 @@ the smoke suite did not exercise the separate branch that skips other managed
 wrappers already on `PATH`. The repair resolves wrapper candidates to their
 real paths before self/managed-wrapper checks and adds focused smoke coverage
 for both the symlink-alias path and the separate managed-wrapper-skip branch.
-Fresh delta review is still pending for the repair.
+`review-002-delta` then passed cleanly with no remaining correctness or test
+findings for the repair.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
+++ b/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
@@ -43,17 +43,17 @@ release install in the normal operator flow.
 
 ## Acceptance Criteria
 
-- [ ] `scripts/install-dev-harness` no longer accepts or documents `--global`,
+- [x] `scripts/install-dev-harness` no longer accepts or documents `--global`,
       and no longer writes or repairs a dev-owned global fallback binary.
-- [ ] Inside an easyharness source tree, the managed wrapper still resolves the
+- [x] Inside an easyharness source tree, the managed wrapper still resolves the
       current worktree's `.local/bin/harness` and fails locally when that
       binary is missing.
-- [ ] Outside easyharness source trees, the managed wrapper dispatches to a
+- [x] Outside easyharness source trees, the managed wrapper dispatches to a
       stable `harness` found on `PATH` and emits a clear actionable error when
       none exists.
-- [ ] The wrapper avoids recursively selecting the managed dev wrapper itself
+- [x] The wrapper avoids recursively selecting the managed dev wrapper itself
       when searching `PATH` for the stable fallback.
-- [ ] Development docs and installer smoke tests describe and verify the new
+- [x] Development docs and installer smoke tests describe and verify the new
       contract centered on Homebrew or other stable PATH installs.
 
 ## Deferred Items
@@ -168,7 +168,14 @@ Revalidated with `bash -n scripts/install-dev-harness`,
 assertion that ordinary installs leave the retired
 `~/.local/share/easyharness/dev/harness` path absent and reran
 `gofmt -w tests/smoke/install_dev_harness_test.go` plus
-`go test ./tests/smoke -run InstallDevHarness -count=1`.
+`go test ./tests/smoke -run InstallDevHarness -count=1`. After
+`review-005-full` requested further changes, tightened out-of-tree PATH
+selection so only `mode: release` candidates qualify as stable fallbacks, and
+extended managed-wrapper coverage to exercise both the legacy wrapper-signature
+branch and the case where another checkout's repo-local dev binary appears on
+`PATH` ahead of the stable install. Revalidated with
+`bash -n scripts/install-dev-harness`, `gofmt -w tests/smoke/install_dev_harness_test.go`,
+and `go test ./tests/smoke -run InstallDevHarness -count=1`.
 
 #### Review Notes
 
@@ -182,7 +189,14 @@ for both the symlink-alias path and the separate managed-wrapper-skip branch.
 findings for the repair. Finalize `review-003-full` later requested one tests
 finding because the suite no longer proved the retired dev-owned global
 fallback path stayed absent during ordinary installs; the repair added that
-assertion and a fresh finalize delta review is now pending.
+assertion and `review-004-delta` passed cleanly for that narrow fix.
+`review-005-full` then requested two more blocking findings: restrict
+out-of-tree fallback selection to stable release-mode binaries rather than any
+non-wrapper `harness` on `PATH`, and add smoke coverage for the legacy
+managed-wrapper detection branch that still remains supported. The repair now
+filters PATH candidates by `mode: release` and extends the smoke suite to
+cover both the legacy-wrapper branch and repo-local dev binaries on `PATH`.
+Fresh full finalize review is now pending for that repaired candidate.
 
 ## Validation Strategy
 
@@ -211,25 +225,54 @@ assertion and a fresh finalize delta review is now pending.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `bash -n scripts/install-dev-harness`
+- `gofmt -w tests/smoke/install_dev_harness_test.go`
+- `go test ./tests/smoke -run InstallDevHarness -count=1`
+- `scripts/install-dev-harness`
+- `harness status`
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- `review-001-full` requested two blocking findings: fix PATH-fallback
+  recursion through symlinked wrapper aliases and add smoke coverage for
+  skipping other managed wrappers already on `PATH`.
+- `review-002-delta` passed cleanly after the wrapper real-path resolution fix
+  and the added managed-wrapper and alias-chain smoke coverage.
+- `review-003-full` requested one blocking tests finding: prove the retired
+  `~/.local/share/easyharness/dev/harness` path stays absent during ordinary
+  installs.
+- `review-004-delta` passed cleanly after adding that retired-path absence
+  assertion to the normal-install smoke.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: pending creation after archive closeout.
+- Ready: awaiting a fresh passing full finalize review for revision `1`, after
+  which the candidate should be archive-ready.
+- Merge Handoff: rerun full finalize review, archive the active plan, commit
+  the archive move and closeout summaries, push branch
+  `codex/retire-dev-global-fallback-path`, open or update the PR, and record
+  publish/CI/sync evidence until `harness status` reaches
+  `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Removed the dev installer's explicit `--global` path and the dev-owned global
+  fallback management under `~/.local/share/easyharness/dev/harness`.
+- Kept the managed wrapper model, but changed out-of-tree dispatch to use a
+  stable `harness` already on `PATH` while preserving strict repo-local binary
+  enforcement inside easyharness source trees.
+- Hardened PATH fallback selection so managed wrappers and symlink aliases are
+  skipped rather than recursively re-entering another dev wrapper.
+- Updated development docs and installer smoke coverage to match the new
+  release-backed PATH fallback contract, including proof that the retired
+  global fallback path stays absent during ordinary installs.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+NONE
 
 ### Follow-Up Issues
 

--- a/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
+++ b/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
@@ -157,11 +157,23 @@ precedence over stable PATH fallback, out-of-tree failure without a stable
 `--version` forwarding, and continued refusal to leave a source tree when the
 local binary is missing. Reinstalled the current worktree with
 `scripts/install-dev-harness` after the script change and reran
-`harness status`.
+`harness status`. After `review-001-full` requested changes, hardened the PATH
+fallback search so symlink aliases to managed wrappers resolve to their real
+targets before candidate selection, and extended smoke coverage to prove both
+symlink-alias skipping and skipping other managed wrappers already on `PATH`.
+Revalidated with `bash -n scripts/install-dev-harness`,
+`gofmt -w tests/smoke/install_dev_harness_test.go`, and
+`go test ./tests/smoke -run InstallDevHarness -count=1`.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-full` requested two blocking findings: symlinked aliases to the
+managed wrapper could recurse forever during out-of-tree PATH fallback, and
+the smoke suite did not exercise the separate branch that skips other managed
+wrappers already on `PATH`. The repair resolves wrapper candidates to their
+real paths before self/managed-wrapper checks and adds focused smoke coverage
+for both the symlink-alias path and the separate managed-wrapper-skip branch.
+Fresh delta review is still pending for the repair.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
+++ b/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
@@ -1,0 +1,215 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-11T23:24:00+08:00"
+source_type: direct_request
+source_refs:
+    - chat://current-session
+size: M
+---
+
+# Retire Dev Global Fallback For Stable PATH Fallback
+
+## Goal
+
+Replace the development wrapper's out-of-tree fallback model so
+`scripts/install-dev-harness` no longer maintains a separate dev-owned global
+fallback binary under the user's home directory.
+
+Inside an easyharness source tree, the wrapper should keep the current strict
+worktree-local behavior and require `<repo>/.local/bin/harness`. Outside an
+easyharness source tree, the wrapper should instead dispatch to a stable
+`harness` already available on `PATH`, which is expected to be the Homebrew
+release install in the normal operator flow.
+
+## Scope
+
+### In Scope
+
+- Remove the `--global` installer path and the dev-owned global fallback file
+  management from `scripts/install-dev-harness`.
+- Change the generated wrapper so out-of-tree invocation resolves a stable
+  `harness` from `PATH` while skipping the managed dev wrapper itself.
+- Keep easyharness source-tree detection authoritative so source-tree
+  invocations still require the current worktree's `.local/bin/harness`.
+- Update development docs and installer smoke coverage to describe and verify
+  the new release-backed fallback contract.
+
+### Out of Scope
+
+- Changing the release packaging or Homebrew publication flow itself.
+- Replacing the worktree-aware wrapper model inside easyharness source trees.
+- Adding Homebrew-specific hardcoded filesystem probing when a stable
+  `harness` is not already present on `PATH`.
+
+## Acceptance Criteria
+
+- [ ] `scripts/install-dev-harness` no longer accepts or documents `--global`,
+      and no longer writes or repairs a dev-owned global fallback binary.
+- [ ] Inside an easyharness source tree, the managed wrapper still resolves the
+      current worktree's `.local/bin/harness` and fails locally when that
+      binary is missing.
+- [ ] Outside easyharness source trees, the managed wrapper dispatches to a
+      stable `harness` found on `PATH` and emits a clear actionable error when
+      none exists.
+- [ ] The wrapper avoids recursively selecting the managed dev wrapper itself
+      when searching `PATH` for the stable fallback.
+- [ ] Development docs and installer smoke tests describe and verify the new
+      contract centered on Homebrew or other stable PATH installs.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Replace wrapper fallback resolution
+
+- Done: [x]
+
+#### Objective
+
+Refactor `scripts/install-dev-harness` and the generated wrapper so the
+out-of-tree dispatch path uses a stable `PATH` binary instead of the dev-owned
+global fallback.
+
+#### Details
+
+The clean target contract is:
+
+- inside easyharness source trees: use `<repo>/.local/bin/harness` only
+- outside easyharness source trees: resolve a stable `harness` from `PATH`
+
+This step removes the installer's `--global` option, the
+`~/.local/share/easyharness/dev/harness` fallback management, and any ordinary
+install self-heal behavior tied to that path. The generated wrapper must skip
+its own managed dev wrapper entry when searching `PATH` so an out-of-tree call
+does not recurse back into itself. The out-of-tree error should point operators
+at the stable release install path rather than suggesting a dev-only global
+refresh.
+
+#### Expected Files
+
+- `scripts/install-dev-harness`
+
+#### Validation
+
+- `bash -n scripts/install-dev-harness`
+- Focused smoke coverage that proves source-tree resolution still wins and that
+  out-of-tree resolution now selects a stable `PATH` binary rather than a
+  dev-managed global file.
+
+#### Execution Notes
+
+Removed the installer's `--global` flag, deleted the dev-owned
+`~/.local/share/easyharness/dev/harness` fallback path management, and changed
+the generated wrapper so out-of-tree execution resolves a stable `harness`
+from `PATH` while skipping managed dev wrappers and its own installed path.
+Validated with `bash -n scripts/install-dev-harness`,
+`gofmt -w tests/smoke/install_dev_harness_test.go`, and
+`go test ./tests/smoke -run InstallDevHarness -count=1`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 and Step 2 form one bounded installer-contract
+slice, so separate Step 1 closeout review would be artificial and the real
+review boundary is the integrated Step 2 candidate.
+
+### Step 2: Rebaseline docs and smoke coverage
+
+- Done: [ ]
+
+#### Objective
+
+Update the operator-facing docs and installer smoke suite to match the new
+stable PATH fallback contract.
+
+#### Details
+
+Tests should stop asserting `--global` behavior and instead cover:
+
+- success when a stable `harness` is available on `PATH` outside source trees
+- failure with a clear message when no stable `harness` is available on `PATH`
+- continued refusal to leave source-tree execution for a stable out-of-tree
+  binary when the local worktree binary is missing
+
+Docs should explain that development installs expose a worktree-aware wrapper
+for source-tree work while ordinary out-of-tree usage should come from the
+stable release install, with Homebrew as the default supported path.
+
+#### Expected Files
+
+- `docs/development.md`
+- `tests/smoke/install_dev_harness_test.go`
+
+#### Validation
+
+- `go test ./tests/smoke -run InstallDevHarness -count=1`
+- Review the updated dev-install docs for consistency with the wrapper's
+  actual runtime behavior.
+
+#### Execution Notes
+
+Updated `docs/development.md` to remove the obsolete `--global` guidance and
+describe the new stable PATH fallback behavior outside source trees. Replaced
+installer smoke coverage with assertions for the removed flag, source-tree
+precedence over stable PATH fallback, out-of-tree failure without a stable
+`harness` on `PATH`, successful out-of-tree stable fallback dispatch, stable
+`--version` forwarding, and continued refusal to leave a source tree when the
+local binary is missing. Reinstalled the current worktree with
+`scripts/install-dev-harness` after the script change and reran
+`harness status`.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run shell validation for the installer script after changing the wrapper
+  template and option parsing.
+- Run the installer-focused smoke suite covering source-tree precedence,
+  out-of-tree stable PATH fallback success, and out-of-tree failure without a
+  stable PATH binary.
+- Re-run `scripts/install-dev-harness` in this worktree after installer changes
+  before relying on direct `harness` commands locally.
+
+## Risks
+
+- Risk: PATH-based lookup could accidentally select the managed dev wrapper
+  again and recurse instead of reaching a stable install.
+  - Mitigation: Make the wrapper detect and skip its own managed wrapper path,
+    and add smoke coverage for the out-of-tree PATH-selection path.
+- Risk: Removing `--global` could leave docs or tests describing an obsolete
+  dev-fallback recovery path.
+  - Mitigation: Update development docs and installer smoke assertions in the
+    same slice so the contract changes atomically.
+- Risk: Source-tree enforcement could regress and silently use a stable PATH
+  binary when the local worktree binary is missing.
+  - Mitigation: Preserve source-tree detection order and keep the explicit
+    missing-local-binary smoke coverage.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
+++ b/docs/plans/active/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
@@ -163,6 +163,11 @@ targets before candidate selection, and extended smoke coverage to prove both
 symlink-alias skipping and skipping other managed wrappers already on `PATH`.
 Revalidated with `bash -n scripts/install-dev-harness`,
 `gofmt -w tests/smoke/install_dev_harness_test.go`, and
+`go test ./tests/smoke -run InstallDevHarness -count=1`. After finalize
+`review-003-full` raised one remaining tests finding, added an explicit smoke
+assertion that ordinary installs leave the retired
+`~/.local/share/easyharness/dev/harness` path absent and reran
+`gofmt -w tests/smoke/install_dev_harness_test.go` plus
 `go test ./tests/smoke -run InstallDevHarness -count=1`.
 
 #### Review Notes
@@ -174,7 +179,10 @@ wrappers already on `PATH`. The repair resolves wrapper candidates to their
 real paths before self/managed-wrapper checks and adds focused smoke coverage
 for both the symlink-alias path and the separate managed-wrapper-skip branch.
 `review-002-delta` then passed cleanly with no remaining correctness or test
-findings for the repair.
+findings for the repair. Finalize `review-003-full` later requested one tests
+finding because the suite no longer proved the retired dev-owned global
+fallback path stayed absent during ordinary installs; the repair added that
+assertion and a fresh finalize delta review is now pending.
 
 ## Validation Strategy
 

--- a/docs/plans/archived/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
+++ b/docs/plans/archived/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
@@ -225,10 +225,20 @@ Fresh full finalize review is now pending for that repaired candidate.
 
 ## Validation Summary
 
+- Revision `1` validation before the first archive:
 - `bash -n scripts/install-dev-harness`
 - `gofmt -w tests/smoke/install_dev_harness_test.go`
 - `go test ./tests/smoke -run InstallDevHarness -count=1`
 - `scripts/install-dev-harness`
+- `harness status`
+- Post-archive GitHub Actions run
+  `https://github.com/catu-ai/easyharness/actions/runs/24286201051` failed
+  because `TestReleaseDocsPresentStableOnboardingSurface` still expected the
+  retired `--global` onboarding text in `docs/development.md`.
+- Revision `2` finalize-fix validation:
+- `gofmt -w tests/smoke/release_docs_test.go`
+- `go test ./tests/smoke -run ReleaseDocsPresentStableOnboardingSurface -count=1`
+- `go test ./...`
 - `harness status`
 
 ## Review Summary
@@ -249,22 +259,41 @@ Fresh full finalize review is now pending for that repaired candidate.
 - `review-006-full` passed cleanly after constraining out-of-tree fallback to
   release-mode PATH candidates and expanding the managed-wrapper smoke to cover
   both marker-based and legacy wrapper signatures.
+- Post-archive CI then invalidated revision `1`: GitHub Actions run
+  `24286201051` failed because `tests/smoke/release_docs_test.go` still
+  asserted the removed `cd /path/to/your-easyharness-checkout` / `--global`
+  development-doc path.
+- `review-007-delta` passed cleanly for revision `2` after updating the
+  release-doc smoke expectations to the new stable PATH / Homebrew onboarding
+  contract.
 
 ## Archive Summary
 
-- Archived At: 2026-04-12T00:01:01+08:00
-- Revision: 1
-- PR: pending creation after archive closeout.
-- Ready: `review-006-full` passed for revision `1`; the candidate is
-  archive-ready.
-- Merge Handoff: archive the active plan, commit the archive move and closeout
-  summaries, push branch `codex/retire-dev-global-fallback-path`, open or
-  update the PR, and record publish/CI/sync evidence until `harness status`
+- Archived At: 2026-04-12T00:10:38+08:00
+- Revision: 2
+- PR: https://github.com/catu-ai/easyharness/pull/145
+- Ready: revision `1` was archived and published, but post-archive CI failed in
+  `TestReleaseDocsPresentStableOnboardingSurface` because the smoke test still
+  expected retired `--global` onboarding guidance. Revision `2` repaired that
+  stale test expectation and `review-007-delta` passed, so the candidate is
+  ready to re-archive.
+- Merge Handoff: complete the revision `2` finalize review, re-archive the
+  active plan, commit and push the tracked plan move plus the smoke-test fix,
+  reuse PR `#145`, and refresh publish/CI/sync evidence until `harness status`
   reaches `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
+
+- Retired the dev-owned global fallback path and the installer's `--global`
+  mode so out-of-tree wrapper dispatch now depends on a stable release-mode
+  `harness` already on `PATH`.
+- Preserved repo-local wrapper dispatch inside easyharness source trees while
+  tightening smoke coverage for managed-wrapper recursion, repo-local dev-binary
+  rejection, release-only PATH fallback, and retired fallback absence.
+- Updated the release-doc smoke to assert the new stable PATH / Homebrew
+  onboarding contract instead of the removed `--global` development flow.
 
 - Removed the dev installer's explicit `--global` path and the dev-owned global
   fallback management under `~/.local/share/easyharness/dev/harness`.

--- a/docs/plans/archived/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
+++ b/docs/plans/archived/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
@@ -243,17 +243,24 @@ Fresh full finalize review is now pending for that repaired candidate.
   installs.
 - `review-004-delta` passed cleanly after adding that retired-path absence
   assertion to the normal-install smoke.
+- `review-005-full` requested two blocking findings: reject repo-local dev
+  binaries as out-of-tree PATH fallbacks and prove both managed-wrapper
+  signatures are skipped during that fallback scan.
+- `review-006-full` passed cleanly after constraining out-of-tree fallback to
+  release-mode PATH candidates and expanding the managed-wrapper smoke to cover
+  both marker-based and legacy wrapper signatures.
 
 ## Archive Summary
 
+- Archived At: 2026-04-12T00:01:01+08:00
+- Revision: 1
 - PR: pending creation after archive closeout.
-- Ready: awaiting a fresh passing full finalize review for revision `1`, after
-  which the candidate should be archive-ready.
-- Merge Handoff: rerun full finalize review, archive the active plan, commit
-  the archive move and closeout summaries, push branch
-  `codex/retire-dev-global-fallback-path`, open or update the PR, and record
-  publish/CI/sync evidence until `harness status` reaches
-  `execution/finalize/await_merge`.
+- Ready: `review-006-full` passed for revision `1`; the candidate is
+  archive-ready.
+- Merge Handoff: archive the active plan, commit the archive move and closeout
+  summaries, push branch `codex/retire-dev-global-fallback-path`, open or
+  update the PR, and record publish/CI/sync evidence until `harness status`
+  reaches `execution/finalize/await_merge`.
 
 ## Outcome Summary
 

--- a/scripts/install-dev-harness
+++ b/scripts/install-dev-harness
@@ -236,6 +236,15 @@ managed_easyharness_wrapper() {
     return 0
 }
 
+release_harness_candidate() {
+  local path="$1"
+  local version_output=""
+
+  version_output="$("${path}" --version 2>/dev/null || true)"
+  [[ -n "${version_output}" ]] || return 1
+  grep -Fq 'mode: release' <<< "${version_output}"
+}
+
 find_stable_harness_on_path() {
   local self_path="$1"
   local self_real_path="$2"
@@ -255,6 +264,9 @@ find_stable_harness_on_path() {
       continue
     fi
     if managed_easyharness_wrapper "${candidate}"; then
+      continue
+    fi
+    if ! release_harness_candidate "${candidate}"; then
       continue
     fi
 

--- a/scripts/install-dev-harness
+++ b/scripts/install-dev-harness
@@ -3,13 +3,12 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: scripts/install-dev-harness [--global] [--install-dir <path>] [--force]
+Usage: scripts/install-dev-harness [--install-dir <path>] [--force]
 
 Build the current repo's harness binary into .local/bin and install a
 worktree-aware `harness` wrapper from a user-local directory.
 
 Options:
-  --global              Refresh the fallback binary used outside easyharness source trees.
   --install-dir <path>  Override the target directory for the harness wrapper.
   --force               Replace an existing non-matching harness entry.
   -h, --help            Show this help text.
@@ -17,14 +16,10 @@ EOF
 }
 
 install_dir=""
-install_global_fallback=0
 force=0
 
 while (($#)); do
   case "$1" in
-    --global)
-      install_global_fallback=1
-      ;;
     --install-dir)
       shift
       if (($# == 0)); then
@@ -122,46 +117,8 @@ choose_install_dir() {
   printf '%s\n' "${repo_root}/.local/dev-bin"
 }
 
-choose_global_fallback_path() {
-  if [[ -n "${HOME:-}" ]]; then
-    printf '%s\n' "${HOME}/.local/share/easyharness/dev/harness"
-    return
-  fi
-
-  printf '%s\n' ""
-}
-
-global_fallback_healthy() {
-  local path="$1"
-  [[ -x "${path}" ]] || return 1
-  "${path}" --version >/dev/null 2>&1
-}
-
-replace_file_atomically() {
-  local src="$1"
-  local dst="$2"
-  local tmp="${dst}.tmp.$$"
-
-  rm -f "${tmp}"
-  cp "${src}" "${tmp}"
-  chmod 755 "${tmp}"
-  if [[ -L "${dst}" ]]; then
-    rm -f "${dst}"
-  fi
-  mv -f "${tmp}" "${dst}"
-}
-
 target_dir="$(choose_install_dir)"
 command_path="${target_dir}/harness"
-global_fallback_path="$(choose_global_fallback_path)"
-
-normalize_path() {
-  local path="$1"
-  local dir base
-  dir="$(cd "$(dirname "${path}")" 2>/dev/null && pwd -P)" || return 1
-  base="$(basename "${path}")"
-  printf '%s/%s\n' "${dir}" "${base}"
-}
 
 if [[ "${command_path}" == "${binary_path}" ]]; then
   echo "Refusing to install the wrapper over the repo-local binary at ${binary_path}." >&2
@@ -170,14 +127,12 @@ if [[ "${command_path}" == "${binary_path}" ]]; then
 fi
 
 wrapper_content() {
-  local fallback_binary_path template
-  fallback_binary_path="$(printf '%q' "${global_fallback_path}")"
+  local template
   template="$(cat <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
 # easyharness-install-dev-wrapper
-fallback_binary_path=__FALLBACK_BINARY_PATH__
 repo_module_line='module github.com/catu-ai/easyharness'
 legacy_repo_module_lines=(
   'module github.com/yzhang1918/microharness'
@@ -230,6 +185,58 @@ find_repo_root() {
   return 1
 }
 
+normalize_path() {
+  local path="$1"
+  local dir base
+  dir="$(cd "$(dirname "${path}")" 2>/dev/null && pwd -P)" || return 1
+  base="$(basename "${path}")"
+  printf '%s/%s\n' "${dir}" "${base}"
+}
+
+managed_easyharness_wrapper() {
+  local path="$1"
+  [[ -f "${path}" && ! -L "${path}" ]] || return 1
+
+  if grep -Fq '# easyharness-install-dev-wrapper' "${path}"; then
+    return 0
+  fi
+
+  grep -Fq 'find_repo_root()' "${path}" &&
+    grep -Fq 'cmd/harness/main.go' "${path}" &&
+    return 0
+}
+
+find_stable_harness_on_path() {
+  local self_path="$1"
+  local dir candidate normalized_candidate
+  IFS=':' read -r -a path_entries <<< "${PATH:-}"
+  for dir in "${path_entries[@]}"; do
+    [[ -z "${dir}" ]] && continue
+    candidate="${dir%/}/harness"
+    [[ -x "${candidate}" ]] || continue
+
+    normalized_candidate="$(normalize_path "${candidate}" 2>/dev/null || true)"
+    if [[ -n "${self_path}" && -n "${normalized_candidate}" && "${normalized_candidate}" == "${self_path}" ]]; then
+      continue
+    fi
+    if managed_easyharness_wrapper "${candidate}"; then
+      continue
+    fi
+
+    printf '%s\n' "${candidate}"
+    return 0
+  done
+
+  return 1
+}
+
+wrapper_path=""
+if wrapper_path="$(normalize_path "${BASH_SOURCE[0]}")"; then
+  :
+else
+  wrapper_path=""
+fi
+
 binary_path=""
 if repo_root="$(find_repo_root)"; then
   binary_path="${repo_root}/.local/bin/harness"
@@ -238,18 +245,18 @@ if repo_root="$(find_repo_root)"; then
     echo "Run scripts/install-dev-harness from this worktree first." >&2
     exit 1
   fi
-elif [[ -n "${fallback_binary_path}" && -x "${fallback_binary_path}" ]]; then
-  binary_path="${fallback_binary_path}"
+elif stable_binary_path="$(find_stable_harness_on_path "${wrapper_path}")"; then
+  binary_path="${stable_binary_path}"
 else
-  echo "Could not find an easyharness source tree from ${PWD}, and the global fallback harness binary is unavailable at ${fallback_binary_path:-<unset>}." >&2
-  echo "Run scripts/install-dev-harness --global from the easyharness checkout you want to use outside source trees." >&2
+  echo "Could not find an easyharness source tree from ${PWD}, and no stable harness binary is available on PATH." >&2
+  echo "Install the stable easyharness release with Homebrew so \`harness\` is on PATH, then rerun this command outside source trees." >&2
   exit 1
 fi
 
 exec "${binary_path}" "$@"
 EOF
 )"
-  printf '%s\n' "${template//__FALLBACK_BINARY_PATH__/${fallback_binary_path}}"
+  printf '%s\n' "${template}"
 }
 
 legacy_easyharness_link() {
@@ -320,41 +327,6 @@ build_args=("-o" "${binary_path}" "-ldflags" "${build_ldflags[*]}" "./cmd/harnes
 )
 "${binary_path}" --help >/dev/null
 
-global_fallback_updated=0
-global_fallback_repaired=0
-refresh_global_fallback=0
-if [[ "${install_global_fallback}" -eq 1 ]]; then
-  refresh_global_fallback=1
-elif [[ -n "${global_fallback_path}" && ( -e "${global_fallback_path}" || -L "${global_fallback_path}" ) ]] && ! global_fallback_healthy "${global_fallback_path}"; then
-  refresh_global_fallback=1
-  global_fallback_repaired=1
-fi
-
-if [[ "${refresh_global_fallback}" -eq 1 ]]; then
-  if [[ -z "${global_fallback_path}" ]]; then
-    echo "Cannot install a global fallback without HOME set." >&2
-    exit 1
-  fi
-
-  mkdir -p "${target_dir}"
-  mkdir -p "$(dirname "${global_fallback_path}")"
-  normalized_command_path="$(normalize_path "${command_path}")"
-  normalized_global_fallback_path="$(normalize_path "${global_fallback_path}")"
-  if [[ "${normalized_command_path}" == "${normalized_global_fallback_path}" ]]; then
-    echo "Refusing to install the wrapper over the global fallback binary at ${global_fallback_path}." >&2
-    echo "Choose a different --install-dir." >&2
-    exit 2
-  fi
-
-  replace_file_atomically "${binary_path}" "${global_fallback_path}"
-  if ! global_fallback_healthy "${global_fallback_path}"; then
-    echo "Installed global fallback at ${global_fallback_path}, but the final path failed its health check." >&2
-    echo "Remove the file and rerun scripts/install-dev-harness --global if the problem persists." >&2
-    exit 1
-  fi
-  global_fallback_updated=1
-fi
-
 mkdir -p "${target_dir}"
 if [[ -e "${command_path}" || -L "${command_path}" ]]; then
   if [[ "${force}" -eq 1 ]]; then
@@ -381,19 +353,6 @@ fi
 echo "Built dev harness binary at ${binary_path}"
 echo "Installed harness wrapper at ${command_path}"
 echo "Verified the repo-local binary directly at ${binary_path}"
-if [[ -n "${global_fallback_path}" ]]; then
-  if [[ "${global_fallback_updated}" -eq 1 ]]; then
-    if [[ "${global_fallback_repaired}" -eq 1 ]]; then
-      echo "Repaired invalid global fallback binary at ${global_fallback_path}"
-    else
-      echo "Updated global fallback binary at ${global_fallback_path}"
-    fi
-  elif [[ -x "${global_fallback_path}" ]]; then
-    echo "Global fallback binary remains at ${global_fallback_path}"
-  else
-    echo "No global fallback binary installed yet; run scripts/install-dev-harness --global to set one."
-  fi
-fi
 
 if [[ ":${PATH}:" == *":${target_dir}:"* ]]; then
   resolved_path="$(command -v harness || true)"

--- a/scripts/install-dev-harness
+++ b/scripts/install-dev-harness
@@ -127,8 +127,7 @@ if [[ "${command_path}" == "${binary_path}" ]]; then
 fi
 
 wrapper_content() {
-  local template
-  template="$(cat <<'EOF'
+  cat <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -193,22 +192,54 @@ normalize_path() {
   printf '%s/%s\n' "${dir}" "${base}"
 }
 
+resolve_existing_path() {
+  local current="$1"
+  local hop_count=0
+
+  [[ -e "${current}" || -L "${current}" ]] || return 1
+
+  while [[ -L "${current}" ]]; do
+    local dir target
+    dir="$(cd "$(dirname "${current}")" 2>/dev/null && pwd -P)" || return 1
+    target="$(readlink "${current}")" || return 1
+    case "${target}" in
+      /*)
+        current="${target}"
+        ;;
+      *)
+        current="${dir}/${target}"
+        ;;
+    esac
+    hop_count=$((hop_count + 1))
+    if (( hop_count > 40 )); then
+      return 1
+    fi
+  done
+
+  [[ -e "${current}" ]] || return 1
+  normalize_path "${current}"
+}
+
 managed_easyharness_wrapper() {
   local path="$1"
-  [[ -f "${path}" && ! -L "${path}" ]] || return 1
+  local inspect_path
 
-  if grep -Fq '# easyharness-install-dev-wrapper' "${path}"; then
+  inspect_path="$(resolve_existing_path "${path}" 2>/dev/null || true)"
+  [[ -n "${inspect_path}" && -f "${inspect_path}" ]] || return 1
+
+  if grep -Fq '# easyharness-install-dev-wrapper' "${inspect_path}"; then
     return 0
   fi
 
-  grep -Fq 'find_repo_root()' "${path}" &&
-    grep -Fq 'cmd/harness/main.go' "${path}" &&
+  grep -Fq 'find_repo_root()' "${inspect_path}" &&
+    grep -Fq 'cmd/harness/main.go' "${inspect_path}" &&
     return 0
 }
 
 find_stable_harness_on_path() {
   local self_path="$1"
-  local dir candidate normalized_candidate
+  local self_real_path="$2"
+  local dir candidate normalized_candidate resolved_candidate
   IFS=':' read -r -a path_entries <<< "${PATH:-}"
   for dir in "${path_entries[@]}"; do
     [[ -z "${dir}" ]] && continue
@@ -216,7 +247,11 @@ find_stable_harness_on_path() {
     [[ -x "${candidate}" ]] || continue
 
     normalized_candidate="$(normalize_path "${candidate}" 2>/dev/null || true)"
+    resolved_candidate="$(resolve_existing_path "${candidate}" 2>/dev/null || true)"
     if [[ -n "${self_path}" && -n "${normalized_candidate}" && "${normalized_candidate}" == "${self_path}" ]]; then
+      continue
+    fi
+    if [[ -n "${self_real_path}" && -n "${resolved_candidate}" && "${resolved_candidate}" == "${self_real_path}" ]]; then
       continue
     fi
     if managed_easyharness_wrapper "${candidate}"; then
@@ -230,12 +265,25 @@ find_stable_harness_on_path() {
   return 1
 }
 
+set_wrapper_paths() {
+  local computed_path="" computed_real_path=""
+  computed_path="$(normalize_path "${BASH_SOURCE[0]}" 2>/dev/null || true)"
+  computed_real_path="$(resolve_existing_path "${BASH_SOURCE[0]}" 2>/dev/null || true)"
+  wrapper_path="${computed_path}"
+  wrapper_real_path="${computed_real_path}"
+}
+
+choose_out_of_tree_binary() {
+  local candidate=""
+  candidate="$(find_stable_harness_on_path "${wrapper_path:-}" "${wrapper_real_path:-}" 2>/dev/null || true)"
+  [[ -n "${candidate}" ]] || return 1
+  stable_binary_path="${candidate}"
+}
+
 wrapper_path=""
-if wrapper_path="$(normalize_path "${BASH_SOURCE[0]}")"; then
-  :
-else
-  wrapper_path=""
-fi
+wrapper_real_path=""
+stable_binary_path=""
+set_wrapper_paths
 
 binary_path=""
 if repo_root="$(find_repo_root)"; then
@@ -245,7 +293,7 @@ if repo_root="$(find_repo_root)"; then
     echo "Run scripts/install-dev-harness from this worktree first." >&2
     exit 1
   fi
-elif stable_binary_path="$(find_stable_harness_on_path "${wrapper_path}")"; then
+elif choose_out_of_tree_binary; then
   binary_path="${stable_binary_path}"
 else
   echo "Could not find an easyharness source tree from ${PWD}, and no stable harness binary is available on PATH." >&2
@@ -255,15 +303,13 @@ fi
 
 exec "${binary_path}" "$@"
 EOF
-)"
-  printf '%s\n' "${template}"
 }
 
 legacy_easyharness_link() {
   local path="$1"
   [[ -L "${path}" ]] || return 1
 
-  local target
+  local target=""
   target="$(readlink "${path}")"
   [[ -n "${target}" ]] || return 1
 

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -3,7 +3,6 @@ package smoke_test
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -11,7 +10,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 
 	"github.com/catu-ai/easyharness/tests/support"
@@ -74,338 +72,54 @@ func TestInstallDevHarnessDefaultsToUserLocalBin(t *testing.T) {
 	}
 }
 
-func TestInstallDevHarnessGlobalDefaultsToUserLocalBinAndRefreshesFallback(t *testing.T) {
+func TestInstallDevHarnessHelpDoesNotMentionGlobalFlag(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
 	repoRoot := copyInstallerFixture(t)
-	tempHome := t.TempDir()
-
 	result := runCommand(
 		t,
 		repoRoot,
 		installerEnv(t, map[string]string{
-			"HOME": tempHome,
-			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
-		}),
-		"/bin/bash",
-		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-		"--global",
-	)
-	if result.ExitCode != 0 {
-		t.Fatalf("install-dev-harness --global failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
-	}
-
-	expectedWrapper := filepath.Join(tempHome, ".local", "bin", "harness")
-	support.RequireFileExists(t, expectedWrapper)
-	support.RequireContains(t, result.Stdout, "Installed harness wrapper at "+expectedWrapper)
-
-	expectedGlobalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
-	support.RequireFileExists(t, expectedGlobalFallback)
-	support.RequireContains(t, result.Stdout, "Updated global fallback binary at "+expectedGlobalFallback)
-
-	writeFixtureFile(t, expectedGlobalFallback, "#!/bin/sh\nprintf 'stale-fallback\\n'\n", 0o755)
-
-	refreshResult := runCommand(
-		t,
-		repoRoot,
-		installerEnv(t, map[string]string{
-			"HOME": tempHome,
-			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
-		}),
-		"/bin/bash",
-		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-		"--global",
-	)
-	if refreshResult.ExitCode != 0 {
-		t.Fatalf("second install-dev-harness --global failed with exit %d\nstdout:\n%s\nstderr:\n%s", refreshResult.ExitCode, refreshResult.Stdout, refreshResult.Stderr)
-	}
-
-	fallbackResult := runCommand(
-		t,
-		t.TempDir(),
-		envWithOverrides(t, map[string]string{
+			"HOME": t.TempDir(),
 			"PATH": installerPath(t),
 		}),
-		expectedWrapper,
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
 		"--help",
 	)
-	if fallbackResult.ExitCode != 0 {
-		t.Fatalf("wrapper using refreshed global fallback failed with exit %d\nstdout:\n%s\nstderr:\n%s", fallbackResult.ExitCode, fallbackResult.Stdout, fallbackResult.Stderr)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness --help failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
 	}
-	if strings.Contains(fallbackResult.CombinedOutput(), "stale-fallback") {
-		t.Fatalf("expected --global refresh to overwrite stale fallback contents\nstdout:\n%s\nstderr:\n%s", fallbackResult.Stdout, fallbackResult.Stderr)
+
+	if strings.Contains(result.CombinedOutput(), "--global") {
+		t.Fatalf("expected help output to omit removed --global flag\nstdout:\n%s\nstderr:\n%s", result.Stdout, result.Stderr)
 	}
-	support.RequireContains(t, refreshResult.Stdout, "Updated global fallback binary at "+expectedGlobalFallback)
 }
 
-func TestInstallDevHarnessGlobalRefreshReplacesFallbackFileObject(t *testing.T) {
+func TestInstallDevHarnessRejectsRemovedGlobalFlag(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
 	repoRoot := copyInstallerFixture(t)
-	tempHome := t.TempDir()
-
-	initialResult := runCommand(
-		t,
-		repoRoot,
-		installerEnv(t, map[string]string{
-			"HOME": tempHome,
-			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
-		}),
-		"/bin/bash",
-		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-		"--global",
-	)
-	if initialResult.ExitCode != 0 {
-		t.Fatalf("initial install-dev-harness --global failed with exit %d\nstdout:\n%s\nstderr:\n%s", initialResult.ExitCode, initialResult.Stdout, initialResult.Stderr)
-	}
-
-	globalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
-	initialInode := fileInode(t, globalFallback)
-	writeFixtureFile(t, globalFallback, "#!/bin/sh\nprintf 'stale-global\\n'\n", 0o755)
-
-	refreshResult := runCommand(
-		t,
-		repoRoot,
-		installerEnv(t, map[string]string{
-			"HOME": tempHome,
-			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
-		}),
-		"/bin/bash",
-		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-		"--global",
-	)
-	if refreshResult.ExitCode != 0 {
-		t.Fatalf("refresh install-dev-harness --global failed with exit %d\nstdout:\n%s\nstderr:\n%s", refreshResult.ExitCode, refreshResult.Stdout, refreshResult.Stderr)
-	}
-
-	refreshedInode := fileInode(t, globalFallback)
-	if refreshedInode == initialInode {
-		t.Fatalf("expected --global refresh to replace the fallback file object, but inode stayed %d", refreshedInode)
-	}
-
-	versionResult := runCommand(
-		t,
-		t.TempDir(),
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
-		}),
-		globalFallback,
-		"--version",
-	)
-	if versionResult.ExitCode != 0 {
-		t.Fatalf("refreshed fallback version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
-	}
-	support.RequireContains(t, versionResult.Stdout, "mode: dev")
-}
-
-func TestInstallDevHarnessGlobalRejectsWrapperInstallDirConflict(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("installer smoke tests require a POSIX shell")
-	}
-
-	repoRoot := copyInstallerFixture(t)
-	tempHome := t.TempDir()
-	conflictingDir := filepath.Join(tempHome, ".local", "share", "easyharness", "dev")
-	conflictingBinary := filepath.Join(conflictingDir, "harness")
-	if err := os.MkdirAll(conflictingDir, 0o755); err != nil {
-		t.Fatalf("mkdir conflicting dir: %v", err)
-	}
-	writeFixtureFile(t, conflictingBinary, "#!/bin/sh\nprintf 'old-global\\n'\n", 0o755)
-
 	result := runCommand(
 		t,
 		repoRoot,
 		installerEnv(t, map[string]string{
-			"HOME": tempHome,
+			"HOME": t.TempDir(),
 			"PATH": installerPath(t),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
 		"--global",
-		"--install-dir", conflictingDir,
 	)
 	if result.ExitCode == 0 {
-		t.Fatalf("expected conflicting --install-dir to fail\nstdout:\n%s\nstderr:\n%s", result.Stdout, result.Stderr)
-	}
-	support.RequireContains(t, result.Stderr, "Refusing to install the wrapper over the global fallback binary")
-
-	fallbackContents, err := os.ReadFile(conflictingBinary)
-	if err != nil {
-		t.Fatalf("read conflicting fallback after failed install: %v", err)
-	}
-	if string(fallbackContents) != "#!/bin/sh\nprintf 'old-global\\n'\n" {
-		t.Fatalf("expected failed install to leave existing fallback untouched, got:\n%s", string(fallbackContents))
-	}
-}
-
-func TestInstallDevHarnessRepairsInvalidExistingGlobalFallback(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("installer smoke tests require a POSIX shell")
+		t.Fatalf("expected removed --global flag to fail\nstdout:\n%s\nstderr:\n%s", result.Stdout, result.Stderr)
 	}
 
-	repoRoot := copyInstallerFixture(t)
-	tempHome := t.TempDir()
-	globalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
-	if err := os.MkdirAll(filepath.Dir(globalFallback), 0o755); err != nil {
-		t.Fatalf("mkdir global fallback dir: %v", err)
-	}
-	writeFixtureFile(t, globalFallback, "#!/bin/sh\nkill -9 $$\n", 0o755)
-
-	result := runCommand(
-		t,
-		repoRoot,
-		installerEnv(t, map[string]string{
-			"HOME": tempHome,
-			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
-		}),
-		"/bin/bash",
-		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-	)
-	if result.ExitCode != 0 {
-		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
-	}
-
-	wrapperPath := filepath.Join(tempHome, ".local", "bin", "harness")
-	support.RequireContains(t, result.Stdout, "Repaired invalid global fallback binary at "+globalFallback)
-
-	versionResult := runCommand(
-		t,
-		t.TempDir(),
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
-		}),
-		wrapperPath,
-		"--version",
-	)
-	if versionResult.ExitCode != 0 {
-		t.Fatalf("wrapper version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
-	}
-	support.RequireContains(t, versionResult.Stdout, "mode: dev")
-	if strings.Contains(versionResult.CombinedOutput(), "killed") {
-		t.Fatalf("expected repaired fallback to avoid killed output\nstdout:\n%s\nstderr:\n%s", versionResult.Stdout, versionResult.Stderr)
-	}
-}
-
-func TestInstallDevHarnessRepairsBrokenSymlinkGlobalFallback(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("installer smoke tests require a POSIX shell")
-	}
-
-	repoRoot := copyInstallerFixture(t)
-	tempHome := t.TempDir()
-	globalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
-	if err := os.MkdirAll(filepath.Dir(globalFallback), 0o755); err != nil {
-		t.Fatalf("mkdir global fallback dir: %v", err)
-	}
-	if err := os.Symlink(filepath.Join(tempHome, "missing-fallback"), globalFallback); err != nil {
-		t.Fatalf("create broken fallback symlink: %v", err)
-	}
-
-	result := runCommand(
-		t,
-		repoRoot,
-		installerEnv(t, map[string]string{
-			"HOME": tempHome,
-			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
-		}),
-		"/bin/bash",
-		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-	)
-	if result.ExitCode != 0 {
-		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
-	}
-	support.RequireContains(t, result.Stdout, "Repaired invalid global fallback binary at "+globalFallback)
-
-	info, err := os.Lstat(globalFallback)
-	if err != nil {
-		t.Fatalf("lstat repaired fallback: %v", err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		t.Fatalf("expected repaired fallback to replace the broken symlink")
-	}
-
-	versionResult := runCommand(
-		t,
-		t.TempDir(),
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
-		}),
-		globalFallback,
-		"--version",
-	)
-	if versionResult.ExitCode != 0 {
-		t.Fatalf("repaired broken-symlink fallback version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
-	}
-	support.RequireContains(t, versionResult.Stdout, "mode: dev")
-}
-
-func TestInstallDevHarnessRepairsDirectorySymlinkGlobalFallback(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("installer smoke tests require a POSIX shell")
-	}
-
-	repoRoot := copyInstallerFixture(t)
-	tempHome := t.TempDir()
-	globalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
-	symlinkTargetDir := filepath.Join(tempHome, "fallback-dir")
-	if err := os.MkdirAll(filepath.Dir(globalFallback), 0o755); err != nil {
-		t.Fatalf("mkdir global fallback dir: %v", err)
-	}
-	if err := os.MkdirAll(symlinkTargetDir, 0o755); err != nil {
-		t.Fatalf("mkdir symlink target dir: %v", err)
-	}
-	if err := os.Symlink(symlinkTargetDir, globalFallback); err != nil {
-		t.Fatalf("create directory fallback symlink: %v", err)
-	}
-
-	result := runCommand(
-		t,
-		repoRoot,
-		installerEnv(t, map[string]string{
-			"HOME": tempHome,
-			"PATH": installerPath(t, filepath.Join(tempHome, ".local", "bin")),
-		}),
-		"/bin/bash",
-		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-	)
-	if result.ExitCode != 0 {
-		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
-	}
-	support.RequireContains(t, result.Stdout, "Repaired invalid global fallback binary at "+globalFallback)
-
-	info, err := os.Lstat(globalFallback)
-	if err != nil {
-		t.Fatalf("lstat repaired directory-symlink fallback: %v", err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		t.Fatalf("expected repaired fallback to replace the directory symlink")
-	}
-
-	targetEntries, err := os.ReadDir(symlinkTargetDir)
-	if err != nil {
-		t.Fatalf("read repaired symlink target dir: %v", err)
-	}
-	if len(targetEntries) != 0 {
-		t.Fatalf("expected repaired directory-symlink target dir to stay empty, found %d entries", len(targetEntries))
-	}
-
-	versionResult := runCommand(
-		t,
-		t.TempDir(),
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
-		}),
-		globalFallback,
-		"--version",
-	)
-	if versionResult.ExitCode != 0 {
-		t.Fatalf("repaired directory-symlink fallback version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
-	}
-	support.RequireContains(t, versionResult.Stdout, "mode: dev")
+	support.RequireContains(t, result.Stderr, "Unknown argument: --global")
 }
 
 func TestInstallDevHarnessVerifiesPATHResolvedWrapperWhenInstallDirIsAlreadyOnPATH(t *testing.T) {
@@ -440,25 +154,24 @@ func TestInstallDevHarnessVerifiesPATHResolvedWrapperWhenInstallDirIsAlreadyOnPA
 	support.RequireContains(t, result.Stdout, "Verified harness on PATH at "+wrapperPath)
 }
 
-func TestInstallDevHarnessWrapperDispatchesToCurrentWorktree(t *testing.T) {
+func TestInstallDevHarnessWrapperDispatchesToCurrentWorktreeOverStablePathFallback(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
 	repoRoot := copyInstallerFixture(t)
-	installDir := filepath.Join(t.TempDir(), "global-bin")
-	homeDir := t.TempDir()
+	installDir := filepath.Join(t.TempDir(), "path-bin")
+	stableDir, _ := newFakeStableHarness(t)
 
 	result := runCommand(
 		t,
 		repoRoot,
 		installerEnv(t, map[string]string{
-			"HOME": homeDir,
-			"PATH": installerPath(t),
+			"HOME": t.TempDir(),
+			"PATH": installerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-		"--global",
 		"--install-dir", installDir,
 	)
 	if result.ExitCode != 0 {
@@ -467,15 +180,13 @@ func TestInstallDevHarnessWrapperDispatchesToCurrentWorktree(t *testing.T) {
 
 	wrapperPath := filepath.Join(installDir, "harness")
 	support.RequireFileExists(t, wrapperPath)
-	globalFallback := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
-	writeFixtureFile(t, globalFallback, "#!/bin/sh\nprintf 'unexpected-global\\n'\n", 0o755)
 
 	_, nestedDir := newFakeWorktree(t)
 	wrapperResult := runCommand(
 		t,
 		nestedDir,
 		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
+			"PATH": installerPath(t, installDir, stableDir),
 		}),
 		wrapperPath,
 		"status",
@@ -486,25 +197,25 @@ func TestInstallDevHarnessWrapperDispatchesToCurrentWorktree(t *testing.T) {
 
 	support.RequireContains(t, wrapperResult.Stdout, "fake worktree harness")
 	support.RequireContains(t, wrapperResult.Stdout, "args=status")
-	if strings.Contains(wrapperResult.CombinedOutput(), "unexpected-global") {
-		t.Fatalf("expected wrapper to prefer the worktree-local binary over the global fallback\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
+	if strings.Contains(wrapperResult.CombinedOutput(), "stable fallback harness") {
+		t.Fatalf("expected wrapper to prefer the worktree-local binary over the stable PATH fallback\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
 	}
 }
 
-func TestInstallDevHarnessWrapperRequiresExplicitGlobalFallbackOutsideWorktree(t *testing.T) {
+func TestInstallDevHarnessWrapperRequiresStableHarnessOnPathOutsideWorktree(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
 	repoRoot := copyInstallerFixture(t)
-	installDir := filepath.Join(t.TempDir(), "global-bin")
+	installDir := filepath.Join(t.TempDir(), "path-bin")
 
 	result := runCommand(
 		t,
 		repoRoot,
 		installerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t),
+			"PATH": installerPath(t, installDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -522,38 +233,38 @@ func TestInstallDevHarnessWrapperRequiresExplicitGlobalFallbackOutsideWorktree(t
 		t,
 		otherProject,
 		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
+			"PATH": installerPath(t, installDir),
 		}),
 		wrapperPath,
 		"--help",
 	)
 	if wrapperResult.ExitCode == 0 {
-		t.Fatalf("expected wrapper without --global fallback to fail outside easyharness source trees\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
+		t.Fatalf("expected wrapper without a stable PATH fallback to fail outside easyharness source trees\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
 	}
 
 	support.RequireContains(t, wrapperResult.Stderr, "Could not find an easyharness source tree")
-	support.RequireContains(t, wrapperResult.Stderr, "scripts/install-dev-harness --global")
+	support.RequireContains(t, wrapperResult.Stderr, "no stable harness binary is available on PATH")
+	support.RequireContains(t, wrapperResult.Stderr, "Install the stable easyharness release with Homebrew")
 }
 
-func TestInstallDevHarnessWrapperUsesExplicitGlobalFallbackOutsideWorktree(t *testing.T) {
+func TestInstallDevHarnessWrapperUsesStableHarnessOnPathOutsideWorktree(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
 	repoRoot := copyInstallerFixture(t)
-	installDir := filepath.Join(t.TempDir(), "global-bin")
-	homeDir := t.TempDir()
+	installDir := filepath.Join(t.TempDir(), "path-bin")
+	stableDir, _ := newFakeStableHarness(t)
 
 	result := runCommand(
 		t,
 		repoRoot,
 		installerEnv(t, map[string]string{
-			"HOME": homeDir,
-			"PATH": installerPath(t),
+			"HOME": t.TempDir(),
+			"PATH": installerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-		"--global",
 		"--install-dir", installDir,
 	)
 	if result.ExitCode != 0 {
@@ -562,48 +273,42 @@ func TestInstallDevHarnessWrapperUsesExplicitGlobalFallbackOutsideWorktree(t *te
 
 	wrapperPath := filepath.Join(installDir, "harness")
 	support.RequireFileExists(t, wrapperPath)
-	globalFallback := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
-	support.RequireFileExists(t, globalFallback)
-	support.RequireContains(t, result.Stdout, "Updated global fallback binary at "+globalFallback)
 
 	otherProject := t.TempDir()
 	helpResult := runCommand(
 		t,
 		otherProject,
 		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
+			"PATH": installerPath(t, installDir, stableDir),
 		}),
 		wrapperPath,
 		"--help",
 	)
 	if helpResult.ExitCode != 0 {
-		t.Fatalf("wrapper global fallback failed with exit %d\nstdout:\n%s\nstderr:\n%s", helpResult.ExitCode, helpResult.Stdout, helpResult.Stderr)
+		t.Fatalf("wrapper stable PATH fallback failed with exit %d\nstdout:\n%s\nstderr:\n%s", helpResult.ExitCode, helpResult.Stdout, helpResult.Stderr)
 	}
 
-	support.RequireContains(t, helpResult.CombinedOutput(), "Usage: harness <command> [subcommand] [flags]")
+	support.RequireContains(t, helpResult.Stdout, "stable fallback harness help")
 }
 
-func TestInstallDevHarnessVersionReportsDevModeAndPath(t *testing.T) {
+func TestInstallDevHarnessVersionReportsStableModeAndPathOutsideWorktree(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
 	repoRoot := copyInstallerFixture(t)
-	installDir := filepath.Join(t.TempDir(), "global-bin")
-	expectedCommit := "0123456789abcdef0123456789abcdef01234567"
-	fakeGitDir := fakeGitDirForHeadCommit(t, repoRoot, expectedCommit)
-	homeDir := t.TempDir()
+	installDir := filepath.Join(t.TempDir(), "path-bin")
+	stableDir, stablePath := newFakeStableHarness(t)
 
 	result := runCommand(
 		t,
 		repoRoot,
 		installerEnv(t, map[string]string{
-			"HOME": homeDir,
-			"PATH": installerPath(t, fakeGitDir),
+			"HOME": t.TempDir(),
+			"PATH": installerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-		"--global",
 		"--install-dir", installDir,
 	)
 	if result.ExitCode != 0 {
@@ -618,7 +323,7 @@ func TestInstallDevHarnessVersionReportsDevModeAndPath(t *testing.T) {
 		t,
 		otherProject,
 		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, fakeGitDir),
+			"PATH": installerPath(t, installDir, stableDir),
 		}),
 		wrapperPath,
 		"--version",
@@ -627,85 +332,18 @@ func TestInstallDevHarnessVersionReportsDevModeAndPath(t *testing.T) {
 		t.Fatalf("wrapper version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
 	}
 
-	if mode := requireVersionField(t, versionResult.Stdout, "mode"); mode != "dev" {
-		t.Fatalf("expected dev mode, got %q\noutput:\n%s", mode, versionResult.Stdout)
+	if mode := requireVersionField(t, versionResult.Stdout, "mode"); mode != "release" {
+		t.Fatalf("expected release mode from stable PATH fallback, got %q\noutput:\n%s", mode, versionResult.Stdout)
 	}
-	if commit := requireVersionField(t, versionResult.Stdout, "commit"); commit != expectedCommit {
-		t.Fatalf("expected injected dev commit %q, got %q\noutput:\n%s", expectedCommit, commit, versionResult.Stdout)
+	if commit := requireVersionField(t, versionResult.Stdout, "commit"); commit != "stable-test-commit" {
+		t.Fatalf("expected stable fallback commit %q, got %q\noutput:\n%s", "stable-test-commit", commit, versionResult.Stdout)
 	}
-	expectedPath := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
-	if path := requireVersionField(t, versionResult.Stdout, "path"); path != expectedPath {
-		t.Fatalf("expected dev path %q, got %q\noutput:\n%s", expectedPath, path, versionResult.Stdout)
+	if path := requireVersionField(t, versionResult.Stdout, "path"); path != stablePath {
+		t.Fatalf("expected stable fallback path %q, got %q\noutput:\n%s", stablePath, path, versionResult.Stdout)
 	}
 	if strings.HasPrefix(strings.TrimSpace(versionResult.Stdout), "{") {
 		t.Fatalf("expected plain-text version output, got %q", versionResult.Stdout)
 	}
-}
-
-func TestInstallDevHarnessNormalInstallDoesNotReplaceExistingGlobalFallback(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("installer smoke tests require a POSIX shell")
-	}
-
-	repoOne := copyInstallerFixture(t)
-	repoTwo := copyInstallerFixture(t)
-	installDir := filepath.Join(t.TempDir(), "global-bin")
-	homeDir := t.TempDir()
-
-	firstInstall := runCommand(
-		t,
-		repoOne,
-		installerEnv(t, map[string]string{
-			"HOME": homeDir,
-			"PATH": installerPath(t),
-		}),
-		"/bin/bash",
-		filepath.Join(repoOne, "scripts", "install-dev-harness"),
-		"--global",
-		"--install-dir", installDir,
-	)
-	if firstInstall.ExitCode != 0 {
-		t.Fatalf("first install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", firstInstall.ExitCode, firstInstall.Stdout, firstInstall.Stderr)
-	}
-
-	globalFallback := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
-	writeFixtureFile(t, globalFallback, "#!/bin/sh\nprintf 'global-from-first\\n'\n", 0o755)
-	initialInode := fileInode(t, globalFallback)
-
-	secondInstall := runCommand(
-		t,
-		repoTwo,
-		installerEnv(t, map[string]string{
-			"HOME": homeDir,
-			"PATH": installerPath(t),
-		}),
-		"/bin/bash",
-		filepath.Join(repoTwo, "scripts", "install-dev-harness"),
-		"--install-dir", installDir,
-	)
-	if secondInstall.ExitCode != 0 {
-		t.Fatalf("second install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", secondInstall.ExitCode, secondInstall.Stdout, secondInstall.Stderr)
-	}
-
-	support.RequireContains(t, secondInstall.Stdout, "Global fallback binary remains at "+globalFallback)
-	if refreshedInode := fileInode(t, globalFallback); refreshedInode != initialInode {
-		t.Fatalf("expected healthy global fallback inode to remain %d, got %d", initialInode, refreshedInode)
-	}
-
-	wrapperPath := filepath.Join(installDir, "harness")
-	wrapperResult := runCommand(
-		t,
-		t.TempDir(),
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
-		}),
-		wrapperPath,
-		"--help",
-	)
-	if wrapperResult.ExitCode != 0 {
-		t.Fatalf("wrapper with preserved global fallback failed with exit %d\nstdout:\n%s\nstderr:\n%s", wrapperResult.ExitCode, wrapperResult.Stdout, wrapperResult.Stderr)
-	}
-	support.RequireContains(t, wrapperResult.Stdout, "global-from-first")
 }
 
 func TestInstallDevHarnessReplacesLegacyManagedWrapperWithoutForce(t *testing.T) {
@@ -714,7 +352,7 @@ func TestInstallDevHarnessReplacesLegacyManagedWrapperWithoutForce(t *testing.T)
 	}
 
 	repoRoot := copyInstallerFixture(t)
-	installDir := filepath.Join(t.TempDir(), "global-bin")
+	installDir := filepath.Join(t.TempDir(), "path-bin")
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		t.Fatalf("mkdir install dir: %v", err)
 	}
@@ -809,7 +447,7 @@ func TestInstallDevHarnessReplacesLegacySymlinkedBinaryWithoutForce(t *testing.T
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repoRoot := copyInstallerFixture(t)
-			installDir := filepath.Join(t.TempDir(), "global-bin")
+			installDir := filepath.Join(t.TempDir(), "path-bin")
 			if err := os.MkdirAll(installDir, 0o755); err != nil {
 				t.Fatalf("mkdir install dir: %v", err)
 			}
@@ -865,25 +503,24 @@ func TestInstallDevHarnessReplacesLegacySymlinkedBinaryWithoutForce(t *testing.T
 	}
 }
 
-func TestInstallDevHarnessWrapperDoesNotUseGlobalFallbackInsideSourceTreeWithoutLocalBinary(t *testing.T) {
+func TestInstallDevHarnessWrapperDoesNotUseStablePathFallbackInsideSourceTreeWithoutLocalBinary(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
 	repoRoot := copyInstallerFixture(t)
-	installDir := filepath.Join(t.TempDir(), "global-bin")
-	homeDir := t.TempDir()
+	installDir := filepath.Join(t.TempDir(), "path-bin")
+	stableDir, _ := newFakeStableHarness(t)
 
 	result := runCommand(
 		t,
 		repoRoot,
 		installerEnv(t, map[string]string{
-			"HOME": homeDir,
-			"PATH": installerPath(t),
+			"HOME": t.TempDir(),
+			"PATH": installerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-		"--global",
 		"--install-dir", installDir,
 	)
 	if result.ExitCode != 0 {
@@ -891,15 +528,12 @@ func TestInstallDevHarnessWrapperDoesNotUseGlobalFallbackInsideSourceTreeWithout
 	}
 
 	_, nestedDir := newFakeWorktreeWithoutLocalBinary(t)
-	globalFallback := filepath.Join(homeDir, ".local", "share", "easyharness", "dev", "harness")
-	writeFixtureFile(t, globalFallback, "#!/bin/sh\nprintf 'unexpected-global-fallback\\n'\n", 0o755)
-
 	wrapperPath := filepath.Join(installDir, "harness")
 	wrapperResult := runCommand(
 		t,
 		nestedDir,
 		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
+			"PATH": installerPath(t, installDir, stableDir),
 		}),
 		wrapperPath,
 		"status",
@@ -910,8 +544,8 @@ func TestInstallDevHarnessWrapperDoesNotUseGlobalFallbackInsideSourceTreeWithout
 
 	support.RequireContains(t, wrapperResult.Stderr, "No repo-local harness binary found at ")
 	support.RequireContains(t, wrapperResult.Stderr, filepath.Join(".local", "bin", "harness"))
-	if strings.Contains(wrapperResult.CombinedOutput(), "unexpected-global-fallback") {
-		t.Fatalf("expected source-tree invocation to refuse the global fallback\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
+	if strings.Contains(wrapperResult.CombinedOutput(), "stable fallback harness") {
+		t.Fatalf("expected source-tree invocation to refuse the stable PATH fallback\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
 	}
 }
 
@@ -1025,25 +659,43 @@ func newFakeWorktreeWithoutLocalBinary(t *testing.T) (string, string) {
 	return root, filepath.Join(root, "nested", "dir")
 }
 
+func newFakeStableHarness(t *testing.T) (string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "harness")
+	writeFixtureFile(
+		t,
+		path,
+		`#!/bin/sh
+set -eu
+
+case "${1:-}" in
+  --help)
+    printf 'stable fallback harness help\n'
+    ;;
+  --version)
+    printf 'version: 0.2.0\n'
+    printf 'mode: release\n'
+    printf 'commit: stable-test-commit\n'
+    printf 'path: %s\n' "$0"
+    ;;
+  *)
+    printf 'stable fallback harness\n'
+    printf 'args=%s\n' "$*"
+    ;;
+esac
+`,
+		0o755,
+	)
+	return dir, path
+}
+
 func writeFixtureFile(t *testing.T, path, contents string, mode os.FileMode) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(contents), mode); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
-}
-
-func fileInode(t *testing.T, path string) uint64 {
-	t.Helper()
-
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat %s: %v", path, err)
-	}
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		t.Fatalf("expected syscall.Stat_t for %s, got %T", path, info.Sys())
-	}
-	return stat.Ino
 }
 
 func envWithOverrides(t *testing.T, overrides map[string]string) []string {
@@ -1149,33 +801,6 @@ func installerPath(t *testing.T, extraDirs ...string) string {
 	addDir("/sbin")
 
 	return strings.Join(dirs, string(os.PathListSeparator))
-}
-
-func fakeGitDirForHeadCommit(t *testing.T, repoRoot, commit string) string {
-	t.Helper()
-
-	realGit, err := exec.LookPath("git")
-	if err != nil {
-		t.Fatalf("find git on PATH: %v", err)
-	}
-
-	dir := t.TempDir()
-	script := fmt.Sprintf(`#!/bin/sh
-set -eu
-
-repo_root=%q
-fake_commit=%q
-real_git=%q
-
-if [ "$#" -ge 4 ] && [ "$1" = "-C" ] && [ "$2" = "$repo_root" ] && [ "$3" = "rev-parse" ] && [ "$4" = "HEAD" ]; then
-  printf '%%s\n' "$fake_commit"
-  exit 0
-fi
-
-exec "$real_git" "$@"
-`, repoRoot, commit, realGit)
-	writeFixtureFile(t, filepath.Join(dir, "git"), script, 0o755)
-	return dir
 }
 
 func runCommand(t *testing.T, workdir string, env []string, argv ...string) commandResult {

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -300,45 +300,63 @@ func TestInstallDevHarnessWrapperSkipsOtherManagedWrappersOnPathOutsideWorktree(
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
-	installDir := filepath.Join(t.TempDir(), "path-bin")
-	managedDir := t.TempDir()
-	stableDir, _ := newFakeStableHarness(t)
-	writeFixtureFile(t, filepath.Join(managedDir, "harness"), fakeManagedWrapperScript("unexpected managed wrapper"), 0o755)
-
-	result := runCommand(
-		t,
-		repoRoot,
-		installerEnv(t, map[string]string{
-			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir, managedDir, stableDir),
-		}),
-		"/bin/bash",
-		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
-		"--install-dir", installDir,
-	)
-	if result.ExitCode != 0 {
-		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	cases := []struct {
+		name   string
+		script string
+	}{
+		{
+			name:   "marker wrapper",
+			script: fakeManagedWrapperScript("unexpected managed wrapper"),
+		},
+		{
+			name:   "legacy wrapper",
+			script: fakeLegacyManagedWrapperScript("unexpected legacy managed wrapper"),
+		},
 	}
 
-	wrapperPath := filepath.Join(installDir, "harness")
-	otherProject := t.TempDir()
-	helpResult := runCommand(
-		t,
-		otherProject,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, installDir, managedDir, stableDir),
-		}),
-		wrapperPath,
-		"--help",
-	)
-	if helpResult.ExitCode != 0 {
-		t.Fatalf("wrapper with other managed wrapper on PATH failed with exit %d\nstdout:\n%s\nstderr:\n%s", helpResult.ExitCode, helpResult.Stdout, helpResult.Stderr)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repoRoot := copyInstallerFixture(t)
+			installDir := filepath.Join(t.TempDir(), "path-bin")
+			managedDir := t.TempDir()
+			stableDir, _ := newFakeStableHarness(t)
+			writeFixtureFile(t, filepath.Join(managedDir, "harness"), tc.script, 0o755)
 
-	support.RequireContains(t, helpResult.Stdout, "stable fallback harness help")
-	if strings.Contains(helpResult.CombinedOutput(), "unexpected managed wrapper") {
-		t.Fatalf("expected wrapper to skip other managed wrappers on PATH\nstdout:\n%s\nstderr:\n%s", helpResult.Stdout, helpResult.Stderr)
+			result := runCommand(
+				t,
+				repoRoot,
+				installerEnv(t, map[string]string{
+					"HOME": t.TempDir(),
+					"PATH": installerPath(t, installDir, managedDir, stableDir),
+				}),
+				"/bin/bash",
+				filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+				"--install-dir", installDir,
+			)
+			if result.ExitCode != 0 {
+				t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+			}
+
+			wrapperPath := filepath.Join(installDir, "harness")
+			otherProject := t.TempDir()
+			helpResult := runCommand(
+				t,
+				otherProject,
+				envWithOverrides(t, map[string]string{
+					"PATH": installerPath(t, installDir, managedDir, stableDir),
+				}),
+				wrapperPath,
+				"--help",
+			)
+			if helpResult.ExitCode != 0 {
+				t.Fatalf("wrapper with other managed wrapper on PATH failed with exit %d\nstdout:\n%s\nstderr:\n%s", helpResult.ExitCode, helpResult.Stdout, helpResult.Stderr)
+			}
+
+			support.RequireContains(t, helpResult.Stdout, "stable fallback harness help")
+			if strings.Contains(helpResult.CombinedOutput(), "unexpected managed wrapper") || strings.Contains(helpResult.CombinedOutput(), "unexpected legacy managed wrapper") {
+				t.Fatalf("expected wrapper to skip other managed wrappers on PATH\nstdout:\n%s\nstderr:\n%s", helpResult.Stdout, helpResult.Stderr)
+			}
+		})
 	}
 }
 
@@ -392,6 +410,52 @@ func TestInstallDevHarnessWrapperSkipsSymlinkAliasesOnPathOutsideWorktree(t *tes
 	}
 
 	support.RequireContains(t, helpResult.Stdout, "stable fallback harness help")
+}
+
+func TestInstallDevHarnessWrapperSkipsRepoLocalDevBinaryOnPathOutsideWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	installDir := filepath.Join(t.TempDir(), "path-bin")
+	devDir, _ := newFakeDevHarness(t)
+	stableDir, _ := newFakeStableHarness(t)
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": t.TempDir(),
+			"PATH": installerPath(t, installDir, devDir, stableDir),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--install-dir", installDir,
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	wrapperPath := filepath.Join(installDir, "harness")
+	otherProject := t.TempDir()
+	helpResult := runCommand(
+		t,
+		otherProject,
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t, installDir, devDir, stableDir),
+		}),
+		wrapperPath,
+		"--help",
+	)
+	if helpResult.ExitCode != 0 {
+		t.Fatalf("wrapper with repo-local dev binary on PATH failed with exit %d\nstdout:\n%s\nstderr:\n%s", helpResult.ExitCode, helpResult.Stdout, helpResult.Stderr)
+	}
+
+	support.RequireContains(t, helpResult.Stdout, "stable fallback harness help")
+	if strings.Contains(helpResult.CombinedOutput(), "unexpected dev binary") {
+		t.Fatalf("expected wrapper to skip repo-local dev binaries on PATH\nstdout:\n%s\nstderr:\n%s", helpResult.Stdout, helpResult.Stderr)
+	}
 }
 
 func TestInstallDevHarnessVersionReportsStableModeAndPathOutsideWorktree(t *testing.T) {
@@ -798,6 +862,48 @@ func fakeManagedWrapperScript(marker string) string {
 	return "#!/bin/sh\n" +
 		"# easyharness-install-dev-wrapper\n" +
 		"printf '" + marker + "\\n'\n"
+}
+
+func fakeLegacyManagedWrapperScript(marker string) string {
+	return "#!/usr/bin/env bash\n" +
+		"set -euo pipefail\n\n" +
+		"find_repo_root() {\n" +
+		"  printf 'legacy-wrapper-root\\n'\n" +
+		"}\n" +
+		"# cmd/harness/main.go\n\n" +
+		"printf '" + marker + "\\n'\n"
+}
+
+func newFakeDevHarness(t *testing.T) (string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "harness")
+	writeFixtureFile(
+		t,
+		path,
+		`#!/bin/sh
+set -eu
+
+case "${1:-}" in
+  --help)
+    printf 'unexpected dev binary\n'
+    ;;
+  --version)
+    printf 'version: dev-test\n'
+    printf 'mode: dev\n'
+    printf 'commit: dev-test-commit\n'
+    printf 'path: %s\n' "$0"
+    ;;
+  *)
+    printf 'unexpected dev binary\n'
+    printf 'args=%s\n' "$*"
+    ;;
+esac
+`,
+		0o755,
+	)
+	return dir, path
 }
 
 func writeFixtureFile(t *testing.T, path, contents string, mode os.FileMode) {

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -2,6 +2,7 @@ package smoke_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/catu-ai/easyharness/tests/support"
 )
@@ -286,6 +288,105 @@ func TestInstallDevHarnessWrapperUsesStableHarnessOnPathOutsideWorktree(t *testi
 	)
 	if helpResult.ExitCode != 0 {
 		t.Fatalf("wrapper stable PATH fallback failed with exit %d\nstdout:\n%s\nstderr:\n%s", helpResult.ExitCode, helpResult.Stdout, helpResult.Stderr)
+	}
+
+	support.RequireContains(t, helpResult.Stdout, "stable fallback harness help")
+}
+
+func TestInstallDevHarnessWrapperSkipsOtherManagedWrappersOnPathOutsideWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	installDir := filepath.Join(t.TempDir(), "path-bin")
+	managedDir := t.TempDir()
+	stableDir, _ := newFakeStableHarness(t)
+	writeFixtureFile(t, filepath.Join(managedDir, "harness"), fakeManagedWrapperScript("unexpected managed wrapper"), 0o755)
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": t.TempDir(),
+			"PATH": installerPath(t, installDir, managedDir, stableDir),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--install-dir", installDir,
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	wrapperPath := filepath.Join(installDir, "harness")
+	otherProject := t.TempDir()
+	helpResult := runCommand(
+		t,
+		otherProject,
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t, installDir, managedDir, stableDir),
+		}),
+		wrapperPath,
+		"--help",
+	)
+	if helpResult.ExitCode != 0 {
+		t.Fatalf("wrapper with other managed wrapper on PATH failed with exit %d\nstdout:\n%s\nstderr:\n%s", helpResult.ExitCode, helpResult.Stdout, helpResult.Stderr)
+	}
+
+	support.RequireContains(t, helpResult.Stdout, "stable fallback harness help")
+	if strings.Contains(helpResult.CombinedOutput(), "unexpected managed wrapper") {
+		t.Fatalf("expected wrapper to skip other managed wrappers on PATH\nstdout:\n%s\nstderr:\n%s", helpResult.Stdout, helpResult.Stderr)
+	}
+}
+
+func TestInstallDevHarnessWrapperSkipsSymlinkAliasesOnPathOutsideWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("installer smoke tests require a POSIX shell")
+	}
+
+	repoRoot := copyInstallerFixture(t)
+	installDir := filepath.Join(t.TempDir(), "path-bin")
+	aliasOneDir := t.TempDir()
+	aliasTwoDir := t.TempDir()
+	stableDir, _ := newFakeStableHarness(t)
+
+	result := runCommand(
+		t,
+		repoRoot,
+		installerEnv(t, map[string]string{
+			"HOME": t.TempDir(),
+			"PATH": installerPath(t, installDir, stableDir),
+		}),
+		"/bin/bash",
+		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
+		"--install-dir", installDir,
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("install-dev-harness failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	wrapperPath := filepath.Join(installDir, "harness")
+	if err := os.Symlink(wrapperPath, filepath.Join(aliasOneDir, "harness")); err != nil {
+		t.Fatalf("create first wrapper alias: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(aliasOneDir, "harness"), filepath.Join(aliasTwoDir, "harness")); err != nil {
+		t.Fatalf("create second wrapper alias: %v", err)
+	}
+
+	otherProject := t.TempDir()
+	helpResult := runCommandWithTimeout(
+		t,
+		5*time.Second,
+		otherProject,
+		envWithOverrides(t, map[string]string{
+			"PATH": installerPath(t, aliasOneDir, aliasTwoDir, installDir, stableDir),
+		}),
+		wrapperPath,
+		"--help",
+	)
+	if helpResult.ExitCode != 0 {
+		t.Fatalf("wrapper with symlink aliases on PATH failed with exit %d\nstdout:\n%s\nstderr:\n%s", helpResult.ExitCode, helpResult.Stdout, helpResult.Stderr)
 	}
 
 	support.RequireContains(t, helpResult.Stdout, "stable fallback harness help")
@@ -691,6 +792,12 @@ esac
 	return dir, path
 }
 
+func fakeManagedWrapperScript(marker string) string {
+	return "#!/bin/sh\n" +
+		"# easyharness-install-dev-wrapper\n" +
+		"printf '" + marker + "\\n'\n"
+}
+
 func writeFixtureFile(t *testing.T, path, contents string, mode os.FileMode) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(contents), mode); err != nil {
@@ -806,7 +913,25 @@ func installerPath(t *testing.T, extraDirs ...string) string {
 func runCommand(t *testing.T, workdir string, env []string, argv ...string) commandResult {
 	t.Helper()
 
-	cmd := exec.Command(argv[0], argv[1:]...)
+	return runCommandWithTimeout(t, 0, workdir, env, argv...)
+}
+
+func runCommandWithTimeout(t *testing.T, timeout time.Duration, workdir string, env []string, argv ...string) commandResult {
+	t.Helper()
+
+	var (
+		cmd    *exec.Cmd
+		cancel func()
+	)
+	if timeout > 0 {
+		var ctx context.Context
+		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		cmd = exec.CommandContext(ctx, argv[0], argv[1:]...)
+	} else {
+		cmd = exec.Command(argv[0], argv[1:]...)
+	}
+
 	cmd.Dir = workdir
 	cmd.Env = env
 
@@ -826,6 +951,9 @@ func runCommand(t *testing.T, workdir string, env []string, argv ...string) comm
 
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
+		if errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("run command %v timed out after %s\nstdout:\n%s\nstderr:\n%s", argv, timeout, stdout.String(), stderr.String())
+		}
 		t.Fatalf("run command %v: %v", argv, err)
 	}
 	result.ExitCode = exitErr.ExitCode()

--- a/tests/smoke/install_dev_harness_test.go
+++ b/tests/smoke/install_dev_harness_test.go
@@ -61,9 +61,11 @@ func TestInstallDevHarnessDefaultsToUserLocalBin(t *testing.T) {
 	}
 
 	expectedWrapper := filepath.Join(tempHome, ".local", "bin", "harness")
+	retiredGlobalFallback := filepath.Join(tempHome, ".local", "share", "easyharness", "dev", "harness")
 	support.RequireContains(t, result.Stdout, "Installed harness wrapper at "+expectedWrapper)
 	support.RequireFileExists(t, expectedWrapper)
 	support.RequireFileMissing(t, filepath.Join(firstPathDir, "harness"))
+	support.RequireFileMissing(t, retiredGlobalFallback)
 
 	info, err := os.Lstat(expectedWrapper)
 	if err != nil {

--- a/tests/smoke/release_docs_test.go
+++ b/tests/smoke/release_docs_test.go
@@ -32,8 +32,13 @@ func TestReleaseDocsPresentStableOnboardingSurface(t *testing.T) {
 		t.Fatalf("read development doc: %v", err)
 	}
 	development := string(developmentData)
-	support.RequireContains(t, development, "cd /path/to/your-easyharness-checkout")
+	normalizedDevelopment := strings.Join(strings.Fields(development), " ")
+	support.RequireContains(t, normalizedDevelopment, "stable `harness` installation to already be available on `PATH`")
+	support.RequireContains(t, normalizedDevelopment, "Homebrew install shown in the root")
 	support.RequireContains(t, development, "bundled Playwright wrapper")
+	if strings.Contains(development, "--global") {
+		t.Fatalf("expected development doc to avoid retired --global guidance, got:\n%s", development)
+	}
 	if strings.Contains(development, "/Users/yaozhang/") {
 		t.Fatalf("expected development doc to avoid workstation-specific absolute paths, got:\n%s", development)
 	}


### PR DESCRIPTION
## Summary
- retire the `scripts/install-dev-harness --global` path and stop maintaining a dev global fallback binary
- keep the managed wrapper, but make out-of-tree invocations resolve only to a stable release-mode `harness` already on `PATH`
- expand smoke coverage for stable fallback selection, managed-wrapper skipping, symlink alias avoidance, and retired-path absence

## Validation
- bash -n scripts/install-dev-harness
- go test ./tests/smoke -run InstallDevHarness -count=1
- scripts/install-dev-harness
- harness review aggregate --round review-006-full

## Plan
- docs/plans/archived/2026-04-11-retire-dev-global-fallback-for-stable-path-fallback.md
