### PR TITLE
Surface idle bootstrap drift reminder in status

### DIFF
--- a/docs/plans/active/2026-04-12-surface-bootstrap-drift-in-status.md
+++ b/docs/plans/active/2026-04-12-surface-bootstrap-drift-in-status.md
@@ -1,0 +1,220 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-12T13:31:37+08:00"
+source_type: direct_request
+source_refs:
+  - chat://current-session
+size: M
+---
+
+# Surface Idle Bootstrap Drift Reminder In Status
+
+## Goal
+
+Make `harness status` proactively remind the agent about repo-local bootstrap
+drift for the current agent's default repository targets only when the
+worktree is idle, instead of leaving stale bootstrap assets discoverable only
+when a human reruns `harness init` or the narrower bootstrap install commands.
+
+This slice should add one shared bootstrap-drift detector that `status` can
+reuse without inventing hidden repo state. The user-visible behavior should
+stay conservative and non-blocking: bootstrap drift becomes a soft reminder for
+the agent, expressed as warning debt plus a repair-oriented next action, not a
+workflow-state transition and not execution debt.
+
+## Scope
+
+### In Scope
+
+- Define the repo-status contract for detecting stale easyharness-managed
+  bootstrap instructions or skills under the current agent's default repo
+  targets.
+- Add a reusable detector for managed bootstrap drift that compares installed
+  managed assets against the currently packaged bootstrap assets.
+- Surface bootstrap drift through `harness status` warnings and next actions
+  only in the `idle` state without changing `state.current_node` or affecting
+  later execution flow.
+- Cover the new behavior with focused status and bootstrap tests and update any
+  normative docs that need to mention proactive `status` surfacing.
+
+### Out of Scope
+
+- Detecting drift for custom bootstrap targets installed earlier with explicit
+  `--dir` or `--file` overrides, because `status` does not persist those paths.
+- Introducing a new standalone `doctor` or `check` command in this slice.
+- Changing `harness init` or resource-install refresh semantics beyond the
+  shared comparison logic needed by `status`.
+- Surfacing bootstrap drift while a plan is active or execution is already in
+  progress.
+
+## Acceptance Criteria
+
+- [x] `harness status` reports a non-blocking warning plus a repair-oriented
+      next action when the worktree is `idle` and the default repo `AGENTS.md`
+      managed block or any default repo managed skill package is stale relative
+      to the running binary's packaged bootstrap assets.
+- [x] `harness status` reports no bootstrap-drift warning when the repo has no
+      default managed bootstrap assets installed yet, or when the installed
+      managed assets already match the packaged assets.
+- [x] Bootstrap drift does not change `state.current_node` and does not block
+      or redirect later workflow execution; it appears only as idle-state
+      warning debt plus an actionable `next_action` such as rerunning
+      `harness init --dry-run`.
+- [x] The detection logic is shared code rather than a one-off `status`
+      content comparison, and automated coverage proves the idle reminder path
+      while active-plan status stays unchanged.
+
+## Deferred Items
+
+- Support for status-based inspection of non-default agent targets or explicit
+  override paths.
+- Richer bootstrap inspection or repair commands if later product work needs
+  more than warnings and ordinary next actions.
+
+## Work Breakdown
+
+### Step 1: Define shared bootstrap drift detection for repo status
+
+- Done: [x]
+
+#### Objective
+
+Add a reusable detector that can classify whether the current agent's default
+repo bootstrap instructions or managed skills are absent, current, or stale.
+
+#### Details
+
+The detector should reuse the existing ownership and version-marker rules from
+bootstrap install instead of inventing a second interpretation. Keep the scope
+to the default repo targets that `harness init` would manage for the current
+agent, because `status` has no durable record of prior override paths. The
+comparison should treat a repository with no managed bootstrap assets as
+"nothing to warn about" rather than drift.
+
+#### Expected Files
+
+- `internal/install/**`
+- `internal/status/**`
+- `docs/specs/bootstrap-install.md`
+
+#### Validation
+
+- Focused unit tests cover fresh, stale, and absent default repo bootstrap
+  states.
+- Shared detection code can be exercised without shelling out through the CLI.
+
+#### Execution Notes
+
+Added `internal/install/drift.go` with a shared repo-bootstrap drift inspector
+that reuses the install package's default repo target resolution, managed block
+markers, managed skill metadata, and canonical packaged asset rendering. The
+detector reports only stale installed managed assets and ignores absent default
+bootstrap assets so untouched repositories stay quiet. Focused validation:
+`go test ./internal/install ./internal/status -count=1` and
+`go test ./tests/smoke -run 'TestStatusReportsIdleWorkspace|TestStatusIdleReportsNonBlockingBootstrapReminderWhenManagedAssetsAreStale' -count=1`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: The detector and idle reminder were implemented as one
+tightly coupled slice, so a separate Step 1 closeout review would split the
+same risk surface before the final branch-level review.
+
+### Step 2: Surface bootstrap drift through status warnings and guidance
+
+- Done: [x]
+
+#### Objective
+
+Teach `harness status` to surface idle-only bootstrap drift as warnings and a
+repair hint while preserving the existing workflow node semantics.
+
+#### Details
+
+Wire the shared detector into the idle path only. Prefer warning text that
+tells the agent the default repo bootstrap assets are stale, that this does
+not block future work, and what optional command to run next. Keep
+`state.current_node` unchanged and leave active-plan status behavior alone.
+Update the status and bootstrap contracts only where the new behavior changes
+the normative expectation, and add focused tests for idle reminders plus
+active-plan non-regression.
+
+#### Expected Files
+
+- `internal/status/service.go`
+- `internal/status/service_test.go`
+- `tests/smoke/**`
+- `docs/specs/cli-contract.md`
+- `docs/specs/bootstrap-install.md`
+
+#### Validation
+
+- `go test` covers idle reminders, no-warning fresh paths, and active-plan
+  non-regression.
+- Targeted smoke coverage proves `harness status` recommends optional bootstrap
+  refresh after managed version markers are made stale while the repo is idle.
+
+#### Execution Notes
+
+Wired the shared detector into the idle-only `status` path so stale default
+repo bootstrap assets now surface as a non-blocking warning plus an optional
+`harness init --dry-run` next action, while active plan and execution nodes
+stay unchanged. Added status unit coverage for stale idle reminders, fresh idle
+silence, and active-plan non-regression; extended smoke coverage for the
+end-to-end idle reminder; and updated the CLI/bootstrap specs to document the
+idle-only reminder contract. Validation:
+`go test ./internal/install ./internal/status -count=1` and
+`go test ./tests/smoke -run 'TestStatusReportsIdleWorkspace|TestStatusIdleReportsNonBlockingBootstrapReminderWhenManagedAssetsAreStale' -count=1`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 depends directly on Step 1's shared detector and
+will be covered by the same final branch-level review, so a separate step
+review would be redundant for this M-sized integrated slice.
+
+## Validation Strategy
+
+- Prefer unit coverage for detector edge cases and `status` warning ordering.
+- Add or update smoke coverage only for the end-to-end idle status reminder
+  surface so the contract is proven through the built binary.
+- Re-run any focused bootstrap/status tests plus the relevant smoke test slice
+  before closeout.
+
+## Risks
+
+- Risk: `status` could start warning on repositories that never installed
+  bootstrap assets, creating noisy false positives.
+  - Mitigation: Treat absent default managed assets as "not applied" and do not
+    warn until at least one managed default target is present and stale.
+- Risk: Status-specific comparison logic could drift from install semantics.
+  - Mitigation: Put the comparison behind shared bootstrap code and reuse the
+    same managed markers and packaged rendering paths.
+- Risk: Adding bootstrap health warnings could crowd out workflow guidance or
+  feel like blocking debt.
+  - Mitigation: Surface the reminder only while `idle`, make the warning
+    explicitly non-blocking, and keep the next action optional and concise.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/archived/2026-04-12-surface-bootstrap-drift-in-status.md
+++ b/docs/plans/archived/2026-04-12-surface-bootstrap-drift-in-status.md
@@ -3,7 +3,7 @@ template_version: 0.2.0
 created_at: "2026-04-12T13:31:37+08:00"
 source_type: direct_request
 source_refs:
