### PR TITLE
Define the machine-local watchlist contract

### DIFF
--- a/docs/plans/archived/2026-04-19-define-machine-local-watchlist-contract.md
+++ b/docs/plans/archived/2026-04-19-define-machine-local-watchlist-contract.md
@@ -206,38 +206,47 @@ docs slice and will be checked in the normal branch-level review round.
 ## Validation Summary
 
 - `harness plan lint docs/plans/active/2026-04-19-define-machine-local-watchlist-contract.md`
-  passed before approval and again after the execution notes and closeout
-  summaries were filled in.
+  passed before approval, after the initial closeout notes were filled in, and
+  again after the revision-2 repair reopened the candidate.
 - Direct reread of `docs/specs/watchlist-contract.md` confirmed the tracked
   spec itself carries the machine-local file location, the minimal persisted
   schema, the path-based identity model, the derived repository-family
   grouping boundary, and the explicit deferral of dashboard-only state such as
   `hidden`.
+- Direct reread after revision 2 confirmed the contract now also fixes the
+  missing foundation-level invariants around path normalization and
+  uniqueness, degraded retention for missing or unreadable workspaces,
+  companion dashboard-local state separation, and crash-safe/concurrent write
+  expectations.
 - Direct reread of `docs/specs/index.md` confirmed the new contract is
   discoverable from the existing specs index without requiring issue or chat
   context.
 - `review-001-full` passed with 0 findings across the `correctness` and
   `docs_consistency` dimensions.
+- `review-002-delta` passed with 0 findings across the same dimensions after
+  the narrow revision-2 contract repair.
 
 ## Review Summary
 
 - `review-001-full`: finalize review passed with 0 findings across the
   `correctness` and `docs_consistency` dimensions.
+- `review-002-delta`: reopen follow-up review passed with 0 findings after the
+  narrow contract repair strengthened invariants without expanding the
+  persisted schema.
 
 ## Archive Summary
 
