### PR TITLE
Make approval and reviewer roles explicit

### DIFF
--- a/.agents/skills/harness-execute/SKILL.md
+++ b/.agents/skills/harness-execute/SKILL.md
@@ -27,7 +27,7 @@ to specific review slots.
 
 `harness-execute` starts only after plan approval is explicit. If the current
 plan is still waiting for approval, stop at the plan boundary, get human
-approval, and record it with `harness plan approve --by=human` before trying
+approval, and record it with `harness plan approve --by human` before trying
 `harness execute start`.
 
 Run `harness status` at controller checkpoints, not just once per session:
@@ -80,7 +80,7 @@ when it is genuinely impractical, and record the reason in the step's
    Active work uses a tracked plan even when the profile is lightweight; only
    archived lightweight snapshots move into `.local/`.
    If status still resolves to `plan`, do not start execution until approval is
-   explicit and `harness plan approve --by=human` has been recorded.
+   explicit and `harness plan approve --by human` has been recorded.
 3. Identify the active or next plan step.
 4. Use the status output to answer four questions:
    - which tracked plan is current
@@ -96,7 +96,7 @@ when it is genuinely impractical, and record the reason in the step's
 
 - `plan`
   - wait for approval or update the plan if scope changed before
-    `harness plan approve --by=human` and `harness execute start`
+    `harness plan approve --by human` and `harness execute start`
 - `execution/step-<n>/implement`
   - continue the current step, fix review findings, or mark the step done once
     the slice is genuinely complete
@@ -156,7 +156,7 @@ Execute is done when:
   pause only long enough to ask and then resume once the answer arrives.
 - Do not submit reviewer results from the controller thread or impersonate a
   reviewer slot yourself. Reviewer submissions belong to bounded reviewer
-  subagents using `harness review submit --by=...`.
+  subagents using `harness review submit --by <reviewer-name>`.
 - Do not bypass node or review gates just because the next action feels obvious.
 - Do not skip TDD for behavior changes without documenting why the usual
   Red/Green/Refactor loop was not practical.

--- a/.agents/skills/harness-execute/SKILL.md
+++ b/.agents/skills/harness-execute/SKILL.md
@@ -25,6 +25,11 @@ including review orchestration. Do not switch the controller into
 `harness-reviewer`; that skill is only for spawned reviewer subagents assigned
 to specific review slots.
 
+`harness-execute` starts only after plan approval is explicit. If the current
+plan is still waiting for approval, stop at the plan boundary, get human
+approval, and record it with `harness plan approve --by=human` before trying
+`harness execute start`.
+
 Run `harness status` at controller checkpoints, not just once per session:
 
 - at start or resume
@@ -74,6 +79,8 @@ when it is genuinely impractical, and record the reason in the step's
    `plan_path`.
    Active work uses a tracked plan even when the profile is lightweight; only
    archived lightweight snapshots move into `.local/`.
+   If status still resolves to `plan`, do not start execution until approval is
+   explicit and `harness plan approve --by=human` has been recorded.
 3. Identify the active or next plan step.
 4. Use the status output to answer four questions:
    - which tracked plan is current
@@ -89,7 +96,7 @@ when it is genuinely impractical, and record the reason in the step's
 
 - `plan`
   - wait for approval or update the plan if scope changed before
-    `harness execute start`
+    `harness plan approve --by=human` and `harness execute start`
 - `execution/step-<n>/implement`
   - continue the current step, fix review findings, or mark the step done once
     the slice is genuinely complete
@@ -138,6 +145,8 @@ Execute is done when:
 
 - Do not ask the human to micromanage routine execution once the plan is
   approved.
+- Do not start execution from the raw task request alone; the newly written
+  tracked plan still needs explicit approval.
 - Do not ask the human whether routine step-closeout or finalize review should
   start once `harness status` and the tracked plan make the next review action
   clear.
@@ -145,6 +154,9 @@ Execute is done when:
   authorization is missing; request it explicitly as soon as you know it will
   be required, and if you still reach the reviewer boundary without approval,
   pause only long enough to ask and then resume once the answer arrives.
+- Do not submit reviewer results from the controller thread or impersonate a
+  reviewer slot yourself. Reviewer submissions belong to bounded reviewer
+  subagents using `harness review submit --by=...`.
 - Do not bypass node or review gates just because the next action feels obvious.
 - Do not skip TDD for behavior changes without documenting why the usual
   Red/Green/Refactor loop was not practical.

--- a/.agents/skills/harness-execute/references/controller-truth-surfaces.md
+++ b/.agents/skills/harness-execute/references/controller-truth-surfaces.md
@@ -5,9 +5,6 @@ self-check for the controller, not a second reviewer protocol.
 
 ## Pre-Review
 
-- approval truth
-  - verify the plan is actually approved before starting execution-sensitive
-    work; the original task request is not enough for a newly written plan
 - scope truth
   - decide whether this round is really `delta` or `full`, and say why a
     narrower or broader pass would be less trustworthy
@@ -27,7 +24,7 @@ self-check for the controller, not a second reviewer protocol.
 
 - reviewer identity truth
   - verify each submission came from a bounded reviewer slot using
-    `harness review submit --by=...`, not from the controller thread standing
+    `harness review submit --by <reviewer-name>`, not from the controller thread standing
     in as its own reviewer
 - submission truth
   - verify every expected slot submitted a real result rather than a missing,

--- a/.agents/skills/harness-execute/references/controller-truth-surfaces.md
+++ b/.agents/skills/harness-execute/references/controller-truth-surfaces.md
@@ -5,6 +5,9 @@ self-check for the controller, not a second reviewer protocol.
 
 ## Pre-Review
 
+- approval truth
+  - verify the plan is actually approved before starting execution-sensitive
+    work; the original task request is not enough for a newly written plan
 - scope truth
   - decide whether this round is really `delta` or `full`, and say why a
     narrower or broader pass would be less trustworthy
@@ -22,6 +25,10 @@ self-check for the controller, not a second reviewer protocol.
 
 ## Pre-Aggregate
 
+- reviewer identity truth
+  - verify each submission came from a bounded reviewer slot using
+    `harness review submit --by=...`, not from the controller thread standing
+    in as its own reviewer
 - submission truth
   - verify every expected slot submitted a real result rather than a missing,
     invalid, or still-skeleton artifact

--- a/.agents/skills/harness-execute/references/review-orchestration.md
+++ b/.agents/skills/harness-execute/references/review-orchestration.md
@@ -195,9 +195,7 @@ Reviewer subagents should submit through:
 harness review submit --round <round-id> --slot <slot> --by <reviewer-name> --input <path>
 ```
 
-The controller must not submit reviewer results on a reviewer's behalf. The
-`--by` value is a lightweight role cue and provenance hint, not a strong
-identity check.
+The controller must not submit reviewer results on a reviewer's behalf.
 
 Reviewer submissions may include optional finding `locations` arrays using
 lightweight repo-relative anchors such as `path/to/file.go`,

--- a/.agents/skills/harness-execute/references/review-orchestration.md
+++ b/.agents/skills/harness-execute/references/review-orchestration.md
@@ -189,6 +189,16 @@ Anchor SHA: <commit-sha-or-none>
 Change summary: <bounded-change-summary>
 ```
 
+Reviewer subagents should submit through:
+
+```bash
+harness review submit --round <round-id> --slot <slot> --by <reviewer-name> --input <path>
+```
+
+The controller must not submit reviewer results on a reviewer's behalf. The
+`--by` value is a lightweight role cue and provenance hint, not a strong
+identity check.
+
 Reviewer submissions may include optional finding `locations` arrays using
 lightweight repo-relative anchors such as `path/to/file.go`,
 `path/to/file.go#L123`, or `path/to/file.go#L1-L3`.

--- a/.agents/skills/harness-plan/SKILL.md
+++ b/.agents/skills/harness-plan/SKILL.md
@@ -78,7 +78,7 @@ Use this skill to create or update the tracked plan that will drive execution.
    - the original task request does not count as approval for the newly
      written plan
    - once the human approves the plan, record that boundary explicitly with
-     `harness plan approve --by=human`
+     `harness plan approve --by human`
    - if the approved execution loop is likely to require reviewer subagents,
      ask for explicit subagent authorization in the same approval exchange so
      execution does not stall later at review time
@@ -94,7 +94,7 @@ The plan is ready when:
 
 - lint passes
 - the resulting tracked plan would resolve to `plan` until
-  `harness plan approve --by=human` and then `harness execute start` are
+  `harness plan approve --by human` and then `harness execute start` are
   recorded
 - when the plan is lightweight, a future agent could still explain why
   lightweight was eligible, know that lightweight is only for `XXS` work, know

--- a/.agents/skills/harness-plan/SKILL.md
+++ b/.agents/skills/harness-plan/SKILL.md
@@ -75,9 +75,13 @@ Use this skill to create or update the tracked plan that will drive execution.
    - lightweight plans are still tracked active plans, so lint the tracked
      file before execution starts
 9. Present the plan for approval before execution starts.
-   If the approved execution loop is likely to require reviewer subagents,
-   ask for explicit subagent authorization in the same approval exchange so
-   execution does not stall later at review time.
+   - the original task request does not count as approval for the newly
+     written plan
+   - once the human approves the plan, record that boundary explicitly with
+     `harness plan approve --by=human`
+   - if the approved execution loop is likely to require reviewer subagents,
+     ask for explicit subagent authorization in the same approval exchange so
+     execution does not stall later at review time
 
 ## Commands
 
@@ -90,7 +94,8 @@ The plan is ready when:
 
 - lint passes
 - the resulting tracked plan would resolve to `plan` until
-  `harness execute start` is recorded
+  `harness plan approve --by=human` and then `harness execute start` are
+  recorded
 - when the plan is lightweight, a future agent could still explain why
   lightweight was eligible, know that lightweight is only for `XXS` work, know
   that archive snapshots move to
@@ -110,6 +115,8 @@ The plan is ready when:
 ## Do Not
 
 - Do not start `harness-execute` before the plan is approved.
+- Do not treat the original user request as implicit approval for a newly
+  written tracked plan.
 - Do not duplicate full CLI enums or placeholder rules from the specs when a
   command or spec already defines them.
 - Do not let deferred work float without being named clearly in the plan.

--- a/.agents/skills/harness-reviewer/SKILL.md
+++ b/.agents/skills/harness-reviewer/SKILL.md
@@ -28,7 +28,7 @@ you do not stop after the first one or two findings.
 Submit exactly one structured payload with:
 
 ```bash
-harness review submit --round <round-id> --slot <slot> --input <path>
+harness review submit --round <round-id> --slot <slot> --by <reviewer-name> --input <path>
 ```
 
 Use this payload shape:
@@ -66,6 +66,8 @@ Rules:
 
 - `summary` is required
 - `findings` may be empty when the slot finds no issues
+- `--by` is required and should name the reviewer thread that owns the slot
+  submission
 - extra top-level fields such as `worklog` are allowed and remain in the stored
   submission artifact, but aggregate still only uses canonical `summary` and
   `findings`
@@ -123,6 +125,8 @@ deferral stale.
    progressive submission artifact to keep coverage and hypotheses visible
    while you continue checking the slot.
 9. Submit the same `submission.json` with `harness review submit`.
+   Include `--by <reviewer-name>` using a short stable name for your reviewer
+   thread, such as `reviewer-correctness` or another clear slot-owned label.
 10. Report the submission receipt back to the controller agent.
 11. Stop once the receipt is reported. The controller agent is responsible for
     closing reviewer subagents after verifying the successful submission.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ For medium or large work:
 Plan approval is explicit. Writing a plan or hearing the original task request
 does not by itself approve execution. After the plan is shown and the human
 approves it, the agent should record that boundary with
-`harness plan approve --by=human` before `harness execute start`.
+`harness plan approve --by human` before `harness execute start`.
 
 For approved low-risk work that explicitly uses `workflow_profile:
 lightweight`, keep the same workflow shape but store the active plan under
@@ -126,8 +126,8 @@ Use `lightweight` only when all of these are true:
 - if the boundary is unclear, default to `standard`
 
 `size` and `workflow_profile` are separate decisions. `XXS` is the only size
-eligible for `lightweight`, but sizes such as `XXS` or `XS` may still use the
-ordinary `standard` workflow when that is the approved path.
+eligible for `lightweight`, and `XXS` may still use the ordinary `standard`
+workflow when that is the approved path.
 
 When drafting a new plan, estimate `size` early. If the initial estimate is
 `XXL`, stop and confirm with the human whether the work should be split first;
@@ -173,7 +173,8 @@ still apply here; review-specific docs add reviewer-slot orchestration,
 aggregation, and same-slot resume rules on top of that shared baseline.
 
 The controller must not submit reviewer results on a reviewer's behalf. Each
-reviewer submission should be recorded through `harness review submit --by=...`
+reviewer submission should be recorded through
+`harness review submit --by <reviewer-name>`
 from the bounded reviewer thread that owns that slot.
 
 Routine review progression is controller-owned once a tracked plan is approved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,15 @@ For medium or large work:
 
 1. Discovery
 2. Plan
-3. Execute
+3. Plan approval
+4. Execute
 4. Archive / publish / await merge approval
 5. Land
+
+Plan approval is explicit. Writing a plan or hearing the original task request
+does not by itself approve execution. After the plan is shown and the human
+approves it, the agent should record that boundary with
+`harness plan approve --by=human` before `harness execute start`.
 
 For approved low-risk work that explicitly uses `workflow_profile:
 lightweight`, keep the same workflow shape but store the active plan under
@@ -118,6 +124,10 @@ Use `lightweight` only when all of these are true:
 - no schema-meaning changes, core state/review/archive/evidence changes,
   release-safety changes, or security-sensitive logic changes
 - if the boundary is unclear, default to `standard`
+
+`size` and `workflow_profile` are separate decisions. `XXS` is the only size
+eligible for `lightweight`, but sizes such as `XXS` or `XS` may still use the
+ordinary `standard` workflow when that is the approved path.
 
 When drafting a new plan, estimate `size` early. If the initial estimate is
 `XXL`, stop and confirm with the human whether the work should be split first;
@@ -161,6 +171,10 @@ belongs to spawned `harness-reviewer` subagents, and the repo-local review
 skills must be followed strictly. The shared rules in `Harness Subagent Use`
 still apply here; review-specific docs add reviewer-slot orchestration,
 aggregation, and same-slot resume rules on top of that shared baseline.
