### PR TITLE
Clarify trust-based core development guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,22 @@ If a change would normally invite a compatibility bridge, stop and choose the
 cleaner end-state unless the requested scope explicitly includes compatibility
 or migration work.
 
+## Trust-Based Core Development
+
+When working on `easyharness` itself, treat the agent as a trusted collaborator
+rather than an adversary to police.
+
+- trust agents by default
+- reduce agent cognitive load when designing prompts, commands, plans, and
+  workflow surfaces
+- prefer clearer workflow cues over pseudo-verification or anti-fraud ceremony
+- do not propose heavier provenance, receipt, or identity mechanics for core
+  workflow when they mainly create the appearance of verification without a
+  real external trust surface
+- if stronger trust guarantees are ever needed, treat that as explicit
+  human-directed integration work rather than silently hardening the core
+  harness by default
+
 ## Development Prerequisite
 
 Before using repo-local skills that call `harness`, make sure the command is

--- a/README.md
+++ b/README.md
@@ -68,9 +68,16 @@ continue the work intentionally.
 
 The product should keep evolving in the same direction:
 
+- trust agents as collaborators by default
 - reduce agent cognitive load
+- prefer workflow clarity over pseudo-verification
 - improve execution quality and legibility
 - help humans steer the work without micromanaging it
+
+When developing `easyharness` core itself, keep the system honest about that
+trust boundary. Prefer lighter workflow cues that help agents stay on track
+over anti-cheating or pseudo-verification mechanics that add ceremony without
+creating a real trust surface.
 
 ## How Humans Steer
 
@@ -162,6 +169,11 @@ the tap token is configured.
 ## For Contributors
 
 This repository is developed primarily through agents.
+
+When changing `easyharness` itself, keep the framework trust-based and
+agent-first. New prompts, commands, or workflow surfaces should make the agent
+easier to guide and less likely to drift, not turn the core harness into an
+identity-verification system or a pile of extra ceremony.
 
 Repo-specific operating guidance lives in [AGENTS.md](./AGENTS.md). Detailed
 local development and maintainer setup lives in


### PR DESCRIPTION
## Summary

- clarify in `README.md` how `easyharness` itself should evolve: trust agents, reduce cognitive load, and prefer workflow clarity over pseudo-verification
- add repo-specific `AGENTS.md` guidance telling future agents not to push easyharness core toward heavier anti-fraud or pseudo-verification mechanics by default
- keep the slice intentionally narrow and repo-local without changing distributed bootstrap assets or CLI behavior

## Validation

- `harness plan lint docs/plans/active/2026-04-12-clarify-trust-based-core-guidance.md` before archive
- final README / AGENTS / plan reread for consistency
- finalize review `review-001-full` passed with no findings

## Lightweight Breadcrumb

This candidate uses the lightweight path because it is an `XXS` repo-specific wording slice limited to `README.md` and the root `AGENTS.md`. It does not change CLI behavior, runtime workflow semantics, or distributed bootstrap assets.