-- Archived At: 2026-04-19T10:51:12+08:00
-- Revision: 1
-- PR: Not opened yet; this candidate still needs the ordinary post-archive
-  commit, push, and PR handoff.
-- Ready: The candidate satisfies the acceptance criteria, keeps the watchlist
-  contract intentionally narrow around machine-local `git-backed workspaces`,
-  and passed `review-001-full` with 0 findings.
-- Merge Handoff: Archive the plan, commit the tracked archive move plus the
-  new watchlist contract and closeout summaries on
-  `codex/define-watchlist-contract`, push the branch, open or refresh the PR,
-  and record publish/CI/sync evidence until `harness status` reaches
-  `execution/finalize/await_merge`.
+- Archived At: 2026-04-19T11:11:16+08:00
+- Revision: 2
+- PR: https://github.com/catu-ai/easyharness/pull/184
+- Ready: Revision 2 keeps the persisted watchlist schema intentionally small
+  while strengthening the contract with path-normalization, degraded-retention,
+  companion-state, and write-integrity invariants, and `review-002-delta`
+  passed clean.
+- Merge Handoff: Re-archive the candidate, commit the tracked re-archive move
+  plus the revision-2 contract refinements on `codex/define-watchlist-contract`,
+  push the branch to refresh PR #184, and refresh publish/CI/sync evidence
+  until `harness status` returns to `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
@@ -255,6 +264,11 @@ docs slice and will be checked in the normal branch-level review round.
   classification as derived read-time facts.
 - Published the new contract in `docs/specs/index.md` so future agents can
   discover it without relying on issue or chat history.
+- Strengthened the foundation-level contract for follow-up watchlist issues by
+  defining normalization and uniqueness expectations for `workspace_path`,
+  explicit retention of missing or unreadable watched workspaces, a separate
+  companion artifact boundary for dashboard-local state, and crash-safe /
+  concurrent-write integrity expectations for future writers.
 
 ### Not Delivered
 

--- a/docs/plans/archived/2026-04-19-define-machine-local-watchlist-contract.md
+++ b/docs/plans/archived/2026-04-19-define-machine-local-watchlist-contract.md
@@ -37,9 +37,11 @@ same remote.
   repository-family grouping derived at read time.
 - Define which dashboard-facing facts are derived on read, including local
   repository grouping and linked-worktree classification.
-- Explicitly keep dashboard-only state such as `hidden` out of the minimal
-  persisted watchlist contract and defer that view-model question to later
-  work.
+- Define the smallest durable metadata needed for remembered-set behavior and
+  future stale or missing handling without turning the watchlist into a broad
+  read model.
+- Define the first membership action boundary so `unwatch` is the one explicit
+  way to remove a workspace from the remembered set.
 
 ### Out of Scope
 
@@ -61,19 +63,22 @@ same remote.
 - [x] The contract distinguishes persisted workspace fields from derived
       dashboard fields, including local repository-family grouping and branch
       or linked-worktree classification.
-- [x] The contract explicitly defers dashboard-only state such as `hidden`
-      rather than folding it into the minimal persisted record.
+- [x] The contract defines a minimal persisted workspace record that now
+      includes durable time metadata needed for remembered-set behavior and
+      later stale handling.
+- [x] The contract explicitly defines `unwatch` as the one membership-removal
+      action and keeps `active`, `completed`, and `missing` as derived states
+      rather than persisted transitions.
 - [x] The new documentation is easy to discover from the existing specs index,
       and the tracked plan lints cleanly.
 
 ## Deferred Items
 
-- The separate contract for dashboard-only view state such as `hidden`,
-  completion filtering, or manual dismissal.
 - Automatic workspace registration behavior on `harness status` or any other
   command.
 - The v1 backend shape for reading or serving the watchlist.
 - Read-model details for aggregating live status across watched workspaces.
+- Any future stale-item cleanup or GC policy beyond explicit `unwatch`.
 - Any later concept of project grouping that merges distinct local clones by
   remote identity.
 
@@ -123,8 +128,11 @@ the initial machine-local identity.
 The spec also records the accepted boundary between persisted and derived
 fields: repository-family grouping, branch display, and linked-worktree
 classification are derived from live Git state instead of stored in the record
-itself. Dashboard-only view state such as `hidden` is deferred explicitly so
-the foundation slice stays narrow. This is a docs-only contract change, so no
+itself. This revision reopened the candidate to replace the earlier
+`hidden`-style direction with a simpler membership model: the main watchlist
+record now carries `watched_at` and `last_seen_at`, while `unwatch` becomes
+the single explicit membership-removal action and `active` / `completed` /
+`missing` stay derived. This is a docs-only contract change, so no
 Red/Green/Refactor loop was needed.
 
 #### Review Notes
@@ -169,7 +177,8 @@ the existing normative specs so future agents can discover it without issue or
 chat context. Re-read the nearby spec and proposal surfaces after the index
 update and did not find any additional wording that needed immediate alignment:
 the new contract already carries the accepted `git-backed workspace`,
-repository-family grouping, and deferred `hidden` decisions directly.
+repository-family grouping, explicit `unwatch`, and the minimal
+`watched_at` / `last_seen_at` metadata direction directly.
 
 #### Review Notes
 
@@ -195,9 +204,9 @@ docs slice and will be checked in the normal branch-level review round.
     identity.
 - Risk: The contract could mix UI-only concerns such as `hidden` into the core
   storage schema, making later read-model work heavier than needed.
-  - Mitigation: Keep the persisted watchlist record minimal and defer view
-    state to the later lifecycle/read-model slices already tracked in the
-    watchlist issue set.
+  - Mitigation: Avoid a separate `hidden` layer in the first contract, keep
+    one explicit `unwatch` action instead, and leave lifecycle buckets such as
+    `active`, `completed`, and `missing` as derived read-model states.
 - Risk: Repository grouping could become ambiguous if the contract tries to
   solve remote-based project identity too early.
   - Mitigation: Limit the initial grouping story to local repository families
@@ -207,17 +216,19 @@ docs slice and will be checked in the normal branch-level review round.
 
 - `harness plan lint docs/plans/active/2026-04-19-define-machine-local-watchlist-contract.md`
   passed before approval, after the initial closeout notes were filled in, and
-  again after the revision-2 repair reopened the candidate.
+  again after the revision-2 and revision-3 repairs reopened the candidate.
 - Direct reread of `docs/specs/watchlist-contract.md` confirmed the tracked
   spec itself carries the machine-local file location, the minimal persisted
   schema, the path-based identity model, the derived repository-family
-  grouping boundary, and the explicit deferral of dashboard-only state such as
-  `hidden`.
+  grouping boundary, and the remembered-set semantics for watched workspaces.
 - Direct reread after revision 2 confirmed the contract now also fixes the
   missing foundation-level invariants around path normalization and
   uniqueness, degraded retention for missing or unreadable workspaces,
-  companion dashboard-local state separation, and crash-safe/concurrent write
-  expectations.
+  crash-safe/concurrent write expectations, and no-silent-drop behavior.
+- Direct reread after revision 3 confirmed the persisted record now includes
+  `watched_at` and `last_seen_at`, the contract uses explicit `unwatch`
+  instead of a separate `hidden` state, and `active` / `completed` /
+  `missing` remain derived read-time states.
 - Direct reread of `docs/specs/index.md` confirmed the new contract is
   discoverable from the existing specs index without requiring issue or chat
   context.
@@ -225,6 +236,13 @@ docs slice and will be checked in the normal branch-level review round.
   `docs_consistency` dimensions.
 - `review-002-delta` passed with 0 findings across the same dimensions after
   the narrow revision-2 contract repair.
+- `review-003-delta` passed with 1 non-blocking docs-consistency finding, then
+  prompted this narrow revision-3 summary refresh so the plan matches the
+  latest contract direction.
+- `review-004-delta` passed with 1 non-blocking docs-consistency finding, then
+  prompted one final execution-note wording fix so the tracked plan no longer
+  uses residual hidden-era language.
+- `review-005-delta` passed with 0 findings after that last wording repair.
 
 ## Review Summary
 
@@ -233,18 +251,29 @@ docs slice and will be checked in the normal branch-level review round.
 - `review-002-delta`: reopen follow-up review passed with 0 findings after the
   narrow contract repair strengthened invariants without expanding the
   persisted schema.
+- `review-003-delta`: reopen follow-up review passed with 1 non-blocking
+  docs-consistency finding asking the active plan summaries to catch up with
+  the revision-3 `unwatch` plus `watched_at` / `last_seen_at` contract
+  direction.
+- `review-004-delta`: reopen follow-up review passed with 1 non-blocking
+  docs-consistency finding pointing out one last hidden-era sentence in the
+  execution notes.
+- `review-005-delta`: final docs-consistency follow-up passed with 0 findings
+  after the execution-note wording repair.
 
 ## Archive Summary
 
-- Archived At: 2026-04-19T11:11:16+08:00
-- Revision: 2
+- Archived At: 2026-04-19T16:29:56+08:00
+- Revision: 3
 - PR: https://github.com/catu-ai/easyharness/pull/184
-- Ready: Revision 2 keeps the persisted watchlist schema intentionally small
-  while strengthening the contract with path-normalization, degraded-retention,
-  companion-state, and write-integrity invariants, and `review-002-delta`
-  passed clean.
+- Ready: Revision 3 keeps the remembered-set contract intentionally small
+  while adding the minimal durable time metadata (`watched_at`,
+  `last_seen_at`), replacing `hidden` with explicit `unwatch`, and keeping
+  `active` / `completed` / `missing` derived; the earlier non-blocking
+  docs-consistency findings have been repaired and `review-005-delta` passed
+  clean.
 - Merge Handoff: Re-archive the candidate, commit the tracked re-archive move
-  plus the revision-2 contract refinements on `codex/define-watchlist-contract`,
+  plus the revision-3 contract refinements on `codex/define-watchlist-contract`,
   push the branch to refresh PR #184, and refresh publish/CI/sync evidence
   until `harness status` returns to `execution/finalize/await_merge`.
 
@@ -258,7 +287,7 @@ docs slice and will be checked in the normal branch-level review round.
   both a repository's primary checkout and linked git worktrees.
 - Fixed one machine-local, user-private file location at
   `~/.easyharness/watchlist.json` and one minimal persisted JSON shape with
-  `version` plus `workspaces[].workspace_path`.
+  `version`, `workspace_path`, `watched_at`, and `last_seen_at`.
 - Defined canonical absolute `workspace_path` as the first machine-local
   identity and kept repository-family grouping, branch, and linked-worktree
   classification as derived read-time facts.
@@ -266,21 +295,22 @@ docs slice and will be checked in the normal branch-level review round.
   discover it without relying on issue or chat history.
 - Strengthened the foundation-level contract for follow-up watchlist issues by
   defining normalization and uniqueness expectations for `workspace_path`,
-  explicit retention of missing or unreadable watched workspaces, a separate
-  companion artifact boundary for dashboard-local state, and crash-safe /
-  concurrent-write integrity expectations for future writers.
+  explicit retention of missing or unreadable watched workspaces, crash-safe /
+  concurrent-write integrity expectations for future writers, and one explicit
+  membership-removal action (`unwatch`) instead of a separate `hidden` state.
 
 ### Not Delivered
 
 - No watchlist write path, dashboard read model, backend implementation shape,
   or UI behavior was implemented in this slice.
-- Dashboard-only view state such as `hidden` remains intentionally deferred to
-  later watchlist lifecycle work.
+- No automatic GC policy or stale-item cleanup flow was implemented in this
+  slice beyond the contract hooks created by `last_seen_at` and explicit
+  `unwatch`.
 
 ### Follow-Up Issues
 
 - `#163` Decide the v1 backend shape for the watchlist dashboard.
 - `#164` Silently register worktrees in the watchlist on harness status.
 - `#165` Build a watchlist-backed dashboard read model.