+
+The controller must not submit reviewer results on a reviewer's behalf. Each
+reviewer submission should be recorded through `harness review submit --by=...`
+from the bounded reviewer thread that owns that slot.
 
 Routine review progression is controller-owned once a tracked plan is approved.
 The controller should not stop to ask the human whether ordinary step-closeout

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -37,7 +37,7 @@ For medium or large work:
 Plan approval is explicit. Writing a plan or hearing the original task request
 does not by itself approve execution. After the plan is shown and the human
 approves it, the agent should record that boundary with
-`harness plan approve --by=human` before `harness execute start`.
+`harness plan approve --by human` before `harness execute start`.
 
 For approved low-risk work that explicitly uses `workflow_profile:
 lightweight`, keep the same workflow shape but store the active plan under
@@ -59,8 +59,8 @@ Use `lightweight` only when all of these are true:
 - if the boundary is unclear, default to `standard`
 
 `size` and `workflow_profile` are separate decisions. `XXS` is the only size
-eligible for `lightweight`, but sizes such as `XXS` or `XS` may still use the
-ordinary `standard` workflow when that is the approved path.
+eligible for `lightweight`, and `XXS` may still use the ordinary `standard`
+workflow when that is the approved path.
 
 When drafting a new plan, estimate `size` early. If the initial estimate is
 `XXL`, stop and confirm with the human whether the work should be split first;
@@ -106,7 +106,8 @@ still apply here; review-specific docs add reviewer-slot orchestration,
 aggregation, and same-slot resume rules on top of that shared baseline.
 
 The controller must not submit reviewer results on a reviewer's behalf. Each
-reviewer submission should be recorded through `harness review submit --by=...`
+reviewer submission should be recorded through
+`harness review submit --by <reviewer-name>`
 from the bounded reviewer thread that owns that slot.
 
 Routine review progression is controller-owned once a tracked plan is approved.

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -29,9 +29,15 @@ For medium or large work:
 
 1. Discovery
 2. Plan
-3. Execute
+3. Plan approval
+4. Execute
 4. Archive / publish / await merge approval
 5. Land
+
+Plan approval is explicit. Writing a plan or hearing the original task request
+does not by itself approve execution. After the plan is shown and the human
+approves it, the agent should record that boundary with
+`harness plan approve --by=human` before `harness execute start`.
 
 For approved low-risk work that explicitly uses `workflow_profile:
 lightweight`, keep the same workflow shape but store the active plan under
@@ -51,6 +57,10 @@ Use `lightweight` only when all of these are true:
 - no schema-meaning changes, core state/review/archive/evidence changes,
   release-safety changes, or security-sensitive logic changes
 - if the boundary is unclear, default to `standard`
+
+`size` and `workflow_profile` are separate decisions. `XXS` is the only size
+eligible for `lightweight`, but sizes such as `XXS` or `XS` may still use the
+ordinary `standard` workflow when that is the approved path.
 
 When drafting a new plan, estimate `size` early. If the initial estimate is
 `XXL`, stop and confirm with the human whether the work should be split first;
@@ -94,6 +104,10 @@ belongs to spawned `harness-reviewer` subagents, and the repo-local review
 skills must be followed strictly. The shared rules in `Harness Subagent Use`
 still apply here; review-specific docs add reviewer-slot orchestration,
 aggregation, and same-slot resume rules on top of that shared baseline.
+
+The controller must not submit reviewer results on a reviewer's behalf. Each
+reviewer submission should be recorded through `harness review submit --by=...`
+from the bounded reviewer thread that owns that slot.
 
 Routine review progression is controller-owned once a tracked plan is approved.
 The controller should not stop to ask the human whether ordinary step-closeout

--- a/assets/bootstrap/skills/harness-execute/SKILL.md
+++ b/assets/bootstrap/skills/harness-execute/SKILL.md
@@ -24,7 +24,7 @@ to specific review slots.
 
 `harness-execute` starts only after plan approval is explicit. If the current
 plan is still waiting for approval, stop at the plan boundary, get human
-approval, and record it with `harness plan approve --by=human` before trying
+approval, and record it with `harness plan approve --by human` before trying
 `harness execute start`.
 
 Run `harness status` at controller checkpoints, not just once per session:
@@ -77,7 +77,7 @@ when it is genuinely impractical, and record the reason in the step's
    Active work uses a tracked plan even when the profile is lightweight; only
    archived lightweight snapshots move into `.local/`.
    If status still resolves to `plan`, do not start execution until approval is
-   explicit and `harness plan approve --by=human` has been recorded.
+   explicit and `harness plan approve --by human` has been recorded.
 3. Identify the active or next plan step.
 4. Use the status output to answer four questions:
    - which tracked plan is current
@@ -93,7 +93,7 @@ when it is genuinely impractical, and record the reason in the step's
 
 - `plan`
   - wait for approval or update the plan if scope changed before
-    `harness plan approve --by=human` and `harness execute start`
+    `harness plan approve --by human` and `harness execute start`
 - `execution/step-<n>/implement`
   - continue the current step, fix review findings, or mark the step done once
     the slice is genuinely complete
@@ -153,7 +153,7 @@ Execute is done when:
   pause only long enough to ask and then resume once the answer arrives.
 - Do not submit reviewer results from the controller thread or impersonate a
   reviewer slot yourself. Reviewer submissions belong to bounded reviewer
-  subagents using `harness review submit --by=...`.
+  subagents using `harness review submit --by <reviewer-name>`.
 - Do not bypass node or review gates just because the next action feels obvious.
 - Do not skip TDD for behavior changes without documenting why the usual
   Red/Green/Refactor loop was not practical.

--- a/assets/bootstrap/skills/harness-execute/SKILL.md
+++ b/assets/bootstrap/skills/harness-execute/SKILL.md
@@ -22,6 +22,11 @@ including review orchestration. Do not switch the controller into
 `harness-reviewer`; that skill is only for spawned reviewer subagents assigned
 to specific review slots.
 
+`harness-execute` starts only after plan approval is explicit. If the current
+plan is still waiting for approval, stop at the plan boundary, get human
+approval, and record it with `harness plan approve --by=human` before trying
+`harness execute start`.
+
 Run `harness status` at controller checkpoints, not just once per session:
 
 - at start or resume
@@ -71,6 +76,8 @@ when it is genuinely impractical, and record the reason in the step's
    `plan_path`.
    Active work uses a tracked plan even when the profile is lightweight; only
    archived lightweight snapshots move into `.local/`.
+   If status still resolves to `plan`, do not start execution until approval is
+   explicit and `harness plan approve --by=human` has been recorded.
 3. Identify the active or next plan step.
 4. Use the status output to answer four questions:
    - which tracked plan is current
@@ -86,7 +93,7 @@ when it is genuinely impractical, and record the reason in the step's
 
 - `plan`
   - wait for approval or update the plan if scope changed before
-    `harness execute start`
+    `harness plan approve --by=human` and `harness execute start`
 - `execution/step-<n>/implement`
   - continue the current step, fix review findings, or mark the step done once
     the slice is genuinely complete
@@ -135,6 +142,8 @@ Execute is done when:
 
 - Do not ask the human to micromanage routine execution once the plan is
   approved.
+- Do not start execution from the raw task request alone; the newly written
+  tracked plan still needs explicit approval.
 - Do not ask the human whether routine step-closeout or finalize review should
   start once `harness status` and the tracked plan make the next review action
   clear.
@@ -142,6 +151,9 @@ Execute is done when:
   authorization is missing; request it explicitly as soon as you know it will
   be required, and if you still reach the reviewer boundary without approval,
   pause only long enough to ask and then resume once the answer arrives.
+- Do not submit reviewer results from the controller thread or impersonate a
+  reviewer slot yourself. Reviewer submissions belong to bounded reviewer
+  subagents using `harness review submit --by=...`.
 - Do not bypass node or review gates just because the next action feels obvious.
 - Do not skip TDD for behavior changes without documenting why the usual
   Red/Green/Refactor loop was not practical.

--- a/assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md
+++ b/assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md
@@ -5,9 +5,6 @@ self-check for the controller, not a second reviewer protocol.
 
 ## Pre-Review
 
-- approval truth
-  - verify the plan is actually approved before starting execution-sensitive
-    work; the original task request is not enough for a newly written plan
 - scope truth
   - decide whether this round is really `delta` or `full`, and say why a
     narrower or broader pass would be less trustworthy
@@ -27,7 +24,7 @@ self-check for the controller, not a second reviewer protocol.
 
 - reviewer identity truth
   - verify each submission came from a bounded reviewer slot using
-    `harness review submit --by=...`, not from the controller thread standing
+    `harness review submit --by <reviewer-name>`, not from the controller thread standing
     in as its own reviewer
 - submission truth
   - verify every expected slot submitted a real result rather than a missing,

--- a/assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md
+++ b/assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md
@@ -5,6 +5,9 @@ self-check for the controller, not a second reviewer protocol.
 
 ## Pre-Review
 
+- approval truth
+  - verify the plan is actually approved before starting execution-sensitive
+    work; the original task request is not enough for a newly written plan
 - scope truth
   - decide whether this round is really `delta` or `full`, and say why a
     narrower or broader pass would be less trustworthy
@@ -22,6 +25,10 @@ self-check for the controller, not a second reviewer protocol.
 
 ## Pre-Aggregate
 
+- reviewer identity truth
+  - verify each submission came from a bounded reviewer slot using
+    `harness review submit --by=...`, not from the controller thread standing
+    in as its own reviewer
 - submission truth
   - verify every expected slot submitted a real result rather than a missing,
     invalid, or still-skeleton artifact

--- a/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
+++ b/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
@@ -195,9 +195,7 @@ Reviewer subagents should submit through:
 harness review submit --round <round-id> --slot <slot> --by <reviewer-name> --input <path>
 ```
 
-The controller must not submit reviewer results on a reviewer's behalf. The
-`--by` value is a lightweight role cue and provenance hint, not a strong
-identity check.
+The controller must not submit reviewer results on a reviewer's behalf.
 
 Reviewer submissions may include optional finding `locations` arrays using
 lightweight repo-relative anchors such as `path/to/file.go`,

--- a/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
+++ b/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
@@ -189,6 +189,16 @@ Anchor SHA: <commit-sha-or-none>
 Change summary: <bounded-change-summary>
 ```
 
+Reviewer subagents should submit through:
+
+```bash
+harness review submit --round <round-id> --slot <slot> --by <reviewer-name> --input <path>
+```
+
+The controller must not submit reviewer results on a reviewer's behalf. The
+`--by` value is a lightweight role cue and provenance hint, not a strong
+identity check.
+
 Reviewer submissions may include optional finding `locations` arrays using
 lightweight repo-relative anchors such as `path/to/file.go`,
 `path/to/file.go#L123`, or `path/to/file.go#L1-L3`.

--- a/assets/bootstrap/skills/harness-plan/SKILL.md
+++ b/assets/bootstrap/skills/harness-plan/SKILL.md
@@ -75,7 +75,7 @@ Use this skill to create or update the tracked plan that will drive execution.
    - the original task request does not count as approval for the newly
      written plan
    - once the human approves the plan, record that boundary explicitly with
-     `harness plan approve --by=human`
+     `harness plan approve --by human`
    - if the approved execution loop is likely to require reviewer subagents,
      ask for explicit subagent authorization in the same approval exchange so
      execution does not stall later at review time
@@ -91,7 +91,7 @@ The plan is ready when:
 
 - lint passes
 - the resulting tracked plan would resolve to `plan` until
-  `harness plan approve --by=human` and then `harness execute start` are
+  `harness plan approve --by human` and then `harness execute start` are
   recorded
 - when the plan is lightweight, a future agent could still explain why
   lightweight was eligible, know that lightweight is only for `XXS` work, know

--- a/assets/bootstrap/skills/harness-plan/SKILL.md
+++ b/assets/bootstrap/skills/harness-plan/SKILL.md
@@ -72,9 +72,13 @@ Use this skill to create or update the tracked plan that will drive execution.
    - lightweight plans are still tracked active plans, so lint the tracked
      file before execution starts
 9. Present the plan for approval before execution starts.
-   If the approved execution loop is likely to require reviewer subagents,
-   ask for explicit subagent authorization in the same approval exchange so
-   execution does not stall later at review time.
+   - the original task request does not count as approval for the newly
+     written plan
+   - once the human approves the plan, record that boundary explicitly with
+     `harness plan approve --by=human`
+   - if the approved execution loop is likely to require reviewer subagents,
+     ask for explicit subagent authorization in the same approval exchange so
+     execution does not stall later at review time
 
 ## Commands
 
@@ -87,7 +91,8 @@ The plan is ready when:
 
 - lint passes
 - the resulting tracked plan would resolve to `plan` until
-  `harness execute start` is recorded
+  `harness plan approve --by=human` and then `harness execute start` are
+  recorded
 - when the plan is lightweight, a future agent could still explain why
   lightweight was eligible, know that lightweight is only for `XXS` work, know
   that archive snapshots move to
@@ -107,6 +112,8 @@ The plan is ready when:
 ## Do Not
 
 - Do not start `harness-execute` before the plan is approved.
+- Do not treat the original user request as implicit approval for a newly
+  written tracked plan.
 - Do not duplicate full CLI enums or placeholder rules from the specs when a
   command or spec already defines them.
 - Do not let deferred work float without being named clearly in the plan.

--- a/assets/bootstrap/skills/harness-reviewer/SKILL.md
+++ b/assets/bootstrap/skills/harness-reviewer/SKILL.md
@@ -25,7 +25,7 @@ you do not stop after the first one or two findings.
 Submit exactly one structured payload with:
 
 ```bash
-harness review submit --round <round-id> --slot <slot> --input <path>
+harness review submit --round <round-id> --slot <slot> --by <reviewer-name> --input <path>
 ```
 
 Use this payload shape:
@@ -63,6 +63,8 @@ Rules:
 
 - `summary` is required
 - `findings` may be empty when the slot finds no issues
+- `--by` is required and should name the reviewer thread that owns the slot
+  submission
 - extra top-level fields such as `worklog` are allowed and remain in the stored
   submission artifact, but aggregate still only uses canonical `summary` and
   `findings`
@@ -120,6 +122,8 @@ deferral stale.
    progressive submission artifact to keep coverage and hypotheses visible
    while you continue checking the slot.
 9. Submit the same `submission.json` with `harness review submit`.