-  - chat://current-session
+    - chat://current-session
 size: M
 ---
 
@@ -195,26 +195,62 @@ review would be redundant for this M-sized integrated slice.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `go test ./internal/install ./internal/status -count=1` passed after the
+  shared detector and idle-only status reminder landed.
+- `go test ./internal/status ./tests/smoke -run 'TestStatusIdleSurfaces|TestStatusIdleSkips|TestStatusActive|TestStatusReportsIdleWorkspace|TestStatusIdleReports' -count=1`
+  passed after adding isolated stale-surface and active-execution
+  non-regression coverage.
+- Reviewer follow-up validation in `review-003-full` reported passing focused
+  `go test` slices for `./internal/install`, `./internal/status`, and
+  `./tests/smoke`.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- `review-001-full` found 1 blocking and 1 non-blocking coverage finding in
+  the `tests` slot; the blocking gap was missing isolated stale-surface
+  coverage, and the non-blocking note asked for broader active-path
+  non-regression.
+- `review-002-delta` reran the `tests` slot against the coverage repair and
+  passed cleanly.
+- `review-003-full` reran `correctness`, `tests`, and `agent_ux`; the full
+  candidate passed with 0 findings after the repair.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-04-12T14:01:21+08:00
+- Revision: 1
+- PR: Not opened yet; this candidate is still branch-local and needs publish
+  handoff after archive.
+- Ready: The candidate has a clean finalize review (`review-003-full`) after
+  one blocking review round and a narrow repair follow-up.
+- Merge Handoff: Archive the plan, commit the tracked archive move plus summary
+  updates, push `codex/idle-bootstrap-drift-status`, record publish/CI/sync
+  evidence, and wait for merge approval once `harness status` reaches
+  `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added a shared install-layer detector for stale default repo bootstrap assets
+  that reuses the same managed block and managed skill rules as `harness init`.
+- Taught `harness status` to surface an idle-only, non-blocking reminder plus
+  optional `harness init --dry-run` guidance when the default repo `AGENTS.md`
+  block or managed skills are stale.
+- Added focused install/status unit coverage and smoke coverage for absent,
+  fresh, combined-stale, instructions-only stale, skills-only stale, and
+  active-path non-regression scenarios.
+- Updated the bootstrap and CLI specs so the idle reminder contract is
+  documented as optional, agent-facing, and non-blocking.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No support was added for detecting drift in custom bootstrap override paths
+  installed with explicit `--dir` or `--file` values.
 
 ### Follow-Up Issues
 
-NONE
+Deferred roadmap items remain intentionally out of scope for this slice:
+status inspection for explicit override bootstrap targets and richer bootstrap
+inspection or repair commands beyond the idle reminder and ordinary `init`
+refresh flow.

--- a/docs/specs/bootstrap-install.md
+++ b/docs/specs/bootstrap-install.md
@@ -58,6 +58,9 @@ Contract:
 - use the same underlying install logic as the resource commands
 - support `--dry-run`
 - support `--agent`, `--dir`, and `--file` overrides for non-default layouts
+- allow other commands such as `harness status` to reuse the same managed-asset
+  comparison logic for non-blocking reminders about stale default repo
+  bootstrap assets
 
 ### `harness skills install|uninstall`
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -193,6 +193,10 @@ For `harness status` specifically:
   current step, starting routine review, or aggregating the active round
 - use `warnings` for recoverable ambiguity or workflow-discipline reminders
   that should not by themselves change `state.current_node`
+- when the worktree is `idle`, `warnings` plus an optional `next_action` may
+  also carry a non-blocking agent reminder that the default repo bootstrap
+  assets are stale relative to the running binary; this reminder must not alter
+  workflow state or block later execution
 - avoid heuristic warnings for "the current slice may now be reviewable"; keep
   that kind of prompt in ordinary `next_actions`
 

--- a/internal/install/drift.go
+++ b/internal/install/drift.go
@@ -1,0 +1,145 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// RepoBootstrapDrift summarizes whether the default repo bootstrap assets for an
+// agent appear stale relative to the currently packaged bootstrap assets.
+type RepoBootstrapDrift struct {
+	ManagedAssetsPresent      bool
+	InstructionsStale         bool
+	StaleManagedSkillPackages []string
+	ExtraManagedSkillPackages []string
+}
+
+func (d RepoBootstrapDrift) Stale() bool {
+	return d.InstructionsStale || len(d.StaleManagedSkillPackages) > 0 || len(d.ExtraManagedSkillPackages) > 0
+}
+
+// InspectRepoBootstrapDrift checks the default repo bootstrap targets for the
+// selected agent without mutating any files.
+func (s Service) InspectRepoBootstrapDrift(agent string) (RepoBootstrapDrift, error) {
+	agent = normalizeAgent(agent)
+	instructionsFile, err := s.resolveInstructionsFile(agent, ScopeRepo, "")
+	if err != nil {
+		return RepoBootstrapDrift{}, err
+	}
+	skillsDir, err := s.resolveSkillsDir(agent, ScopeRepo, "")
+	if err != nil {
+		return RepoBootstrapDrift{}, err
+	}
+
+	instructionsPresent, instructionsStale, err := s.inspectManagedInstructionsDrift(instructionsFile, skillsDir)
+	if err != nil {
+		return RepoBootstrapDrift{}, err
+	}
+	skillPresent, staleSkills, extraSkills, err := s.inspectManagedSkillsDrift(skillsDir)
+	if err != nil {
+		return RepoBootstrapDrift{}, err
+	}
+
+	sort.Strings(staleSkills)
+	sort.Strings(extraSkills)
+	return RepoBootstrapDrift{
+		ManagedAssetsPresent:      instructionsPresent || skillPresent,
+		InstructionsStale:         instructionsStale,
+		StaleManagedSkillPackages: staleSkills,
+		ExtraManagedSkillPackages: extraSkills,
+	}, nil
+}
+
+func (s Service) inspectManagedInstructionsDrift(targetFile, skillsDir string) (present bool, stale bool, err error) {
+	data, err := os.ReadFile(targetFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+
+	existing := string(data)
+	beginMatches := instructionsManagedBlockBeginPattern.FindAllStringIndex(existing, -1)
+	endMatches := instructionsManagedBlockEndPattern.FindAllStringIndex(existing, -1)
+	if err := validateManagedBlockLayout(beginMatches, endMatches); err != nil {
+		return false, false, err
+	}
+	if len(beginMatches) == 0 {
+		return false, false, nil
+	}
+
+	lineEnding := detectLineEnding(existing)
+	expected := trimTrailingLineBreaks(renderManagedBlock(lineEnding, pathLabel(s.Workdir, skillsDir), s.versionTag()))
+	current := trimTrailingLineBreaks(existing[beginMatches[0][0]:endMatches[0][1]])
+	return true, normalizeText(current) != normalizeText(expected), nil
+}
+
+func (s Service) inspectManagedSkillsDrift(targetDir string) (present bool, stale []string, extra []string, err error) {
+	installed, err := discoverInstalledSkills(targetDir)
+	if err != nil {
+		return false, nil, nil, err
+	}
+	canonical, err := s.renderCanonicalSkillFiles()
+	if err != nil {
+		return false, nil, nil, err
+	}
+
+	for skillName, state := range installed {
+		if !state.Managed {
+			continue
+		}
+		present = true
+		expectedFiles, ok := canonical[skillName]
+		if !ok {
+			extra = append(extra, skillName)
+			continue
+		}
+		match, err := managedSkillPackageMatches(state.Root, expectedFiles)
+		if err != nil {
+			return false, nil, nil, err
+		}
+		if !match {
+			stale = append(stale, skillName)
+		}
+	}
+
+	return present, stale, extra, nil
+}
+
+func managedSkillPackageMatches(root string, expectedFiles map[string]string) (bool, error) {
+	existingFiles, err := walkFiles(root)
+	if err != nil {
+		return false, err
+	}
+	expectedPaths := make(map[string]string, len(expectedFiles))
+	for relPath, content := range expectedFiles {
+		expectedPaths[filepath.Join(root, filepath.FromSlash(relPath))] = content
+	}
+
+	if len(existingFiles) != len(expectedPaths) {
+		return false, nil
+	}
+	for _, existing := range existingFiles {
+		expected, ok := expectedPaths[existing]
+		if !ok {
+			return false, nil
+		}
+		current, err := os.ReadFile(existing)
+		if err != nil {
+			return false, err
+		}
+		if string(current) != expected {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func normalizeText(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+	return strings.TrimSpace(content)
+}

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -95,6 +95,118 @@ func TestInitRefreshesManagedBlockWithoutTouchingUserContent(t *testing.T) {
 	}
 }
 
+func TestInspectRepoBootstrapDriftIgnoresAbsentManagedAssets(t *testing.T) {
+	root := t.TempDir()
+
+	drift, err := testService(root).InspectRepoBootstrapDrift("codex")
+	if err != nil {
+		t.Fatalf("InspectRepoBootstrapDrift: %v", err)
+	}
+	if drift.ManagedAssetsPresent {
+		t.Fatalf("expected absent repo bootstrap assets to stay untracked, got %#v", drift)
+	}
+	if drift.Stale() {
+		t.Fatalf("expected absent repo bootstrap assets to avoid stale drift, got %#v", drift)
+	}
+}
+
+func TestInspectRepoBootstrapDriftReportsManagedAssetsAsFreshAfterInit(t *testing.T) {
+	root := t.TempDir()
+	svc := testService(root)
+	if result := svc.Init(Options{}); !result.OK {
+		t.Fatalf("init failed: %#v", result)
+	}
+
+	drift, err := svc.InspectRepoBootstrapDrift("codex")
+	if err != nil {
+		t.Fatalf("InspectRepoBootstrapDrift: %v", err)
+	}
+	if !drift.ManagedAssetsPresent {
+		t.Fatalf("expected init-installed assets to count as managed, got %#v", drift)
+	}
+	if drift.Stale() {
+		t.Fatalf("expected init-installed assets to be fresh, got %#v", drift)
+	}
+}
+
+func TestInspectRepoBootstrapDriftReportsStaleManagedInstructionsAndSkills(t *testing.T) {
+	root := t.TempDir()
+	svc := testService(root)
+	if result := svc.Init(Options{}); !result.OK {
+		t.Fatalf("init failed: %#v", result)
+	}
+
+	agentsPath := filepath.Join(root, "AGENTS.md")
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	staleAgents := strings.Replace(string(agentsData), `<!-- easyharness:begin version="`, `<!-- easyharness:begin version="stale-`, 1)
+	if err := os.WriteFile(agentsPath, []byte(staleAgents), 0o644); err != nil {
+		t.Fatalf("write stale AGENTS.md: %v", err)
+	}
+
+	skillPath := filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md")
+	skillData, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read skill: %v", err)
+	}
+	staleSkill := strings.Replace(string(skillData), "easyharness-version:", "easyharness-version: stale-", 1)
+	if err := os.WriteFile(skillPath, []byte(staleSkill), 0o644); err != nil {
+		t.Fatalf("write stale skill: %v", err)
+	}
+
+	drift, err := svc.InspectRepoBootstrapDrift("codex")
+	if err != nil {
+		t.Fatalf("InspectRepoBootstrapDrift: %v", err)
+	}
+	if !drift.ManagedAssetsPresent {
+		t.Fatalf("expected stale managed assets to still count as present, got %#v", drift)
+	}
+	if !drift.InstructionsStale {
+		t.Fatalf("expected stale managed block to be reported, got %#v", drift)
+	}
+	if len(drift.StaleManagedSkillPackages) != 1 || drift.StaleManagedSkillPackages[0] != "harness-discovery" {
+		t.Fatalf("expected stale harness-discovery package, got %#v", drift)
+	}
+}
+
+func TestInspectRepoBootstrapDriftReportsUnexpectedManagedSkillPackages(t *testing.T) {
+	root := t.TempDir()
+	svc := testService(root)
+	if result := svc.InstallSkills(Options{}); !result.OK {
+		t.Fatalf("install skills failed: %#v", result)
+	}
+
+	extraRoot := filepath.Join(root, ".agents/skills/custom-managed")
+	if err := os.MkdirAll(extraRoot, 0o755); err != nil {
+		t.Fatalf("mkdir extra managed skill: %v", err)
+	}
+	extraBody := strings.Join([]string{
+		"---",
+		"name: custom-managed",
+		"description: Unexpected managed skill for drift detection.",
+		"metadata:",
+		"  easyharness-managed: \"true\"",
+		"  easyharness-version: v9.9.9",
+		"---",
+		"",
+		"# Custom",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(extraRoot, "SKILL.md"), []byte(extraBody), 0o644); err != nil {
+		t.Fatalf("write extra managed skill: %v", err)
+	}
+
+	drift, err := svc.InspectRepoBootstrapDrift("codex")
+	if err != nil {
+		t.Fatalf("InspectRepoBootstrapDrift: %v", err)
+	}
+	if len(drift.ExtraManagedSkillPackages) != 1 || drift.ExtraManagedSkillPackages[0] != "custom-managed" {
+		t.Fatalf("expected unexpected managed skill package to surface, got %#v", drift)
+	}
+}
+
 func TestInstallSkillsRejectsNonManagedConflicts(t *testing.T) {
 	root := t.TempDir()
 	conflictPath := filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md")

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/catu-ai/easyharness/internal/contracts"
 	"github.com/catu-ai/easyharness/internal/evidence"
+	"github.com/catu-ai/easyharness/internal/install"
 	"github.com/catu-ai/easyharness/internal/lifecycle"
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/runstate"
@@ -76,7 +77,7 @@ func (s Service) read(acquireLock bool) Result {
 	planPath, err := plan.DetectCurrentPath(s.Workdir)
 	if err != nil {
 		if errors.Is(err, plan.ErrNoCurrentPlan) {
-			return idleResult(currentPlan)
+			return idleResult(s.Workdir, currentPlan)
 		}
 		return Result{
 			OK:      false,
@@ -951,7 +952,7 @@ func buildPublishNextActions(facts *Facts) []NextAction {
 	return actions
 }
 
-func idleResult(currentPlan *runstate.CurrentPlan) Result {
+func idleResult(workdir string, currentPlan *runstate.CurrentPlan) Result {
 	result := Result{
 		OK:      true,
 		Command: "status",
@@ -968,10 +969,51 @@ func idleResult(currentPlan *runstate.CurrentPlan) Result {
 			LastLandedPlanPath: currentPlan.LastLandedPlanPath,
 			LastLandedAt:       currentPlan.LastLandedAt,
 		}
+	} else {
+		result.Summary = "No current plan is active in this worktree."
+	}
+
+	drift, err := install.Service{Workdir: workdir}.InspectRepoBootstrapDrift("codex")
+	if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("Unable to inspect the default repo bootstrap assets for the idle reminder: %v", err))
 		return result
 	}
-	result.Summary = "No current plan is active in this worktree."
+	if drift.Stale() {
+		result.Warnings = append(result.Warnings, buildIdleBootstrapDriftWarning(drift))
+		command := "harness init --dry-run"
+		action := NextAction{
+			Command:     &command,
+			Description: "Optionally inspect the default repo bootstrap refresh with harness init --dry-run, then rerun harness init if you and the human want to update AGENTS.md and the managed skills.",
+		}
+		result.NextAction = append([]NextAction{action}, result.NextAction...)
+	}
+
 	return result
+}
+
+func buildIdleBootstrapDriftWarning(drift install.RepoBootstrapDrift) string {
+	affected := make([]string, 0, 3)
+	if drift.InstructionsStale {
+		affected = append(affected, "the AGENTS.md managed block")
+	}
+	if staleCount := len(drift.StaleManagedSkillPackages); staleCount > 0 {
+		if staleCount == 1 {
+			affected = append(affected, "1 managed skill package")
+		} else {
+			affected = append(affected, fmt.Sprintf("%d managed skill packages", staleCount))
+		}
+	}
+	if extraCount := len(drift.ExtraManagedSkillPackages); extraCount > 0 {
+		if extraCount == 1 {
+			affected = append(affected, "1 stale managed skill package that is no longer in the packaged bootstrap set")
+		} else {
+			affected = append(affected, fmt.Sprintf("%d stale managed skill packages that are no longer in the packaged bootstrap set", extraCount))
+		}
+	}
+	if len(affected) == 0 {
+		return "The default repo bootstrap assets appear stale relative to the running easyharness binary. This is a non-blocking reminder for the agent and does not affect later execution."
+	}
+	return fmt.Sprintf("The default repo bootstrap assets for Codex are stale relative to the running easyharness binary (%s). This is a non-blocking reminder for the agent and does not affect later execution.", strings.Join(affected, ", "))
 }
 
 func currentStepIndex(doc *plan.Document) int {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/catu-ai/easyharness/internal/evidence"
+	"github.com/catu-ai/easyharness/internal/install"
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/review"
 	"github.com/catu-ai/easyharness/internal/runstate"
@@ -2271,6 +2272,108 @@ func TestStatusIdleNodeAfterLand(t *testing.T) {
 	}
 	if result.Artifacts == nil || result.Artifacts.LastLandedPlanPath != "docs/plans/archived/2026-03-18-status-plan.md" {
 		t.Fatalf("unexpected artifacts: %#v", result.Artifacts)
+	}
+}
+
+func TestStatusIdleSurfacesNonBlockingBootstrapReminderWhenManagedAssetsAreStale(t *testing.T) {
+	root := t.TempDir()
+	svc := install.Service{Workdir: root}
+	if result := svc.Init(install.Options{}); !result.OK {
+		t.Fatalf("init failed: %#v", result)
+	}
+
+	agentsPath := filepath.Join(root, "AGENTS.md")
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	staleAgents := strings.Replace(string(agentsData), `<!-- easyharness:begin version="`, `<!-- easyharness:begin version="stale-`, 1)
+	if err := os.WriteFile(agentsPath, []byte(staleAgents), 0o644); err != nil {
+		t.Fatalf("write stale AGENTS.md: %v", err)
+	}
+
+	skillPath := filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md")
+	skillData, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read skill: %v", err)
+	}
+	staleSkill := strings.Replace(string(skillData), "easyharness-version:", "easyharness-version: stale-", 1)
+	if err := os.WriteFile(skillPath, []byte(staleSkill), 0o644); err != nil {
+		t.Fatalf("write stale skill: %v", err)
+	}
+
+	result := status.Service{Workdir: root}.Read()
+	if !result.OK {
+		t.Fatalf("expected idle result, got %#v", result)
+	}
+	if result.State.CurrentNode != "idle" {
+		t.Fatalf("expected idle node, got %#v", result.State)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatalf("expected idle bootstrap reminder warning, got %#v", result)
+	}
+	if !strings.Contains(strings.Join(result.Warnings, "\n"), "non-blocking reminder") {
+		t.Fatalf("expected non-blocking reminder wording, got %#v", result.Warnings)
+	}
+	if len(result.NextAction) == 0 || result.NextAction[0].Command == nil || *result.NextAction[0].Command != "harness init --dry-run" {
+		t.Fatalf("expected optional bootstrap refresh guidance first, got %#v", result.NextAction)
+	}
+	if !strings.Contains(result.NextAction[0].Description, "Optionally inspect") {
+		t.Fatalf("expected optional reminder phrasing, got %#v", result.NextAction)
+	}
+}
+
+func TestStatusIdleSkipsBootstrapReminderWhenManagedAssetsAreFresh(t *testing.T) {
+	root := t.TempDir()
+	svc := install.Service{Workdir: root}
+	if result := svc.Init(install.Options{}); !result.OK {
+		t.Fatalf("init failed: %#v", result)
+	}
+
+	result := status.Service{Workdir: root}.Read()
+	if !result.OK {
+		t.Fatalf("expected idle result, got %#v", result)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("expected fresh idle bootstrap state to stay quiet, got %#v", result.Warnings)
+	}
+	if len(result.NextAction) == 0 || result.NextAction[0].Command != nil {
+		t.Fatalf("expected ordinary idle guidance first, got %#v", result.NextAction)
+	}
+}
+
+func TestStatusActivePlanDoesNotSurfaceIdleBootstrapReminder(t *testing.T) {
+	root := t.TempDir()
+	svc := install.Service{Workdir: root}
+	if result := svc.Init(install.Options{}); !result.OK {
+		t.Fatalf("init failed: %#v", result)
+	}
+
+	agentsPath := filepath.Join(root, "AGENTS.md")
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	staleAgents := strings.Replace(string(agentsData), `<!-- easyharness:begin version="`, `<!-- easyharness:begin version="stale-`, 1)
+	if err := os.WriteFile(agentsPath, []byte(staleAgents), 0o644); err != nil {
+		t.Fatalf("write stale AGENTS.md: %v", err)
+	}
+
+	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
+		return content
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if !result.OK {
+		t.Fatalf("expected plan result, got %#v", result)
+	}
+	if result.State.CurrentNode != "plan" {
+		t.Fatalf("expected plan node, got %#v", result.State)
+	}
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "bootstrap assets for Codex") {
+			t.Fatalf("did not expect idle-only bootstrap reminder during active work, got %#v", result.Warnings)
+		}
 	}
 }
 

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -2282,25 +2282,8 @@ func TestStatusIdleSurfacesNonBlockingBootstrapReminderWhenManagedAssetsAreStale
 		t.Fatalf("init failed: %#v", result)
 	}
 
-	agentsPath := filepath.Join(root, "AGENTS.md")
-	agentsData, err := os.ReadFile(agentsPath)
-	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
-	}
-	staleAgents := strings.Replace(string(agentsData), `<!-- easyharness:begin version="`, `<!-- easyharness:begin version="stale-`, 1)
-	if err := os.WriteFile(agentsPath, []byte(staleAgents), 0o644); err != nil {
-		t.Fatalf("write stale AGENTS.md: %v", err)
-	}
-
-	skillPath := filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md")
-	skillData, err := os.ReadFile(skillPath)
-	if err != nil {
-		t.Fatalf("read skill: %v", err)
-	}
-	staleSkill := strings.Replace(string(skillData), "easyharness-version:", "easyharness-version: stale-", 1)
-	if err := os.WriteFile(skillPath, []byte(staleSkill), 0o644); err != nil {
-		t.Fatalf("write stale skill: %v", err)
-	}
+	staleManagedInstructions(t, root)
+	staleManagedSkill(t, root, "harness-discovery")
 
 	result := status.Service{Workdir: root}.Read()
 	if !result.OK {
@@ -2320,6 +2303,42 @@ func TestStatusIdleSurfacesNonBlockingBootstrapReminderWhenManagedAssetsAreStale
 	}
 	if !strings.Contains(result.NextAction[0].Description, "Optionally inspect") {
 		t.Fatalf("expected optional reminder phrasing, got %#v", result.NextAction)
+	}
+}
+
+func TestStatusIdleSurfacesReminderWhenManagedInstructionsAreStale(t *testing.T) {
+	root := t.TempDir()
+	svc := install.Service{Workdir: root}
+	if result := svc.Init(install.Options{}); !result.OK {
+		t.Fatalf("init failed: %#v", result)
+	}
+
+	staleManagedInstructions(t, root)
+
+	result := status.Service{Workdir: root}.Read()
+	if !result.OK {
+		t.Fatalf("expected idle result, got %#v", result)
+	}
+	if len(result.Warnings) == 0 || !strings.Contains(strings.Join(result.Warnings, "\n"), "AGENTS.md managed block") {
+		t.Fatalf("expected stale instructions reminder, got %#v", result.Warnings)
+	}
+}
+
+func TestStatusIdleSurfacesReminderWhenManagedSkillsAreStale(t *testing.T) {
+	root := t.TempDir()
+	svc := install.Service{Workdir: root}
+	if result := svc.Init(install.Options{}); !result.OK {
+		t.Fatalf("init failed: %#v", result)
+	}
+
+	staleManagedSkill(t, root, "harness-discovery")
+
+	result := status.Service{Workdir: root}.Read()
+	if !result.OK {
+		t.Fatalf("expected idle result, got %#v", result)
+	}
+	if len(result.Warnings) == 0 || !strings.Contains(strings.Join(result.Warnings, "\n"), "managed skill package") {
+		t.Fatalf("expected stale managed-skill reminder, got %#v", result.Warnings)
 	}
 }
 
@@ -2349,15 +2368,7 @@ func TestStatusActivePlanDoesNotSurfaceIdleBootstrapReminder(t *testing.T) {
 		t.Fatalf("init failed: %#v", result)
 	}
 
-	agentsPath := filepath.Join(root, "AGENTS.md")
-	agentsData, err := os.ReadFile(agentsPath)
-	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
-	}
-	staleAgents := strings.Replace(string(agentsData), `<!-- easyharness:begin version="`, `<!-- easyharness:begin version="stale-`, 1)
-	if err := os.WriteFile(agentsPath, []byte(staleAgents), 0o644); err != nil {
-		t.Fatalf("write stale AGENTS.md: %v", err)
-	}
+	staleManagedInstructions(t, root)
 
 	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
 		return content
@@ -2373,6 +2384,36 @@ func TestStatusActivePlanDoesNotSurfaceIdleBootstrapReminder(t *testing.T) {
 	for _, warning := range result.Warnings {
 		if strings.Contains(warning, "bootstrap assets for Codex") {
 			t.Fatalf("did not expect idle-only bootstrap reminder during active work, got %#v", result.Warnings)
+		}
+	}
+}
+
+func TestStatusActiveExecutionDoesNotSurfaceIdleBootstrapReminder(t *testing.T) {
+	root := t.TempDir()
+	svc := install.Service{Workdir: root}
+	if result := svc.Init(install.Options{}); !result.OK {
+		t.Fatalf("init failed: %#v", result)
+	}
+
+	staleManagedInstructions(t, root)
+
+	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
+		return content
+	})
+	writeState(t, root, "2026-03-18-status-plan", map[string]any{
+		"execution_started_at": "2026-03-18T10:05:00+08:00",
+	})
+
+	result := status.Service{Workdir: root}.Read()
+	if !result.OK {
+		t.Fatalf("expected execution result, got %#v", result)
+	}
+	if result.State.CurrentNode != "execution/step-1/implement" {
+		t.Fatalf("expected execution node, got %#v", result.State)
+	}
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "bootstrap assets for Codex") {
+			t.Fatalf("did not expect idle-only bootstrap reminder during execution, got %#v", result.Warnings)
 		}
 	}
 }
@@ -2811,6 +2852,32 @@ func writePlan(t *testing.T, root, relPath string, mutate func(string) string) s
 func writeCurrentPlan(t *testing.T, root, relPath string) {
 	t.Helper()
 	writeCurrentPlanPayload(t, root, map[string]any{"plan_path": relPath})
+}
+
+func staleManagedInstructions(t *testing.T, root string) {
+	t.Helper()
+	agentsPath := filepath.Join(root, "AGENTS.md")
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	staleAgents := strings.Replace(string(agentsData), `<!-- easyharness:begin version="`, `<!-- easyharness:begin version="stale-`, 1)
+	if err := os.WriteFile(agentsPath, []byte(staleAgents), 0o644); err != nil {
+		t.Fatalf("write stale AGENTS.md: %v", err)
+	}
+}
+
+func staleManagedSkill(t *testing.T, root, skillName string) {
+	t.Helper()
+	skillPath := filepath.Join(root, ".agents/skills", skillName, "SKILL.md")
+	skillData, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read skill %s: %v", skillName, err)
+	}
+	staleSkill := strings.Replace(string(skillData), "easyharness-version:", "easyharness-version: stale-", 1)
+	if err := os.WriteFile(skillPath, []byte(staleSkill), 0o644); err != nil {
+		t.Fatalf("write stale skill %s: %v", skillName, err)
+	}
 }
 
 func writeCurrentPlanPayload(t *testing.T, root string, payloadMap map[string]any) {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -18,6 +18,7 @@ type statusResult struct {
 	State   struct {
 		CurrentNode string `json:"current_node"`
 	} `json:"state"`
+	Warnings []string `json:"warnings"`
 	NextAction []struct {
 		Command     *string `json:"command"`
 		Description string  `json:"description"`
@@ -149,6 +150,52 @@ func TestStatusReportsIdleWorkspace(t *testing.T) {
 	}
 	if payload.NextAction[0].Description != "Start discovery or create a new tracked plan when the next slice is ready." {
 		t.Fatalf("expected idle handoff guidance, got %#v", payload)
+	}
+	if len(payload.Warnings) != 0 {
+		t.Fatalf("expected clean idle workspace to avoid warnings, got %#v", payload.Warnings)
+	}
+}
+
+func TestStatusIdleReportsNonBlockingBootstrapReminderWhenManagedAssetsAreStale(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	initResult := support.Run(t, workspace.Root, "init")
+	support.RequireSuccess(t, initResult)
+	support.RequireNoStderr(t, initResult)
+
+	agentsPath := workspace.Path("AGENTS.md")
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	staleAgents := strings.Replace(string(agentsData), `<!-- easyharness:begin version="`, `<!-- easyharness:begin version="stale-`, 1)
+	if err := os.WriteFile(agentsPath, []byte(staleAgents), 0o644); err != nil {
+		t.Fatalf("write stale AGENTS.md: %v", err)
+	}
+
+	skillPath := workspace.Path(".agents/skills/harness-discovery/SKILL.md")
+	skillData, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read managed skill: %v", err)
+	}
+	staleSkill := strings.Replace(string(skillData), "easyharness-version:", "easyharness-version: stale-", 1)
+	if err := os.WriteFile(skillPath, []byte(staleSkill), 0o644); err != nil {
+		t.Fatalf("write stale managed skill: %v", err)
+	}
+
+	result := support.Run(t, workspace.Root, "status")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[statusResult](t, result)
+	if payload.State.CurrentNode != "idle" {
+		t.Fatalf("expected idle state, got %#v", payload)
+	}
+	if len(payload.Warnings) == 0 || !strings.Contains(strings.Join(payload.Warnings, "\n"), "non-blocking reminder") {
+		t.Fatalf("expected non-blocking bootstrap reminder, got %#v", payload.Warnings)
+	}
+	if len(payload.NextAction) == 0 || payload.NextAction[0].Command == nil || *payload.NextAction[0].Command != "harness init --dry-run" {
+		t.Fatalf("expected optional refresh command first, got %#v", payload.NextAction)
 	}
 }
 

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -18,7 +18,7 @@ type statusResult struct {
 	State   struct {
 		CurrentNode string `json:"current_node"`
 	} `json:"state"`
-	Warnings []string `json:"warnings"`
+	Warnings   []string `json:"warnings"`
 	NextAction []struct {
 		Command     *string `json:"command"`
 		Description string  `json:"description"`
@@ -163,25 +163,8 @@ func TestStatusIdleReportsNonBlockingBootstrapReminderWhenManagedAssetsAreStale(
 	support.RequireSuccess(t, initResult)
 	support.RequireNoStderr(t, initResult)
 
-	agentsPath := workspace.Path("AGENTS.md")
-	agentsData, err := os.ReadFile(agentsPath)
-	if err != nil {
-		t.Fatalf("read AGENTS.md: %v", err)
-	}
-	staleAgents := strings.Replace(string(agentsData), `<!-- easyharness:begin version="`, `<!-- easyharness:begin version="stale-`, 1)
-	if err := os.WriteFile(agentsPath, []byte(staleAgents), 0o644); err != nil {
-		t.Fatalf("write stale AGENTS.md: %v", err)
-	}
-
-	skillPath := workspace.Path(".agents/skills/harness-discovery/SKILL.md")
-	skillData, err := os.ReadFile(skillPath)
-	if err != nil {
-		t.Fatalf("read managed skill: %v", err)
-	}
-	staleSkill := strings.Replace(string(skillData), "easyharness-version:", "easyharness-version: stale-", 1)
-	if err := os.WriteFile(skillPath, []byte(staleSkill), 0o644); err != nil {
-		t.Fatalf("write stale managed skill: %v", err)
-	}
+	staleManagedInstructionsAtPath(t, workspace.Path("AGENTS.md"))
+	staleManagedSkillAtPath(t, workspace.Path(".agents/skills/harness-discovery/SKILL.md"))
 
 	result := support.Run(t, workspace.Root, "status")
 	support.RequireSuccess(t, result)
@@ -196,6 +179,44 @@ func TestStatusIdleReportsNonBlockingBootstrapReminderWhenManagedAssetsAreStale(
 	}
 	if len(payload.NextAction) == 0 || payload.NextAction[0].Command == nil || *payload.NextAction[0].Command != "harness init --dry-run" {
 		t.Fatalf("expected optional refresh command first, got %#v", payload.NextAction)
+	}
+}
+
+func TestStatusIdleReportsReminderWhenOnlyManagedInstructionsAreStale(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	initResult := support.Run(t, workspace.Root, "init")
+	support.RequireSuccess(t, initResult)
+	support.RequireNoStderr(t, initResult)
+
+	staleManagedInstructionsAtPath(t, workspace.Path("AGENTS.md"))
+
+	result := support.Run(t, workspace.Root, "status")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[statusResult](t, result)
+	if len(payload.Warnings) == 0 || !strings.Contains(strings.Join(payload.Warnings, "\n"), "AGENTS.md managed block") {
+		t.Fatalf("expected stale instructions reminder, got %#v", payload.Warnings)
+	}
+}
+
+func TestStatusIdleReportsReminderWhenOnlyManagedSkillsAreStale(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	initResult := support.Run(t, workspace.Root, "init")
+	support.RequireSuccess(t, initResult)
+	support.RequireNoStderr(t, initResult)
+
+	staleManagedSkillAtPath(t, workspace.Path(".agents/skills/harness-discovery/SKILL.md"))
+
+	result := support.Run(t, workspace.Root, "status")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[statusResult](t, result)
+	if len(payload.Warnings) == 0 || !strings.Contains(strings.Join(payload.Warnings, "\n"), "managed skill package") {
+		t.Fatalf("expected stale managed-skill reminder, got %#v", payload.Warnings)
 	}
 }
 
@@ -217,6 +238,30 @@ func TestPlanTemplatePrintsToStdoutByDefault(t *testing.T) {
 	support.RequireContains(t, result.Stdout, "created_at: 2026-03-22T00:00:00Z")
 	support.RequireContains(t, result.Stdout, "source_type: issue")
 	support.RequireContains(t, result.Stdout, "source_refs: [\"#6\"]")
+}
+
+func staleManagedInstructionsAtPath(t *testing.T, agentsPath string) {
+	t.Helper()
+	agentsData, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	staleAgents := strings.Replace(string(agentsData), `<!-- easyharness:begin version="`, `<!-- easyharness:begin version="stale-`, 1)
+	if err := os.WriteFile(agentsPath, []byte(staleAgents), 0o644); err != nil {
+		t.Fatalf("write stale AGENTS.md: %v", err)
+	}
+}
+
+func staleManagedSkillAtPath(t *testing.T, skillPath string) {
+	t.Helper()
+	skillData, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read managed skill: %v", err)
+	}
+	staleSkill := strings.Replace(string(skillData), "easyharness-version:", "easyharness-version: stale-", 1)
+	if err := os.WriteFile(skillPath, []byte(staleSkill), 0o644); err != nil {
+		t.Fatalf("write stale managed skill: %v", err)
+	}
 }
 
 func TestInitBootstrapsFreshRepository(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a shared install-layer detector for stale default repo bootstrap assets
- surface an idle-only, non-blocking bootstrap reminder in `harness status`
- add install/status/smoke coverage for stale instructions, stale managed skills, and active-path non-regression

## Validation
- `go test ./internal/install ./internal/status -count=1`
- `go test ./internal/status ./tests/smoke -run 'TestStatusIdleSurfaces|TestStatusIdleSkips|TestStatusActive|TestStatusReportsIdleWorkspace|TestStatusIdleReports' -count=1`
- reviewer follow-up validation in `review-003-full` reported passing focused `go test` slices for `./internal/install`, `./internal/status`, and `./tests/smoke`