-- `#166` Define completed and hidden lifecycle for watched worktrees.
+- `#166` Define completed and unwatch lifecycle for watched worktrees.
 - `#167` Ship a minimal watchlist dashboard UI.

--- a/docs/plans/archived/2026-04-19-define-machine-local-watchlist-contract.md
+++ b/docs/plans/archived/2026-04-19-define-machine-local-watchlist-contract.md
@@ -1,0 +1,272 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-19T10:43:16+08:00"
+approved_at: "2026-04-19T10:46:58+08:00"
+source_type: issue
+source_refs:
+    - '#162'
+size: XS
+---
+
+# Define the machine-local watchlist contract
+
+## Goal
+
+Define the first machine-local watchlist contract that future dashboard and
+registration work can build on without reopening basic storage questions. The
+result should let a cold reader point to one user-private watchlist location,
+understand the minimal persisted record shape, and see which read-model or UI
+fields are intentionally derived instead of stored.
+
+This slice should keep the contract narrow. The watchlist should track
+`git-backed workspaces`, not only linked git worktrees, so direct work in a
+repository's primary checkout remains a first-class case. The contract should
+also stay machine-local: the initial grouping model should treat a local
+repository family (primary checkout plus any linked worktrees) as the natural
+UI grouping unit without trying to merge separate clones that merely share the
+same remote.
+
+## Scope
+
+### In Scope
+
+- Define the machine-local, user-private storage location for the watchlist.
+- Define the minimal persisted record for watched `git-backed workspaces`,
+  including the durable identity needed for local use.
+- Define the terminology split between watched `workspace` records and
+  repository-family grouping derived at read time.
+- Define which dashboard-facing facts are derived on read, including local
+  repository grouping and linked-worktree classification.
+- Explicitly keep dashboard-only state such as `hidden` out of the minimal
+  persisted watchlist contract and defer that view-model question to later
+  work.
+
+### Out of Scope
+
+- Implementing watchlist writes, registration, or migration behavior.
+- Building the dashboard UI or read model beyond the contract detail needed to
+  explain persisted-versus-derived fields.
+- Supporting non-git directories as watched items in this initial contract.
+- Defining remote-URL-based project grouping or cross-clone deduplication.
+- Choosing daemon versus on-demand backend architecture beyond what the
+  storage contract must assume.
+
+## Acceptance Criteria
+
+- [x] A tracked spec names one machine-local, user-private watchlist location
+      and one minimal persisted schema for watched `git-backed workspaces`.
+- [x] The contract explicitly states that a watched `workspace` may be either
+      a repository's primary checkout or a linked git worktree, and does not
+      require linked-worktree-specific metadata for identity.
+- [x] The contract distinguishes persisted workspace fields from derived
+      dashboard fields, including local repository-family grouping and branch
+      or linked-worktree classification.
+- [x] The contract explicitly defers dashboard-only state such as `hidden`
+      rather than folding it into the minimal persisted record.
+- [x] The new documentation is easy to discover from the existing specs index,
+      and the tracked plan lints cleanly.
+
+## Deferred Items
+
+- The separate contract for dashboard-only view state such as `hidden`,
+  completion filtering, or manual dismissal.
+- Automatic workspace registration behavior on `harness status` or any other
+  command.
+- The v1 backend shape for reading or serving the watchlist.
+- Read-model details for aggregating live status across watched workspaces.
+- Any later concept of project grouping that merges distinct local clones by
+  remote identity.
+
+## Work Breakdown
+
+### Step 1: Define the minimal watched-workspace contract
+
+- Done: [x]
+
+#### Objective
+
+Write the normative contract for the minimal machine-local watchlist record
+and its identity model.
+
+#### Details
+
+The contract should intentionally shift the vocabulary from "watched worktree"
+to "watched workspace" where that broader term is more accurate. It should
+state that the watchlist only covers git-backed workspaces for now, so both a
+repository's primary checkout and any linked git worktrees qualify. Identity
+should stay machine-local and path-oriented enough for an XS slice: the spec
+should define the minimal persisted fields and explain that repository-family
+grouping, branch display, and linked-worktree classification are derived at
+read time rather than persisted as primary identity.
+
+#### Expected Files
+
+- `docs/specs/watchlist-contract.md`
+
+#### Validation
+
+- A cold reader can identify the watchlist file location and record shape from
+  the spec alone.
+- The spec makes the git-backed prerequisite explicit without narrowing the
+  surface to linked worktrees only.
+
+#### Execution Notes
+
+Added `docs/specs/watchlist-contract.md` as the new normative contract for the
+first machine-local watchlist slice. The spec deliberately narrows the watched
+unit to `git-backed workspace` so both a repository's primary checkout and any
+linked worktrees are first-class cases. It fixes one storage location at
+`~/.easyharness/watchlist.json`, defines a minimal JSON file shape with
+`version` plus `workspaces[].workspace_path`, and makes canonical absolute path
+the initial machine-local identity.
+
+The spec also records the accepted boundary between persisted and derived
+fields: repository-family grouping, branch display, and linked-worktree
+classification are derived from live Git state instead of stored in the record
+itself. Dashboard-only view state such as `hidden` is deferred explicitly so
+the foundation slice stays narrow. This is a docs-only contract change, so no
+Red/Green/Refactor loop was needed.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 is a documentation-only contract definition and
+will receive branch-level review during the ordinary execute closeout flow.
+
+### Step 2: Publish the contract in the docs index and align issue-facing wording
+
+- Done: [x]
+
+#### Objective
+
+Make the new contract easy to discover and ensure the repository-visible
+wording matches the accepted discovery decisions.
+
+#### Details
+
+Add the new watchlist contract doc to the specs index, and update any nearby
+prose that still frames the minimal contract as linked-worktree-only if that
+wording would mislead future readers. Keep the edits narrow: this step is for
+discoverability and terminology alignment, not for expanding the feature
+scope.
+
+#### Expected Files
+
+- `docs/specs/index.md`
+- `docs/specs/watchlist-contract.md`
+- another nearby docs file only if minimal wording alignment is needed
+
+#### Validation
+
+- The specs index points clearly to the watchlist contract.
+- Terminology stays consistent with the planned model of git-backed
+  workspaces, derived repository-family grouping, and deferred dashboard-only
+  state.
+
+#### Execution Notes
+
+Updated `docs/specs/index.md` to publish the new watchlist contract alongside
+the existing normative specs so future agents can discover it without issue or
+chat context. Re-read the nearby spec and proposal surfaces after the index
+update and did not find any additional wording that needed immediate alignment:
+the new contract already carries the accepted `git-backed workspace`,
+repository-family grouping, and deferred `hidden` decisions directly.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This discoverability update is part of the same small
+docs slice and will be checked in the normal branch-level review round.
+
+## Validation Strategy
+
+- Re-read the finished contract as if the discovery chat were unavailable and
+  verify that the key decisions are self-contained in tracked docs.
+- Run `harness plan lint` on this plan before approval and again after plan
+  updates during execution.
+- During execution, validate the wording against issue `#162` and the umbrella
+  watchlist issue so the spec stays aligned with the accepted product shape
+  without overcommitting to later implementation details.
+
+## Risks
+
+- Risk: The contract could accidentally overfit to linked git worktrees and
+  exclude direct work in a repository's primary checkout.
+  - Mitigation: Make `git-backed workspace` the persisted unit explicitly, and
+    treat linked-worktree status as derived metadata rather than the base
+    identity.
+- Risk: The contract could mix UI-only concerns such as `hidden` into the core
+  storage schema, making later read-model work heavier than needed.
+  - Mitigation: Keep the persisted watchlist record minimal and defer view
+    state to the later lifecycle/read-model slices already tracked in the
+    watchlist issue set.
+- Risk: Repository grouping could become ambiguous if the contract tries to
+  solve remote-based project identity too early.
+  - Mitigation: Limit the initial grouping story to local repository families
+    and defer cross-clone grouping to a later explicit design slice.
+
+## Validation Summary
+
+- `harness plan lint docs/plans/active/2026-04-19-define-machine-local-watchlist-contract.md`
+  passed before approval and again after the execution notes and closeout
+  summaries were filled in.
+- Direct reread of `docs/specs/watchlist-contract.md` confirmed the tracked
+  spec itself carries the machine-local file location, the minimal persisted
+  schema, the path-based identity model, the derived repository-family
+  grouping boundary, and the explicit deferral of dashboard-only state such as
+  `hidden`.
+- Direct reread of `docs/specs/index.md` confirmed the new contract is
+  discoverable from the existing specs index without requiring issue or chat
+  context.
+- `review-001-full` passed with 0 findings across the `correctness` and
+  `docs_consistency` dimensions.
+
+## Review Summary
+
+- `review-001-full`: finalize review passed with 0 findings across the
+  `correctness` and `docs_consistency` dimensions.
+
+## Archive Summary
+
+- Archived At: 2026-04-19T10:51:12+08:00
+- Revision: 1
+- PR: Not opened yet; this candidate still needs the ordinary post-archive
+  commit, push, and PR handoff.
+- Ready: The candidate satisfies the acceptance criteria, keeps the watchlist
+  contract intentionally narrow around machine-local `git-backed workspaces`,
+  and passed `review-001-full` with 0 findings.
+- Merge Handoff: Archive the plan, commit the tracked archive move plus the
+  new watchlist contract and closeout summaries on
+  `codex/define-watchlist-contract`, push the branch, open or refresh the PR,
+  and record publish/CI/sync evidence until `harness status` reaches
+  `execution/finalize/await_merge`.
+
+## Outcome Summary
+
+### Delivered
+
+- Added `docs/specs/watchlist-contract.md` as the normative machine-local
+  watchlist contract for the first watchlist foundation slice.
+- Defined the watched unit as a `git-backed workspace`, explicitly covering
+  both a repository's primary checkout and linked git worktrees.
+- Fixed one machine-local, user-private file location at
+  `~/.easyharness/watchlist.json` and one minimal persisted JSON shape with
+  `version` plus `workspaces[].workspace_path`.
+- Defined canonical absolute `workspace_path` as the first machine-local
+  identity and kept repository-family grouping, branch, and linked-worktree
+  classification as derived read-time facts.
+- Published the new contract in `docs/specs/index.md` so future agents can
+  discover it without relying on issue or chat history.
+
+### Not Delivered
+
+- No watchlist write path, dashboard read model, backend implementation shape,
+  or UI behavior was implemented in this slice.
+- Dashboard-only view state such as `hidden` remains intentionally deferred to
+  later watchlist lifecycle work.
+
+### Follow-Up Issues
+
+- `#163` Decide the v1 backend shape for the watchlist dashboard.
+- `#164` Silently register worktrees in the watchlist on harness status.
+- `#165` Build a watchlist-backed dashboard read model.
+- `#166` Define completed and hidden lifecycle for watched worktrees.
+- `#167` Ship a minimal watchlist dashboard UI.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -18,6 +18,10 @@
 - [Contract Registry](./contract.md): normative guide to the checked-in JSON
   Schema registry, its ownership model, the public-vs-runtime boundary, and
   what is intentionally not rendered as duplicated markdown.
