### PR TITLE
Add machine-local watchlist touch foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ harness ui
 UI for human steering: the place to inspect the current plan, workflow status,
 and execution summaries without reconstructing the story from shell history.
 
+Machine-local easyharness watchlist data defaults under `~/.easyharness`. Set
+`EASYHARNESS_HOME` to override that root when you want `watchlist.json` to
+live somewhere else on the current machine. Absolute values are used as-is;
+relative values are anchored under your home directory, and escaping relative
+paths such as `../escape` are rejected.
+
 ## Stability
 
 `easyharness` is evolving quickly, and breaking changes may happen between

--- a/docs/plans/archived/2026-04-19-add-machine-local-watchlist-touch-foundation.md
+++ b/docs/plans/archived/2026-04-19-add-machine-local-watchlist-touch-foundation.md
@@ -1,0 +1,435 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-19T21:40:36+08:00"
+approved_at: "2026-04-19T21:41:50+08:00"
+source_type: direct_request
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/164
+size: M
+---
+
+# Add machine-local watchlist touch foundation
+
+## Goal
+
+Add the first machine-local watchlist write path so successful core harness
+workflow commands can silently register or refresh the current workspace
+without changing their user-facing output semantics. The implementation should
+make the watchlist a best-effort dashboard/index side effect rather than a new
+workflow control-plane dependency.
+
+This slice should keep the persisted watchlist shape small and stable for the
+first dashboard foundation. Use a single `watchlist.json` index under an
+easyharness home directory, support an `EASYHARNESS_HOME` override for that
+root, and defer any future per-workspace directory layer until the dashboard
+actually needs richer workspace-local data.
+
+## Scope
+
+### In Scope
+
+- Add a shared machine-local watchlist writer that persists the current
+  workspace in `watchlist.json` under `EASYHARNESS_HOME` when set or
+  `~/.easyharness` by default.
+- Normalize the current workspace path before duplicate detection and store one
+  record per canonical workspace path with stable `watched_at` plus refreshed
+  `last_seen_at`.
+- Make watchlist touch a best-effort side effect of successful core workflow
+  services rather than a command-name allowlist or low-level file-access hook.
+- Treat `harness status`, lifecycle commands, review commands, and evidence
+  submit as the initial core workflow surfaces that confirm the current
+  workspace locally.
+- Keep `harness ui`, bootstrap/resource commands, `harness plan template`,
+  `harness plan lint`, `--version`, and help paths out of the touch flow.
+- Update the watchlist spec and README anywhere the new home-directory
+  override or best-effort writer semantics become part of the public contract.
+- Add focused tests for path normalization, record convergence, concurrent-safe
+  rewrite behavior, core-versus-non-core command boundaries, and non-fatal
+  watchlist write failures.
+
+### Out of Scope
+
+- Introducing persisted `workspace_key` fields or a `workspaces/<key>/`
+  directory layer in this slice.
+- Building `harness dashboard`, changing `harness ui` routing, or adding UI
+  write actions such as `Unwatch`.
+- Adding watchlist touch to non-core utility/bootstrap commands just because
+  they run in a repository.
+- Treating watchlist persistence failures as command failures or surfacing new
+  banners/prompts in ordinary command output.
+
+## Acceptance Criteria
+
+- [x] Successful completion of core workflow services silently registers or
+      refreshes the current workspace in machine-local `watchlist.json`.
+- [x] Repeated touch of the same canonical workspace path converges to one
+      record, preserves `watched_at`, and may refresh `last_seen_at`.
+- [x] The watchlist root resolves from `EASYHARNESS_HOME` when set and falls
+      back to `~/.easyharness` otherwise; the config surface is documented in
+      the README and any affected spec text.
+- [x] `harness status` still registers idle workspaces, while `harness ui`,
+      `harness plan lint`, bootstrap/resource commands, `--version`, and help
+      do not touch the watchlist.
+- [x] Watchlist rewrites are crash-safe and do not silently drop unrelated
+      workspace records during ordinary concurrent use.
+- [x] Watchlist write failures are treated as best-effort side effects: the
+      primary command still succeeds and preserves its existing output/exit
+      semantics.
+- [x] The tracked plan and tests make the future two-layer direction explicit
+      as deferred work, without prematurely persisting workspace keys.
+
+## Deferred Items
+
+- Add a future per-workspace local data layer such as
+  `~/.easyharness/workspaces/<derived-key>/` if the dashboard later needs
+  richer workspace-local caches or remote-signal materialization.
+- Add explicit `unwatch` behavior, degraded-route cleanup actions, or any
+  archive/GC policy for unwatched workspaces.
+- Revisit whether future dashboard routing should persist a workspace key once
+  the read-time route-key contract and any per-workspace storage layer are
+  ready to converge together.
+
+## Work Breakdown
+
+### Step 1: Define the watchlist storage and configuration contract
+
+- Done: [x]
+
+#### Objective
+
+Lock the v1 watchlist foundation around one machine-local `watchlist.json`
+index plus an overridable easyharness home root, without expanding into a
+persisted workspace-key or per-workspace directory contract yet.
+
+#### Details
+
+Update the normative watchlist contract to describe the default home root plus
+`EASYHARNESS_HOME` override, clarify that repeated touch converges on one
+canonical workspace record while preserving `watched_at`, and make best-effort
+touch semantics explicit where the command-trigger language becomes normative.
+Keep the file shape minimal: `version`, `workspace_path`, `watched_at`, and
+`last_seen_at`.
+
+The README should explain the environment variable only as a configuration
+surface for the machine-local easyharness home root; it should not imply that
+dashboard or workspace-local storage is already broader than this slice.
+
+#### Expected Files
+
+- `docs/specs/watchlist-contract.md`
+- `README.md`
+
+#### Validation
+
+- A cold reader can tell where `watchlist.json` lives by default, how
+  `EASYHARNESS_HOME` overrides that root, and that v1 still persists only the
+  single-file watchlist index.
+- The contract language matches the accepted direction: no persisted
+  `workspace_key`, no per-workspace folder yet, and watchlist touch is
+  best-effort.
+
+#### Execution Notes
+
+Updated `docs/specs/watchlist-contract.md` so the storage root now supports
+`EASYHARNESS_HOME` with `~/.easyharness` as the default, repeated touch is
+described as canonical-path convergence plus `last_seen_at` refresh, and
+watchlist persistence is explicitly documented as a best-effort side effect
+for successful core workflow commands. Updated `README.md` with the new
+machine-local home override note without overclaiming that a per-workspace data
+layer already exists.
+
+#### Review Notes
+
+PASSED after `review-001-full` requested changes on duplicate convergence and
+command-boundary coverage, `review-002-delta` passed correctness but left one
+remaining tests gap on excluded-surface coverage, and `review-003-delta`
+passed after the final CLI no-touch matrix repair.
+
+### Step 2: Add a shared best-effort watchlist writer
+
+- Done: [x]
+
+#### Objective
+
+Implement one shared watchlist persistence path that can register or refresh
+the current workspace safely without changing the behavior of core workflow
+commands when the local watchlist write fails.
+
+#### Details
+
+Add a small machine-local watchlist package that resolves the easyharness home
+root, normalizes the current workspace path, loads the current watchlist,
+converges duplicate registration on the canonical path, preserves
+`watched_at`, refreshes `last_seen_at`, and rewrites the file with crash-safe
+replacement. The writer should coordinate concurrent writes so one command does
+not silently lose another workspace record.
+
+The API should make it easy for callers to treat touch as best-effort. Prefer
+returning an error that the caller may intentionally suppress rather than
+mixing watchlist failures into lifecycle/review/evidence/status result
+contracts.
+
+#### Expected Files
+
+- new watchlist package under `internal/`
+- any shared atomic-write or lock helpers that need a narrow extension
+- focused tests for watchlist persistence behavior
+
+#### Validation
+
+- Tests cover default-root resolution, `EASYHARNESS_HOME` override, path
+  convergence, `watched_at` preservation, `last_seen_at` refresh, and
+  concurrent-safe rewrite behavior.
+- A simulated watchlist write failure can be observed by the caller without
+  forcing the watchlist package itself to own command-level rollback behavior.
+
+#### Execution Notes
+
+Added `internal/watchlist` with an overridable home-root resolver, canonical
+workspace-path normalization via absolute-path plus symlink resolution, one
+record per canonical path, stable `watched_at`, refreshed `last_seen_at`,
+crash-safe atomic rewrite, and a serialized lock file under the easyharness
+home root. Focused tests cover the default root, `EASYHARNESS_HOME` override,
+canonical path convergence, repeated touch semantics, concurrent writes that
+preserve unrelated workspace records, and non-adjacent duplicate-record
+coalescing after the first review round surfaced a merge bug. Finalize repair
+after `review-007-full` tightened the watched path to the git workspace root
+instead of an arbitrary successful command cwd, and the package now returns a
+non-git sentinel when a caller points it at a directory outside any checkout.
+After `review-009-full` found that a fake `.git` marker could still slip
+through, the writer now resolves the workspace root through
+`git rev-parse --show-toplevel` so only real git-backed checkouts qualify for
+registration. After `review-013-full`, the writer also resolves relative
+`EASYHARNESS_HOME` overrides under the user's home directory so one override
+value still points at one stable machine-local root instead of fragmenting by
+caller cwd. Follow-up delta repair now also rejects parent-directory forms
+such as `../escape` so a relative override cannot silently walk back out of
+the user-home anchor.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 shipped as part of the same integrated watchlist
+foundation slice that Step 1 review already examined broadly, including the
+writer implementation and its regression tests.
+
+### Step 3: Hook core workflow services without command-shape heuristics
+
+- Done: [x]
+
+#### Objective
+
+Touch the watchlist only when a core workflow service successfully confirms the
+current workspace, while keeping non-core commands and `harness ui` outside the
+flow.
+
+#### Details
+
+Wire a shared best-effort touch callback into the existing service-success
+boundaries instead of matching on command names or guessing from result JSON
+shapes. Use the existing lifecycle/review/evidence post-success hooks where
+available, and extend `status` with a similarly narrow success hook so idle
+status reads still register the workspace.
+
+Do not add touch behavior in low-level runstate or UI read paths. `harness ui`
+must remain excluded even though it reads workspace state, so dashboard/UI
+polling cannot inflate recency.
+
+#### Expected Files
+
+- `internal/cli/app.go`
+- `internal/status/service.go`
+- `internal/lifecycle/service.go`
+- `internal/review/service.go`
+- `internal/evidence/service.go`
+- command/service tests that pin core versus non-core behavior
+
+#### Validation
+
+- Successful `status`, lifecycle, review, and evidence flows touch the
+  watchlist.
+- `harness ui`, `harness plan lint`, bootstrap/resource commands, `--version`,
+  and help do not.
+- Watchlist touch failures do not change command JSON payloads or exit codes on
+  otherwise successful commands.
+
+#### Execution Notes
+
+Added success-only best-effort callbacks to `status`, `lifecycle`, `review`,
+and `evidence` services so watchlist touch can run after the existing strict
+timeline hooks without changing command failure behavior. `internal/cli/app.go`
+now wires those callbacks through one shared watchlist toucher using the
+current workdir plus injected env/home resolvers. Non-core commands remain
+untouched because they never receive the new success callback. Added CLI tests
+that prove idle `harness status` creates a watchlist record, `harness plan
+lint` does not, and a watchlist home-resolution failure still leaves `status`
+successful. Follow-up delta repairs expanded the CLI matrix so `plan template`,
+`skills install --dry-run`, `--version`, root help, `init --dry-run`, and
+`ui --help` are all pinned as no-touch surfaces, while lifecycle, review, and
+evidence families each have positive touch coverage. Finalize repair after
+`review-007-full` moved the best-effort touch trigger into one shared
+successful-result postprocessor in `internal/cli/app.go`, which keeps the
+core-service boundary intact while removing repeated per-entrypoint callback
+plumbing. After `review-009-full`, the CLI regression matrix now also pins
+watchlist registration for `plan approve`, `archive`, `land`, `land complete`,
+and both `reopen` modes so the centralized lifecycle route stays explicit in
+tests rather than relying on one representative command. The last repair also
+adds linked git worktree coverage plus a real `/api/status` UI no-touch test
+so the core workflow contract is pinned for both accepted workspace forms and
+the excluded steering surface. Follow-up repair broadens that UI coverage
+across `/api/status`, `/api/plan`, `/api/review`, `/api/timeline`, `/`, and
+normal `harness ui` startup so the entire excluded steering surface is pinned
+against accidental watchlist writes.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 3 was not an independently reviewable slice; the
+same integrated Step 1 review boundary covered the service-hook wiring and CLI
+command-boundary behavior together with the storage contract changes.
+
+### Step 4: Prove the contract with focused command and documentation coverage
+
+- Done: [x]
+
+#### Objective
+
+Close the slice with repository-visible proof that the watchlist foundation is
+ durable, non-invasive, and understandable without discovery chat.
+
+#### Details
+
+Add or update focused tests around the watchlist package plus CLI/service
+boundaries, and run the relevant Go test targets that exercise the new
+best-effort behavior. Validation should prove the command-success path for
+status and at least one representative lifecycle/review/evidence command, plus
+the exclusion path for `harness ui` or another non-core command.
+
+Make sure the final tracked docs explain the new home-root override and do not
+overclaim that the per-workspace storage layer already exists.
+
+#### Expected Files
+
+- watchlist package tests
+- affected service or CLI tests
+- `README.md`
+- `docs/specs/watchlist-contract.md`
+- `docs/plans/active/2026-04-19-add-machine-local-watchlist-touch-foundation.md`
+
+#### Validation
+
+- Focused Go tests for the watchlist package and affected command/service
+  boundaries pass.
+- `harness plan lint` passes on this tracked plan.
+- A future agent could execute the slice from this plan alone and understand
+  both the current single-file contract and the deferred two-layer direction.
+
+#### Execution Notes
+
+Validated the slice with `go test ./internal/watchlist ./internal/cli
+./internal/status ./internal/lifecycle ./internal/review ./internal/evidence
+-count=1` and `go test ./... -count=1`. Also re-ran `harness status` as a
+controller checkpoint after implementation to confirm the tracked plan still
+resolves cleanly before review orchestration. After `review-007-full`
+requested changes, added focused CLI coverage for non-git `status` no-touch
+behavior and upgraded the review command fixture to use a real git repository
+anchor before rerunning `go test ./internal/watchlist ./internal/cli
+./internal/status ./internal/lifecycle ./internal/review ./internal/evidence
+-count=1`. After `review-009-full`, replaced fake git markers in the watchlist
+and CLI fixtures with real initialized repositories, added explicit lifecycle
+watchlist assertions for the remaining routed commands, and reran the same
+focused Go test set to confirm the repair.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 4 is repository-level validation and closeout
+proof for the integrated slice rather than a separate behavior surface, so it
+rides on the Step 1 review boundary plus the recorded validation commands.
+
+## Validation Strategy
+
+- Use focused Go tests for the new watchlist package and the affected CLI or
+  service boundaries instead of relying only on manual command runs.
+- Re-run the most relevant package-level tests for `status`, `lifecycle`,
+  `review`, and `evidence` wherever the watchlist-success hooks land.
+- Lint the tracked plan before asking for approval.
+
+## Risks
+
+- Risk: Path canonicalization or concurrent rewrite logic could still allow
+  duplicate or lost records under real-world local usage.
+  - Mitigation: Centralize normalization and rewrite behavior in one shared
+    package with focused concurrency/duplicate tests instead of scattering file
+    mutation across commands.
+- Risk: Hooking touch at the wrong layer could accidentally include `harness ui`
+  or utility commands, or could turn watchlist failures into workflow
+  failures.
+  - Mitigation: Wire touch only at explicit core-service success boundaries and
+    pin exclusion/non-fatal behavior in tests.
+- Risk: Introducing `EASYHARNESS_HOME` could drift from docs or imply broader
+  storage semantics than this slice actually implements.
+  - Mitigation: Update the spec and README in the same slice and state
+    explicitly that v1 still persists only `watchlist.json`.
+
+## Validation Summary
+
+- `harness plan lint docs/plans/active/2026-04-19-add-machine-local-watchlist-touch-foundation.md` passes after the final closeout notes.
+- Focused suites pass for the touched surfaces, including
+  `go test ./internal/watchlist ./internal/cli ./internal/status ./internal/lifecycle ./internal/review ./internal/evidence ./internal/ui -count=1`.
+- Full repository validation passes with `go test ./... -count=1`.
+- Targeted regressions now cover linked git worktrees, stable and rejected
+  relative `EASYHARNESS_HOME` overrides, lifecycle command touch routes, and
+  the excluded `harness ui` steering surface.
+
+## Review Summary
+
+- The candidate closed with a clean finalize full review in `review-019-full`.
+- Earlier finalize rounds surfaced and repaired: duplicate-record merge
+  convergence, missing no-touch and failure-path coverage, non-git workspace
+  registration, incomplete lifecycle/UI coverage, fake `.git` acceptance,
+  relative-home fragmentation/escape behavior, and README/spec drift around
+  `EASYHARNESS_HOME`.
+- Final reviewer consensus is that the watchlist writer, CLI touch routing,
+  docs contract, and excluded UI surface now align with the accepted slice.
+
+## Archive Summary
+
+- Archived At: 2026-04-19T23:01:18+08:00
+- Revision: 1
+- PR: Not created yet; publish handoff after archive should push the branch and
+  open or refresh the PR before evidence submission.
+- Ready: Acceptance criteria are satisfied, finalize full review
+  `review-019-full` passed cleanly, and local validation covers the writer,
+  CLI/service boundaries, linked worktrees, and excluded UI surfaces.
+- Merge Handoff: Run `harness archive`, commit the tracked archive move plus
+  these closeout notes, push the branch, open/update the PR, record publish/CI/
+  sync evidence, and stop once `harness status` reaches
+  `execution/finalize/await_merge`.
+
+## Outcome Summary
+
+### Delivered
+
+- Added a shared machine-local watchlist writer under `internal/watchlist`
+  with crash-safe rewrite, duplicate convergence, stable `watched_at`,
+  refreshed `last_seen_at`, and canonical git-backed workspace-root
+  registration.
+- Routed best-effort watchlist touching through successful core workflow
+  results for status, lifecycle, review, and evidence commands without
+  changing their existing output/exit behavior.
+- Documented `EASYHARNESS_HOME` plus the final contract for absolute and
+  relative overrides, and pinned the excluded `harness ui` surface so read-only
+  steering paths do not refresh recency.
+
+### Not Delivered
+
+- No per-workspace `workspaces/<derived-key>/` storage layer, persisted
+  workspace key, explicit `unwatch`, or archive/GC flow was added in this
+  slice.
+- No dashboard write actions or broader `harness ui` behavior changes were
+  introduced beyond protecting the existing read-only surface from watchlist
+  writes.
+
+### Follow-Up Issues
+
+- No GitHub follow-up issue was created during this slice. Deferred follow-up
+  remains captured in `## Deferred Items`: future per-workspace local data,
+  explicit membership-removal behavior, and any later route-key persistence.

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -39,6 +39,16 @@ The watchlist file lives at:
 
 - `~/.easyharness/watchlist.json`
 