+   Include `--by <reviewer-name>` using a short stable name for your reviewer
+   thread, such as `reviewer-correctness` or another clear slot-owned label.
 10. Report the submission receipt back to the controller agent.
 11. Stop once the receipt is reported. The controller agent is responsible for
     closing reviewer subagents after verifying the successful submission.

--- a/docs/plans/active/2026-04-12-make-approval-and-review-roles-explicit.md
+++ b/docs/plans/active/2026-04-12-make-approval-and-review-roles-explicit.md
@@ -1,0 +1,358 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-12T12:07:00+08:00"
+source_type: direct_request
+source_refs: []
+size: M
+---
+
+# Make approval and review roles explicit in the harness workflow
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Reduce agent workflow slips around plan approval and reviewer boundaries by
+making those moments explicit in the CLI and bootstrap guidance instead of
+leaving them mostly implicit in prompt text. The new workflow should still be
+agent-operated and trust-based: agents execute the harness commands, and the
+system assumes agents will not fabricate human approval, but the command
+surface should make the required steps much harder to miss.
+
+The main product change is a new explicit approval step in the plan lifecycle:
+`harness plan approve --by=human`. Approval becomes a durable tracked plan
+fact through `approved_at` frontmatter, while `harness execute start` remains a
+separate execution milestone and refuses to proceed until approval is recorded.
+Review submission should gain a similar lightweight role cue through a `--by`
+flag so reviewer work is easier for agents to keep distinct from controller
+work without turning harness into an identity-verification system.
+
+## Scope
+
+### In Scope
+
+- Add a new `harness plan approve --by=human` command to make human approval an
+  explicit workflow transition before execution starts.
+- Extend the tracked plan contract to carry a durable `approved_at` frontmatter
+  field for plans approved through the new workflow.
+- Keep `harness execute start` as a separate execution-start milestone, but
+  require recorded approval before it can succeed.
+- Update `harness status` and related lifecycle guidance so approval-seeking is
+  an explicit next action rather than an implied prerequisite.
+- Add `--by` to `harness review submit` as a lightweight reviewer-role cue and
+  persist that role hint in the stored review submission artifact.
+- Update bootstrap prompts, CLI/spec docs, and focused tests so agents learn
+  and the repository enforces the new command shape consistently.
+- Preserve the trust-based operating model: no strong identity verification or
+  external approval service is required for this slice.
+
+### Out of Scope
+
+- Strong authentication or cryptographic proof that approval came from a human
+  or that review came from a distinct runtime actor.
+- A separate external approval queue, web UI, or out-of-band human signoff
+  service.
+- Broad redesign of the full harness lifecycle beyond approval and reviewer
+  role cues.
+- Backfilling historical archived plans with new approval metadata.
+
+## Acceptance Criteria
+
+- [x] `harness plan approve --by=human` exists, records approval on the tracked
+      active plan, and updates workflow/status output so approval is no longer
+      an implicit step.
+- [x] New tracked plans may carry `approved_at` in frontmatter after approval,
+      and plan/schema/lint behavior clearly documents and tolerates missing
+      values for historical plans that predate this workflow.
+- [x] `harness execute start` fails with a clear message when approval has not
+      been recorded, and succeeds normally once approval exists.
+- [x] `harness status` and related lifecycle guidance explicitly tell agents to
+      seek Human approval and run `harness plan approve --by=human` before
+      execution when the plan is ready but not yet approved.
+- [x] `harness review submit` accepts a `--by` role cue, persists it, and the
+      reviewer skill plus review docs teach reviewer subagents to use it.
+- [x] Bootstrap prompts, CLI/spec docs, and focused automated tests cover the
+      approval boundary, reviewer-role cue, and the fact that `size` and
+      `workflow_profile` remain independent concepts.
+
+## Deferred Items
+
+- Strong actor identity enforcement for controller versus reviewer submissions.
+- Any future richer approval provenance beyond the tracked `approved_at`
+  timestamp and the trust-based `--by=human` command shape.
+- Non-Codex-specific integration hooks for external approval tools.
+
+## Work Breakdown
+
+### Step 1: Define the approval and reviewer-role contract
+
+- Done: [x]
+
+#### Objective
+
+Make the intended workflow shape explicit in the tracked specs and bootstrap
+guidance before changing runtime behavior.
+
+#### Details
+
+This step should update the contract surfaces that teach both humans and agents
+how the harness works: the managed `AGENTS.md` block, `harness-plan`,
+`harness-execute`, `harness-reviewer`, and the CLI/spec docs. The contract
+should say plainly that a direct request to do work does not by itself approve
+the newly written plan; approval becomes explicit through `harness plan approve
+--by=human`. It should also say that reviewer-role separation is prompted by
+`harness review submit --by=...`, but harness still relies on trust rather than
+hard identity verification in this slice.
+
+The size versus workflow-profile clarification belongs here too: approval and
+review-role fixes should not leave the recent `size` / `lightweight` confusion
+unaddressed. The docs should make it explicit that `size` describes magnitude,
+while `workflow_profile` separately decides whether a plan is `lightweight`.
+`XS` remains a normal standard-plan size.
+
+#### Expected Files
+
+- `assets/bootstrap/agents-managed-block.md`
+- `assets/bootstrap/skills/harness-plan/SKILL.md`
+- `assets/bootstrap/skills/harness-execute/SKILL.md`
+- `assets/bootstrap/skills/harness-reviewer/SKILL.md`
+- `assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md`
+- `assets/bootstrap/skills/harness-execute/references/review-orchestration.md`
+- `docs/specs/cli-contract.md`
+- `docs/specs/plan-schema.md`
+
+#### Validation
+
+- The docs and prompts consistently describe explicit plan approval, separate
+  execute start semantics, and the reviewer-role cue.
+- A cold reader can tell that the new approval step is explicit, trust-based,
+  and separate from execution start.
+
+#### Execution Notes
+
+Updated the bootstrap-managed AGENTS block, `harness-plan`,
+`harness-execute`, `harness-reviewer`, and the execute-controller references
+to make the approval boundary explicit. The contract now states that writing a
+plan or receiving the original task request does not approve execution, that
+agents must record approval with `harness plan approve --by=human` before
+`harness execute start`, and that reviewer subagents should submit through
+`harness review submit --by <reviewer-name>`.
+
+This step also clarified the `size` versus `workflow_profile` distinction in
+the managed docs and spec text so `lightweight` is no longer conflated with
+small-but-standard slices such as `XS`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This contract-editing step stayed inside one coherent
+controller-owned implementation slice and was reviewed at finalize time with
+the full behavior change in view.
+
+### Step 2: Add the CLI and runtime support for explicit approval
+
+- Done: [x]
+
+#### Objective
+
+Implement the new approval command and make lifecycle/status behavior depend on
+recorded approval before execution can start.
+
+#### Details
+
+This step should add `harness plan approve --by=human` to the CLI, teach the
+plan document/frontmatter model about `approved_at`, and update lifecycle
+services so `execute start` refuses unapproved plans with a clear error. The
+status and next-action surfaces should point agents toward approval when the
+current plan is still waiting for it.
+
+Historical plans should remain readable and lint-compatible without any bulk
+backfill. The implementation should define one clean legacy rule for missing
+`approved_at` instead of faking historical timestamps into old plans. Runtime
+and status behavior should stay clear about the difference between “this plan
+predates the explicit approval field” and “this active plan still needs human
+approval now.”
+
+#### Expected Files
+
+- `internal/cli/app.go`
+- `internal/lifecycle/service.go`
+- `internal/plan/document.go`
+- `internal/plan/lint.go`
+- `internal/plan/template.go` only if template/frontmatter examples need
+  structural changes
+- supporting contract/schema files under `schema/` and `internal/contracts/`
+  as needed
+
+#### Validation
+
+- The new command writes approval into the tracked plan and is reflected by
+  status.
+- `execute start` fails before approval and succeeds after approval.
+- Legacy plans without `approved_at` still have a documented, tested behavior
+  rather than forcing repository-wide backfill.
+
+#### Execution Notes
+
+Added `harness plan approve --by=human` to the CLI and lifecycle service,
+persisting approval as tracked-plan frontmatter `approved_at`. The lifecycle
+service now renders and validates the updated plan file, keeps approval
+idempotent, and rejects approval attempts after execution has already started.
+
+`harness execute start` now refuses unapproved active plans while still
+tolerating already-executing legacy state that predates explicit approval.
+`harness status` now distinguishes between unapproved plans, which prompt the
+controller to ask the human and run `harness plan approve --by=human`, and
+approved plans that are ready for `harness execute start`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: The runtime and status gate changes were intentionally
+reviewed together with the reviewer-role persistence and end-to-end tests
+instead of as an isolated mid-slice checkpoint.
+
+### Step 3: Add reviewer-role cues and focused regression coverage
+
+- Done: [x]
+
+#### Objective
+
+Complete the workflow change by adding `review submit --by`, syncing the
+materialized bootstrap outputs, and adding focused tests that keep the new
+approval and reviewer-role contracts from drifting.
+
+#### Details
+
+This step should extend review submission inputs and artifacts with the `--by`
+cue, update the reviewer skill to tell reviewer subagents to choose and submit
+their reviewer name/role explicitly, and add targeted tests for the new
+command shapes and next-action messaging. Because the repository dogsfoods the
+bootstrap assets, any source-asset edits must be followed by
+`scripts/sync-bootstrap-assets`.
+
+The tests should not try to prove real human identity. Instead they should
+assert the repository-owned contract: the approval step is explicit, the
+execute gate is enforced, the reviewer cue is persisted, and the docs/prompts
+continue to describe the intended workflow precisely.
+
+#### Expected Files
+
+- `assets/bootstrap/`
+- `.agents/skills/` and root `AGENTS.md` after sync
+- `internal/review/service.go`
+- `schema/inputs/review.submission.schema.json`
+- focused tests under `internal/..._test.go`, `tests/e2e/`, or `tests/smoke/`
+  matching the changed behavior
+- `scripts/sync-bootstrap-assets`
+
+#### Validation
+
+- `scripts/sync-bootstrap-assets` leaves the materialized bootstrap outputs in
+  sync with the edited source assets.
+- Focused tests cover approval gating, status guidance, and reviewer `--by`
+  persistence.
+- The repository's own prompts and generated outputs teach the same workflow.
+
+#### Execution Notes
+
+Extended `harness review submit` to require `--by`, persisted the reviewer
+label in stored submission artifacts, and validated it before aggregation.
+Updated the CLI help, contract schemas, generated schema index, bootstrap
+outputs, and focused unit/e2e/smoke tests so the approval gate and reviewer
+role cue are enforced consistently.
+
+The repo-local dogfood material was resynced with `scripts/sync-bootstrap-assets`
+and `scripts/sync-contract-artifacts`, and the full `go test ./...` suite
+passed after the contract updates.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This regression-coverage step existed to lock down the
+same end-to-end behavior that finalize review inspects, so a separate
+step-closeout round would have duplicated the final reviewer pass.
+
+## Validation Strategy
+
+- Run `harness plan lint` on the new tracked plan before seeking approval.
+- Use focused unit/e2e coverage for the approval command, execution gate,
+  status guidance, and review submission cue instead of a broad unrelated test
+  sweep.
+- Re-sync bootstrap assets and verify both source assets and materialized
+  outputs reflect the same explicit approval/reviewer-role contract.
+
+## Risks
+
+- Risk: approval semantics become muddy if `plan approve` and `execute start`
+  are not kept clearly separate.
+  - Mitigation: keep approval as a tracked-plan fact and preserve
+    `execute start` as the distinct execution-start milestone in both docs and
+    runtime behavior.
+- Risk: introducing `approved_at` could accidentally force noisy history
+  backfill or break older plans.
+  - Mitigation: define a clean legacy-missing rule, tolerate historical
+    absence, and test that old plans remain valid without backfill.
+- Risk: `review submit --by` could look like strong identity enforcement even
+  though this slice intentionally remains trust-based.
+  - Mitigation: document the flag as a role cue and provenance hint, not an
+    authenticated identity claim.
+
+## Validation Summary
+
+- Added focused regression coverage for:
+  - `PlanApprove` recording and refreshing `approved_at`
+  - `ExecuteStart` rejecting unapproved plans
+  - `review submit --by` persisting reviewer provenance
+  - aggregate tolerating legacy stored submissions without `by`
+- Re-synced bootstrap and contract artifacts with:
+  - `scripts/sync-bootstrap-assets`
+  - `scripts/sync-contract-artifacts`
+- Verified the repo-local binary after reinstalling with:
+  - `scripts/install-dev-harness`
+- Passed full repository validation with:
+  - `go test ./...`
+
+## Review Summary
+
+- `review-001-full` requested changes.
+  - Findings: repeat `plan approve` did not refresh `approved_at`, and
+    aggregate became too strict about legacy stored submissions missing `by`.
+- Addressed the blocking findings by:
+  - making repeat `PlanApprove` rewrite `approved_at`
+  - keeping `review submit --by` required for new submissions while allowing
+    aggregate to read legacy stored submissions without `by`
+  - adding a focused assertion that persisted submissions store reviewer
+    provenance in `submission.by`
+- `review-002-full` passed cleanly with reviewer subagent follow-up confirming
+  the fixes and contract alignment.
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+- Added explicit plan approval via `harness plan approve --by=human`.
+- Persisted approval in tracked plan frontmatter as `approved_at`.
+- Gated `harness execute start` on recorded approval while preserving legacy
+  already-executing tolerance.
+- Added `--by` to `harness review submit` and stored reviewer provenance in
+  submission artifacts.
+- Updated status guidance, managed prompts, specs, generated schemas, and
+  regression coverage to teach and enforce the new workflow.
+
+### Not Delivered
+
+- Strong actor identity enforcement or cryptographic proof of reviewer /
+  approver identity.
+- External approval-system integrations beyond the trust-based local command
+  flow.
+
+### Follow-Up Issues
+
+- #149 Track stronger approval and reviewer provenance after explicit approval
+  rollout

--- a/docs/plans/archived/2026-04-12-make-approval-and-review-roles-explicit.md
+++ b/docs/plans/archived/2026-04-12-make-approval-and-review-roles-explicit.md
@@ -24,7 +24,7 @@ system assumes agents will not fabricate human approval, but the command
 surface should make the required steps much harder to miss.
 
 The main product change is a new explicit approval step in the plan lifecycle:
-`harness plan approve --by=human`. Approval becomes a durable tracked plan
+`harness plan approve --by human`. Approval becomes a durable tracked plan
 fact through `approved_at` frontmatter, while `harness execute start` remains a
 separate execution milestone and refuses to proceed until approval is recorded.
 Review submission should gain a similar lightweight role cue through a `--by`
@@ -35,7 +35,7 @@ work without turning harness into an identity-verification system.
 
 ### In Scope
 
-- Add a new `harness plan approve --by=human` command to make human approval an
+- Add a new `harness plan approve --by human` command to make human approval an
   explicit workflow transition before execution starts.
 - Extend the tracked plan contract to carry a durable `approved_at` frontmatter
   field for plans approved through the new workflow.
@@ -62,7 +62,7 @@ work without turning harness into an identity-verification system.
 
 ## Acceptance Criteria
 
-- [x] `harness plan approve --by=human` exists, records approval on the tracked
+- [x] `harness plan approve --by human` exists, records approval on the tracked
       active plan, and updates workflow/status output so approval is no longer
       an implicit step.
 - [x] New tracked plans may carry `approved_at` in frontmatter after approval,
@@ -71,7 +71,7 @@ work without turning harness into an identity-verification system.
 - [x] `harness execute start` fails with a clear message when approval has not
       been recorded, and succeeds normally once approval exists.
 - [x] `harness status` and related lifecycle guidance explicitly tell agents to
-      seek Human approval and run `harness plan approve --by=human` before
+      seek Human approval and run `harness plan approve --by human` before
       execution when the plan is ready but not yet approved.
 - [x] `harness review submit` accepts a `--by` role cue, persists it, and the
       reviewer skill plus review docs teach reviewer subagents to use it.
@@ -83,7 +83,7 @@ work without turning harness into an identity-verification system.
 
 - Strong actor identity enforcement for controller versus reviewer submissions.
 - Any future richer approval provenance beyond the tracked `approved_at`
-  timestamp and the trust-based `--by=human` command shape.
+  timestamp and the trust-based `--by human` command shape.
 - Non-Codex-specific integration hooks for external approval tools.
 
 ## Work Breakdown
@@ -104,8 +104,8 @@ how the harness works: the managed `AGENTS.md` block, `harness-plan`,
 `harness-execute`, `harness-reviewer`, and the CLI/spec docs. The contract
 should say plainly that a direct request to do work does not by itself approve
 the newly written plan; approval becomes explicit through `harness plan approve
---by=human`. It should also say that reviewer-role separation is prompted by
-`harness review submit --by=...`, but harness still relies on trust rather than
+--by human`. It should also say that reviewer-role separation is prompted by
+`harness review submit --by <reviewer-name>`, but harness still relies on trust rather than
 hard identity verification in this slice.
 
 The size versus workflow-profile clarification belongs here too: approval and
@@ -138,7 +138,7 @@ Updated the bootstrap-managed AGENTS block, `harness-plan`,
 `harness-execute`, `harness-reviewer`, and the execute-controller references
 to make the approval boundary explicit. The contract now states that writing a
 plan or receiving the original task request does not approve execution, that
-agents must record approval with `harness plan approve --by=human` before
+agents must record approval with `harness plan approve --by human` before
 `harness execute start`, and that reviewer subagents should submit through
 `harness review submit --by <reviewer-name>`.
 
@@ -163,7 +163,7 @@ recorded approval before execution can start.
 
 #### Details
 
-This step should add `harness plan approve --by=human` to the CLI, teach the
+This step should add `harness plan approve --by human` to the CLI, teach the
 plan document/frontmatter model about `approved_at`, and update lifecycle
 services so `execute start` refuses unapproved plans with a clear error. The
 status and next-action surfaces should point agents toward approval when the
@@ -197,7 +197,7 @@ approval now.”
 
 #### Execution Notes
 
-Added `harness plan approve --by=human` to the CLI and lifecycle service,
+Added `harness plan approve --by human` to the CLI and lifecycle service,
 persisting approval as tracked-plan frontmatter `approved_at`. The lifecycle
 service now renders and validates the updated plan file, keeps approval
 idempotent, and rejects approval attempts after execution has already started.
@@ -205,7 +205,7 @@ idempotent, and rejects approval attempts after execution has already started.
 `harness execute start` now refuses unapproved active plans while still
 tolerating already-executing legacy state that predates explicit approval.
 `harness status` now distinguishes between unapproved plans, which prompt the
-controller to ask the human and run `harness plan approve --by=human`, and
+controller to ask the human and run `harness plan approve --by human`, and
 approved plans that are ready for `harness execute start`.
 
 #### Review Notes
@@ -264,6 +264,17 @@ Updated the CLI help, contract schemas, generated schema index, bootstrap
 outputs, and focused unit/e2e/smoke tests so the approval gate and reviewer
 role cue are enforced consistently.
 
+Follow-up PR review comments then tightened the published wording:
+
+- command examples now consistently use `--by human` and
+  `--by <reviewer-name>` rather than mixing flag styles
+- the managed agreement now states only that `XXS` may still choose the
+  ordinary standard workflow, without pulling `XS` into the same sentence
+- the reviewer-orchestration reference no longer adds the extra “not a strong
+  identity check” reminder inside the reviewer submission prompt
+- the controller pre-review checklist no longer includes an out-of-place
+  approval check
+
 The repo-local dogfood material was resynced with `scripts/sync-bootstrap-assets`
 and `scripts/sync-contract-artifacts`, and the full `go test ./...` suite
 passed after the contract updates.
@@ -313,6 +324,9 @@ step-closeout round would have duplicated the final reviewer pass.
   - `scripts/install-dev-harness`
 - Passed full repository validation with:
   - `go test ./...`
+- After PR wording follow-up, reran targeted validation with:
+  - `harness plan lint docs/plans/active/2026-04-12-make-approval-and-review-roles-explicit.md`
+  - `go test ./internal/status ./tests/smoke`
 
 ## Review Summary
 
@@ -327,20 +341,29 @@ step-closeout round would have duplicated the final reviewer pass.
     provenance in `submission.by`
 - `review-002-full` passed cleanly with reviewer subagent follow-up confirming
   the fixes and contract alignment.
+- PR review comments then requested wording cleanup around `--by` examples,
+  `XXS` versus `lightweight`, the pre-review checklist, and reviewer prompt
+  tone.
+- `review-003-full` passed cleanly after the wording follow-up confirmed those
+  contract surfaces stayed aligned.
 
 ## Archive Summary
 
-- Archived At: 2026-04-12T13:42:10+08:00
-- Revision: 1
+- Archived At: 2026-04-12T14:02:34+08:00
+- Revision: 2
 - PR: https://github.com/catu-ai/easyharness/pull/150
-- Ready: Candidate validated, reviewed, and ready for archive plus publish/CI/sync evidence before waiting for merge approval.
-- Merge Handoff: After archive, commit and push the tracked plan move, record publish/CI/sync evidence on PR #150, and then wait for explicit human merge approval.
+- Ready: Candidate revalidated after PR comment wording follow-up and ready for
+  archive plus fresh publish/CI/sync evidence before waiting for merge
+  approval.
+- Merge Handoff: After archive, commit and push the reopened finalize-fix
+  updates, refresh publish/CI/sync evidence on PR #150 for revision 2, and
+  then wait for explicit human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-- Added explicit plan approval via `harness plan approve --by=human`.
+- Added explicit plan approval via `harness plan approve --by human`.
 - Persisted approval in tracked plan frontmatter as `approved_at`.
 - Gated `harness execute start` on recorded approval while preserving legacy
   already-executing tolerance.
@@ -348,6 +371,10 @@ step-closeout round would have duplicated the final reviewer pass.
   submission artifacts.
 - Updated status guidance, managed prompts, specs, generated schemas, and
   regression coverage to teach and enforce the new workflow.
+- Followed up on PR comments by standardizing `--by` examples to space
+  separation, tightening the `XXS` / `lightweight` wording, removing the
+  pre-review approval checklist item, and simplifying the reviewer
+  orchestration note.
 
 ### Not Delivered
 

--- a/docs/plans/archived/2026-04-12-make-approval-and-review-roles-explicit.md
+++ b/docs/plans/archived/2026-04-12-make-approval-and-review-roles-explicit.md
@@ -330,7 +330,11 @@ step-closeout round would have duplicated the final reviewer pass.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-04-12T13:42:10+08:00
+- Revision: 1
+- PR: https://github.com/catu-ai/easyharness/pull/150
+- Ready: Candidate validated, reviewed, and ready for archive plus publish/CI/sync evidence before waiting for merge approval.
+- Merge Handoff: After archive, commit and push the tracked plan move, record publish/CI/sync evidence on PR #150, and then wait for explicit human merge approval.
 
 ## Outcome Summary
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -750,7 +750,7 @@ Purpose:
 Contract:
 
 - require the current plan to be active
-- require `--by=human`
+- require `--by human`
 - treat this command as a trust-based workflow acknowledgment rather than a
   strong identity check; harness records the approval boundary but does not
   authenticate the actor

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -612,11 +612,14 @@ controller agent.
 
 Contract:
 
+- require `--by <reviewer-name>` as a lightweight reviewer-role cue
 - accept the reviewer payload via `--input <path>` or stdin
 - validate that the submission matches an expected slot
 - treat top-level `summary` and `findings` as the canonical aggregate fields
 - allow extra top-level reviewer worklog fields in the submission payload and
   preserve them in the stored submission artifact
+- preserve the `--by` value in the stored submission artifact as review
+  provenance
 - allow each finding to omit `locations` or provide `locations: []string`
   using lightweight repo-relative anchors in one of these forms:
   - `path/to/file.go`
@@ -637,6 +640,11 @@ Recommended next action:
   only when the slot instructions still materially match; immediate closeout
   is the safe default
 - on validation failure, fix the reviewer artifact and resubmit
+
+The main controller agent should not use this command to stand in as its own
+reviewer. In Codex, reviewer submission still belongs in a bounded reviewer
+subagent thread, with `--by` acting as a role cue rather than a strong
+identity assertion.
 
 ### `harness review aggregate`
 
@@ -715,6 +723,10 @@ Purpose:
 Contract:
 
 - require the current plan to be active before recording execution start
+- require explicit plan approval to already be recorded before execution can
+  start
+- reject the command with a clear error when the current active plan still
+  lacks recorded approval
 - persist the execution-start milestone in plan-local runtime state
 - update `.local/harness/current-plan.json` to point at the active tracked plan
 - return the shared v0.2 envelope with the post-command
@@ -727,6 +739,32 @@ Recommended next action:
 
 - continue the current tracked step and keep step-local `Execution Notes` and
   `Review Notes` current as implementation proceeds
+
+### `harness plan approve`
+
+Purpose:
+
+- record explicit human approval for the current active tracked plan before
+  execution starts
+
+Contract:
+
+- require the current plan to be active
+- require `--by=human`
+- treat this command as a trust-based workflow acknowledgment rather than a
+  strong identity check; harness records the approval boundary but does not
+  authenticate the actor
+- persist approval durably in the tracked plan frontmatter as `approved_at`
+- keep approval separate from `harness execute start`; approval records the
+  human steering boundary, while execution start records the later execution
+  milestone
+- return a concise result that steers the agent toward `harness execute start`
+  after approval is recorded
+
+Recommended next action:
+
+- start execution with `harness execute start` once the approved plan is ready
+  for implementation
 
 ### `harness archive`
 

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -165,8 +165,8 @@ approved_at: 2026-03-17T10:30:00+08:00
   - supported values are `XXS`, `XS`, `S`, `M`, `L`, `XL`, and `XXL`
   - size describes magnitude, coordination weight, and review load; it does
     not by itself prove the work is low-risk
-  - size and `workflow_profile` are separate decisions; small sizes such as
-    `XXS` or `XS` may still use the ordinary `standard` workflow
+  - size and `workflow_profile` are separate decisions; `XXS` may still use
+    the ordinary `standard` workflow
   - `XXS` is the only size that may use `workflow_profile: lightweight`
   - an initial `XXL` estimate is a planning warning, not a routine default:
     before execution approval, the controller should stop, confirm the size
@@ -206,7 +206,7 @@ approved_at: 2026-03-17T10:30:00+08:00
 - `approved_at`
   - optional RFC3339 timestamp with offset
   - records when an active tracked plan was explicitly approved through the
-    harness workflow, for example via `harness plan approve --by=human`
+    harness workflow, for example via `harness plan approve --by human`
   - historical plans that predate the explicit approval command may omit this
     field without backfill
   - when present, it marks approval of the tracked markdown plan package,

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -80,6 +80,8 @@ Rules:
 
 - approval covers the markdown plan and its matching supplements directory as
   one plan package
+- explicit approval for a newly written plan should be recorded durably in the
+  tracked plan frontmatter rather than inferred only from chat context
 - bulky but durable execution detail that should survive context compaction may
   live in supplements, such as spec drafts, formulas, design notes, or other
   structured reasoning that is too large or awkward for the main markdown
@@ -133,6 +135,7 @@ created_at: 2026-03-17T10:12:01+08:00
 source_type: direct_request
 source_refs: []
 size: M
+approved_at: 2026-03-17T10:30:00+08:00
 ---
 ```
 
@@ -162,6 +165,8 @@ size: M
   - supported values are `XXS`, `XS`, `S`, `M`, `L`, `XL`, and `XXL`
   - size describes magnitude, coordination weight, and review load; it does
     not by itself prove the work is low-risk
+  - size and `workflow_profile` are separate decisions; small sizes such as
+    `XXS` or `XS` may still use the ordinary `standard` workflow
   - `XXS` is the only size that may use `workflow_profile: lightweight`
   - an initial `XXL` estimate is a planning warning, not a routine default:
     before execution approval, the controller should stop, confirm the size
@@ -198,6 +203,14 @@ size: M
 
 ### Optional Fields
 