+- [Watchlist Contract](./watchlist-contract.md): normative machine-local
+  storage contract for watched git-backed workspaces, including the minimal
+  persisted schema, path-based local identity, and the boundary between
+  persisted workspace records and derived repository-family grouping.
 - [Schema Registry](../../schema/index.json): checked-in JSON Schema index for
   command outputs, command inputs, shared shapes, and CLI-owned local JSON
   artifacts, with each entry labeled by surface.

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -75,6 +75,23 @@ The minimal persisted workspace record is intentionally small:
 This contract does not require any additional persisted per-workspace fields in
 the first slice.
 
+## Path Normalization and Uniqueness
+
+Writers must normalize `workspace_path` before comparing or persisting records.
+
+The normalization contract for this first slice is:
+
+- resolve the path to an absolute local filesystem path before writing
+- use one canonical textual path per watched workspace for duplicate detection
+- treat the normalized `workspace_path` as the uniqueness key in
+  `workspaces[]`
+
+This spec intentionally does not fix every platform-specific normalization
+detail yet. Later implementation may need to clarify symlink or case-folding
+rules per platform, but it must still preserve one clear rule: repeated
+registration of the same local workspace must converge on one canonical
+`workspace_path` record rather than creating duplicates.
+
 ## Identity Model
 
 For this first machine-local contract, watched-workspace identity is the
