### PR TITLE
Define dashboard entrypoint and migration architecture

### DIFF
--- a/docs/plans/archived/2026-04-19-define-dashboard-entrypoint-and-migration-architecture.md
+++ b/docs/plans/archived/2026-04-19-define-dashboard-entrypoint-and-migration-architecture.md
@@ -1,0 +1,349 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-19T21:05:00+08:00"
+approved_at: "2026-04-19T20:42:25+08:00"
+source_type: issue
+source_refs:
+    - '#163'
+size: XS
+---
+
+# Define the dashboard entrypoint and migration architecture
+
+## Goal
+
+Define the v1 product and backend shape for the machine-local dashboard so
+future implementation work can proceed without reopening command semantics,
+routing, or migration questions. The result should tell a cold reader what
+`harness dashboard` replaces, how it starts, what its default landing page is,
+how workspace detail routing works, and which watchlist signal drives the
+dashboard ordering model.
+
+This slice should stay architecture-focused and narrow. It should record the
+accepted dashboard behavior for `0.3.0`, the `0.3.x` deprecation path for
+`harness ui`, and the minimal watchlist-touching behavior that lets the
+dashboard treat `last_seen_at` as the recency signal. It should not implement
+the dashboard or expand the watchlist schema just to make routing prettier.
+
+## Scope
+
+### In Scope
+
+- Record `harness dashboard` as the new UI entrypoint targeted for `0.3.0`,
+  including its role as the eventual replacement for `harness ui`.
+- Define the startup semantics for `harness dashboard`: explicit command
+  invocation, on-demand local server, no background daemon, and default landing
+  route at `/dashboard`.
+- Define the `0.3.x` transition behavior for `harness ui`, including a
+  deprecation warning and compatibility redirect into the dashboard-owned
+  workspace detail surface.
+- Define the workspace route model for dashboard-owned navigation, including
+  `/workspace/<workspace_key>` and the decision to derive `workspace_key` from
+  canonical `workspace_path` at read time instead of persisting a new watchlist
+  field.
+- Define the accepted dashboard ordering and recency signal around
+  `last_seen_at`, including the expectation that major harness commands refresh
+  the field through a shared watchlist writer when they successfully confirm
+  the current workspace locally.
+- Define the degraded routing behavior for missing, unreadable, or unknown
+  watched workspaces and record that `Unwatch` is the only dashboard-local
+  write action in v1.
+
+### Out of Scope
+
+- Implementing `harness dashboard`, the watchlist read model, or the dashboard
+  UI.
+- Reworking the current single-workspace `status`, `plan`, `timeline`, or
+  `review` page model beyond recording that the dashboard should reuse it.
+- Adding a daemon, broker, singleton server discovery, push transport, file
+  watching, or any other background-process architecture.
+- Adding `--workspace` direct-open flags or using a raw-path URL scheme for
+  workspace routes.
+- Expanding the watchlist file schema with a persisted `workspace_id` or any
+  other new routing-only field.
+- General cross-workspace workflow mutations beyond the one explicit `Unwatch`
+  action.
+
+## Acceptance Criteria
+
+- [x] Tracked docs record `harness dashboard` as the explicit `0.3.0` UI
+      entrypoint, with on-demand local-server startup semantics and default
+      landing at `/dashboard`.
+- [x] Tracked docs record the `0.3.x` deprecation path for `harness ui`,
+      including console warning behavior and compatibility routing into the
+      dashboard-owned workspace detail surface.
+- [x] Tracked docs define `/workspace/<workspace_key>` as the workspace route
+      model, specify that `workspace_key` is a deterministic read-time
+      derivative of canonical `workspace_path`, and reject both raw-path URLs
+      and a new persisted watchlist ID for v1.
+- [x] Tracked docs define `last_seen_at` as the dashboard recency signal,
+      including the expectation that major successful harness commands refresh
+      it through a shared watchlist writer rather than ad hoc per-command file
+      rewrites.
+- [x] Tracked docs describe degraded routing behavior: missing or unreadable
+      watched workspaces render a simple degraded page, unknown keys are
+      treated as not currently watched, and `Unwatch` is the only
+      dashboard-local write action in v1.
+- [x] The plan lints cleanly and the resulting documentation is self-contained
+      enough that a future agent could implement the dashboard entrypoint
+      without relying on discovery chat.
+
+## Deferred Items
+
+- The dashboard watchlist read model and any concrete API payload shape for the
+  dashboard home page.
+- The concrete implementation of the shared watchlist writer and its locking
+  mechanism.
+- Any richer workspace-home redesign beyond the existing single-workspace page
+  model reused from `harness ui`.
+- Route parameters, filters, search, or any future direct-open flags for
+  dashboard navigation.
+- Push-driven refresh, background monitoring, notifications, or any always-on
+  service architecture.
+- Any future reason to persist a stable workspace ID that is distinct from the
+  canonical path-derived route key.
+
+## Work Breakdown
+
+### Step 1: Record the dashboard command and migration contract
+
+- Done: [x]
+
+#### Objective
+
+Write the tracked product and command contract for `harness dashboard` and the
+`harness ui` deprecation window.
+
+#### Details
+
+Capture the accepted product boundary from discovery so future implementation
+work does not revisit whether the dashboard is a page inside `harness ui` or a
+new top-level command. The docs should make clear that `harness dashboard`
+becomes the new UI entrypoint in `0.3.0`, always starts with `/dashboard`,
+runs only when the command is invoked, and starts one on-demand local server
+per command run. The same step should define `harness ui` as a temporary
+compatibility command for `0.3.x`: it prints a deprecation warning, opens the
+dashboard-owned workspace detail entry for the current workspace, and does not
+introduce singleton-server reuse or any daemon-like behavior.
+
+#### Expected Files
+
+- `docs/specs/proposals/harness-ui-steering-surface.md`
+- another nearby tracked doc only if a second durable location is needed for
+  the migration contract
+
+#### Validation
+
+- A cold reader can explain the difference between `harness dashboard` and the
+  deprecated `harness ui` command from tracked docs alone.
+- The docs explicitly reject daemon, singleton-server, and implicit background
+  startup behavior for v1.
+
+#### Execution Notes
+
+Updated `docs/specs/proposals/harness-ui-steering-surface.md` to carry the
+accepted `0.3.0` dashboard entrypoint direction directly in tracked docs. The
+proposal now treats `harness dashboard` as the explicit machine-local UI
+command, fixes `/dashboard` as the default landing route, rejects daemon or
+singleton-server behavior, and defines `harness ui` as a deprecated
+compatibility command through `0.3.x` that opens the dashboard-owned workspace
+detail route for the current workspace.
+
+The same proposal revision also records that the dashboard home owns
+machine-local workspace selection while selected workspace detail should reuse
+the existing dense `Status` / `Plan` / `Timeline` / `Review` workbench model.
+This was a docs-only architecture slice, so Red/Green/Refactor TDD was not
+practical or necessary; validation relied on direct reread of the tracked doc,
+`git diff --check`, and later branch-level review.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 is a tracked-docs architecture update and will
+receive branch-level review during the ordinary execute review flow.
+
+### Step 2: Define workspace routing, recency, and degraded-state behavior
+
+- Done: [x]
+
+#### Objective
+
+Write the tracked routing and watchlist semantics that the dashboard depends
+on for workspace detail navigation.
+
+#### Details
+
+Record that the dashboard home owns machine-local navigation while workspace
+detail should reuse the current single-workspace `status` / `plan` /
+`timeline` / `review` model instead of inventing a second workspace-home
+shell. Define `/workspace/<workspace_key>` as the route family, where
+`workspace_key` is derived deterministically from canonical `workspace_path` at
+read time so the watchlist contract can stay minimal. The docs should explain
+that the dashboard orders watched workspaces by `last_seen_at`, that major
+successful harness commands are expected to refresh that field through a shared
+watchlist writer, and that missing or unreadable watched workspaces render a
+simple degraded page with `Unwatch` as the one allowed dashboard-local action.
+Unknown keys should be treated as "not currently watched" rather than as a
+recoverable special case with extra history state.
+
+#### Expected Files
+
+- `docs/specs/watchlist-contract.md`
+- `docs/specs/proposals/harness-ui-steering-surface.md`
+- another nearby tracked doc only if a small discoverability or terminology
+  alignment edit is needed
+
+#### Validation
+
+- The docs clearly separate route-level "not currently watched" handling from
+  degraded watched-workspace states such as `missing` or `unreadable`.
+- The chosen `workspace_key` story keeps the watchlist schema minimal and
+  still lets a future implementation resolve dashboard routes from watchlist
+  data alone.
+
+#### Execution Notes
+
+Updated `docs/specs/watchlist-contract.md` to define the dashboard-facing
+watchlist semantics that issue `#163` needs before implementation. The spec
+now names `last_seen_at` as the machine-local dashboard recency signal, states
+that major successful harness commands may refresh it through one shared
+watchlist writer, and defines `/workspace/<workspace_key>` as a route family
+whose key is derived deterministically from canonical `workspace_path` at read
+time instead of persisting a new route-only ID.
+
+The same revision adds explicit degraded-state expectations: watched
+workspaces may surface as `unreadable`, missing or unreadable watched entries
+should still resolve to a degraded workspace page, unknown keys are treated as
+"not currently watched", and `Unwatch` remains the one explicit cleanup action
+instead of a broader dashboard mutation surface. This was also a docs-only
+change, so no TDD loop was needed; validation relied on direct reread,
+cross-checking the proposal wording, and `git diff --check`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 is a tracked-docs contract update and will be
+validated through the normal reviewer round for the branch.
+
+## Validation Strategy
+
+- Run `harness plan lint` on this plan before approval and again after any
+  plan edits during execution.
+- During execution, reread the updated tracked docs as if the discovery chat
+  were unavailable and confirm they carry the dashboard command semantics,
+  migration path, routing model, recency signal, and degraded-state behavior
+  directly.
+- Cross-check the updated wording against issue `#163`, the watchlist contract,
+  and the existing UI steering proposal so the accepted architecture lands in
+  tracked docs instead of staying in issue or chat history alone.
+
+## Risks
+
+- Risk: The documentation could leave enough ambiguity that a future agent
+  reopens daemon, singleton-server, or raw-path-routing options during
+  implementation.
+  - Mitigation: State the rejected alternatives explicitly in the dashboard
+    command and route contract rather than implying them only indirectly.
+- Risk: `last_seen_at` could become an underspecified signal if the docs do not
+  tie it to a shared watchlist writer and successful command confirmation.
+  - Mitigation: Record the refresh expectation clearly and defer the concrete
+    locking mechanism as an implementation detail rather than leaving the
+    signal undefined.
+- Risk: Missing and unknown workspace states could blur together and produce a
+  confusing detail-page experience.
+  - Mitigation: Document degraded watched-workspace pages separately from
+    "not currently watched" routing outcomes, and keep `Unwatch` as the one
+    explicit cleanup action for degraded watched entries.
+
+## Validation Summary
+
+- `harness plan lint docs/plans/active/2026-04-19-define-dashboard-entrypoint-and-migration-architecture.md`
+  passed before approval and again after execution notes and archive-ready
+  summaries were filled in.
+- `git diff --check` passed after the tracked proposal and watchlist-contract
+  edits landed.
+- Direct reread of `docs/specs/proposals/harness-ui-steering-surface.md`
+  confirmed the tracked proposal now carries the accepted `harness dashboard`
+  entrypoint, `/dashboard` default landing route, `0.3.x` deprecation path for
+  `harness ui`, and the reuse of the existing workspace workbench model under
+  `/workspace/<workspace_key>`.
+- Direct reread of `docs/specs/watchlist-contract.md` confirmed the tracked
+  contract now treats `last_seen_at` as the dashboard recency signal, defines
+  the route-key derivation and collision expectations, and records degraded
+  routing outcomes for missing, unreadable, and no-longer-watched workspaces.
+- Cross-check against issue `#163` and the existing UI steering proposal
+  confirmed that the accepted dashboard entrypoint, migration, routing, and
+  `Unwatch` cleanup decisions now live in tracked docs rather than only in chat
+  or issue discussion.
+
+## Review Summary
+
+- `review-001-full` covered the finalize candidate across the `correctness`
+  and `docs_consistency` dimensions.
+- Reviewer slot `correctness` submitted by `reviewer-correctness` found 0
+  issues after checking the active plan, the updated proposal, the updated
+  watchlist contract, and nearby spec surfaces for contract conflicts.
+- Reviewer slot `docs_consistency` submitted by `reviewer-docs-consistency`
+  found 0 issues after checking that the plan, proposal, and contract tell one
+  coherent implementation story for dashboard entrypoint, route semantics,
+  recency, and degraded workspace handling.
+- `harness review aggregate --round review-001-full` passed cleanly with 0
+  blocking and 0 non-blocking findings.
+
+## Archive Summary
+
+- Archived At: 2026-04-19T20:47:44+08:00
+- Revision: 1
+- PR: NONE
+- Ready: Revision 1 satisfies the tracked acceptance criteria for issue
+  `#163`, documents `harness dashboard` as the `0.3.0` UI entrypoint, keeps
+  `harness ui` as a deprecated `0.3.x` compatibility command, reuses the
+  existing workspace workbench model under `/workspace/<workspace_key>`, and
+  records `last_seen_at`, degraded routing, and `Unwatch` semantics in the
+  watchlist contract; `review-001-full` passed cleanly.
+- Merge Handoff: Archive this candidate, commit the tracked archive move plus
+  the proposal/contract updates on `codex/define-dashboard-entrypoint`, push
+  the branch, open or refresh the PR, and record publish/CI/sync evidence
+  until `harness status` reaches `execution/finalize/await_merge`.
+
+## Outcome Summary
+
+### Delivered
+
+- Updated `docs/specs/proposals/harness-ui-steering-surface.md` to define
+  `harness dashboard` as the explicit `0.3.0` UI entrypoint, default
+  `/dashboard` landing route, and machine-local home for watched workspaces.
+- Recorded the `0.3.x` migration path where `harness ui` remains available as
+  a deprecated compatibility command that opens the dashboard-owned workspace
+  detail route for the current workspace.
+- Documented that selected workspace detail should reuse the existing dense
+  `Status`, `Plan`, `Timeline`, and `Review` workbench model instead of adding
+  a second workspace-home shell.
+- Extended `docs/specs/watchlist-contract.md` so `last_seen_at` is the
+  dashboard recency signal and major successful harness commands are expected
+  to refresh it through one shared watchlist writer.
+- Defined `/workspace/<workspace_key>` as a deterministic read-time route key
+  derived from canonical `workspace_path`, while explicitly rejecting raw-path
+  URLs and a new persisted watchlist route ID for v1.
+- Recorded degraded routing expectations for missing, unreadable, and unknown
+  watched workspaces, and kept `Unwatch` as the one explicit dashboard-local
+  cleanup action.
+
+### Not Delivered
+
+- No `harness dashboard` command, server, read model, or UI implementation was
+  built in this slice.
+- No concrete shared watchlist-writer implementation or locking mechanism was
+  added in this slice beyond documenting the contract expectation.
+- No direct-open flags, search/filter behavior, push-driven refresh, or
+  broader dashboard mutation surface was added in this slice.
+
+### Follow-Up Issues
+
+- `#164` Silently register worktrees in the watchlist on harness status.
+  This remains the main follow-up for the shared watchlist-touching write path
+  that will refresh `last_seen_at` and keep the dashboard list current.
+- `#165` Build a watchlist-backed dashboard read model.
+  This follow-up should realize the machine-local dashboard home and the
+  recency-ordered watched-workspace list documented here.
+- `#167` Ship a minimal watchlist dashboard UI.
+  This follow-up should implement the new `harness dashboard` entrypoint and
+  the dashboard-owned workspace navigation described in this slice.