+- `approved_at`
+  - optional RFC3339 timestamp with offset
+  - records when an active tracked plan was explicitly approved through the
+    harness workflow, for example via `harness plan approve --by=human`
+  - historical plans that predate the explicit approval command may omit this
+    field without backfill
+  - when present, it marks approval of the tracked markdown plan package,
+    including any matching `supplements/<plan-stem>/` directory
 - `workflow_profile`
   - optional explicit workflow selector
   - supported value is `lightweight`

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -148,6 +148,8 @@ func (a *App) runPlan(args []string) int {
 		return a.runPlanTemplate(args[1:])
 	case "lint":
 		return a.runPlanLint(args[1:])
+	case "approve":
+		return a.runPlanApprove(args[1:])
 	case "-h", "--help", "help":
 		a.printPlanUsage()
 		return 0
@@ -645,6 +647,43 @@ func (a *App) runPlanLint(args []string) int {
 	return 1
 }
 
+func (a *App) runPlanApprove(args []string) int {
+	fs := flag.NewFlagSet("harness plan approve", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	by := fs.String("by", "", "Approval source. Use human after the human explicitly approves execution.")
+	fs.Usage = func() {
+		fmt.Fprintln(a.Stderr, "Usage: harness plan approve --by human")
+		fmt.Fprintln(a.Stderr)
+		fmt.Fprintln(a.Stderr, "Record the explicit human approval boundary for the current active plan before execution starts.")
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 || strings.TrimSpace(*by) == "" {
+		fs.Usage()
+		return 2
+	}
+
+	workdir, err := a.Getwd()
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
+		return 1
+	}
+	recordedAt := a.Now().Format(time.RFC3339)
+	beforeStatus := readStatusSnapshot(workdir)
+	result := lifecycle.Service{
+		Workdir: workdir,
+		Now:     a.Now,
+		AfterMutation: lifecycleTimelineHook(workdir, beforeStatus, recordedAt, map[string]any{
+			"by": strings.TrimSpace(*by),
+		}),
+	}.PlanApprove(*by)
+	return a.writeJSONResult(result)
+}
+
 func (a *App) runStatus(args []string) int {
 	fs := flag.NewFlagSet("harness status", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
@@ -729,9 +768,10 @@ func (a *App) runReviewSubmit(args []string) int {
 	fs.SetOutput(a.Stderr)
 	roundID := fs.String("round", "", "Review round ID.")
 	slot := fs.String("slot", "", "Reviewer slot name.")
+	by := fs.String("by", "", "Reviewer identity label for this submission.")
 	inputPath := fs.String("input", "", "Read the reviewer submission JSON from this path. Defaults to stdin.")
 	fs.Usage = func() {
-		fmt.Fprintln(a.Stderr, "Usage: harness review submit --round <round-id> --slot <slot> [--input <path>]")
+		fmt.Fprintln(a.Stderr, "Usage: harness review submit --round <round-id> --slot <slot> --by <reviewer-name> [--input <path>]")
 		fmt.Fprintln(a.Stderr)
 		fmt.Fprintln(a.Stderr, "Record one reviewer submission for the selected review round and slot.")
 	}
@@ -741,7 +781,7 @@ func (a *App) runReviewSubmit(args []string) int {
 		}
 		return 2
 	}
-	if fs.NArg() != 0 || strings.TrimSpace(*roundID) == "" || strings.TrimSpace(*slot) == "" {
+	if fs.NArg() != 0 || strings.TrimSpace(*roundID) == "" || strings.TrimSpace(*slot) == "" || strings.TrimSpace(*by) == "" {
 		fs.Usage()
 		return 2
 	}
@@ -758,10 +798,13 @@ func (a *App) runReviewSubmit(args []string) int {
 	recordedAt := a.Now().Format(time.RFC3339)
 	beforeStatus := readUnlockedStatusSnapshot(workdir)
 	result := review.Service{
-		Workdir:     workdir,
-		Now:         a.Now,
-		AfterSubmit: reviewSubmitTimelineHook(workdir, beforeStatus, recordedAt, inputBytes),
-	}.Submit(*roundID, *slot, inputBytes)
+		Workdir: workdir,
+		Now:     a.Now,
+		AfterSubmit: reviewSubmitTimelineHook(workdir, beforeStatus, recordedAt, map[string]any{
+			"by":    strings.TrimSpace(*by),
+			"input": json.RawMessage(inputBytes),
+		}),
+	}.Submit(*roundID, *slot, *by, inputBytes)
 	return a.writeJSONResult(result)
 }
 
@@ -961,6 +1004,7 @@ func (a *App) printRootUsage() {
 	fmt.Fprintln(a.Stderr, "Commands:")
 	fmt.Fprintln(a.Stderr, "  plan template   Render the packaged plan template")
 	fmt.Fprintln(a.Stderr, "  plan lint       Validate a tracked plan")
+	fmt.Fprintln(a.Stderr, "  plan approve    Record explicit human approval for the current plan")
 	fmt.Fprintln(a.Stderr, "  execute start   Record the execution-start milestone")
 	fmt.Fprintln(a.Stderr, "  evidence submit Record append-only CI, publish, or sync evidence")
 	fmt.Fprintln(a.Stderr, "  review start    Create a deterministic review round")
@@ -983,6 +1027,7 @@ func (a *App) printPlanUsage() {
 	fmt.Fprintln(a.Stderr, "Subcommands:")
 	fmt.Fprintln(a.Stderr, "  template   Render the packaged plan template")
 	fmt.Fprintln(a.Stderr, "  lint       Validate a tracked plan")
+	fmt.Fprintln(a.Stderr, "  approve    Record explicit human approval for the current plan")
 }
 
 func (a *App) printReviewUsage() {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -181,6 +181,7 @@ func TestPlanLintCommandReturnsJSON(t *testing.T) {
 	}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 	ensurePlanSizeInFile(t, outputPath, "M")
 
 	stdout.Reset()
@@ -437,6 +438,7 @@ func TestStatusCommandReturnsJSON(t *testing.T) {
 	}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 
 	stdout.Reset()
 	stderr.Reset()
@@ -473,6 +475,7 @@ func TestExecuteStartCommandReturnsJSON(t *testing.T) {
 	}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 
 	stdout.Reset()
 	stderr.Reset()
@@ -514,6 +517,7 @@ func TestExecuteStartRollsBackWhenTimelineAppendFails(t *testing.T) {
 	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Generated Plan", "--output", outputPath}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 	if err := os.MkdirAll(filepath.Join(root, ".local/harness/plans/2026-03-18-test-plan/events.jsonl"), 0o755); err != nil {
 		t.Fatalf("seed broken event index path: %v", err)
 	}
@@ -631,6 +635,7 @@ func TestReviewStartCommandAppendsTimelineEvent(t *testing.T) {
 	}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 
 	stdout.Reset()
 	stderr.Reset()
@@ -683,6 +688,7 @@ func TestReviewStartCommandReturnsSchemaValidationErrors(t *testing.T) {
 	}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 	if exitCode := app.Run([]string{"execute", "start"}); exitCode != 0 {
 		t.Fatalf("execute start failed with %d: %s", exitCode, stderr.String())
 	}
@@ -729,6 +735,7 @@ func TestReviewSubmitCommandAppendsTimelineEvent(t *testing.T) {
 	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Review Submit Plan", "--output", outputPath}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 	if exitCode := app.Run([]string{"execute", "start"}); exitCode != 0 {
 		t.Fatalf("execute start failed with %d: %s", exitCode, stderr.String())
 	}
@@ -743,7 +750,7 @@ func TestReviewSubmitCommandAppendsTimelineEvent(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	app.Stdin = bytes.NewBufferString(`{"summary":"Looks good","findings":[]}`)
-	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness"}); exitCode != 0 {
+	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness", "--by", "reviewer-correctness"}); exitCode != 0 {
 		t.Fatalf("review submit failed with %d: %s", exitCode, stderr.String())
 	}
 
@@ -764,6 +771,7 @@ func TestReviewSubmitCommandDoesNotFailWhenStateMutationLockIsHeld(t *testing.T)
 	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Review Submit Lock Plan", "--output", outputPath}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 	if exitCode := app.Run([]string{"execute", "start"}); exitCode != 0 {
 		t.Fatalf("execute start failed with %d: %s", exitCode, stderr.String())
 	}
@@ -784,7 +792,7 @@ func TestReviewSubmitCommandDoesNotFailWhenStateMutationLockIsHeld(t *testing.T)
 	stdout.Reset()
 	stderr.Reset()
 	app.Stdin = bytes.NewBufferString(`{"summary":"Looks good","findings":[]}`)
-	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness"}); exitCode != 0 {
+	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness", "--by", "reviewer-correctness"}); exitCode != 0 {
 		t.Fatalf("expected review submit success while state lock is held, got %d: %s", exitCode, stderr.String())
 	}
 }
@@ -803,6 +811,7 @@ func TestReviewSubmitCommandReturnsSchemaValidationErrors(t *testing.T) {
 	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Review Submit Plan", "--output", outputPath}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 	if exitCode := app.Run([]string{"execute", "start"}); exitCode != 0 {
 		t.Fatalf("execute start failed with %d: %s", exitCode, stderr.String())
 	}
@@ -817,7 +826,7 @@ func TestReviewSubmitCommandReturnsSchemaValidationErrors(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	app.Stdin = bytes.NewBufferString(`{"findings":[]}`)
-	exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness"})
+	exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness", "--by", "reviewer-correctness"})
 	if exitCode != 1 {
 		t.Fatalf("expected schema validation failure, got %d: %s", exitCode, stderr.String())
 	}
@@ -852,6 +861,7 @@ func TestReviewAggregateCommandAppendsTimelineEvent(t *testing.T) {
 	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Review Aggregate Plan", "--output", outputPath}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 	if exitCode := app.Run([]string{"execute", "start"}); exitCode != 0 {
 		t.Fatalf("execute start failed with %d: %s", exitCode, stderr.String())
 	}
@@ -866,7 +876,7 @@ func TestReviewAggregateCommandAppendsTimelineEvent(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	app.Stdin = bytes.NewBufferString(`{"summary":"Looks good","findings":[]}`)
-	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness"}); exitCode != 0 {
+	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness", "--by", "reviewer-correctness"}); exitCode != 0 {
 		t.Fatalf("review submit failed with %d: %s", exitCode, stderr.String())
 	}
 
@@ -893,6 +903,7 @@ func TestReviewSubmitRollsBackWhenTimelineAppendFails(t *testing.T) {
 	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Review Submit Rollback Plan", "--output", outputPath}); exitCode != 0 {
 		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
 	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
 	if exitCode := app.Run([]string{"execute", "start"}); exitCode != 0 {
 		t.Fatalf("execute start failed with %d: %s", exitCode, stderr.String())
 	}
@@ -915,7 +926,7 @@ func TestReviewSubmitRollsBackWhenTimelineAppendFails(t *testing.T) {
 	stdout.Reset()
 	stderr.Reset()
 	app.Stdin = bytes.NewBufferString(`{"summary":"Looks good","findings":[]}`)
-	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness"}); exitCode != 1 {
+	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness", "--by", "reviewer-correctness"}); exitCode != 1 {
 		t.Fatalf("expected review submit failure when timeline append fails, got %d", exitCode)
 	}
 
@@ -1627,4 +1638,30 @@ func ensurePlanSizeInFile(t *testing.T, path, size string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write plan file: %v", err)
 	}
+}
+
+func approvePlanInFile(t *testing.T, path, approvedAt string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read plan file: %v", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "approved_at:") {
+			lines[i] = "approved_at: " + approvedAt
+			if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+				t.Fatalf("write approved plan file: %v", err)
+			}
+			return
+		}
+		if strings.HasPrefix(line, "created_at:") {
+			lines = append(lines[:i+1], append([]string{"approved_at: " + approvedAt}, lines[i+1:]...)...)
+			if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+				t.Fatalf("write approved plan file: %v", err)
+			}
+			return
+		}
+	}
+	t.Fatalf("created_at frontmatter line not found in %s", path)
 }

--- a/internal/cli/timeline_events.go
+++ b/internal/cli/timeline_events.go
@@ -96,7 +96,7 @@ func reviewStartTimelineHook(workdir string, before *status.Result, recordedAt s
 	}
 }
 