@@ -90,6 +107,23 @@ This choice is intentionally local and path-oriented:
 If a workspace moves to a different path, that is a different watched
 workspace under this initial contract. The first contract does not attempt to
 preserve identity across path moves.
+
+## Missing or Unreadable Workspaces
+
+The watchlist is a remembered local set, not a best-effort snapshot of only
+currently readable directories.
+
+If a previously watched `workspace_path` later becomes:
+
+- missing
+- unreadable
+- no longer a valid Git-backed workspace
+
+the watchlist record should remain present until a later local lifecycle action
+explicitly removes or hides it.
+
+Read-model and UI layers should surface those entries as explicit degraded
+states rather than silently dropping them from the watched set.
 
 ## Derived Repository Grouping
 
@@ -144,7 +178,27 @@ In particular, fields such as:
 must not be folded into the minimal persisted watchlist record defined here.
 
 Those concerns belong to a later local view-model or lifecycle contract once
-the dashboard behavior is ready to define.
+the dashboard behavior is ready to define. That later dashboard-local state
+should live in a separate machine-local companion artifact rather than
+retrofitting UI-only fields into `watchlist.json`.
+
+## Write Expectations
+
+This spec does not define which command writes the watchlist, but any future
+writer must preserve basic local integrity expectations:
+
+- writes must not silently drop unrelated existing workspace records
+- duplicate registration attempts must converge on one record per normalized
+  `workspace_path`
+- persistence should use crash-safe replacement rather than partial in-place
+  writes when the file is rewritten
+- concurrent write paths must avoid last-writer-wins corruption that would
+  lose another workspace record
+
+The exact file-locking or mutation-coordination mechanism is an implementation
+detail for later work, but these integrity expectations are part of the
+watchlist contract because silent registration during commands such as
+`harness status` will depend on them.
 
 ## Non-Goals
 

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -54,7 +54,9 @@ The watchlist file is UTF-8 JSON with one top-level object:
   "version": 1,
   "workspaces": [
     {
-      "workspace_path": "/absolute/path/to/workspace"
+      "workspace_path": "/absolute/path/to/workspace",
+      "watched_at": "2026-04-19T03:00:00Z",
+      "last_seen_at": "2026-04-19T03:00:00Z"
     }
   ]
 }