+If `EASYHARNESS_HOME` is set to a non-empty path:
+
+- an absolute value places the watchlist at
+  `$EASYHARNESS_HOME/watchlist.json`
+- a relative value is resolved under the current user's home directory before
+  writing, so `relative-home` means
+  `~/relative-home/watchlist.json`
+- a relative value that would escape above the user's home directory, such as
+  `../escape`, is invalid and must be rejected
+
 This location is machine-local and user-private. It is not a repository-shared
 artifact and must not be written into the repository itself.
 
@@ -86,12 +96,12 @@ The minimal persisted workspace record is intentionally small:
 This contract does not require any additional persisted per-workspace fields in
 the first slice.
 
-Major harness commands that successfully confirm the current workspace locally
-may refresh `last_seen_at`, not just explicit watchlist-management commands.
-The exact command list is an implementation detail, but the intended shape for
-the dashboard is that routine successful commands such as `harness status`,
-`harness plan lint`, or `harness review start` can keep the recency signal
-fresh when they pass through one shared watchlist writer.
+Successful core harness workflow commands may refresh `last_seen_at`, not just
+explicit watchlist-management commands. The exact command list is an
+implementation detail, but the intended shape for the dashboard is that
+routine successful workflow confirmations such as `harness status`,
+`harness review start`, or lifecycle/evidence commands can keep the recency
+signal fresh when they pass through one shared watchlist writer.
 
 ## Path Normalization and Uniqueness
 