--- a/docs/specs/proposals/harness-ui-steering-surface.md
+++ b/docs/specs/proposals/harness-ui-steering-surface.md
@@ -4,8 +4,10 @@
 
 This document is a non-normative proposal.
 
-It describes a recommended direction for a future `harness ui` surface. It
-does not change the current CLI, plan, or state contracts by itself.
+It describes the recommended steering-surface direction as the current
+single-workspace `harness ui` workbench evolves into a machine-local
+`harness dashboard`. It does not change the current CLI, plan, or state
+contracts by itself.
 
 ## Background
 
@@ -15,6 +17,8 @@ Two open issues define the current UI problem space:
   for local status and trajectory visualization
 - [Issue #70](https://github.com/catu-ai/easyharness/issues/70): define the
   human steering surface for harness UI and status
+- [Issue #163](https://github.com/catu-ai/easyharness/issues/163): decide the
+  v1 backend and entrypoint shape for the watchlist-backed dashboard
 
 Several interaction principles are already clear enough to state directly:
 
@@ -24,8 +28,8 @@ Several interaction principles are already clear enough to state directly:
 - file trees, diffs, and review artifacts need a document-style viewer
 - a global deck of all possible actions becomes noisy and hard to steer from
 
-This proposal turns those principles into a real `harness ui` direction for
-the current repository.
+This proposal turns those principles into the accepted direction for the
+dashboard-era steering surface in the current repository.
 
 ## Purpose
 
@@ -43,12 +47,13 @@ The UI should complement `harness status`, not replace it.
 
 ## Goals
 
-- provide a clear human steering surface for the current worktree
+- provide a clear human steering surface for the current machine-local
+  dashboard and the selected watched workspace
 - stay grounded in existing tracked files and `.local/harness` runtime
   artifacts
 - make `next actions`, blockers, and review state easy to understand
 - show plans, tracked diffs, review artifacts, and recent trajectory in one
-  dense local workbench
+  dense local workbench once a workspace is selected
 - minimize full-page scrolling and avoid multi-screen dashboard sprawl
 - keep the product visually calm, technical, and legible under sustained use
 
@@ -64,8 +69,10 @@ The UI should complement `harness status`, not replace it.
 
 ## Summary
 
-The recommended product shape is a local `harness ui` workbench for the
-current repository. It should feel closer to VS Code than to a dashboard:
+The recommended product shape is a local `harness dashboard` entrypoint with a
+dashboard home plus a dense workbench for each watched workspace. The
+workspace detail surface should still feel closer to VS Code than to a
+marketing-style dashboard:
 
 - narrow top bar
 - icon-only activity rail on the left
@@ -73,19 +80,43 @@ current repository. It should feel closer to VS Code than to a dashboard:
 - editor/detail pane on the right
 - collapsible bottom status drawer
 
-The UI should read from `harness status`, tracked plan files, git diff, and
-`.local/harness` artifacts. It should present those sources through a dense,
-document-oriented interface instead of inventing new product-only state.
+The dashboard should read from the machine-local watchlist plus
+`harness status`, tracked plan files, git diff, and `.local/harness`
+artifacts for the selected workspace. It should present those sources through
+one machine-local entrypoint and one dense document-oriented workspace surface
+instead of inventing new product-only state.
 
 ## Product Shape
 
 ### Entry Point
 
-`harness ui` should start a local server for the current working repository and
-open a local workbench surface.
+`harness dashboard` should be the explicit UI command starting in `0.3.0`.
+Running it should start one on-demand local server for the current command run
+and open a machine-local dashboard at `/dashboard`.
 
-It should inspect the actual current worktree and its harness artifacts rather
-than a disposable demo workspace.
+The command should work from any directory. The dashboard home should be backed
+by the machine-local watchlist rather than by the shell's current working
+directory.
+
+`harness dashboard` should not introduce:
+
+- a background daemon
+- singleton server reuse across separate command runs
+- implicit startup without an explicit command invocation
+
+### Transition from `harness ui`
+
+`harness ui` should be treated as a compatibility command during `0.3.x`, not
+as a long-term parallel product entrypoint.
+
+During that deprecation window:
+
+- `harness ui` should print a deprecation warning in the console
+- `harness ui` should still start a local UI session on demand
+- the opened surface should be the dashboard-owned workspace detail route for
+  the current workspace rather than a separate legacy workbench
+
+The goal is a smooth migration path, not two permanent UI products.
 
 ### Default Role
 
@@ -100,7 +131,7 @@ should be contextual and sparse rather than the main organizing principle.
 
 `harness status` remains the fast, scriptable, agent-facing summary.
 
-`harness ui` should provide:
+The steering surface should provide:
 
 - denser context
 - artifact navigation
@@ -108,23 +139,45 @@ should be contextual and sparse rather than the main organizing principle.
 - latest-change inspection
 - clearer human steering moments
 
-`harness ui` should not fork a second interpretation of workflow state. When
+The steering surface should not fork a second interpretation of workflow state. When
 possible, it should render the `harness status` view more richly rather than
 reinterpret it from scratch.
 
+### Relationship between Dashboard Home and Workspace Detail
+
+`/dashboard` is the machine-local home page.
+
+It should:
+
+- list watched workspaces
+- order them by recency using watchlist data
+- let the user enter a specific watched workspace
+- surface degraded watched entries such as missing or unreadable workspaces
+
+Workspace detail should live under `/workspace/<workspace_key>`.
+
+That route family should:
+
+- reuse the existing single-workspace workbench model
+- keep `Status` as the workspace overview page
+- preserve the current `Plan`, `Timeline`, and `Review` views instead of
+  inventing a second workspace-home shell
+
 ## Design Principles
 
-### One Page, Not a Dashboard
+### One Dense Workspace Page, Plus a Small Dashboard Home
 
-The main workbench should fit the important information on one screen:
+The selected-workspace workbench should fit the important information on one
+screen:
 
 - current status
 - next actions
 - changed files or active review evidence
 - recent trajectory
 
-The user should navigate panes, tabs, and drawers, not scroll through stacked
-marketing-style sections.
+The dashboard home may be more list-oriented, but it should still avoid
+stacked marketing-style sections and should hand off quickly into the dense
+workspace workbench.
 
 ### Dense and Quiet
 
@@ -192,7 +245,7 @@ VS Code.
 
 ### Activity Rail
 
-The left rail should use icons only. Recommended sections:
+The workspace-detail left rail should use icons only. Recommended sections:
 
 - Overview
 - Reviews
@@ -203,7 +256,7 @@ The rail should stay narrow and visually secondary.
 
 ### Overview
 
-Overview is the main steering entry.
+Within workspace detail, Overview is the main steering entry.
 
 It should show:
 
@@ -267,7 +320,8 @@ These controls should not live in the main header.
 
 ### Top Bar
 
-The top bar should be thin and mostly infrastructural:
+The top bar should be thin and mostly infrastructural in both the dashboard
+home and workspace detail:
 
 - repository or worktree path
 - connection or freshness indicator
@@ -275,6 +329,21 @@ The top bar should be thin and mostly infrastructural:
 
 It should not contain large branding or duplicate state already visible in the
 status drawer.
+
+### Dashboard Home
+
+The dashboard home should stay lightweight and machine-local.
+
+It should:
+
+- default to the watched-workspace list instead of a specific repo
+- sort watched workspaces by watchlist recency
+- make the current workspace easy to find without requiring direct-open flags
+- present missing or unreadable watched entries as explicit degraded rows
+
+The home page does not need a second dashboard-only workspace summary shell.
+Its job is to help the user pick a watched workspace and move into the
+existing workbench model.
 
 ### Explorer and Editor Panes
 
@@ -293,7 +362,7 @@ interaction model.
 The bottom drawer should be default-open on first load and collapsible after
 that.
 
-It should contain:
+Within workspace detail it should contain:
 
 - current node
 - status summary
@@ -370,21 +439,49 @@ Several interaction patterns are worth preserving:
 - visually heavy header and card-based layout
 - product energy spent on explaining the UI instead of helping a human steer
 
+## Routing and Degraded States
+
+### Workspace Route Model
+
+Workspace detail should use:
+
+- `/workspace/<workspace_key>`
+
+The route key should be an opaque deterministic value derived from the watched
+workspace's canonical path at read time. The URL should not expose the raw
+absolute path, and the watchlist should not grow a separate persisted
+route-only ID just to support the route family.
+
+### Missing, Unreadable, and Unknown Workspace Routes
+
+If a watched workspace is still in the watchlist but is currently missing or
+unreadable, `/workspace/<workspace_key>` should render a simple degraded page
+instead of failing hard or silently redirecting away.
+
+That degraded page may offer one local cleanup action:
+
+- `Unwatch`
+
+If the key does not match any currently watched workspace, the route should be
+treated as not currently watched. The product does not need extra tombstone or
+history state just to distinguish "never existed" from "used to be watched."
+
 ## Proposed Phasing
 
-### Phase 1: Read-First Steering Workbench
+### Phase 1: Dashboard Entrypoint and Workspace Reuse
 
 Ship:
 
-- top-level `harness ui`
-- Overview, Reviews, Timeline, Settings
-- status drawer
-- artifact inspection grounded in harness-owned data, not a general-purpose IDE
-  browser
+- top-level `harness dashboard`
+- `/dashboard` as the machine-local home page
+- `/workspace/<workspace_key>` backed by the existing workspace workbench model
+- Overview, Reviews, Timeline, Settings within workspace detail
+- status drawer within workspace detail
+- `harness ui` as a deprecated compatibility command through `0.3.x`
 
 Defer:
 
-- direct action triggers beyond minimal refresh or open behaviors
+- direct action triggers beyond minimal refresh, open, or `Unwatch`
 
 ### Phase 2: Contextual Steering Actions
 
@@ -404,12 +501,13 @@ Extend the workbench when remote facts become first-class:
 - merge readiness
 - sync drift
 
-This phase should build on the same steering surface rather than creating a
-separate dashboard.
+This phase should build on the same dashboard-owned steering surface rather
+than creating a second remote-only product shell.
 
 ## Open Questions
 
-- which steering actions truly belong in the UI versus staying CLI-only
+- which steering actions truly belong in the UI versus staying CLI-only beyond
+  the accepted `Unwatch` action
 - whether Overview and Timeline should be separate primary sections or one
   combined steering view
 - how much remote PR and CI state should appear before the contracts for those
@@ -419,15 +517,18 @@ separate dashboard.
 
 ## Recommendation
 
-Treat issue #70 as the product-definition frame and issue #2 as the delivery
-vehicle.
+Treat issue #70 as the workspace-detail product-definition frame, issue #2 as
+the original delivery vehicle for the workbench model, and issue #163 as the
+accepted entrypoint-and-migration decision.
 
-Build `harness ui` as a dense local steering workbench for the current repo,
-not as a dashboard. Preserve the artifact-first, status-grounded model, and
-carry forward the strongest interaction patterns outlined above:
+Build `harness dashboard` as the machine-local home and route owner for the
+same dense steering workbench model, with the selected workspace reusing the
+existing `Status`, `Plan`, `Timeline`, and `Review` shape. Preserve the
+artifact-first, status-grounded model, and carry forward the strongest
+interaction patterns outlined above:
 
 - VS Code-like workbench structure
-- one-page density
+- one dense workspace page plus a small machine-local dashboard home
 - strong status and next-action visibility
 - file, diff, and review artifact inspection as first-class tasks
 - contextual human steering instead of a giant action deck

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -73,6 +73,8 @@ Contract:
 - `watched_at` records when the workspace first entered the watchlist
 - `last_seen_at` records the latest successful watchlist-touching harness
   command that confirmed this workspace locally
+- `last_seen_at` is the dashboard's recency signal for ordering watched
+  workspaces on the machine-local home page
 - duplicate `workspace_path` values are invalid
 
 The minimal persisted workspace record is intentionally small:
@@ -83,6 +85,13 @@ The minimal persisted workspace record is intentionally small:
 
 This contract does not require any additional persisted per-workspace fields in
 the first slice.
+
+Major harness commands that successfully confirm the current workspace locally
+may refresh `last_seen_at`, not just explicit watchlist-management commands.
+The exact command list is an implementation detail, but the intended shape for
+the dashboard is that routine successful commands such as `harness status`,
+`harness plan lint`, or `harness review start` can keep the recency signal
+fresh when they pass through one shared watchlist writer.
 
 ## Path Normalization and Uniqueness
 
@@ -116,6 +125,33 @@ This choice is intentionally local and path-oriented:
 If a workspace moves to a different path, that is a different watched
 workspace under this initial contract. The first contract does not attempt to
 preserve identity across path moves.
+
+## Dashboard Route Key
+
+The dashboard may expose watched workspaces through a route family such as:
+
+- `/workspace/<workspace_key>`
+
+For v1, `workspace_key` is a read-time derived value, not a persisted
+watchlist field.
+
+Contract:
+
+- the route key must be derived deterministically from canonical
+  `workspace_path`
+- the route key must be opaque enough that the dashboard does not need to
+  expose raw absolute paths in URLs
+- the watchlist file must not grow a separate persisted route-only
+  `workspace_id` field for this first slice
+- readers must be able to resolve `workspace_key` back to a watched workspace
+  by rereading the current watchlist and deriving keys again from canonical
+  `workspace_path`
+- if a reader encounters a route-key collision, it must surface an explicit
+  error rather than silently choosing one workspace
+
+The exact derivation algorithm is an implementation detail for later work so
+long as it remains deterministic for the same canonical `workspace_path`
+within a given implementation revision.
 
 ## Missing or Unreadable Workspaces
 
@@ -168,11 +204,13 @@ Derived at read time:
 
 - repository root or top-level path
 - local repository-family grouping key
+- dashboard route key derived from canonical `workspace_path`
 - branch name
 - whether the workspace is the repository's primary checkout or a linked
   worktree
-- whether a watched workspace currently presents as `active`, `completed`, or
-  `missing`
+- whether a watched workspace currently presents as `active`, `completed`,
+  `missing`, or another explicit degraded read-time state such as
+  `unreadable`
 - live harness status or dashboard summary fields
 
 The contract prefers deriving these facts from the current filesystem and Git
@@ -207,6 +245,7 @@ At minimum, later read-model and UI work may classify a watched workspace as:
 - `active`
 - `completed`
 - `missing`
+- `unreadable`
 
 These are read-time states for currently watched entries, not membership
 transitions stored in the watchlist file.
@@ -218,6 +257,8 @@ In particular:
 - deleting the local directory does not remove the workspace from the
   watchlist by itself; it instead becomes a `missing` watched workspace until
   the user explicitly unwatches it
+- a permissions or probe failure may surface as `unreadable` without removing
+  the workspace from the watchlist
 
 ## No Automatic GC In V1
 
@@ -231,6 +272,18 @@ Later work may add user-facing cleanup or stale-item policies, but v1 should
 not silently discard watched entries just because they have gone idle,
 unreadable, or missing.
 
+## Dashboard Routing Outcomes
+
+For dashboard workspace-detail routing:
+
+- a watched workspace that is now `missing` or `unreadable` should still
+  resolve to an explicit degraded workspace page rather than being silently
+  dropped or redirected away
+- a route key that does not match any current watched workspace should be
+  treated as "not currently watched"
+- the first dashboard slice does not need extra watchlist history state just
+  to distinguish "never watched" from "used to be watched and later unwatched"
+
 ## Write Expectations
 
 This spec does not define which command writes the watchlist, but any future
@@ -242,6 +295,8 @@ writer must preserve basic local integrity expectations:
 - rewriting an existing watched record should preserve `watched_at`
 - rewriting an existing watched record may refresh `last_seen_at` when the
   watchlist-touching command successfully confirms the workspace
+- major harness commands should refresh `last_seen_at` through one shared
+  watchlist writer rather than ad hoc per-command file mutation paths
 - persistence should use crash-safe replacement rather than partial in-place
   writes when the file is rewritten
 - concurrent write paths must avoid last-writer-wins corruption that would


### PR DESCRIPTION
## Summary
- define `harness dashboard` as the explicit 0.3.0 UI entrypoint and deprecate `harness ui` through 0.3.x
- record `/dashboard` and `/workspace/<workspace_key>` semantics while reusing the existing single-workspace workbench model
- extend the watchlist contract with `last_seen_at` recency, route-key derivation, degraded workspace routing, and `Unwatch` cleanup boundaries

## Testing
- harness plan lint docs/plans/archived/2026-04-19-define-dashboard-entrypoint-and-migration-architecture.md
- git diff --check

Closes #163