@@ -65,12 +67,19 @@ Contract:
 - `version` is required and identifies the watchlist file format version
 - `workspaces` is required and contains zero or more watched workspace records
 - each `workspace_path` is required
+- each `watched_at` is required
+- each `last_seen_at` is required
 - each `workspace_path` must be an absolute canonical local filesystem path
+- `watched_at` records when the workspace first entered the watchlist
+- `last_seen_at` records the latest successful watchlist-touching harness
+  command that confirmed this workspace locally
 - duplicate `workspace_path` values are invalid
 
 The minimal persisted workspace record is intentionally small:
 
 - `workspace_path`
+- `watched_at`
+- `last_seen_at`
 
 This contract does not require any additional persisted per-workspace fields in
 the first slice.
@@ -120,7 +129,7 @@ If a previously watched `workspace_path` later becomes:
 - no longer a valid Git-backed workspace
 
 the watchlist record should remain present until a later local lifecycle action
-explicitly removes or hides it.
+explicitly unwatches it.
 
 Read-model and UI layers should surface those entries as explicit degraded
 states rather than silently dropping them from the watched set.
@@ -152,6 +161,8 @@ Persisted:
 
 - `version`
 - `workspaces[].workspace_path`
+- `workspaces[].watched_at`
+- `workspaces[].last_seen_at`
 
 Derived at read time:
 