@@ -108,7 +118,9 @@ This spec intentionally does not fix every platform-specific normalization
 detail yet. Later implementation may need to clarify symlink or case-folding
 rules per platform, but it must still preserve one clear rule: repeated
 registration of the same local workspace must converge on one canonical
-`workspace_path` record rather than creating duplicates.
+`workspace_path` record rather than creating duplicates. Repeated touch of the
+same workspace may refresh `last_seen_at`, but it should preserve the original
+`watched_at`.
 
 ## Identity Model
 
@@ -164,8 +176,8 @@ If a previously watched `workspace_path` later becomes:
 - unreadable
 - no longer a valid Git-backed workspace
 
-the watchlist record should remain present until a later local lifecycle action
-explicitly unwatches it.
+the watchlist record should remain present until later explicit
+membership-removal behavior exists and removes it.
 
 Read-model and UI layers should surface those entries as explicit degraded
 states rather than silently dropping them from the watched set.
@@ -221,19 +233,13 @@ state instead of persisting copies that can drift.
 Watchlist membership is binary in this first contract:
 
 - a workspace is watched because a record exists in `watchlist.json`
-- a workspace stops being watched only through `unwatch`, which removes that
-  record from the watchlist
+- this touch-foundation slice does not yet define a membership-removal command
 
 This contract does not define a separate dashboard-local `hidden` state.
 
-The first contract keeps one explicit user-controlled action:
-
-- `unwatch`
-  - remove the watched workspace record from `watchlist.json`
-  - stop including that workspace in the watched set and dashboard read model
-
-If a later command such as `harness status` re-registers the same workspace,
-that creates a new watched record again under the ordinary watchlist rules.
+Future work may add an explicit local action such as `unwatch` to remove a
+workspace record from `watchlist.json`, but that user-facing removal path is
+deferred beyond this machine-local touch foundation.
 
 ## Derived Lifecycle States
 
@@ -256,7 +262,7 @@ In particular:
   the workspace from the watchlist
 - deleting the local directory does not remove the workspace from the
   watchlist by itself; it instead becomes a `missing` watched workspace until
-  the user explicitly unwatches it
+  later explicit membership-removal behavior exists and removes it
 - a permissions or probe failure may surface as `unreadable` without removing
   the workspace from the watchlist
 
@@ -266,7 +272,8 @@ This first contract does not define silent automatic garbage collection.
 
 The watchlist is a remembered local set, not an auto-pruned mirror of the
 current filesystem. The combination of `last_seen_at`, derived `missing`
-status, and explicit `unwatch` is enough for the first slice.
+status, and deferred explicit membership-removal behavior is enough for this
+touch-foundation slice.
 
 Later work may add user-facing cleanup or stale-item policies, but v1 should
 not silently discard watched entries just because they have gone idle,
@@ -295,12 +302,17 @@ writer must preserve basic local integrity expectations:
 - rewriting an existing watched record should preserve `watched_at`
 - rewriting an existing watched record may refresh `last_seen_at` when the
   watchlist-touching command successfully confirms the workspace
-- major harness commands should refresh `last_seen_at` through one shared
-  watchlist writer rather than ad hoc per-command file mutation paths
+- major core workflow commands should refresh `last_seen_at` through one
+  shared watchlist writer rather than ad hoc per-command file mutation paths
 - persistence should use crash-safe replacement rather than partial in-place
   writes when the file is rewritten
 - concurrent write paths must avoid last-writer-wins corruption that would
   lose another workspace record
+
+Because the watchlist is a machine-local dashboard/index aid rather than the
+workflow control plane, watchlist persistence should be treated as a
+best-effort side effect. A watchlist write failure should not by itself change
+the success/failure result of an otherwise successful core workflow command.
 
 The exact file-locking or mutation-coordination mechanism is an implementation
 detail for later work, but these integrity expectations are part of the

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -22,25 +22,30 @@ import (
 	"github.com/catu-ai/easyharness/internal/status"
 	"github.com/catu-ai/easyharness/internal/ui"
 	versioninfo "github.com/catu-ai/easyharness/internal/version"
+	"github.com/catu-ai/easyharness/internal/watchlist"
 )
 
 type App struct {
-	Stdout  io.Writer
-	Stderr  io.Writer
-	Stdin   io.Reader
-	Now     func() time.Time
-	Getwd   func() (string, error)
-	Version func() versioninfo.Info
+	Stdout      io.Writer
+	Stderr      io.Writer
+	Stdin       io.Reader
+	Now         func() time.Time
+	Getwd       func() (string, error)
+	LookupEnv   func(string) (string, bool)
+	UserHomeDir func() (string, error)
+	Version     func() versioninfo.Info
 }
 
 func New(stdout, stderr io.Writer) *App {
 	return &App{
-		Stdout:  stdout,
-		Stderr:  stderr,
-		Stdin:   os.Stdin,
-		Now:     time.Now,
-		Getwd:   os.Getwd,
-		Version: versioninfo.Current,
+		Stdout:      stdout,
+		Stderr:      stderr,
+		Stdin:       os.Stdin,
+		Now:         time.Now,
+		Getwd:       os.Getwd,
+		LookupEnv:   os.LookupEnv,
+		UserHomeDir: os.UserHomeDir,
+		Version:     versioninfo.Current,
 	}
 }
 