-func reviewSubmitTimelineHook(workdir string, before *status.Result, recordedAt string, input []byte) func(reviewSubmitResult) error {
+func reviewSubmitTimelineHook(workdir string, before *status.Result, recordedAt string, input any) func(reviewSubmitResult) error {
 	return func(result reviewSubmitResult) error {
 		return appendTimelineEvent(
 			workdir,

--- a/internal/contracts/lifecycle.go
+++ b/internal/contracts/lifecycle.go
@@ -1,8 +1,8 @@
 package contracts
 
 // LifecycleResult is the JSON result shape currently shared by
-// `harness execute start`, `harness archive`, `harness reopen`, `harness land`,
-// and `harness land complete`.
+// `harness plan approve`, `harness execute start`, `harness archive`,
+// `harness reopen`, `harness land`, and `harness land complete`.
 type LifecycleResult struct {
 	// OK reports whether the command succeeded.
 	OK bool `json:"ok"`

--- a/internal/contracts/registry.go
+++ b/internal/contracts/registry.go
@@ -68,7 +68,7 @@ func SchemaRegistry() []SchemaEntry {
 			Group:       "command_results",
 			Path:        "schema/commands/lifecycle.result.schema.json",
 			Title:       "Lifecycle command result",
-			Description: "Shared JSON output shape for lifecycle commands such as `harness execute start`, `harness archive`, `harness reopen`, `harness land`, and `harness land complete`.",
+			Description: "Shared JSON output shape for lifecycle commands such as `harness plan approve`, `harness execute start`, `harness archive`, `harness reopen`, `harness land`, and `harness land complete`.",
 			Shape:       "output",
 			Type:        reflect.TypeFor[LifecycleResult](),
 		},

--- a/internal/contracts/review.go
+++ b/internal/contracts/review.go
@@ -153,6 +153,9 @@ type ReviewSubmission struct {
 	// Dimension is the human-readable review dimension label.
 	Dimension string `json:"dimension"`
 
+	// By is the reviewer-provided identity label for the submitted slot.
+	By string `json:"by,omitempty"`
+
 	// SubmittedAt is the submission timestamp.
 	SubmittedAt string `json:"submitted_at,omitempty"`
 
@@ -397,6 +400,7 @@ func (s ReviewSubmission) MarshalJSON() ([]byte, error) {
 		RoundID:     s.RoundID,
 		Slot:        s.Slot,
 		Dimension:   s.Dimension,
+		By:          s.By,
 		SubmittedAt: s.SubmittedAt,
 		Summary:     s.Summary,
 		Findings:    s.Findings,
@@ -413,6 +417,7 @@ func (s *ReviewSubmission) UnmarshalJSON(data []byte) error {
 	s.RoundID = payload.RoundID
 	s.Slot = payload.Slot
 	s.Dimension = payload.Dimension
+	s.By = payload.By
 	s.SubmittedAt = payload.SubmittedAt
 	s.Summary = payload.Summary
 	s.Findings = payload.Findings
@@ -549,6 +554,7 @@ type reviewSubmissionPayload struct {
 	RoundID     string          `json:"round_id"`
 	Slot        string          `json:"slot"`
 	Dimension   string          `json:"dimension"`
+	By          string          `json:"by,omitempty"`
 	SubmittedAt string          `json:"submitted_at,omitempty"`
 	Summary     string          `json:"summary,omitempty"`
 	Findings    []ReviewFinding `json:"findings,omitempty"`
@@ -563,6 +569,7 @@ var reviewSubmissionInputIgnoredExtraFields = map[string]bool{
 	"round_id":     true,
 	"slot":         true,
 	"dimension":    true,
+	"by":           true,
 	"submitted_at": true,
 }
 
@@ -570,6 +577,7 @@ var reviewSubmissionKnownFields = map[string]bool{
 	"round_id":     true,
 	"slot":         true,
 	"dimension":    true,
+	"by":           true,
 	"submitted_at": true,
 	"summary":      true,
 	"findings":     true,

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -52,7 +52,7 @@ func (s Service) ExecuteStart() Result {
 	if !doc.ExplicitlyApproved() && !doc.ExecutionStarted(state) {
 		return errorResult("execute start", "Current plan is waiting for recorded human approval.", []CommandError{{
 			Path:    "frontmatter.approved_at",
-			Message: "record plan approval with `harness plan approve --by=human` after the human approves execution",
+			Message: "record plan approval with `harness plan approve --by human` after the human approves execution",
 		}})
 	}
 
@@ -148,7 +148,7 @@ func (s Service) PlanApprove(by string) Result {
 	if normalizedBy != "human" {
 		return errorResult("plan approve", "Plan approval must be recorded as a human decision.", []CommandError{{
 			Path:    "by",
-			Message: "expected `--by=human`",
+			Message: "expected `--by human`",
 		}})
 	}
 

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -49,6 +49,12 @@ func (s Service) ExecuteStart() Result {
 			Message: fmt.Sprintf("execute start requires an active plan, got status=%q", doc.DerivedPlanStatus()),
 		}})
 	}
+	if !doc.ExplicitlyApproved() && !doc.ExecutionStarted(state) {
+		return errorResult("execute start", "Current plan is waiting for recorded human approval.", []CommandError{{
+			Path:    "frontmatter.approved_at",
+			Message: "record plan approval with `harness plan approve --by=human` after the human approves execution",
+		}})
+	}
 
 	if state == nil {
 		state = &runstate.State{Revision: 1}
@@ -113,6 +119,98 @@ func (s Service) ExecuteStart() Result {
 			issues = append(issues, CommandError{Path: "state", Message: fmt.Sprintf("rollback current-plan pointer: %v", restoreErr)})
 		}
 		return issues
+	})
+}
+
+func (s Service) PlanApprove(by string) Result {
+	now := s.now()
+	currentPath, doc, editable, _, relCurrentPath, state, statePath, release, errResult := s.loadCurrentPlan()
+	if errResult != nil {
+		errResult.Command = "plan approve"
+		return *errResult
+	}
+	defer release()
+
+	if doc.DerivedPlanStatus() != "active" {
+		return errorResult("plan approve", "Current plan is not active.", []CommandError{{
+			Path:    "plan.status",
+			Message: fmt.Sprintf("plan approve requires an active plan, got status=%q", doc.DerivedPlanStatus()),
+		}})
+	}
+	if doc.ExecutionStarted(state) {
+		return errorResult("plan approve", "Execution has already started for the current active plan.", []CommandError{{
+			Path:    "state.execution_started_at",
+			Message: "plan approval must be recorded before `harness execute start`",
+		}})
+	}
+
+	normalizedBy := strings.ToLower(strings.TrimSpace(by))
+	if normalizedBy != "human" {
+		return errorResult("plan approve", "Plan approval must be recorded as a human decision.", []CommandError{{
+			Path:    "by",
+			Message: "expected `--by=human`",
+		}})
+	}
+
+	alreadyApproved := doc.ExplicitlyApproved()
+	originalContent, err := os.ReadFile(currentPath)
+	if err != nil {
+		return errorResult("plan approve", "Unable to snapshot the tracked plan before recording approval.", []CommandError{{
+			Path:    "plan",
+			Message: err.Error(),
+		}})
+	}
+	editable.Frontmatter.ApprovedAt = now.Format(time.RFC3339)
+	content, err := renderEditablePlan(editable.Frontmatter, editable.Body)
+	if err != nil {
+		return errorResult("plan approve", "Unable to render the tracked plan with approval metadata.", []CommandError{{
+			Path:    "frontmatter",
+			Message: err.Error(),
+		}})
+	}
+	if err := os.WriteFile(currentPath, []byte(content), 0o644); err != nil {
+		return errorResult("plan approve", "Unable to persist the tracked plan approval.", []CommandError{{
+			Path:    "plan",
+			Message: err.Error(),
+		}})
+	}
+	if lint := plan.LintFile(currentPath); !lint.OK {
+		_ = os.WriteFile(currentPath, originalContent, 0o644)
+		return errorResult("plan approve", "Updated tracked plan did not pass validation.", lintErrorsToCommandErrors(lint.Errors))
+	}
+
+	summary := "Recorded human approval for the current active plan."
+	if alreadyApproved {
+		summary = "Refreshed recorded human approval for the current active plan."
+	}
+
+	var facts *Facts
+	if revision := runstate.CurrentRevision(state); revision > 0 {
+		facts = &Facts{Revision: revision}
+	}
+
+	result := Result{
+		OK:      true,
+		Command: "plan approve",
+		Summary: summary,
+		State: State{
+			CurrentNode: "plan",
+		},
+		Facts: facts,
+		Artifacts: &Artifacts{
+			FromPlanPath:   relCurrentPath,
+			LocalStatePath: statePath,
+		},
+		NextAction: []NextAction{
+			{Command: strPtr("harness execute start"), Description: "Start execution once implementation is ready to begin on the approved tracked plan."},
+			{Command: nil, Description: "If scope changes after approval but before implementation begins, update the tracked plan and refresh the approval boundary before executing."},
+		},
+	}
+	return s.finalizeMutation(result, func() []CommandError {
+		if err := os.WriteFile(currentPath, originalContent, 0o644); err != nil {
+			return []CommandError{{Path: "plan", Message: fmt.Sprintf("rollback tracked plan approval: %v", err)}}
+		}
+		return nil
 	})
 }
 

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -240,6 +240,66 @@ func TestExecuteStartPersistsMilestoneAndPointer(t *testing.T) {
 	}
 }
 
+func TestPlanApproveRecordsAndRefreshesApprovedAt(t *testing.T) {
+	root := t.TempDir()
+	activeRelPath := "docs/plans/active/2026-03-18-plan-approve.md"
+	planPath := filepath.Join(root, activeRelPath)
+	writeFile(t, planPath, stripApprovedAt(buildAwaitingPlan(t, "Plan Approve Refresh")))
+
+	svc := lifecycle.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 1, 0, 0, 0, time.UTC)
+		},
+	}
+	first := svc.PlanApprove("human")
+	if !first.OK {
+		t.Fatalf("expected first plan approve success, got %#v", first)
+	}
+	firstDoc, err := plan.LoadFile(planPath)
+	if err != nil {
+		t.Fatalf("load plan after first approval: %v", err)
+	}
+	if firstDoc.Frontmatter.ApprovedAt != "2026-03-18T01:00:00Z" {
+		t.Fatalf("expected first approved_at timestamp, got %#v", firstDoc.Frontmatter)
+	}
+
+	svc.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 1, 10, 0, 0, time.UTC)
+	}
+	second := svc.PlanApprove("human")
+	if !second.OK {
+		t.Fatalf("expected second plan approve success, got %#v", second)
+	}
+	if !strings.Contains(second.Summary, "Refreshed") {
+		t.Fatalf("expected refreshed approval summary, got %#v", second)
+	}
+	secondDoc, err := plan.LoadFile(planPath)
+	if err != nil {
+		t.Fatalf("load plan after second approval: %v", err)
+	}
+	if secondDoc.Frontmatter.ApprovedAt != "2026-03-18T01:10:00Z" {
+		t.Fatalf("expected refreshed approved_at timestamp, got %#v", secondDoc.Frontmatter)
+	}
+}
+
+func TestExecuteStartRejectsUnapprovedPlan(t *testing.T) {
+	root := t.TempDir()
+	activeRelPath := "docs/plans/active/2026-03-18-execute-start-unapproved.md"
+	writeFile(t, filepath.Join(root, activeRelPath), stripApprovedAt(buildAwaitingPlan(t, "Execute Start Unapproved")))
+
+	result := lifecycle.Service{Workdir: root}.ExecuteStart()
+	if result.OK {
+		t.Fatalf("expected execute start to reject unapproved plan, got %#v", result)
+	}
+	if result.Summary != "Current plan is waiting for recorded human approval." {
+		t.Fatalf("unexpected summary: %#v", result)
+	}
+	if len(result.Errors) == 0 || result.Errors[0].Path != "frontmatter.approved_at" {
+		t.Fatalf("expected approval error path, got %#v", result.Errors)
+	}
+}
+
 func TestExecuteStartBackfillsLegacyExecutingPlan(t *testing.T) {
 	root := t.TempDir()
 	activeRelPath := "docs/plans/active/2026-03-18-execute-start-legacy.md"
@@ -1525,7 +1585,7 @@ func TestLandReadsEvidenceArtifactsWhenStateIsSparse(t *testing.T) {
 		t.Fatalf("save current plan: %v", err)
 	}
 	if _, err := runstate.SaveState(root, "2026-03-18-landed-plan", &runstate.State{
-		Revision:       3,
+		Revision: 3,
 	}); err != nil {
 		t.Fatalf("save legacy state: %v", err)
 	}
@@ -1840,7 +1900,20 @@ func buildAwaitingPlan(t *testing.T, title string) string {
 	if err != nil {
 		t.Fatalf("render template: %v", err)
 	}
-	return strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
+	rendered = strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
+	return strings.Replace(rendered, "created_at: 2026-03-18T02:00:00Z", "created_at: 2026-03-18T02:00:00Z\napproved_at: 2026-03-18T02:05:00Z", 1)
+}
+
+func stripApprovedAt(content string) string {
+	lines := strings.Split(content, "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.HasPrefix(line, "approved_at:") {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	return strings.Join(filtered, "\n")
 }
 
 func writeFile(t *testing.T, path, content string) {

--- a/internal/plan/lint.go
+++ b/internal/plan/lint.go
@@ -61,6 +61,7 @@ var (
 type Frontmatter struct {
 	TemplateVersion string   `yaml:"template_version"`
 	CreatedAt       string   `yaml:"created_at"`
+	ApprovedAt      string   `yaml:"approved_at,omitempty"`
 	SourceType      string   `yaml:"source_type"`
 	SourceRefs      []string `yaml:"source_refs"`
 	Size            string   `yaml:"size"`
@@ -254,6 +255,13 @@ func validateFrontmatter(ctx *lintContext) []LintIssue {
 	}
 	if strings.TrimSpace(ctx.frontmatter.CreatedAt) == "" {
 		issues = append(issues, LintIssue{Path: "frontmatter.created_at", Message: "must not be empty"})
+	}
+	if _, ok := ctx.rawFrontmatter["approved_at"]; ok {
+		if strings.TrimSpace(ctx.frontmatter.ApprovedAt) == "" {
+			issues = append(issues, LintIssue{Path: "frontmatter.approved_at", Message: "must not be empty when provided"})
+		} else if _, err := time.Parse(time.RFC3339, ctx.frontmatter.ApprovedAt); err != nil {
+			issues = append(issues, LintIssue{Path: "frontmatter.approved_at", Message: "must be RFC3339"})
+		}
 	}
 	if strings.TrimSpace(ctx.frontmatter.SourceType) == "" {
 		issues = append(issues, LintIssue{Path: "frontmatter.source_type", Message: "must not be empty"})

--- a/internal/plan/runtime.go
+++ b/internal/plan/runtime.go
@@ -1,6 +1,10 @@
 package plan
 
-import "github.com/catu-ai/easyharness/internal/runstate"
+import (
+	"strings"
+
+	"github.com/catu-ai/easyharness/internal/runstate"
+)
 
 func (d *Document) DerivedPlanStatus() string {
 	switch d.PathKind {
@@ -22,6 +26,17 @@ func (d *Document) WorkflowProfile() string {
 
 func (d *Document) UsesLightweightProfile() bool {
 	return d.WorkflowProfile() == WorkflowProfileLightweight
+}
+
+func (d *Document) ApprovedAt() string {
+	if d == nil {
+		return ""
+	}
+	return strings.TrimSpace(d.Frontmatter.ApprovedAt)
+}
+
+func (d *Document) ExplicitlyApproved() bool {
+	return d.ApprovedAt() != ""
 }
 
 func (d *Document) ExecutionStarted(state *runstate.State) bool {

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -270,7 +270,7 @@ func (s Service) Start(specBytes []byte) StartResult {
 	})
 }
 
-func (s Service) Submit(roundID, slot string, inputBytes []byte) SubmitResult {
+func (s Service) Submit(roundID, slot, reviewerName string, inputBytes []byte) SubmitResult {
 	lockedPlanPath, release, err := s.acquireReviewMutationLock()
 	if err == nil {
 		defer release()
@@ -311,6 +311,14 @@ func (s Service) Submit(roundID, slot string, inputBytes []byte) SubmitResult {
 			Errors:  []CommandError{{Path: "slot", Message: fmt.Sprintf("unknown slot %q for review round %q", slot, roundID)}},
 		}
 	}
+	if strings.TrimSpace(reviewerName) == "" {
+		return SubmitResult{
+			OK:      false,
+			Command: "review submit",
+			Summary: "Reviewer identity is required.",
+			Errors:  []CommandError{{Path: "by", Message: "review submit requires a non-empty reviewer identity label"}},
+		}
+	}
 
 	var input SubmissionInput
 	if issues := inputschema.DecodeAndValidate("inputs.review.submission", "submission", inputBytes, &input); len(issues) > 0 {
@@ -335,6 +343,7 @@ func (s Service) Submit(roundID, slot string, inputBytes []byte) SubmitResult {
 		RoundID:     roundID,
 		Slot:        slotDef.Slot,
 		Dimension:   slotDef.Name,
+		By:          strings.TrimSpace(reviewerName),
 		SubmittedAt: now,
 		Summary:     strings.TrimSpace(input.Summary),
 		Findings:    input.Findings,

--- a/internal/review/service_internal_test.go
+++ b/internal/review/service_internal_test.go
@@ -121,7 +121,7 @@ func TestAggregateRestoresPreviousAggregateWhenStateSaveFails(t *testing.T) {
 	svc.Now = func() time.Time {
 		return time.Date(2026, 4, 1, 10, 1, 0, 0, time.UTC)
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSONBytes(t, SubmissionInput{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSONBytes(t, SubmissionInput{
 		Summary: "Looks good.",
 	}))
 	if !submit.OK {
@@ -210,7 +210,7 @@ func TestSubmitRestoresSubmissionWhenLedgerWriteFails(t *testing.T) {
 	svc.Now = func() time.Time {
 		return time.Date(2026, 4, 1, 10, 1, 0, 0, time.UTC)
 	}
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSONBytes(t, SubmissionInput{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSONBytes(t, SubmissionInput{
 		Summary: "Looks good.",
 	}))
 	if result.OK {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -503,7 +503,7 @@ func TestSubmitStoresSubmissionAndUpdatesLedger(t *testing.T) {
 	svc.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 1, 5, 0, 0, time.UTC)
 	}
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Found a targeted issue.",
 		Findings: []review.Finding{
 			{
@@ -527,6 +527,9 @@ func TestSubmitStoresSubmissionAndUpdatesLedger(t *testing.T) {
 	}
 	if err := json.Unmarshal(data, &submission); err != nil {
 		t.Fatalf("unmarshal submission: %v", err)
+	}
+	if submission.By != "reviewer-correctness" {
+		t.Fatalf("expected persisted reviewer identity, got %#v", submission)
 	}
 	if len(submission.Findings) != 1 || len(submission.Findings[0].Locations) != 2 {
 		t.Fatalf("expected persisted locations, got %#v", submission.Findings)
@@ -564,7 +567,7 @@ func TestSubmitDoesNotRequireStateMutationLock(t *testing.T) {
 	}
 	defer release()
 
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Looks good.",
 	}))
 	if !result.OK {
@@ -593,7 +596,7 @@ func TestSubmitRejectsUnknownFindingProperty(t *testing.T) {
 		t.Fatalf("start failed: %#v", start)
 	}
 
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", []byte(`{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", []byte(`{
 		"summary": "Looks good.",
 		"findings": [
 			{
@@ -631,7 +634,7 @@ func TestSubmitRejectsUnknownSlot(t *testing.T) {
 		t.Fatalf("start failed: %#v", start)
 	}
 
-	result := svc.Submit(start.Artifacts.RoundID, "missing", mustJSON(t, review.SubmissionInput{
+	result := svc.Submit(start.Artifacts.RoundID, "missing", "reviewer-missing", mustJSON(t, review.SubmissionInput{
 		Summary: "Looks good.",
 	}))
 	if result.OK {
@@ -661,7 +664,7 @@ func TestSubmitRejectsEmptyLocationString(t *testing.T) {
 		t.Fatalf("start failed: %#v", start)
 	}
 
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Found one issue.",
 		Findings: []review.Finding{
 			{
@@ -699,7 +702,7 @@ func TestSubmitRejectsNullLocations(t *testing.T) {
 		t.Fatalf("start failed: %#v", start)
 	}
 
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, map[string]any{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, map[string]any{
 		"summary": "Found one issue.",
 		"findings": []any{
 			map[string]any{
@@ -737,7 +740,7 @@ func TestSubmitAcceptsAndPreservesExtraTopLevelFields(t *testing.T) {
 		t.Fatalf("start failed: %#v", start)
 	}
 
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", []byte(`{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", []byte(`{
 		"round_id":"stale-round",
 		"slot":"stale-slot",
 		"dimension":"stale-dimension",
@@ -805,7 +808,7 @@ func TestSubmitRejectsWrongFindingSeverityType(t *testing.T) {
 		t.Fatalf("start failed: %#v", start)
 	}
 
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", []byte(`{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", []byte(`{
 		"summary":"Found one issue.",
 		"findings":[{"severity":1,"title":"Wrong type","details":"Severity must be a string."}]
 	}`))
@@ -836,7 +839,7 @@ func TestSubmitRejectsMissingRequiredSummary(t *testing.T) {
 		t.Fatalf("start failed: %#v", start)
 	}
 
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", []byte(`{"findings":[]}`))
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", []byte(`{"findings":[]}`))
 	if result.OK {
 		t.Fatalf("expected failure, got %#v", result)
 	}
@@ -864,7 +867,7 @@ func TestSubmitPreservesExplicitEmptyLocationsArray(t *testing.T) {
 		t.Fatalf("start failed: %#v", start)
 	}
 
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, map[string]any{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, map[string]any{
 		"summary": "Found one issue.",
 		"findings": []any{
 			map[string]any{
@@ -916,7 +919,7 @@ func TestSubmitAcceptsFindingWithoutLocations(t *testing.T) {
 		t.Fatalf("start failed: %#v", start)
 	}
 
-	result := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	result := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Found one issue.",
 		Findings: []review.Finding{
 			{
@@ -993,7 +996,7 @@ func TestAggregateDeltaPassUpdatesState(t *testing.T) {
 	if !start.OK {
 		t.Fatalf("start failed: %#v", start)
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Looks good.",
 	}))
 	if !submit.OK {
@@ -1019,6 +1022,47 @@ func TestAggregateDeltaPassUpdatesState(t *testing.T) {
 	}
 }
 
+func TestAggregateAcceptsLegacySubmissionWithoutBy(t *testing.T) {
+	root := t.TempDir()
+	writeExecutingPlan(t, root, "docs/plans/active/2026-03-18-review-contract.md")
+
+	svc := review.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 2, 5, 0, 0, time.UTC)
+		},
+	}
+	start := svc.Start(mustJSON(t, review.Spec{
+		Kind:      "delta",
+		AnchorSHA: "anchor-sha",
+		Dimensions: []review.Dimension{
+			{Name: "correctness", Instructions: "Check aggregate compatibility."},
+		},
+	}))
+	if !start.OK {
+		t.Fatalf("expected start success, got %#v", start)
+	}
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
+		Summary: "Looks good.",
+	}))
+	if !submit.OK {
+		t.Fatalf("expected submit success, got %#v", submit)
+	}
+	data, err := os.ReadFile(submit.Artifacts.SubmissionPath)
+	if err != nil {
+		t.Fatalf("read submission: %v", err)
+	}
+	legacy := strings.Replace(string(data), "\"by\": \"reviewer-correctness\",\n", "", 1)
+	if err := os.WriteFile(submit.Artifacts.SubmissionPath, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("rewrite legacy submission: %v", err)
+	}
+
+	result := svc.Aggregate(start.Artifacts.RoundID)
+	if !result.OK {
+		t.Fatalf("expected aggregate to tolerate legacy missing by, got %#v", result)
+	}
+}
+
 func TestAggregateRejectsNonActiveRound(t *testing.T) {
 	root := t.TempDir()
 	writeArchiveReadyFinalizePlan(t, root, "docs/plans/active/2026-03-18-review-contract.md")
@@ -1038,7 +1082,7 @@ func TestAggregateRejectsNonActiveRound(t *testing.T) {
 	if !stale.OK {
 		t.Fatalf("stale round start failed: %#v", stale)
 	}
-	submit := svc.Submit(stale.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	submit := svc.Submit(stale.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Looks good.",
 	}))
 	if !submit.OK {
@@ -1188,7 +1232,7 @@ func TestAggregateRejectsWhenReviewMutationLockIsHeld(t *testing.T) {
 	if !start.OK {
 		t.Fatalf("start failed: %#v", start)
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Looks good.",
 	}))
 	if !submit.OK {
@@ -1228,7 +1272,7 @@ func TestAggregateRejectsWhenStateMutationLockIsHeld(t *testing.T) {
 	if !start.OK {
 		t.Fatalf("start failed: %#v", start)
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Looks good.",
 	}))
 	if !submit.OK {
@@ -1272,7 +1316,7 @@ func TestAggregatePrefersReviewMutationLockWhenBothLocksAreHeld(t *testing.T) {
 	if !start.OK {
 		t.Fatalf("start failed: %#v", start)
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Looks good.",
 	}))
 	if !submit.OK {
@@ -1312,7 +1356,7 @@ func TestAggregateFullWithBlockingFindings(t *testing.T) {
 	if !start.OK {
 		t.Fatalf("start failed: %#v", start)
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, review.SubmissionInput{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, review.SubmissionInput{
 		Summary: "Found a blocker.",
 		Findings: []review.Finding{
 			{
@@ -1371,7 +1415,7 @@ func TestAggregatePreservesExplicitEmptyLocationsArray(t *testing.T) {
 	if !start.OK {
 		t.Fatalf("start failed: %#v", start)
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSON(t, map[string]any{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSON(t, map[string]any{
 		"summary": "Found one issue.",
 		"findings": []any{
 			map[string]any{

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -656,7 +656,7 @@ func buildNextActions(node string, facts *Facts, reviewCtx *reviewContext, block
 		if !planApproved {
 			return []NextAction{
 				{Command: nil, Description: "Ask the human to approve the tracked plan before execution begins."},
-				{Command: strPtr("harness plan approve --by=human"), Description: "After the human approves in chat, record that approval boundary on the tracked plan."},
+				{Command: strPtr("harness plan approve --by human"), Description: "After the human approves in chat, record that approval boundary on the tracked plan."},
 				{Command: nil, Description: "If scope changed before approval, update the tracked plan first."},
 			}
 		}

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -159,6 +159,7 @@ func (s Service) read(acquireLock bool) Result {
 
 	reviewCtx, reviewWarnings := loadReviewContext(s.Workdir, planStem, doc, state)
 	result.Warnings = append(result.Warnings, reviewWarnings...)
+	planApproved := doc.ExplicitlyApproved()
 	if reviewCtx != nil && isStructuralReviewTrigger(reviewCtx.Trigger) && strings.TrimSpace(reviewCtx.RoundID) != "" {
 		result.Artifacts.ReviewRoundID = reviewCtx.RoundID
 	}
@@ -233,8 +234,8 @@ func (s Service) read(acquireLock bool) Result {
 	}
 	missingStepReminder, reminderWarnings := loadMissingStepCloseoutReminder(s.Workdir, planStem, doc, reviewCtx, result.State.CurrentNode)
 	result.Warnings = append(result.Warnings, reminderWarnings...)
-	result.Summary = buildSummary(result.State.CurrentNode, facts, reviewCtx, blockers, missingStepReminder, currentPlan)
-	result.NextAction = buildNextActions(result.State.CurrentNode, facts, reviewCtx, blockers)
+	result.Summary = buildSummary(result.State.CurrentNode, facts, reviewCtx, blockers, missingStepReminder, currentPlan, planApproved)
+	result.NextAction = buildNextActions(result.State.CurrentNode, facts, reviewCtx, blockers, planApproved)
 	if missingStepReminder != nil {
 		result.Warnings = append(result.Warnings, buildMissingStepCloseoutWarnings(result.State.CurrentNode, missingStepReminder)...)
 		result.NextAction = prependMissingStepCloseoutActions(result.State.CurrentNode, result.NextAction, facts, reviewCtx, missingStepReminder)
@@ -520,7 +521,7 @@ func archivedCandidateReadyForMerge(evidenceCtx *evidenceContext) bool {
 	return true
 }
 
-func buildSummary(node string, facts *Facts, reviewCtx *reviewContext, blockers []StatusError, reminder *missingStepCloseoutReminder, currentPlan *runstate.CurrentPlan) string {
+func buildSummary(node string, facts *Facts, reviewCtx *reviewContext, blockers []StatusError, reminder *missingStepCloseoutReminder, currentPlan *runstate.CurrentPlan, planApproved bool) string {
 	if strings.HasPrefix(node, "execution/finalize/") && reminder != nil && reminder.hasDebt() && !pendingReopenedNewStep(node, facts) {
 		return buildMissingStepCloseoutSummary(node, reviewCtx, reminder)
 	}
@@ -532,7 +533,10 @@ func buildSummary(node string, facts *Facts, reviewCtx *reviewContext, blockers 
 		}
 		return "No current plan is active in this worktree."
 	case "plan":
-		return "Current plan exists, but execution has not started yet."
+		if planApproved {
+			return "Current plan is approved and ready for execution to start."
+		}
+		return "Current plan exists, but execution is still waiting for explicit human approval."
 	case "execution/finalize/review":
 		if reviewCtx != nil && reviewCtx.InFlight {
 			return "Plan is in finalize review and waiting for the active review round to be aggregated."
@@ -642,16 +646,23 @@ func buildMissingStepCloseoutSummary(node string, reviewCtx *reviewContext, remi
 	}
 }
 
-func buildNextActions(node string, facts *Facts, reviewCtx *reviewContext, blockers []StatusError) []NextAction {
+func buildNextActions(node string, facts *Facts, reviewCtx *reviewContext, blockers []StatusError, planApproved bool) []NextAction {
 	switch node {
 	case "idle":
 		return []NextAction{
 			{Command: nil, Description: "Start discovery or create a new tracked plan when the next slice is ready."},
 		}
 	case "plan":
+		if !planApproved {
+			return []NextAction{
+				{Command: nil, Description: "Ask the human to approve the tracked plan before execution begins."},
+				{Command: strPtr("harness plan approve --by=human"), Description: "After the human approves in chat, record that approval boundary on the tracked plan."},
+				{Command: nil, Description: "If scope changed before approval, update the tracked plan first."},
+			}
+		}
 		return []NextAction{
-			{Command: strPtr("harness execute start"), Description: "Start execution once the plan is approved for implementation."},
-			{Command: nil, Description: "If scope changed before implementation begins, update the tracked plan first."},
+			{Command: strPtr("harness execute start"), Description: "Start execution now that the tracked plan is approved for implementation."},
+			{Command: nil, Description: "If scope changed after approval but before implementation begins, update the tracked plan and refresh approval before executing."},
 		}
 	case "execution/finalize/review":
 		if reviewCtx != nil && reviewCtx.InFlight {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -36,7 +36,7 @@ func TestStatusPlanNodeForActivePlan(t *testing.T) {
 	if len(result.NextAction) < 2 || result.NextAction[0].Command != nil {
 		t.Fatalf("expected human-approval guidance first, got %#v", result.NextAction)
 	}
-	if result.NextAction[1].Command == nil || *result.NextAction[1].Command != "harness plan approve --by=human" {
+	if result.NextAction[1].Command == nil || *result.NextAction[1].Command != "harness plan approve --by human" {
 		t.Fatalf("expected explicit approval guidance, got %#v", result.NextAction)
 	}
 

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -33,8 +33,11 @@ func TestStatusPlanNodeForActivePlan(t *testing.T) {
 	if result.State.CurrentNode != "plan" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
-	if result.NextAction[0].Command == nil || *result.NextAction[0].Command != "harness execute start" {
-		t.Fatalf("expected execute-start guidance, got %#v", result.NextAction)
+	if len(result.NextAction) < 2 || result.NextAction[0].Command != nil {
+		t.Fatalf("expected human-approval guidance first, got %#v", result.NextAction)
+	}
+	if result.NextAction[1].Command == nil || *result.NextAction[1].Command != "harness plan approve --by=human" {
+		t.Fatalf("expected explicit approval guidance, got %#v", result.NextAction)
 	}
 
 	state, _, err := runstate.LoadState(root, "2026-03-18-status-plan")
@@ -51,6 +54,24 @@ func TestStatusPlanNodeForActivePlan(t *testing.T) {
 	}
 	if got := doc.DerivedLifecycle(nil); got != "awaiting_plan_approval" {
 		t.Fatalf("expected lifecycle to derive from the plan alone, got %q", got)
+	}
+}
+
+func TestStatusPlanNodeForApprovedActivePlan(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
+		return approvePlanContent(content, "2026-03-18T10:05:00+08:00")
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if !result.OK {
+		t.Fatalf("expected OK status result, got %#v", result)
+	}
+	if result.State.CurrentNode != "plan" {
+		t.Fatalf("unexpected node: %#v", result.State)
+	}
+	if result.NextAction[0].Command == nil || *result.NextAction[0].Command != "harness execute start" {
+		t.Fatalf("expected execute-start guidance for approved plan, got %#v", result.NextAction)
 	}
 }
 
@@ -2462,7 +2483,7 @@ func TestStatusReentersReviewedStepAfterFailedExplicitEarlierStepRepair(t *testi
 	svc.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 11, 12, 0, 0, time.FixedZone("CST", 8*60*60))
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSONBytes(t, review.SubmissionInput{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSONBytes(t, review.SubmissionInput{
 		Summary: "The repair still needs work.",
 		Findings: []review.Finding{
 			{
@@ -2539,7 +2560,7 @@ func TestStatusReturnsToLaterFrontierAfterCleanExplicitEarlierStepRepair(t *test
 	svc.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 11, 22, 0, 0, time.FixedZone("CST", 8*60*60))
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSONBytes(t, review.SubmissionInput{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSONBytes(t, review.SubmissionInput{
 		Summary:  "The earlier-step repair is now clean.",
 		Findings: nil,
 	}))
@@ -2609,7 +2630,7 @@ func TestStatusReturnsToFinalizeReviewAfterCleanExplicitEarlierStepRepair(t *tes
 	svc.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 11, 32, 0, 0, time.FixedZone("CST", 8*60*60))
 	}
-	submit := svc.Submit(start.Artifacts.RoundID, "correctness", mustJSONBytes(t, review.SubmissionInput{
+	submit := svc.Submit(start.Artifacts.RoundID, "correctness", "reviewer-correctness", mustJSONBytes(t, review.SubmissionInput{
 		Summary:  "The finalize-context earlier-step repair is clean.",
 		Findings: nil,
 	}))
@@ -2703,6 +2724,21 @@ func writePlan(t *testing.T, root, relPath string, mutate func(string) string) s
 		t.Fatalf("write plan: %v", err)
 	}
 	return path
+}
+
+func approvePlanContent(content, approvedAt string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "approved_at:") {
+			lines[i] = "approved_at: " + approvedAt
+			return strings.Join(lines, "\n")
+		}
+		if strings.HasPrefix(line, "created_at:") {
+			lines = append(lines[:i+1], append([]string{"approved_at: " + approvedAt}, lines[i+1:]...)...)
+			return strings.Join(lines, "\n")
+		}
+	}
+	return content
 }
 
 func writeCurrentPlan(t *testing.T, root, relPath string) {

--- a/schema/artifacts/review-submission.schema.json
+++ b/schema/artifacts/review-submission.schema.json
@@ -48,6 +48,10 @@
           "type": "string",
           "description": "Dimension is the human-readable review dimension label."
         },
+        "by": {
+          "type": "string",
+          "description": "By is the reviewer-provided identity label for the submitted slot."
+        },
         "submitted_at": {
           "type": "string",
           "description": "SubmittedAt is the submission timestamp."

--- a/schema/commands/lifecycle.result.schema.json
+++ b/schema/commands/lifecycle.result.schema.json
@@ -138,7 +138,7 @@
         "state",
         "next_actions"
       ],
-      "description": "LifecycleResult is the JSON result shape currently shared by `harness execute start`, `harness archive`, `harness reopen`, `harness land`, and `harness land complete`."
+      "description": "LifecycleResult is the JSON result shape currently shared by `harness plan approve`, `harness execute start`, `harness archive`, `harness reopen`, `harness land`, and `harness land complete`."
     },
     "LifecycleState": {
       "properties": {
@@ -183,5 +183,5 @@
     }
   },
   "title": "Lifecycle command result",
-  "description": "Shared JSON output shape for lifecycle commands such as `harness execute start`, `harness archive`, `harness reopen`, `harness land`, and `harness land complete`."
+  "description": "Shared JSON output shape for lifecycle commands such as `harness plan approve`, `harness execute start`, `harness archive`, `harness reopen`, `harness land`, and `harness land complete`."
 }

--- a/schema/index.json
+++ b/schema/index.json
@@ -177,7 +177,7 @@
       "group": "command_results",
       "surface": "public",
       "title": "Lifecycle command result",
-      "description": "Shared JSON output shape for lifecycle commands such as `harness execute start`, `harness archive`, `harness reopen`, `harness land`, and `harness land complete`.",
+      "description": "Shared JSON output shape for lifecycle commands such as `harness plan approve`, `harness execute start`, `harness archive`, `harness reopen`, `harness land`, and `harness land complete`.",
       "path": "schema/commands/lifecycle.result.schema.json",
       "id": "https://github.com/catu-ai/easyharness/tree/main/schema/commands/lifecycle.result.schema.json",
       "go_type": "github.com/catu-ai/easyharness/internal/contracts.LifecycleResult"

--- a/tests/e2e/explicit_step_repair_test.go
+++ b/tests/e2e/explicit_step_repair_test.go
@@ -35,6 +35,7 @@ func TestExplicitStepRepairTransitionsWithBuiltBinary(t *testing.T) {
 	lint := support.Run(t, workspace.Root, "plan", "lint", planRelPath)
 	support.RequireSuccess(t, lint)
 	support.RequireNoStderr(t, lint)
+	support.ApprovePlan(t, planPath, "2026-04-08T00:05:00Z")
 
 	execute := support.Run(t, workspace.Root, "execute", "start")
 	support.RequireSuccess(t, execute)

--- a/tests/e2e/finalize_closeout_gate_test.go
+++ b/tests/e2e/finalize_closeout_gate_test.go
@@ -32,6 +32,7 @@ func TestFinalizeReviewStartAndArchiveRejectEarlierCloseoutDebtWithBuiltBinary(t
 	lint := support.Run(t, workspace.Root, "plan", "lint", planRelPath)
 	support.RequireSuccess(t, lint)
 	support.RequireNoStderr(t, lint)
+	support.ApprovePlan(t, planPath, "2026-04-08T00:05:00Z")
 
 	execute := support.Run(t, workspace.Root, "execute", "start")
 	support.RequireSuccess(t, execute)
@@ -92,11 +93,11 @@ func TestFinalizeReviewStartAndArchiveRejectEarlierCloseoutDebtWithBuiltBinary(t
 		"plan_stem":            planStem,
 		"revision":             1,
 		"active_review_round": map[string]any{
-			"round_id":    "review-001-full",
-			"kind":        "full",
-			"revision":    1,
-			"aggregated":  true,
-			"decision":    "pass",
+			"round_id":   "review-001-full",
+			"kind":       "full",
+			"revision":   1,
+			"aggregated": true,
+			"decision":   "pass",
 		},
 	})
 	support.RequireFileExists(t, statePath)

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -328,6 +328,7 @@ func submitReviewSlot(t *testing.T, workspace *support.Workspace, roundID string
 		"review", "submit",
 		"--round", roundID,
 		"--slot", slot.Slot,
+		"--by", "reviewer-"+slot.Slot,
 		"--input", submissionPath,
 	)
 	support.RequireSuccess(t, submit)
@@ -518,6 +519,7 @@ func runPassingDeltaReviewAndComplete(t *testing.T, workspace *support.Workspace
 func drivePlanToArchivedPublishNode(t *testing.T, workspace *support.Workspace, planPath string, stepTitles ...string) lifecycleCommandResult {
 	t.Helper()
 
+	support.ApprovePlan(t, planPath, "2026-03-22T00:05:00Z")
 	execute := support.Run(t, workspace.Root, "execute", "start")
 	support.RequireSuccess(t, execute)
 	support.RequireNoStderr(t, execute)

--- a/tests/e2e/lightweight_workflow_test.go
+++ b/tests/e2e/lightweight_workflow_test.go
@@ -41,6 +41,7 @@ func TestLightweightWorkflowWithBuiltBinary(t *testing.T) {
 
 	preExecuteStatus := runStatus(t, workspace.Root)
 	assertNode(t, preExecuteStatus, "plan")
+	support.ApprovePlan(t, planPath, "2026-03-31T00:05:00Z")
 
 	execute := support.Run(t, workspace.Root, "execute", "start")
 	support.RequireSuccess(t, execute)

--- a/tests/e2e/reopen_new_step_test.go
+++ b/tests/e2e/reopen_new_step_test.go
@@ -38,6 +38,7 @@ func TestReopenNewStepWithBuiltBinary(t *testing.T) {
 	lint := support.Run(t, workspace.Root, "plan", "lint", planRelPath)
 	support.RequireSuccess(t, lint)
 	support.RequireNoStderr(t, lint)
+	support.ApprovePlan(t, planPath, "2026-03-23T00:05:00Z")
 
 	execute := support.Run(t, workspace.Root, "execute", "start")
 	support.RequireSuccess(t, execute)

--- a/tests/e2e/review_repair_loop_test.go
+++ b/tests/e2e/review_repair_loop_test.go
@@ -36,6 +36,7 @@ func TestReviewRepairLoopsWithBuiltBinary(t *testing.T) {
 	lint := support.Run(t, workspace.Root, "plan", "lint", planRelPath)
 	support.RequireSuccess(t, lint)
 	support.RequireNoStderr(t, lint)
+	support.ApprovePlan(t, planPath, "2026-03-23T00:05:00Z")
 
 	execute := support.Run(t, workspace.Root, "execute", "start")
 	support.RequireSuccess(t, execute)

--- a/tests/e2e/review_workflow_test.go
+++ b/tests/e2e/review_workflow_test.go
@@ -45,6 +45,7 @@ func TestReviewWorkflowWithBuiltBinary(t *testing.T) {
 	assertNode(t, preExecuteStatus, "plan")
 	stillPlannedStatus := runStatus(t, workspace.Root)
 	assertNode(t, stillPlannedStatus, "plan")
+	support.ApprovePlan(t, planPath, "2026-03-22T00:05:00Z")
 
 	execute := support.Run(t, workspace.Root, "execute", "start")
 	support.RequireSuccess(t, execute)

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -57,6 +57,7 @@ func TestHelpShowsTopLevelUsage(t *testing.T) {
 	support.RequireContains(t, result.CombinedOutput(), "--version       Print concise debug information for the running harness binary")
 	support.RequireContains(t, result.CombinedOutput(), "plan template   Render the packaged plan template")
 	support.RequireContains(t, result.CombinedOutput(), "plan lint       Validate a tracked plan")
+	support.RequireContains(t, result.CombinedOutput(), "plan approve    Record explicit human approval for the current plan")
 	support.RequireContains(t, result.CombinedOutput(), "execute start   Record the execution-start milestone")
 	support.RequireContains(t, result.CombinedOutput(), "evidence submit Record append-only CI, publish, or sync evidence")
 	support.RequireContains(t, result.CombinedOutput(), "review start    Create a deterministic review round")

--- a/tests/support/plan.go
+++ b/tests/support/plan.go
@@ -38,6 +38,26 @@ func EnsurePlanSize(t *testing.T, path, size string) {
 	writePlanFile(t, path, updated)
 }
 
+func ApprovePlan(t *testing.T, path, approvedAt string) {
+	t.Helper()
+
+	content := readPlanFile(t, path)
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "approved_at:") {
+			lines[i] = "approved_at: " + approvedAt
+			writePlanFile(t, path, strings.Join(lines, "\n"))
+			return
+		}
+		if strings.HasPrefix(line, "created_at:") {
+			lines = append(lines[:i+1], append([]string{"approved_at: " + approvedAt}, lines[i+1:]...)...)
+			writePlanFile(t, path, strings.Join(lines, "\n"))
+			return
+		}
+	}
+	t.Fatalf("created_at frontmatter line not found in %s", path)
+}
+
 func InsertPlanSize(content, size string) string {
 	lines := strings.Split(content, "\n")
 	replaced := false


### PR DESCRIPTION
## Summary

- add explicit `harness plan approve --by=human` and persist `approved_at`
- gate `harness execute start` on recorded approval and improve status guidance
- add reviewer `--by` provenance, sync dogfood/bootstrap/contracts, and expand regression coverage

## Validation

- `go test ./...`

## Follow-Up

- Closes #149 only as follow-up tracking? No. Related: #149