@@ -160,27 +171,65 @@ Derived at read time:
 - branch name
 - whether the workspace is the repository's primary checkout or a linked
   worktree
+- whether a watched workspace currently presents as `active`, `completed`, or
+  `missing`
 - live harness status or dashboard summary fields
 
 The contract prefers deriving these facts from the current filesystem and Git
 state instead of persisting copies that can drift.
 
-## Deferred View State
+## Membership and User Action
 
-Dashboard-only view state is out of scope for this minimal watchlist contract.
+Watchlist membership is binary in this first contract:
 
-In particular, fields such as:
+- a workspace is watched because a record exists in `watchlist.json`
+- a workspace stops being watched only through `unwatch`, which removes that
+  record from the watchlist
 
-- `hidden`
-- completion filtering
-- manual dismissal or archive-like dashboard preferences
+This contract does not define a separate dashboard-local `hidden` state.
 
-must not be folded into the minimal persisted watchlist record defined here.
+The first contract keeps one explicit user-controlled action:
 
-Those concerns belong to a later local view-model or lifecycle contract once
-the dashboard behavior is ready to define. That later dashboard-local state
-should live in a separate machine-local companion artifact rather than
-retrofitting UI-only fields into `watchlist.json`.
+- `unwatch`
+  - remove the watched workspace record from `watchlist.json`
+  - stop including that workspace in the watched set and dashboard read model
+
+If a later command such as `harness status` re-registers the same workspace,
+that creates a new watched record again under the ordinary watchlist rules.
+
+## Derived Lifecycle States
+
+The first contract keeps dashboard lifecycle classification derived instead of
+persisted.
+
+At minimum, later read-model and UI work may classify a watched workspace as:
+
+- `active`
+- `completed`
+- `missing`
+
+These are read-time states for currently watched entries, not membership
+transitions stored in the watchlist file.
+
+In particular:
+
+- a harness plan moving through `archive` or back to `idle` does not remove
+  the workspace from the watchlist
+- deleting the local directory does not remove the workspace from the
+  watchlist by itself; it instead becomes a `missing` watched workspace until
+  the user explicitly unwatches it
+
+## No Automatic GC In V1
+
+This first contract does not define silent automatic garbage collection.
+
+The watchlist is a remembered local set, not an auto-pruned mirror of the
+current filesystem. The combination of `last_seen_at`, derived `missing`
+status, and explicit `unwatch` is enough for the first slice.
+
+Later work may add user-facing cleanup or stale-item policies, but v1 should
+not silently discard watched entries just because they have gone idle,
+unreadable, or missing.
 
 ## Write Expectations
 
@@ -190,6 +239,9 @@ writer must preserve basic local integrity expectations:
 - writes must not silently drop unrelated existing workspace records
 - duplicate registration attempts must converge on one record per normalized
   `workspace_path`
+- rewriting an existing watched record should preserve `watched_at`
+- rewriting an existing watched record may refresh `last_seen_at` when the
+  watchlist-touching command successfully confirms the workspace
 - persistence should use crash-safe replacement rather than partial in-place
   writes when the file is rewritten
 - concurrent write paths must avoid last-writer-wins corruption that would
@@ -209,3 +261,5 @@ This spec does not:
 - define a dashboard read model beyond the persisted-versus-derived boundary
 - merge separate local clones into one project because they share a remote
 - support non-git watched directories in the first slice