@@ -263,7 +268,7 @@ func (a *App) runEvidenceSubmit(args []string) int {
 			"input": json.RawMessage(inputBytes),
 		}),
 	}.Submit(*kind, inputBytes)
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runLandEntry(args []string) int {
@@ -301,7 +306,7 @@ func (a *App) runLandEntry(args []string) int {
 			"commit": strings.TrimSpace(*commit),
 		}),
 	}.Land(*prURL, *commit)
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runInit(args []string) int {
@@ -682,7 +687,7 @@ func (a *App) runPlanApprove(args []string) int {
 			"by": strings.TrimSpace(*by),
 		}),
 	}.PlanApprove(*by)
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runStatus(args []string) int {
@@ -711,16 +716,7 @@ func (a *App) runStatus(args []string) int {
 	}
 
 	result := status.Service{Workdir: workdir}.Read()
-	encoder := json.NewEncoder(a.Stdout)
-	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(result); err != nil {
-		fmt.Fprintf(a.Stderr, "encode status result: %v\n", err)
-		return 1
-	}
-	if result.OK {
-		return 0
-	}
-	return 1
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runReviewStart(args []string) int {
@@ -761,7 +757,7 @@ func (a *App) runReviewStart(args []string) int {
 		Now:        a.Now,
 		AfterStart: reviewStartTimelineHook(workdir, beforeStatus, recordedAt, specBytes),
 	}.Start(specBytes)
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runReviewSubmit(args []string) int {
@@ -806,7 +802,7 @@ func (a *App) runReviewSubmit(args []string) int {
 			"input": json.RawMessage(inputBytes),
 		}),
 	}.Submit(*roundID, *slot, *by, inputBytes)
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runReviewAggregate(args []string) int {
@@ -840,7 +836,7 @@ func (a *App) runReviewAggregate(args []string) int {
 		Now:            a.Now,
 		AfterAggregate: reviewAggregateTimelineHook(workdir, beforeStatus, recordedAt, map[string]any{"round_id": *roundID}),
 	}.Aggregate(*roundID)
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runExecuteStart(args []string) int {
@@ -873,7 +869,7 @@ func (a *App) runExecuteStart(args []string) int {
 		Now:           a.Now,
 		AfterMutation: lifecycleTimelineHook(workdir, beforeStatus, recordedAt, nil),
 	}.ExecuteStart()
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runLandComplete(args []string) int {
@@ -906,7 +902,7 @@ func (a *App) runLandComplete(args []string) int {
 		Now:           a.Now,
 		AfterMutation: lifecycleTimelineHook(workdir, beforeStatus, recordedAt, nil),
 	}.LandComplete()
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runArchive(args []string) int {
@@ -939,7 +935,7 @@ func (a *App) runArchive(args []string) int {
 		Now:           a.Now,
 		AfterMutation: lifecycleTimelineHook(workdir, beforeStatus, recordedAt, nil),
 	}.Archive()
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) runReopen(args []string) int {
@@ -973,7 +969,7 @@ func (a *App) runReopen(args []string) int {
 		Now:           a.Now,
 		AfterMutation: lifecycleTimelineHook(workdir, beforeStatus, recordedAt, map[string]any{"mode": *mode}),
 	}.Reopen(*mode)
-	return a.writeJSONResult(result)
+	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
 func (a *App) resolveTimestamp(timestampValue, dateValue string) (time.Time, error) {
@@ -1090,6 +1086,23 @@ func (f *stringListFlag) Set(value string) error {
 	return nil
 }
 
+func (a *App) touchWatchlist(workdir string) {
+	service := watchlist.Service{
+		LookupEnv:   a.LookupEnv,
+		UserHomeDir: a.UserHomeDir,
+		Now:         a.Now,
+	}
+	_ = service.Touch(workdir)
+}
+
+func (a *App) writeJSONResultForWorkdir(workdir string, value any) int {
+	exitCode := a.writeJSONResult(value)
+	if exitCode == 0 && watchlistTouchEnabled(value) {
+		a.touchWatchlist(workdir)
+	}
+	return exitCode
+}
+
 func (a *App) readInput(path string) ([]byte, error) {
 	if strings.TrimSpace(path) != "" {
 		return os.ReadFile(path)
@@ -1143,4 +1156,13 @@ func (a *App) writeJSONResult(value any) int {
 		}
 	}
 	return 1
+}
+
+func watchlistTouchEnabled(value any) bool {
+	switch value.(type) {
+	case evidence.Result, lifecycle.Result, review.AggregateResult, review.StartResult, review.SubmitResult, status.Result:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -89,6 +90,23 @@ func TestPlanTemplateSizeFlagSeedsExplicitSize(t *testing.T) {
 	if !strings.Contains(stdout.String(), "size: XL") {
 		t.Fatalf("expected explicit size in template, got:\n%s", stdout.String())
 	}
+}
+
+func TestPlanTemplateDoesNotTouchWatchlist(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	home := t.TempDir()
+	app.UserHomeDir = func() (string, error) { return home, nil }
+
+	exitCode := app.Run([]string{
+		"plan", "template",
+		"--title", "Watchlist Exclusion",
+	})
+	if exitCode != 0 {
+		t.Fatalf("plan template failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistAbsent(t, home)
 }
 
 func TestVersionFlagPrintsJSONBuildInfo(t *testing.T) {
@@ -361,7 +379,9 @@ func TestInstructionsInstallCommandWritesManagedAssets(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	app := cli.New(stdout, stderr)
 	root := t.TempDir()
+	home := t.TempDir()
 	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
 
 	exitCode := app.Run([]string{"instructions", "install"})
 	if exitCode != 0 {
@@ -378,6 +398,7 @@ func TestInstructionsInstallCommandWritesManagedAssets(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(root, "AGENTS.md")); err != nil {
 		t.Fatalf("expected AGENTS.md to be written: %v", err)
 	}
+	assertWatchlistAbsent(t, home)
 }
 
 func TestSkillsCommandRejectsInvalidScope(t *testing.T) {
@@ -472,12 +493,219 @@ func TestStatusCommandReturnsJSON(t *testing.T) {
 	}
 }
 
+func TestStatusCommandTouchesWatchlistForIdleWorkspace(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
+	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 15, 0, 0, 0, time.UTC)
+	}
+
+	exitCode := app.Run([]string{"status"})
+	if exitCode != 0 {
+		t.Fatalf("status command failed with %d: %s", exitCode, stderr.String())
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".easyharness", "watchlist.json"))
+	if err != nil {
+		t.Fatalf("expected watchlist file after status, err=%v", err)
+	}
+	var payload struct {
+		Workspaces []struct {
+			WorkspacePath string `json:"workspace_path"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decode watchlist: %v\n%s", err, data)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve canonical workspace: %v", err)
+	}
+	if len(payload.Workspaces) != 1 || payload.Workspaces[0].WorkspacePath != canonicalRoot {
+		t.Fatalf("unexpected watchlist payload: %#v", payload)
+	}
+}
+
+func TestStatusCommandTouchesWatchlistForIdleLinkedWorktree(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	repoRoot := filepath.Join(t.TempDir(), "workspace")
+	home := t.TempDir()
+	initGitRepoWithCommit(t, repoRoot)
+	linked := filepath.Join(t.TempDir(), "linked-worktree")
+	runGit(t, repoRoot, "worktree", "add", "-b", "linked-status-branch", linked, "HEAD")
+	app.Getwd = func() (string, error) { return linked, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 15, 5, 0, 0, time.UTC)
+	}
+
+	exitCode := app.Run([]string{"status"})
+	if exitCode != 0 {
+		t.Fatalf("status command failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistContainsWorkspace(t, home, linked)
+}
+
+func TestStatusCommandDoesNotTouchWatchlistOutsideGitWorkspace(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	home := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
+
+	exitCode := app.Run([]string{"status"})
+	if exitCode != 0 {
+		t.Fatalf("status command failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistAbsent(t, home)
+}
+
+func TestPlanLintDoesNotTouchWatchlist(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	home := t.TempDir()
+	app.UserHomeDir = func() (string, error) { return home, nil }
+	outputPath := filepath.Join(t.TempDir(), "docs/plans/active/2026-03-17-test-plan.md")
+
+	if exitCode := app.Run([]string{
+		"plan", "template",
+		"--title", "CLI Generated Plan",
+		"--output", outputPath,
+	}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
+	ensurePlanSizeInFile(t, outputPath, "M")
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode := app.Run([]string{"plan", "lint", outputPath})
+	if exitCode != 0 {
+		t.Fatalf("lint command failed with %d: %s", exitCode, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(home, ".easyharness", "watchlist.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected plan lint to avoid touching watchlist, err=%v", err)
+	}
+}
+
+func TestStatusCommandIgnoresWatchlistWriteFailure(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	seedGitWorkspace(t, root)
+	app.Getwd = func() (string, error) { return root, nil }
+	app.LookupEnv = func(string) (string, bool) { return "", false }
+	app.UserHomeDir = func() (string, error) { return "", errors.New("watchlist-home-boom") }
+
+	exitCode := app.Run([]string{"status"})
+	if exitCode != 0 {
+		t.Fatalf("expected status to succeed despite watchlist failure, got %d: %s", exitCode, stderr.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON status output: %v\n%s", err, stdout.String())
+	}
+	if ok, _ := payload["ok"].(bool); !ok {
+		t.Fatalf("expected status success payload, got %#v", payload)
+	}
+}
+
+func TestVersionCommandDoesNotTouchWatchlist(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	home := t.TempDir()
+	app.UserHomeDir = func() (string, error) { return home, nil }
+
+	exitCode := app.Run([]string{"--version"})
+	if exitCode != 0 {
+		t.Fatalf("version command failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistAbsent(t, home)
+}
+
+func TestHelpDoesNotTouchWatchlist(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	home := t.TempDir()
+	app.UserHomeDir = func() (string, error) { return home, nil }
+
+	exitCode := app.Run([]string{"help"})
+	if exitCode != 0 {
+		t.Fatalf("help command failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistAbsent(t, home)
+}
+
+func TestInitDryRunDoesNotTouchWatchlist(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	home := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
+
+	exitCode := app.Run([]string{"init", "--dry-run"})
+	if exitCode != 0 {
+		t.Fatalf("init --dry-run failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistAbsent(t, home)
+}
+
+func TestSkillsInstallDryRunDoesNotTouchWatchlist(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	home := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
+
+	exitCode := app.Run([]string{"skills", "install", "--dry-run"})
+	if exitCode != 0 {
+		t.Fatalf("skills install --dry-run failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistAbsent(t, home)
+}
+
+func TestUIHelpDoesNotTouchWatchlist(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	home := t.TempDir()
+	app.UserHomeDir = func() (string, error) { return home, nil }
+
+	exitCode := app.Run([]string{"ui", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("ui help failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistAbsent(t, home)
+}
+
 func TestExecuteStartCommandReturnsJSON(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	app := cli.New(stdout, stderr)
 	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
 	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
 	app.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 15, 0, 0, 0, time.FixedZone("CST", 8*60*60))
 	}
@@ -515,6 +743,65 @@ func TestExecuteStartCommandReturnsJSON(t *testing.T) {
 	}
 	if timelineResult.Events[0].Command != "plan" || timelineResult.Events[1].Command != "execute start" {
 		t.Fatalf("unexpected execute-start timeline events: %#v", timelineResult.Events)
+	}
+	assertWatchlistContainsWorkspace(t, home, root)
+}
+
+func TestPlanApproveTouchesWatchlist(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
+	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 14, 55, 0, 0, time.FixedZone("CST", 8*60*60))
+	}
+
+	outputPath := filepath.Join(root, "docs/plans/active/2026-03-18-test-plan.md")
+	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Approve Plan", "--output", outputPath}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	ensurePlanSizeInFile(t, outputPath, "M")
+
+	stdout.Reset()
+	stderr.Reset()
+	if exitCode := app.Run([]string{"plan", "approve", "--by", "human"}); exitCode != 0 {
+		t.Fatalf("plan approve failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistContainsWorkspace(t, home, root)
+}
+
+func TestExecuteStartIgnoresWatchlistWriteFailure(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	seedGitWorkspace(t, root)
+	app.Getwd = func() (string, error) { return root, nil }
+	app.LookupEnv = func(string) (string, bool) { return "", false }
+	app.UserHomeDir = func() (string, error) { return "", errors.New("watchlist-home-boom") }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 15, 0, 0, 0, time.FixedZone("CST", 8*60*60))
+	}
+
+	outputPath := filepath.Join(root, "docs/plans/active/2026-03-18-test-plan.md")
+	if exitCode := app.Run([]string{
+		"plan", "template",
+		"--title", "CLI Generated Plan",
+		"--output", outputPath,
+	}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode := app.Run([]string{"execute", "start"})
+	if exitCode != 0 {
+		t.Fatalf("expected execute start to succeed despite watchlist failure, got %d: %s", exitCode, stderr.String())
 	}
 }
 
@@ -565,7 +852,10 @@ func TestEvidenceSubmitCommandReturnsJSON(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	app := cli.New(stdout, stderr)
 	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
 	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
 	app.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 6, 0, 0, 0, time.UTC)
 	}
@@ -595,6 +885,32 @@ func TestEvidenceSubmitCommandReturnsJSON(t *testing.T) {
 	}
 	if timelineResult.Events[0].Command != "plan" || timelineResult.Events[1].Command != "evidence submit" {
 		t.Fatalf("unexpected evidence timeline events: %#v", timelineResult.Events)
+	}
+	assertWatchlistContainsWorkspace(t, home, root)
+}
+
+func TestEvidenceSubmitIgnoresWatchlistWriteFailure(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	seedGitWorkspace(t, root)
+	app.Getwd = func() (string, error) { return root, nil }
+	app.LookupEnv = func(string) (string, bool) { return "", false }
+	app.UserHomeDir = func() (string, error) { return "", errors.New("watchlist-home-boom") }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 6, 0, 0, 0, time.UTC)
+	}
+
+	writeArchivedPlanForCLI(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	app.Stdin = bytes.NewBufferString(`{"status":"success","provider":"github-actions"}`)
+	exitCode := app.Run([]string{"evidence", "submit", "--kind", "ci"})
+	if exitCode != 0 {
+		t.Fatalf("expected evidence submit to succeed despite watchlist failure, got %d: %s", exitCode, stderr.String())
 	}
 }
 
@@ -682,6 +998,91 @@ func TestReviewStartCommandAppendsTimelineEvent(t *testing.T) {
 	last := timelineResult.Events[len(timelineResult.Events)-1]
 	if last.Command != "review start" {
 		t.Fatalf("unexpected review-start timeline event: %#v", last)
+	}
+}
+
+func TestReviewCommandsTouchWatchlist(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	home := t.TempDir()
+	anchor := initGitRepoWithCommit(t, root)
+	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 15, 0, 0, 0, time.FixedZone("CST", 8*60*60))
+	}
+
+	outputPath := filepath.Join(root, "docs/plans/active/2026-03-18-test-plan.md")
+	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Review Touch Plan", "--output", outputPath}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
+	if exitCode := app.Run([]string{"execute", "start"}); exitCode != 0 {
+		t.Fatalf("execute start failed with %d: %s", exitCode, stderr.String())
+	}
+	if err := os.Remove(watchlistPathForHome(home)); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove watchlist after execute start: %v", err)
+	}
+
+	app.Stdin = bytes.NewBufferString(`{"kind":"delta","anchor_sha":"` + anchor + `","dimensions":[{"name":"correctness","instructions":"Check the status and contracts."}]}`)
+	if exitCode := app.Run([]string{"review", "start"}); exitCode != 0 {
+		t.Fatalf("review start failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistContainsWorkspace(t, home, root)
+	if err := os.Remove(watchlistPathForHome(home)); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove watchlist after review start: %v", err)
+	}
+
+	app.Stdin = bytes.NewBufferString(`{"summary":"Looks good.","findings":[]}`)
+	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness", "--by", "reviewer-correctness"}); exitCode != 0 {
+		t.Fatalf("review submit failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistContainsWorkspace(t, home, root)
+	if err := os.Remove(watchlistPathForHome(home)); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove watchlist after review submit: %v", err)
+	}
+
+	if exitCode := app.Run([]string{"review", "aggregate", "--round", "review-001-delta"}); exitCode != 0 {
+		t.Fatalf("review aggregate failed with %d: %s", exitCode, stderr.String())
+	}
+	assertWatchlistContainsWorkspace(t, home, root)
+}
+
+func TestReviewAggregateIgnoresWatchlistWriteFailure(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	anchor := initGitRepoWithCommit(t, root)
+	app.Getwd = func() (string, error) { return root, nil }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 15, 0, 0, 0, time.FixedZone("CST", 8*60*60))
+	}
+
+	outputPath := filepath.Join(root, "docs/plans/active/2026-03-18-test-plan.md")
+	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Review Failure Plan", "--output", outputPath}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
+	if exitCode := app.Run([]string{"execute", "start"}); exitCode != 0 {
+		t.Fatalf("execute start failed with %d: %s", exitCode, stderr.String())
+	}
+
+	app.Stdin = bytes.NewBufferString(`{"kind":"delta","anchor_sha":"` + anchor + `","dimensions":[{"name":"correctness","instructions":"Check the status and contracts."}]}`)
+	if exitCode := app.Run([]string{"review", "start"}); exitCode != 0 {
+		t.Fatalf("review start failed with %d: %s", exitCode, stderr.String())
+	}
+	app.Stdin = bytes.NewBufferString(`{"summary":"Looks good.","findings":[]}`)
+	if exitCode := app.Run([]string{"review", "submit", "--round", "review-001-delta", "--slot", "correctness", "--by", "reviewer-correctness"}); exitCode != 0 {
+		t.Fatalf("review submit failed with %d: %s", exitCode, stderr.String())
+	}
+
+	app.LookupEnv = func(string) (string, bool) { return "", false }
+	app.UserHomeDir = func() (string, error) { return "", errors.New("watchlist-home-boom") }
+	if exitCode := app.Run([]string{"review", "aggregate", "--round", "review-001-delta"}); exitCode != 0 {
+		t.Fatalf("expected review aggregate to succeed despite watchlist failure, got %d: %s", exitCode, stderr.String())
 	}
 }
 
@@ -992,7 +1393,10 @@ func TestArchiveCommandAppendsTimelineEvent(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	app := cli.New(stdout, stderr)
 	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
 	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
 	app.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
 	}
@@ -1030,6 +1434,7 @@ func TestArchiveCommandAppendsTimelineEvent(t *testing.T) {
 	assertLifecycleEnvelope(t, payload, "execution/finalize/publish", 1)
 
 	assertLastTimelineEventCommand(t, root, "archive")
+	assertWatchlistContainsWorkspace(t, home, root)
 }
 
 func TestLandCommandReturnsJSON(t *testing.T) {
@@ -1037,7 +1442,10 @@ func TestLandCommandReturnsJSON(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	app := cli.New(stdout, stderr)
 	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
 	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
 	app.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 6, 0, 0, 0, time.UTC)
 	}
@@ -1070,6 +1478,7 @@ func TestLandCommandReturnsJSON(t *testing.T) {
 	}
 
 	assertLastTimelineEventCommand(t, root, "land")
+	assertWatchlistContainsWorkspace(t, home, root)
 }
 
 func TestReopenNewStepCommandReturnsJSON(t *testing.T) {
@@ -1077,7 +1486,10 @@ func TestReopenNewStepCommandReturnsJSON(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	app := cli.New(stdout, stderr)
 	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
 	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
 	app.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 7, 0, 0, 0, time.UTC)
 	}
@@ -1133,6 +1545,7 @@ func TestReopenNewStepCommandReturnsJSON(t *testing.T) {
 	if len(statusResult.NextAction) == 0 || !strings.Contains(statusResult.NextAction[0].Description, "Add a new unfinished step") {
 		t.Fatalf("expected new-step guidance after reopen, got %#v", statusResult.NextAction)
 	}
+	assertWatchlistContainsWorkspace(t, home, root)
 }
 
 func TestReopenFinalizeFixCommandReturnsJSON(t *testing.T) {
@@ -1140,7 +1553,10 @@ func TestReopenFinalizeFixCommandReturnsJSON(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	app := cli.New(stdout, stderr)
 	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
 	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
 	app.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 7, 15, 0, 0, time.UTC)
 	}
@@ -1191,6 +1607,7 @@ func TestReopenFinalizeFixCommandReturnsJSON(t *testing.T) {
 	}
 
 	assertLastTimelineEventCommand(t, root, "reopen")
+	assertWatchlistContainsWorkspace(t, home, root)
 }
 
 func TestReopenCommandRequiresMode(t *testing.T) {
@@ -1362,7 +1779,10 @@ func TestLandCompleteCommandReturnsJSON(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	app := cli.New(stdout, stderr)
 	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
 	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
 	app.Now = func() time.Time {
 		return time.Date(2026, 3, 18, 6, 0, 0, 0, time.UTC)
 	}
@@ -1399,6 +1819,7 @@ func TestLandCompleteCommandReturnsJSON(t *testing.T) {
 	}
 
 	assertLastTimelineEventCommand(t, root, "land complete")
+	assertWatchlistContainsWorkspace(t, home, root)
 }
 
 func TestLandCommandRejectsActivePlanWithoutWritingLandedMarker(t *testing.T) {
@@ -1679,4 +2100,69 @@ func approvePlanInFile(t *testing.T, path, approvedAt string) {
 		}
 	}
 	t.Fatalf("created_at frontmatter line not found in %s", path)
+}
+
+func watchlistPathForHome(home string) string {
+	return filepath.Join(home, ".easyharness", "watchlist.json")
+}
+
+func assertWatchlistAbsent(t *testing.T, home string) {
+	t.Helper()
+	if _, err := os.Stat(watchlistPathForHome(home)); !os.IsNotExist(err) {
+		t.Fatalf("expected no watchlist at %s, err=%v", watchlistPathForHome(home), err)
+	}
+}
+
+func assertWatchlistContainsWorkspace(t *testing.T, home, root string) {
+	t.Helper()
+	data, err := os.ReadFile(watchlistPathForHome(home))
+	if err != nil {
+		t.Fatalf("read watchlist file: %v", err)
+	}
+	var payload struct {
+		Workspaces []struct {
+			WorkspacePath string `json:"workspace_path"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decode watchlist file: %v\n%s", err, data)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve canonical workspace: %v", err)
+	}
+	if len(payload.Workspaces) != 1 || payload.Workspaces[0].WorkspacePath != canonicalRoot {
+		t.Fatalf("unexpected watchlist payload: %#v", payload)
+	}
+}
+
+func seedGitWorkspace(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir git workspace root %q: %v", root, err)
+	}
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.name", "Codex Test")
+	runGit(t, root, "config", "user.email", "codex@example.com")
+}
+
+func initGitRepoWithCommit(t *testing.T, root string) string {
+	t.Helper()
+	seedGitWorkspace(t, root)
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("test repo\n"), 0o644); err != nil {
+		t.Fatalf("write git fixture file: %v", err)
+	}
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-m", "test fixture")
+	return runGit(t, root, "rev-parse", "HEAD")
+}
+
+func runGit(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
 }

--- a/internal/evidence/service.go
+++ b/internal/evidence/service.go
@@ -23,6 +23,7 @@ type Service struct {
 	Workdir       string
 	Now           func() time.Time
 	AfterMutation func(Result) error
+	AfterSuccess  func(Result)
 }
 
 type Result = contracts.EvidenceSubmitResult
@@ -345,6 +346,9 @@ func errorResult(command, summary string, errors []CommandError) Result {
 
 func (s Service) finalizeMutation(result Result, rollback func() []CommandError) Result {
 	if !result.OK || s.AfterMutation == nil {
+		if result.OK && s.AfterSuccess != nil {
+			s.AfterSuccess(result)
+		}
 		return result
 	}
 	if err := s.AfterMutation(result); err != nil {
@@ -353,6 +357,9 @@ func (s Service) finalizeMutation(result Result, rollback func() []CommandError)
 			issues = append(issues, rollback()...)
 		}
 		return errorResult(result.Command, "Unable to record the timeline event for the successful command result.", issues)
+	}
+	if s.AfterSuccess != nil {
+		s.AfterSuccess(result)
 	}
 	return result
 }

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -20,6 +20,7 @@ type Service struct {
 	Workdir       string
 	Now           func() time.Time
 	AfterMutation func(Result) error
+	AfterSuccess  func(Result)
 }
 
 type Result = contracts.LifecycleResult
@@ -945,6 +946,9 @@ func errorResult(command, summary string, errors []CommandError) Result {
 
 func (s Service) finalizeMutation(result Result, rollback func() []CommandError) Result {
 	if !result.OK || s.AfterMutation == nil {
+		if result.OK && s.AfterSuccess != nil {
+			s.AfterSuccess(result)
+		}
 		return result
 	}
 	if err := s.AfterMutation(result); err != nil {
@@ -953,6 +957,9 @@ func (s Service) finalizeMutation(result Result, rollback func() []CommandError)
 			issues = append(issues, rollback()...)
 		}
 		return errorResult(result.Command, "Unable to record the timeline event for the successful command result.", issues)
+	}
+	if s.AfterSuccess != nil {
+		s.AfterSuccess(result)
 	}
 	return result
 }

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -27,11 +27,14 @@ var saveState = runstate.SaveState
 var writeJSON = writeJSONFile
 
 type Service struct {
-	Workdir        string
-	Now            func() time.Time
-	AfterStart     func(StartResult) error
-	AfterSubmit    func(SubmitResult) error
-	AfterAggregate func(AggregateResult) error
+	Workdir               string
+	Now                   func() time.Time
+	AfterStart            func(StartResult) error
+	AfterSubmit           func(SubmitResult) error
+	AfterAggregate        func(AggregateResult) error
+	AfterStartSuccess     func(StartResult)
+	AfterSubmitSuccess    func(SubmitResult)
+	AfterAggregateSuccess func(AggregateResult)
 }
 
 type Spec = contracts.ReviewSpec
@@ -1172,6 +1175,9 @@ func buildAggregateNextActions(kind, decision string) []NextAction {
 
 func (s Service) finalizeStart(result StartResult, rollback func() []CommandError) StartResult {
 	if !result.OK || s.AfterStart == nil {
+		if result.OK && s.AfterStartSuccess != nil {
+			s.AfterStartSuccess(result)
+		}
 		return result
 	}
 	if err := s.AfterStart(result); err != nil {
@@ -1186,11 +1192,17 @@ func (s Service) finalizeStart(result StartResult, rollback func() []CommandErro
 			Errors:  issues,
 		}
 	}
+	if s.AfterStartSuccess != nil {
+		s.AfterStartSuccess(result)
+	}
 	return result
 }
 
 func (s Service) finalizeSubmit(result SubmitResult, rollback func() []CommandError) SubmitResult {
 	if !result.OK || s.AfterSubmit == nil {
+		if result.OK && s.AfterSubmitSuccess != nil {
+			s.AfterSubmitSuccess(result)
+		}
 		return result
 	}
 	if err := s.AfterSubmit(result); err != nil {
@@ -1205,11 +1217,17 @@ func (s Service) finalizeSubmit(result SubmitResult, rollback func() []CommandEr
 			Errors:  issues,
 		}
 	}
+	if s.AfterSubmitSuccess != nil {
+		s.AfterSubmitSuccess(result)
+	}
 	return result
 }
 
 func (s Service) finalizeAggregate(result AggregateResult, rollback func() []CommandError) AggregateResult {
 	if !result.OK || s.AfterAggregate == nil {
+		if result.OK && s.AfterAggregateSuccess != nil {
+			s.AfterAggregateSuccess(result)
+		}
 		return result
 	}
 	if err := s.AfterAggregate(result); err != nil {
@@ -1223,6 +1241,9 @@ func (s Service) finalizeAggregate(result AggregateResult, rollback func() []Com
 			Summary: "Unable to record the timeline event for the successful command result.",
 			Errors:  issues,
 		}
+	}
+	if s.AfterAggregateSuccess != nil {
+		s.AfterAggregateSuccess(result)
 	}
 	return result
 }

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -19,7 +19,8 @@ import (
 )
 
 type Service struct {
-	Workdir string
+	Workdir      string
+	AfterSuccess func(Result)
 }
 
 type Result = contracts.StatusResult
@@ -78,7 +79,7 @@ func (s Service) read(acquireLock bool) Result {
 	planPath, err := plan.DetectCurrentPath(s.Workdir)
 	if err != nil {
 		if errors.Is(err, plan.ErrNoCurrentPlan) {
-			return idleResult(s.Workdir, currentPlan)
+			return s.finalizeRead(idleResult(s.Workdir, currentPlan))
 		}
 		return Result{
 			OK:      false,
@@ -278,6 +279,14 @@ func (s Service) read(acquireLock bool) Result {
 		result.Artifacts = nil
 	}
 
+	return s.finalizeRead(result)
+}
+
+func (s Service) finalizeRead(result Result) Result {
+	if !result.OK || s.AfterSuccess == nil {
+		return result
+	}
+	s.AfterSuccess(result)
 	return result
 }
 

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -54,6 +55,53 @@ func TestNewHandlerServesStatusJSON(t *testing.T) {
 	}
 	if payload.State.CurrentNode == "" {
 		t.Fatalf("expected current_node, got %#v", payload)
+	}
+}
+
+func TestNewHandlerStatusDoesNotTouchWatchlist(t *testing.T) {
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, workdir)
+	home := t.TempDir()
+	t.Setenv("EASYHARNESS_HOME", home)
+
+	handler, err := NewHandler(workdir)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", recorder.Code)
+	}
+	if _, err := os.Stat(filepath.Join(home, "watchlist.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected UI status request to avoid watchlist writes, err=%v", err)
+	}
+}
+
+func TestUIReadSurfacesDoNotTouchWatchlist(t *testing.T) {
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, workdir)
+	home := t.TempDir()
+	t.Setenv("EASYHARNESS_HOME", home)
+
+	handler, err := NewHandler(workdir)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	for _, path := range []string{"/api/status", "/api/plan", "/api/review", "/api/timeline", "/"} {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		handler.ServeHTTP(recorder, request)
+		if recorder.Code >= http.StatusInternalServerError {
+			t.Fatalf("expected %s to avoid server error, got %d", path, recorder.Code)
+		}
+		if _, err := os.Stat(filepath.Join(home, "watchlist.json")); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to avoid watchlist writes, err=%v", path, err)
+		}
 	}
 }
 
@@ -820,6 +868,75 @@ func TestServerRunPrintsListeningURLWithoutOpeningBrowser(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for server shutdown")
 	}
+}
+
+func TestServerRunStartupDoesNotTouchWatchlist(t *testing.T) {
+	logs := &lockedBuffer{}
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, workdir)
+	home := t.TempDir()
+	t.Setenv("EASYHARNESS_HOME", home)
+
+	server := Server{
+		Workdir:     workdir,
+		Host:        "127.0.0.1",
+		Port:        0,
+		Stdout:      logs,
+		Stderr:      io.Discard,
+		OpenBrowser: false,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- server.Run(ctx)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(logs.String(), "Harness UI listening at http://") {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !strings.Contains(logs.String(), "Harness UI listening at http://") {
+		t.Fatalf("expected listening URL in stdout, got %q", logs.String())
+	}
+	if _, err := os.Stat(filepath.Join(home, "watchlist.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected UI startup to avoid watchlist writes, err=%v", err)
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server shutdown")
+	}
+}
+
+func seedGitWorkspace(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir git workspace root %q: %v", root, err)
+	}
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.name", "Codex Test")
+	runGit(t, root, "config", "user.email", "codex@example.com")
+}
+
+func runGit(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func renderPlanFixture(t *testing.T, title string) string {

--- a/internal/watchlist/watchlist.go
+++ b/internal/watchlist/watchlist.go
@@ -1,0 +1,345 @@
+package watchlist
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	envHome = "EASYHARNESS_HOME"
+	version = 1
+)
+
+var ErrNotGitWorkspace = errors.New("workspace is not git-backed")
+
+type Service struct {
+	LookupEnv   func(string) (string, bool)
+	UserHomeDir func() (string, error)
+	Now         func() time.Time
+}
+
+type File struct {
+	Version    int         `json:"version"`
+	Workspaces []Workspace `json:"workspaces"`
+}
+
+type Workspace struct {
+	WorkspacePath string `json:"workspace_path"`
+	WatchedAt     string `json:"watched_at"`
+	LastSeenAt    string `json:"last_seen_at"`
+}
+
+func (s Service) Touch(workdir string) error {
+	if strings.TrimSpace(workdir) == "" {
+		return fmt.Errorf("resolve workspace: empty path")
+	}
+
+	home, err := s.easyharnessHome()
+	if err != nil {
+		return err
+	}
+	canonicalPath, err := canonicalWorkspacePath(workdir)
+	if err != nil {
+		return err
+	}
+
+	release, err := acquireLock(home)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	path := filepath.Join(home, "watchlist.json")
+	data, err := loadFile(path)
+	if err != nil {
+		return err
+	}
+
+	now := s.now().UTC().Format(time.RFC3339)
+	data.Workspaces = upsertWorkspace(data.Workspaces, canonicalPath, now)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal watchlist.json: %w", err)
+	}
+	return writeJSONAtomic(path, payload, 0o644)
+}
+
+func (s Service) easyharnessHome() (string, error) {
+	if lookup := s.LookupEnv; lookup != nil {
+		if value, ok := lookup(envHome); ok && strings.TrimSpace(value) != "" {
+			return s.resolveConfiguredHome(value)
+		}
+	} else if value := strings.TrimSpace(os.Getenv(envHome)); value != "" {
+		return s.resolveConfiguredHome(value)
+	}
+
+	home, err := s.userHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".easyharness"), nil
+}
+
+func (s Service) now() time.Time {
+	if s.Now != nil {
+		return s.Now()
+	}
+	return time.Now()
+}
+
+func (s Service) resolveConfiguredHome(value string) (string, error) {
+	candidate := filepath.Clean(strings.TrimSpace(value))
+	if filepath.IsAbs(candidate) {
+		return candidate, nil
+	}
+	home, err := s.userHomeDir()
+	if err != nil {
+		return "", err
+	}
+	resolved := filepath.Clean(filepath.Join(home, candidate))
+	relative, err := filepath.Rel(home, resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolve configured home: %w", err)
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("resolve configured home: relative path escapes user home")
+	}
+	return resolved, nil
+}
+
+func (s Service) userHomeDir() (string, error) {
+	var (
+		home string
+		err  error
+	)
+	if s.UserHomeDir != nil {
+		home, err = s.UserHomeDir()
+	} else {
+		home, err = os.UserHomeDir()
+	}
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	if strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("resolve user home: empty path")
+	}
+	return filepath.Clean(strings.TrimSpace(home)), nil
+}
+
+func loadFile(path string) (File, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return File{Version: version, Workspaces: []Workspace{}}, nil
+		}
+		return File{}, err
+	}
+
+	var decoded File
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return File{}, fmt.Errorf("parse watchlist.json: %w", err)
+	}
+	switch decoded.Version {
+	case 0:
+		return File{}, fmt.Errorf("parse watchlist.json: missing version")
+	case version:
+	default:
+		return File{}, fmt.Errorf("parse watchlist.json: unsupported version %d", decoded.Version)
+	}
+	if decoded.Workspaces == nil {
+		decoded.Workspaces = []Workspace{}
+	}
+	return decoded, nil
+}
+
+func upsertWorkspace(workspaces []Workspace, canonicalPath, seenAt string) []Workspace {
+	next := make([]Workspace, 0, len(workspaces)+1)
+	indexByPath := make(map[string]int, len(workspaces)+1)
+	merged := false
+	for _, workspace := range workspaces {
+		workspace.WorkspacePath = strings.TrimSpace(workspace.WorkspacePath)
+		if workspace.WorkspacePath == canonicalPath {
+			if strings.TrimSpace(workspace.WatchedAt) == "" {
+				workspace.WatchedAt = seenAt
+			}
+			workspace.LastSeenAt = laterTimestamp(workspace.LastSeenAt, seenAt)
+			merged = true
+		}
+
+		if idx, ok := indexByPath[workspace.WorkspacePath]; ok {
+			existing := &next[idx]
+			existing.WatchedAt = earlierTimestamp(existing.WatchedAt, workspace.WatchedAt)
+			existing.LastSeenAt = laterTimestamp(existing.LastSeenAt, workspace.LastSeenAt)
+			continue
+		}
+
+		next = append(next, workspace)
+		indexByPath[workspace.WorkspacePath] = len(next) - 1
+	}
+	if !merged {
+		next = append(next, Workspace{
+			WorkspacePath: canonicalPath,
+			WatchedAt:     seenAt,
+			LastSeenAt:    seenAt,
+		})
+	}
+	return next
+}
+
+func canonicalWorkspacePath(workdir string) (string, error) {
+	root, err := gitWorkspaceRoot(workdir)
+	if err != nil {
+		return "", err
+	}
+	absolute, err := filepath.Abs(strings.TrimSpace(root))
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace absolute path: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace symlinks: %w", err)
+	}
+	return filepath.Clean(resolved), nil
+}
+
+func gitWorkspaceRoot(workdir string) (string, error) {
+	workdir = strings.TrimSpace(workdir)
+	if workdir == "" {
+		return "", fmt.Errorf("resolve workspace: empty path")
+	}
+	current, err := filepath.Abs(workdir)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace absolute path: %w", err)
+	}
+	output, err := exec.Command("git", "-C", filepath.Clean(current), "rev-parse", "--show-toplevel").CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", ErrNotGitWorkspace
+		}
+		return "", fmt.Errorf("detect git workspace root: %w", err)
+	}
+	root := strings.TrimSpace(string(output))
+	if root == "" {
+		return "", ErrNotGitWorkspace
+	}
+	return root, nil
+}
+
+func earlierTimestamp(a, b string) string {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	}
+	at, aerr := time.Parse(time.RFC3339, a)
+	bt, berr := time.Parse(time.RFC3339, b)
+	if aerr == nil && berr == nil {
+		if bt.Before(at) {
+			return b
+		}
+		return a
+	}
+	if b < a {
+		return b
+	}
+	return a
+}
+
+func laterTimestamp(a, b string) string {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	}
+	at, aerr := time.Parse(time.RFC3339, a)
+	bt, berr := time.Parse(time.RFC3339, b)
+	if aerr == nil && berr == nil {
+		if bt.After(at) {
+			return b
+		}
+		return a
+	}
+	if b > a {
+		return b
+	}
+	return a
+}
+
+func acquireLock(home string) (func(), error) {
+	lockPath := filepath.Join(home, ".watchlist.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return func() {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+	}, nil
+}
+
+func writeJSONAtomic(path string, data []byte, perm os.FileMode) (err error) {
+	dir := filepath.Dir(path)
+	tempFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	defer func() {
+		if err == nil {
+			return
+		}
+		_ = tempFile.Close()
+		_ = os.Remove(tempPath)
+	}()
+
+	if err := tempFile.Chmod(perm); err != nil {
+		return err
+	}
+	if _, err := tempFile.Write(data); err != nil {
+		return err
+	}
+	if err := tempFile.Sync(); err != nil {
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+
+	dirFile, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer dirFile.Close()
+	if err := dirFile.Sync(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/watchlist/watchlist_test.go
+++ b/internal/watchlist/watchlist_test.go
@@ -1,0 +1,400 @@
+package watchlist
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTouchUsesDefaultEasyharnessHome(t *testing.T) {
+	userHome := t.TempDir()
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, workdir)
+
+	svc := Service{
+		UserHomeDir: func() (string, error) { return userHome, nil },
+		Now: func() time.Time {
+			return time.Date(2026, 4, 19, 1, 2, 3, 0, time.UTC)
+		},
+	}
+	if err := svc.Touch(workdir); err != nil {
+		t.Fatalf("touch watchlist: %v", err)
+	}
+
+	got := readWatchlistFile(t, filepath.Join(userHome, ".easyharness", "watchlist.json"))
+	if got.Version != version {
+		t.Fatalf("expected version %d, got %#v", version, got)
+	}
+	if len(got.Workspaces) != 1 {
+		t.Fatalf("expected 1 workspace, got %#v", got.Workspaces)
+	}
+	canonical, err := filepath.EvalSymlinks(workdir)
+	if err != nil {
+		t.Fatalf("resolve canonical workspace: %v", err)
+	}
+	if got.Workspaces[0].WorkspacePath != canonical {
+		t.Fatalf("expected workspace path %q, got %#v", workdir, got.Workspaces[0])
+	}
+}
+
+func TestTouchUsesEasyharnessHomeOverride(t *testing.T) {
+	customHome := filepath.Join(t.TempDir(), "custom-home")
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, workdir)
+
+	svc := Service{
+		LookupEnv: func(key string) (string, bool) {
+			if key == envHome {
+				return customHome, true
+			}
+			return "", false
+		},
+		UserHomeDir: func() (string, error) { return t.TempDir(), nil },
+	}
+	if err := svc.Touch(workdir); err != nil {
+		t.Fatalf("touch watchlist: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(customHome, "watchlist.json")); err != nil {
+		t.Fatalf("expected watchlist in custom home, err=%v", err)
+	}
+}
+
+func TestTouchUsesRelativeEasyharnessHomeOverrideUnderUserHome(t *testing.T) {
+	userHome := t.TempDir()
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, workdir)
+	firstCwd := t.TempDir()
+	secondCwd := t.TempDir()
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalCwd); chdirErr != nil {
+			t.Fatalf("restore cwd: %v", chdirErr)
+		}
+	}()
+
+	svc := Service{
+		LookupEnv: func(key string) (string, bool) {
+			if key == envHome {
+				return "relative-home", true
+			}
+			return "", false
+		},
+		UserHomeDir: func() (string, error) { return userHome, nil },
+	}
+	for _, cwd := range []string{firstCwd, secondCwd} {
+		if err := os.Chdir(cwd); err != nil {
+			t.Fatalf("chdir %q: %v", cwd, err)
+		}
+		if err := svc.Touch(workdir); err != nil {
+			t.Fatalf("touch watchlist from %q: %v", cwd, err)
+		}
+	}
+
+	got := readWatchlistFile(t, filepath.Join(userHome, "relative-home", "watchlist.json"))
+	if len(got.Workspaces) != 1 {
+		t.Fatalf("expected one workspace in stable relative override root, got %#v", got.Workspaces)
+	}
+}
+
+func TestTouchRejectsRelativeEasyharnessHomeOverrideThatEscapesUserHome(t *testing.T) {
+	userHome := t.TempDir()
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, workdir)
+
+	svc := Service{
+		LookupEnv: func(key string) (string, bool) {
+			if key == envHome {
+				return "../escape", true
+			}
+			return "", false
+		},
+		UserHomeDir: func() (string, error) { return userHome, nil },
+	}
+	if err := svc.Touch(workdir); err == nil || !strings.Contains(err.Error(), "escapes user home") {
+		t.Fatalf("expected escaping relative override error, got %v", err)
+	}
+}
+
+func TestTouchPreservesWatchedAtAndRefreshesLastSeenAt(t *testing.T) {
+	userHome := t.TempDir()
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, workdir)
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	svc.Now = func() time.Time { return time.Date(2026, 4, 19, 1, 0, 0, 0, time.UTC) }
+	if err := svc.Touch(workdir); err != nil {
+		t.Fatalf("initial touch: %v", err)
+	}
+	initial := readWatchlistFile(t, filepath.Join(userHome, ".easyharness", "watchlist.json"))
+
+	svc.Now = func() time.Time { return time.Date(2026, 4, 19, 2, 0, 0, 0, time.UTC) }
+	if err := svc.Touch(workdir); err != nil {
+		t.Fatalf("second touch: %v", err)
+	}
+	updated := readWatchlistFile(t, filepath.Join(userHome, ".easyharness", "watchlist.json"))
+	if len(updated.Workspaces) != 1 {
+		t.Fatalf("expected one workspace after repeated touch, got %#v", updated.Workspaces)
+	}
+	if updated.Workspaces[0].WatchedAt != initial.Workspaces[0].WatchedAt {
+		t.Fatalf("expected watched_at to stay stable, got %#v -> %#v", initial.Workspaces[0], updated.Workspaces[0])
+	}
+	if updated.Workspaces[0].LastSeenAt == initial.Workspaces[0].LastSeenAt {
+		t.Fatalf("expected last_seen_at to refresh, got %#v -> %#v", initial.Workspaces[0], updated.Workspaces[0])
+	}
+}
+
+func TestTouchConvergesSymlinkedWorkspacePaths(t *testing.T) {
+	userHome := t.TempDir()
+	target := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, target)
+	symlink := filepath.Join(t.TempDir(), "workspace-link")
+	if err := os.Symlink(target, symlink); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	if err := svc.Touch(symlink); err != nil {
+		t.Fatalf("touch symlinked path: %v", err)
+	}
+	if err := svc.Touch(target); err != nil {
+		t.Fatalf("touch resolved path: %v", err)
+	}
+
+	got := readWatchlistFile(t, filepath.Join(userHome, ".easyharness", "watchlist.json"))
+	if len(got.Workspaces) != 1 {
+		t.Fatalf("expected one converged workspace, got %#v", got.Workspaces)
+	}
+	canonical, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatalf("resolve canonical workspace: %v", err)
+	}
+	if got.Workspaces[0].WorkspacePath != canonical {
+		t.Fatalf("expected canonical target path %q, got %#v", target, got.Workspaces[0])
+	}
+}
+
+func TestTouchConcurrentWritesPreserveUnrelatedRecords(t *testing.T) {
+	userHome := t.TempDir()
+	root := t.TempDir()
+	first := filepath.Join(root, "workspace-a")
+	second := filepath.Join(root, "workspace-b")
+	for _, path := range []string{first, second} {
+		seedGitWorkspace(t, path)
+	}
+
+	var wg sync.WaitGroup
+	for i, path := range []string{first, second} {
+		wg.Add(1)
+		go func(idx int, workdir string) {
+			defer wg.Done()
+			svc := Service{
+				UserHomeDir: func() (string, error) { return userHome, nil },
+				Now: func() time.Time {
+					return time.Date(2026, 4, 19, 3, idx, 0, 0, time.UTC)
+				},
+			}
+			if err := svc.Touch(workdir); err != nil {
+				t.Errorf("touch %q: %v", workdir, err)
+			}
+		}(i, path)
+	}
+	wg.Wait()
+
+	got := readWatchlistFile(t, filepath.Join(userHome, ".easyharness", "watchlist.json"))
+	if len(got.Workspaces) != 2 {
+		t.Fatalf("expected both workspaces after concurrent touches, got %#v", got.Workspaces)
+	}
+}
+
+func TestTouchCoalescesNonAdjacentDuplicateWorkspaceRecords(t *testing.T) {
+	userHome := t.TempDir()
+	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+	first := filepath.Join(t.TempDir(), "workspace-a")
+	second := filepath.Join(t.TempDir(), "workspace-b")
+	for _, path := range []string{first, second} {
+		seedGitWorkspace(t, path)
+	}
+	canonicalFirst, err := filepath.EvalSymlinks(first)
+	if err != nil {
+		t.Fatalf("resolve canonical first workspace: %v", err)
+	}
+	canonicalSecond, err := filepath.EvalSymlinks(second)
+	if err != nil {
+		t.Fatalf("resolve canonical second workspace: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(watchlistPath), 0o755); err != nil {
+		t.Fatalf("mkdir watchlist dir: %v", err)
+	}
+	seed := File{
+		Version: version,
+		Workspaces: []Workspace{
+			{WorkspacePath: canonicalFirst, WatchedAt: "2026-04-19T01:00:00Z", LastSeenAt: "2026-04-19T01:00:00Z"},
+			{WorkspacePath: canonicalSecond, WatchedAt: "2026-04-19T01:05:00Z", LastSeenAt: "2026-04-19T01:05:00Z"},
+			{WorkspacePath: canonicalFirst, WatchedAt: "2026-04-19T01:10:00Z", LastSeenAt: "2026-04-19T01:10:00Z"},
+		},
+	}
+	payload, err := json.MarshalIndent(seed, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal seed watchlist: %v", err)
+	}
+	if err := os.WriteFile(watchlistPath, payload, 0o644); err != nil {
+		t.Fatalf("write seed watchlist: %v", err)
+	}
+
+	svc := Service{
+		UserHomeDir: func() (string, error) { return userHome, nil },
+		Now: func() time.Time {
+			return time.Date(2026, 4, 19, 2, 0, 0, 0, time.UTC)
+		},
+	}
+	if err := svc.Touch(first); err != nil {
+		t.Fatalf("touch watchlist: %v", err)
+	}
+
+	got := readWatchlistFile(t, watchlistPath)
+	if len(got.Workspaces) != 2 {
+		t.Fatalf("expected duplicate workspace records to coalesce, got %#v", got.Workspaces)
+	}
+	if got.Workspaces[0].WorkspacePath != canonicalFirst || got.Workspaces[1].WorkspacePath != canonicalSecond {
+		t.Fatalf("unexpected coalesced order/content: %#v", got.Workspaces)
+	}
+	if got.Workspaces[0].WatchedAt != "2026-04-19T01:00:00Z" {
+		t.Fatalf("expected earliest watched_at to survive, got %#v", got.Workspaces[0])
+	}
+	if got.Workspaces[0].LastSeenAt != "2026-04-19T02:00:00Z" {
+		t.Fatalf("expected refreshed last_seen_at on merged workspace, got %#v", got.Workspaces[0])
+	}
+	if got.Workspaces[1].LastSeenAt != "2026-04-19T01:05:00Z" {
+		t.Fatalf("expected unrelated workspace to remain unchanged, got %#v", got.Workspaces[1])
+	}
+}
+
+func TestTouchUsesGitWorkspaceRootForNestedDirectory(t *testing.T) {
+	userHome := t.TempDir()
+	root := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, root)
+	nested := filepath.Join(root, "docs", "plans")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested workspace path: %v", err)
+	}
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	if err := svc.Touch(nested); err != nil {
+		t.Fatalf("touch nested path: %v", err)
+	}
+
+	got := readWatchlistFile(t, filepath.Join(userHome, ".easyharness", "watchlist.json"))
+	if len(got.Workspaces) != 1 {
+		t.Fatalf("expected one workspace, got %#v", got.Workspaces)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve canonical root: %v", err)
+	}
+	if got.Workspaces[0].WorkspacePath != canonicalRoot {
+		t.Fatalf("expected git workspace root %q, got %#v", canonicalRoot, got.Workspaces[0])
+	}
+}
+
+func TestTouchReturnsErrNotGitWorkspaceOutsideGitCheckout(t *testing.T) {
+	userHome := t.TempDir()
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	err := svc.Touch(workdir)
+	if !errors.Is(err, ErrNotGitWorkspace) {
+		t.Fatalf("expected ErrNotGitWorkspace, got %v", err)
+	}
+}
+
+func TestTouchRejectsFakeGitMarker(t *testing.T) {
+	userHome := t.TempDir()
+	workdir := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(filepath.Join(workdir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir fake git marker: %v", err)
+	}
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	err := svc.Touch(workdir)
+	if !errors.Is(err, ErrNotGitWorkspace) {
+		t.Fatalf("expected fake git marker to be rejected, got %v", err)
+	}
+}
+
+func TestTouchRegistersLinkedGitWorktree(t *testing.T) {
+	userHome := t.TempDir()
+	root := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, root)
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("root repo\n"), 0o644); err != nil {
+		t.Fatalf("write root repo file: %v", err)
+	}
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-m", "fixture")
+
+	linked := filepath.Join(t.TempDir(), "linked-worktree")
+	runGit(t, root, "worktree", "add", "-b", "linked-branch", linked, "HEAD")
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	if err := svc.Touch(linked); err != nil {
+		t.Fatalf("touch linked worktree: %v", err)
+	}
+
+	got := readWatchlistFile(t, filepath.Join(userHome, ".easyharness", "watchlist.json"))
+	if len(got.Workspaces) != 1 {
+		t.Fatalf("expected one linked worktree record, got %#v", got.Workspaces)
+	}
+	canonicalLinked, err := filepath.EvalSymlinks(linked)
+	if err != nil {
+		t.Fatalf("resolve linked worktree: %v", err)
+	}
+	if got.Workspaces[0].WorkspacePath != canonicalLinked {
+		t.Fatalf("expected linked worktree path %q, got %#v", canonicalLinked, got.Workspaces[0])
+	}
+}
+
+func readWatchlistFile(t *testing.T, path string) File {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read watchlist file: %v", err)
+	}
+	var decoded File
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("decode watchlist file: %v\n%s", err, data)
+	}
+	return decoded
+}
+
+func seedGitWorkspace(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir git workspace root %q: %v", root, err)
+	}
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.name", "Codex Test")
+	runGit(t, root, "config", "user.email", "codex@example.com")
+}
+
+func runGit(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}


### PR DESCRIPTION
## Summary
- add a shared machine-local watchlist writer rooted at `EASYHARNESS_HOME` or `~/.easyharness`
- touch the watchlist from successful core workflow services instead of command-name allowlists or low-level file hooks
- cover best-effort failures, linked worktrees, excluded non-core surfaces, and the documented home override contract

## Validation
- `go test ./... -count=1`

## Plan
- [2026-04-19-add-machine-local-watchlist-touch-foundation](docs/plans/archived/2026-04-19-add-machine-local-watchlist-touch-foundation.md)

Closes #164