+- define any dashboard-local `hidden` state or secondary visibility layer
+  beyond explicit `unwatch`

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -1,0 +1,157 @@
+# Watchlist Contract
+
+## Purpose
+
+Define the normative machine-local storage contract for the first easyharness
+watchlist. This contract exists so later watchlist registration, read-model,
+and dashboard work can build on one clear local storage shape instead of
+reopening basic questions about what is watched, where it is stored, and which
+facts belong in persisted data versus derived UI state.
+
+This spec is intentionally narrow. It defines the minimal persisted watchlist
+record for local use. It does not define write triggers, backend shape, or UI
+behavior beyond the persisted-versus-derived boundary needed to keep later
+slices coherent.
+
+## Watched Unit
+
+The watched unit is a `git-backed workspace`.
+
+A watched workspace is a local filesystem checkout that:
+
+- is backed by a Git working tree
+- is intended to run easyharness in that checkout
+
+This definition includes both:
+
+- a repository's primary checkout
+- a linked checkout created through `git worktree`
+
+The watchlist contract must not assume that every watched workspace is a
+linked worktree. Direct work in a repository's primary checkout is a
+first-class case.
+
+This first contract does not support non-git directories as watched items.
+
+## Storage Location
+
+The watchlist file lives at:
+
+- `~/.easyharness/watchlist.json`
+
+This location is machine-local and user-private. It is not a repository-shared
+artifact and must not be written into the repository itself.
+
+The parent directory may later hold other machine-local easyharness files, but
+this contract defines only the watchlist file above.
+
+## File Shape
+
+The watchlist file is UTF-8 JSON with one top-level object:
+
+```json
+{
+  "version": 1,
+  "workspaces": [
+    {
+      "workspace_path": "/absolute/path/to/workspace"
+    }
+  ]
+}
+```
+
+Contract:
+
+- `version` is required and identifies the watchlist file format version
+- `workspaces` is required and contains zero or more watched workspace records
+- each `workspace_path` is required
+- each `workspace_path` must be an absolute canonical local filesystem path
+- duplicate `workspace_path` values are invalid
+
+The minimal persisted workspace record is intentionally small:
+
+- `workspace_path`
+
+This contract does not require any additional persisted per-workspace fields in
+the first slice.
+
+## Identity Model
+
+For this first machine-local contract, watched-workspace identity is the
+canonical absolute `workspace_path`.
+
+This choice is intentionally local and path-oriented:
+
+- it keeps the persisted record small enough for an XS foundation slice
+- it supports both primary checkouts and linked worktrees with one model
+- it avoids introducing synthetic IDs before later read-model or write-path
+  work proves they are necessary
+
+If a workspace moves to a different path, that is a different watched
+workspace under this initial contract. The first contract does not attempt to
+preserve identity across path moves.
+
+## Derived Repository Grouping
+
+The watchlist persists watched workspaces, not repository groups.
+
+Repository-family grouping is derived at read time from Git metadata. The
+intended local grouping model is:
+
+- a repository's primary checkout and any linked git worktrees belong to the
+  same local repository family
+- separate local clones remain separate families even when they point to the
+  same remote
+
+The exact Git probe is an implementation detail, but the grouping contract
+must be consistent with local repository-family identity rather than
+remote-URL-based project identity.
+
+This lets the UI treat `workspace` as the base watched unit while still
+grouping related local checkouts together.
+
+## Persisted Versus Derived Fields
+
+Persist only the minimal watched-workspace set in the watchlist file.
+
+Persisted:
+
+- `version`
+- `workspaces[].workspace_path`
+
+Derived at read time:
+
+- repository root or top-level path
+- local repository-family grouping key
+- branch name
+- whether the workspace is the repository's primary checkout or a linked
+  worktree
+- live harness status or dashboard summary fields
+
+The contract prefers deriving these facts from the current filesystem and Git
+state instead of persisting copies that can drift.
+
+## Deferred View State
+
+Dashboard-only view state is out of scope for this minimal watchlist contract.
+
+In particular, fields such as:
+
+- `hidden`
+- completion filtering
+- manual dismissal or archive-like dashboard preferences
+
+must not be folded into the minimal persisted watchlist record defined here.
+
+Those concerns belong to a later local view-model or lifecycle contract once
+the dashboard behavior is ready to define.
+
+## Non-Goals
+
+This spec does not:
+
+- define when or how workspaces are added to the watchlist
+- define daemon versus on-demand backend architecture
+- define a dashboard read model beyond the persisted-versus-derived boundary
+- merge separate local clones into one project because they share a remote
+- support non-git watched directories in the first slice


### PR DESCRIPTION
## Summary
- add a normative watchlist contract spec for machine-local git-backed workspaces
- define the minimal persisted schema, path-based identity, and derived repository-family grouping boundary
- publish the new watchlist contract from the specs index and archive the tracked plan for #162

## Testing
- harness plan lint docs/plans/archived/2026-04-19-define-machine-local-watchlist-contract.md
- finalize review `review-001-full` passed with 0 findings

Closes #162
