### PR TITLE
Build watchlist dashboard read model

### DIFF
--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -268,7 +268,7 @@ Follow-up `review-007-delta` passed with no findings.
 
 ### Step 4: Serve the dashboard model through the UI backend
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -299,7 +299,12 @@ command.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added `GET /api/dashboard` to the UI server and wired it to
+`dashboard.Service{}.Read()`. The endpoint returns dashboard JSON, rejects
+non-GET methods, reports service-unavailable for top-level dashboard load
+failures, and does not rewrite the machine-local watchlist. Validation:
+`go test ./internal/ui ./internal/dashboard ./internal/watchlist -count=1`;
+`git diff --check`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -260,6 +260,10 @@ untested, and that Git probe failures could be classified as
 to `ReadUnlocked()`, added active-workspace no-mutation coverage, and refined
 Git probe failure classification. Validation:
 `go test ./internal/dashboard ./internal/watchlist ./internal/contractsync -count=1`.
+`review-006-delta` confirmed the non-mutating status fix but found the Git
+probe parser still treated some unreadable `.git` metadata as
+`not_git_workspace` and the parser boundary was not directly tested. Added
+marker-aware Git probe classification and direct parser-boundary coverage.
 
 ### Step 4: Serve the dashboard model through the UI backend
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -185,7 +185,11 @@ record invalid reasons such as `unreadable`, `not_git_workspace`, and
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-003-delta` found one blocking agent-UX gap: lifecycle states were
+documented, but the concrete dashboard payload boundary was still implicit.
+Added the top-level result, lifecycle group, and per-workspace entry field
+contract to `docs/specs/watchlist-contract.md`, plus proposal wording that the
+frontend should consume stable groups rather than derive field names.
 
 ### Step 3: Build the dashboard summary service
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -264,6 +264,7 @@ Git probe failure classification. Validation:
 probe parser still treated some unreadable `.git` metadata as
 `not_git_workspace` and the parser boundary was not directly tested. Added
 marker-aware Git probe classification and direct parser-boundary coverage.
+Follow-up `review-007-delta` passed with no findings.
 
 ### Step 4: Serve the dashboard model through the UI backend
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -194,7 +194,7 @@ Follow-up `review-004-delta` passed with no findings.
 
 ### Step 3: Build the dashboard summary service
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -243,7 +243,13 @@ expanding the top-level dashboard state enum.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added `internal/dashboard` with a read-only service that loads the watchlist,
+probes watched paths, reuses `status.Service` for readable Git workspaces,
+classifies entries into stable dashboard lifecycle groups, and preserves raw
+`current_node` on readable status entries. Added `internal/contracts`
+dashboard types, registered the UI resource schema, synced generated contract
+artifacts, and aligned the spec field name with the existing UI `resource`
+pattern. Validation: `go test ./internal/dashboard ./internal/watchlist ./internal/contractsync -count=1`; `scripts/sync-contract-artifacts --check`; `git diff --check`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -253,7 +253,13 @@ pattern. Validation: `go test ./internal/dashboard ./internal/watchlist ./intern
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-005-delta` found that default dashboard reads used the locking status
+path for active workspaces, that active default-status read-only behavior was
+untested, and that Git probe failures could be classified as
+`not_git_workspace` instead of `unreadable`. Switched the default status path
+to `ReadUnlocked()`, added active-workspace no-mutation coverage, and refined
+Git probe failure classification. Validation:
+`go test ./internal/dashboard ./internal/watchlist ./internal/contractsync -count=1`.
 
 ### Step 4: Serve the dashboard model through the UI backend
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -190,6 +190,7 @@ documented, but the concrete dashboard payload boundary was still implicit.
 Added the top-level result, lifecycle group, and per-workspace entry field
 contract to `docs/specs/watchlist-contract.md`, plus proposal wording that the
 frontend should consume stable groups rather than derive field names.
+Follow-up `review-004-delta` passed with no findings.
 
 ### Step 3: Build the dashboard summary service
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -143,7 +143,7 @@ with no findings.
 
 ### Step 2: Document the dashboard read model contract
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -176,7 +176,12 @@ spec rewrite.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Updated the watchlist contract and dashboard steering proposal to document the
+read-time dashboard projection over `watchlist.json` plus per-workspace
+status. The specs now separate raw `current_node` from dashboard lifecycle
+state, define `active`, `completed`, `idle`, `missing`, and `invalid`, and
+record invalid reasons such as `unreadable`, `not_git_workspace`, and
+`status_error`. Validation: `git diff --check -- docs/specs/watchlist-contract.md docs/specs/proposals/harness-ui-steering-surface.md`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -308,7 +308,11 @@ failures, and does not rewrite the machine-local watchlist. Validation:
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-008-delta` found one blocking tests gap: the endpoint no-rewrite test
+seeded a missing watched path but did not assert the missing degraded entry was
+present in the JSON response. Added response assertions for the `missing`
+group entry and reran
+`go test ./internal/ui ./internal/dashboard ./internal/watchlist -count=1`.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -135,7 +135,10 @@ versions, and preserving persisted workspace records as read.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` found one blocking tests gap: existing-file reads did not
+prove the file bytes or mtime were preserved. Added
+`TestReadExistingWatchlistDoesNotRewriteFile` and reran
+`go test ./internal/watchlist -count=1`.
 
 ### Step 2: Document the dashboard read model contract
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -313,6 +313,7 @@ seeded a missing watched path but did not assert the missing degraded entry was
 present in the JSON response. Added response assertions for the `missing`
 group entry and reran
 `go test ./internal/ui ./internal/dashboard ./internal/watchlist -count=1`.
+Follow-up `review-009-delta` passed with no findings.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -138,7 +138,8 @@ versions, and preserving persisted workspace records as read.
 `review-001-delta` found one blocking tests gap: existing-file reads did not
 prove the file bytes or mtime were preserved. Added
 `TestReadExistingWatchlistDoesNotRewriteFile` and reran
-`go test ./internal/watchlist -count=1`.
+`go test ./internal/watchlist -count=1`. Follow-up `review-002-delta` passed
+with no findings.
 
 ### Step 2: Document the dashboard read model contract
 

--- a/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -1,0 +1,332 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-22T22:36:21+08:00"
+approved_at: "2026-04-22T22:56:56+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/165
+size: M
+---
+
+# Build Watchlist Dashboard Read Model
+
+## Goal
+
+Build the read-only backend model that turns the machine-local watchlist into
+dashboard-ready watched workspace summaries. The model should preserve the raw
+harness workflow state for each readable workspace while adding a dashboard
+lifecycle state that is honest about active work, completed landed work, idle
+but ambiguous workspaces, missing paths, and invalid watched entries.
+
+This slice should give the future dashboard UI one compact API payload to read
+without making the frontend reimplement watchlist parsing, status resolution,
+recency ordering, or degraded-entry handling.
+
+## Scope
+
+### In Scope
+
+- Add a read-only watchlist reader that loads the machine-local
+  `watchlist.json` without mutating harness workflow or watchlist state.
+- Add a dashboard read model service that summarizes every watched workspace.
+- Reuse the existing `status.Service` for readable watched workspaces so
+  `current_node`, summary, warnings, blockers, next actions, and artifacts stay
+  consistent with `harness status`.
+- Expose both raw `current_node` and a dashboard lifecycle state for each
+  watched workspace.
+- Classify dashboard states as `active`, `completed`, `idle`, `missing`, or
+  `invalid`.
+- Treat `execution/finalize/await_merge` and `land` as `active`, because they
+  still require human steering or post-merge bookkeeping.
+- Treat `current_node: "idle"` with last-landed context as `completed`.
+- Treat ordinary `current_node: "idle"` without last-landed context as `idle`
+  rather than pretending it is completed.
+- Surface invalid watched entries with a reason such as `unreadable`,
+  `not_git_workspace`, or `status_error`.
+- Update the tracked watchlist/dashboard contract docs so future UI work can
+  consume the read model without reverse-engineering Go types or tests.
+- Serve the read model through a UI server API endpoint suitable for the future
+  dashboard home.
+- Add focused tests for watchlist reads, dashboard classification, degraded
+  entries, recency ordering, and API behavior.
+
+### Out of Scope
+
+- Building the dashboard frontend UI.
+- Adding the `harness dashboard` CLI entrypoint.
+- Adding filesystem watching, notifications, or background refresh.
+- Adding dashboard-local write actions such as unwatch.
+- Changing the persisted watchlist schema.
+- Adding compatibility shims for obsolete watchlist or status shapes.
+
+## Acceptance Criteria
+
+- [ ] The dashboard read model reads watched workspaces from the machine-local
+      watchlist and returns one compact summary per watched entry.
+- [ ] Each readable workspace summary exposes the raw harness `current_node`
+      alongside a dashboard lifecycle state.
+- [ ] `execution/finalize/await_merge`, `land`, and other non-idle readable
+      nodes classify as `active`.
+- [ ] Idle workspaces with `artifacts.last_landed_at` classify as `completed`.
+- [ ] Idle workspaces without last-landed context classify as `idle`, not
+      `completed`.
+- [ ] Missing watched paths classify as `missing` and remain visible in the
+      model.
+- [ ] Existing but invalid watched paths classify as `invalid` with a reason
+      that preserves whether the path was unreadable, not git-backed, or failed
+      status resolution.
+- [ ] The read model is read-only and tests prove it does not touch or rewrite
+      the watchlist or workflow state.
+- [ ] Dashboard entries are ordered by watchlist recency using `last_seen_at`,
+      with deterministic fallback ordering for malformed or equal timestamps.
+- [ ] A UI server API endpoint returns the dashboard read model as JSON without
+      disturbing the existing `/api/status`, `/api/plan`, `/api/timeline`, or
+      `/api/review` endpoints.
+- [ ] Tracked specs document the dashboard read model payload boundary,
+      `current_node` exposure, dashboard lifecycle states, and invalid reason
+      semantics.
+
+## Deferred Items
+
+- Implement the `harness dashboard` command and default `/dashboard` route in a
+  follow-up dashboard entrypoint slice.
+- Build the frontend dashboard home and workspace navigation in the minimal UI
+  slice.
+- Add dashboard-local unwatch behavior after the read model and UI shape are
+  proven.
+
+## Work Breakdown
+
+### Step 1: Add a read-only watchlist loading API
+
+- Done: [x]
+
+#### Objective
+
+Expose a public watchlist read path that resolves the same machine-local home
+as `Touch` and loads the persisted watchlist without writing files.
+
+#### Details
+
+Keep the persisted watchlist schema unchanged. The reader should share the
+existing home resolution and parse validation behavior where possible, but it
+must not acquire write-only behavior, update timestamps, canonicalize entries
+by rewriting the file, or silently drop malformed workspace records that the
+dashboard should present as invalid entries later.
+
+#### Expected Files
+
+- `internal/watchlist/watchlist.go`
+- `internal/watchlist/watchlist_test.go`
+
+#### Validation
+
+- Add or update watchlist tests that cover default and `EASYHARNESS_HOME`
+  loading, missing watchlist files, invalid JSON or unsupported versions, and
+  no write/timestamp side effects during reads.
+
+#### Execution Notes
+
+Added `watchlist.Service.Read()` as a read-only loader that resolves the same
+machine-local home as `Touch` and returns the parsed `watchlist.json` model
+without creating files or updating timestamps. Added focused coverage for
+default home, `EASYHARNESS_HOME`, missing files, invalid JSON, unsupported
+versions, and preserving persisted workspace records as read.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Document the dashboard read model contract
+
+- Done: [ ]
+
+#### Objective
+
+Update tracked specs with the read model contract that the implementation and
+future dashboard UI should share.
+
+#### Details
+
+Document that the dashboard read model is a read-time projection over
+`watchlist.json` plus per-workspace harness status. The docs should state that
+readable entries expose raw `current_node` separately from dashboard lifecycle
+state; that lifecycle states are `active`, `completed`, `idle`, `missing`, and
+`invalid`; that ordinary idle without last-landed context remains `idle`; and
+that invalid entries carry a reason such as `unreadable`, `not_git_workspace`,
+or `status_error`.
+
+Keep this as contract alignment for the read model, not a broader dashboard UI
+spec rewrite.
+
+#### Expected Files
+
+- `docs/specs/watchlist-contract.md`
+- `docs/specs/proposals/harness-ui-steering-surface.md` if nearby dashboard
+  wording needs to stay aligned
+
+#### Validation
+
+- Reread the changed spec sections against this plan and issue #165.
+- Run `git diff --check` for the documentation changes.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Build the dashboard summary service
+
+- Done: [ ]
+
+#### Objective
+
+Create a dashboard read model that turns watchlist entries into ordered,
+dashboard-ready workspace summaries while preserving raw harness status fields.
+
+#### Details
+
+The service should read the watchlist once, then inspect each watched
+workspace. For readable workspaces, call `status.Service{Workdir:
+workspace_path}.Read()` and map the returned status into a compact dashboard
+entry. Keep `current_node` as a first-class field when status is readable.
+
+Dashboard lifecycle mapping should be:
+
+- `active`: status is readable and `current_node` is anything except `idle`.
+- `completed`: status is readable, `current_node` is `idle`, and status
+  artifacts include last-landed context.
+- `idle`: status is readable, `current_node` is `idle`, and no last-landed
+  context is present.
+- `missing`: the watched path no longer exists.
+- `invalid`: the watched path exists but cannot be treated as a valid readable
+  harness workspace.
+
+Use an `invalid_reason` or equivalent field to distinguish `unreadable`,
+`not_git_workspace`, `status_error`, and other concrete invalid cases without
+expanding the top-level dashboard state enum.
+
+#### Expected Files
+
+- `internal/dashboard/service.go`
+- `internal/dashboard/service_test.go`
+- `internal/contracts/dashboard.go`
+- `internal/contracts/registry.go`
+- generated schema files if the repository's schema generation expects the new
+  contract to be registered
+
+#### Validation
+
+- Add focused dashboard service tests for active, completed, idle, missing,
+  not-git, unreadable, and status-error entries.
+- Cover recency ordering by `last_seen_at` and deterministic fallback ordering
+  for equal, empty, or malformed timestamps.
+- Cover that the service remains read-only by checking watchlist and workflow
+  state files are not created or modified during reads.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 4: Serve the dashboard model through the UI backend
+
+- Done: [ ]
+
+#### Objective
+
+Expose the dashboard read model through a JSON endpoint that the future
+dashboard home can consume.
+
+#### Details
+
+Add a small endpoint such as `GET /api/dashboard` to the existing UI server.
+The endpoint should return the dashboard read model and should not trigger
+watchlist writes. Keep existing workbench endpoints unchanged. This step does
+not need to add frontend rendering, route handling, or the `harness dashboard`
+command.
+
+#### Expected Files
+
+- `internal/ui/server.go`
+- `internal/ui/server_test.go`
+- `web/src/types.ts` only if the current frontend type surface already tracks
+  backend response types for unused endpoints
+
+#### Validation
+
+- Add server tests that prove `GET /api/dashboard` returns dashboard JSON,
+  rejects non-GET methods, returns degraded entries instead of dropping them,
+  and avoids watchlist writes.
+- Run the focused Go tests for watchlist, dashboard, and UI server packages.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run `harness plan lint` before execution approval.
+- During execution, use focused package tests first:
+  `go test ./internal/watchlist ./internal/dashboard ./internal/ui -count=1`.
+- Run broader Go coverage if contract or status integration changes spill into
+  shared packages: `go test ./internal/... -count=1`.
+- If generated schema or contract docs change, run the repository's existing
+  schema generation or validation command identified during implementation.
+
+## Risks
+
+- Risk: Dashboard lifecycle states could blur with harness workflow
+  `current_node` states.
+  - Mitigation: Keep `current_node` exposed directly and make dashboard state a
+    separate presentation lifecycle field with explicit tests for ambiguous
+    idle behavior.
+- Risk: The dashboard service could accidentally mutate the watchlist or
+  workflow state while reading many workspaces.
+  - Mitigation: Use read-only APIs and add regression tests that inspect file
+    absence or modification times around dashboard reads.
+- Risk: Invalid watched entries could be silently dropped by convenience
+  filtering.
+  - Mitigation: Test missing, unreadable, not-git, and status-error entries as
+    first-class returned summaries with reasons.
+- Risk: Multi-worktree status reads could be slow or expose inconsistent
+  partial state.
+  - Mitigation: Keep the first model simple and synchronous, return per-entry
+    degraded status for failures, and defer caching or background refresh until
+    dashboard UI behavior proves it is needed.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/archived/2026-04-22-build-watchlist-dashboard-read-model.md
+++ b/docs/plans/archived/2026-04-22-build-watchlist-dashboard-read-model.md
@@ -61,28 +61,28 @@ recency ordering, or degraded-entry handling.
 
 ## Acceptance Criteria
 
-- [ ] The dashboard read model reads watched workspaces from the machine-local
+- [x] The dashboard read model reads watched workspaces from the machine-local
       watchlist and returns one compact summary per watched entry.
-- [ ] Each readable workspace summary exposes the raw harness `current_node`
+- [x] Each readable workspace summary exposes the raw harness `current_node`
       alongside a dashboard lifecycle state.
-- [ ] `execution/finalize/await_merge`, `land`, and other non-idle readable
+- [x] `execution/finalize/await_merge`, `land`, and other non-idle readable
       nodes classify as `active`.
-- [ ] Idle workspaces with `artifacts.last_landed_at` classify as `completed`.
-- [ ] Idle workspaces without last-landed context classify as `idle`, not
+- [x] Idle workspaces with `artifacts.last_landed_at` classify as `completed`.
+- [x] Idle workspaces without last-landed context classify as `idle`, not
       `completed`.
-- [ ] Missing watched paths classify as `missing` and remain visible in the
+- [x] Missing watched paths classify as `missing` and remain visible in the
       model.
-- [ ] Existing but invalid watched paths classify as `invalid` with a reason
+- [x] Existing but invalid watched paths classify as `invalid` with a reason
       that preserves whether the path was unreadable, not git-backed, or failed
       status resolution.
-- [ ] The read model is read-only and tests prove it does not touch or rewrite
+- [x] The read model is read-only and tests prove it does not touch or rewrite
       the watchlist or workflow state.
-- [ ] Dashboard entries are ordered by watchlist recency using `last_seen_at`,
+- [x] Dashboard entries are ordered by watchlist recency using `last_seen_at`,
       with deterministic fallback ordering for malformed or equal timestamps.
-- [ ] A UI server API endpoint returns the dashboard read model as JSON without
+- [x] A UI server API endpoint returns the dashboard read model as JSON without
       disturbing the existing `/api/status`, `/api/plan`, `/api/timeline`, or
       `/api/review` endpoints.
-- [ ] Tracked specs document the dashboard read model payload boundary,
+- [x] Tracked specs document the dashboard read model payload boundary,
       `current_node` exposure, dashboard lifecycle states, and invalid reason
       semantics.
 
@@ -348,26 +348,70 @@ Follow-up `review-009-delta` passed with no findings.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `harness plan lint docs/plans/active/2026-04-22-build-watchlist-dashboard-read-model.md`
+- `go test ./internal/watchlist -count=1`
+- `go test ./internal/dashboard ./internal/watchlist ./internal/contractsync -count=1`
+- `go test ./internal/ui ./internal/dashboard ./internal/watchlist -count=1`
+- `go test ./internal/dashboard ./internal/watchlist ./internal/ui -count=1`
+- `scripts/sync-contract-artifacts --check`
+- `git diff --check`
+- `go test ./internal/... -count=1`
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step 1 delta review: `review-001-delta` requested one no-rewrite test fix;
+  `review-002-delta` passed after adding bytes and mtime coverage.
+- Step 2 delta review: `review-003-delta` requested concrete payload-boundary
+  docs; `review-004-delta` passed after documenting result/group/workspace
+  fields.
+- Step 3 delta review: `review-005-delta` and `review-006-delta` requested
+  read-only status behavior and Git probe classification fixes;
+  `review-007-delta` passed after `ReadUnlocked()` and marker-aware parser
+  coverage.
+- Step 4 delta review: `review-008-delta` requested endpoint coverage proving
+  missing watched entries remain in the response; `review-009-delta` passed.
+- Finalize review: `review-010-full` requested malformed path rejection and
+  explicit route-key collision diagnostics, plus one schema wording cleanup.
+  `review-011-full` passed with no findings after the repair.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-04-22T23:33:36+08:00
+- Revision: 1
+- PR: not opened yet; publish closeout should create the PR from branch
+  `codex/issue-165-dashboard-read-model` and include `Closes #165`.
+- Ready: Acceptance criteria are satisfied, focused and full internal
+  validation passed, generated contract schemas are in sync, and
+  `review-011-full` passed cleanly.
+- Merge Handoff: After archive, commit the tracked plan move, push the branch,
+  open the PR, record publish/CI/sync evidence, and stop at merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added a read-only watchlist loader and tests proving reads do not create or
+  rewrite `watchlist.json`.
+- Added the dashboard read model contract, generated schema registration, and
+  tracked spec updates for lifecycle groups, raw `current_node`, invalid
+  reasons, route keys, and degraded entries.
+- Added `internal/dashboard` service behavior for active, completed, idle,
+  missing, invalid, malformed path, route-key collision, recency sorting, and
+  read-only status integration.
+- Added `GET /api/dashboard` with tests for JSON response shape, method
+  rejection, missing/degraded entries, and no watchlist rewrite side effects.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Dashboard frontend rendering, the `harness dashboard` entrypoint, background
+  refresh, notifications, dashboard-local write actions, and persisted
+  watchlist schema changes remain out of scope for this slice.
 
 ### Follow-Up Issues
 
-NONE
+- #156 tracks the broader machine-local watchlist dashboard epic:
+  https://github.com/catu-ai/easyharness/issues/156
+- #166 tracks completed/hidden lifecycle and dashboard-local hide/archive
+  semantics: https://github.com/catu-ai/easyharness/issues/166
+- #167 tracks the minimal watchlist dashboard UI and entrypoint:
+  https://github.com/catu-ai/easyharness/issues/167

--- a/docs/specs/proposals/harness-ui-steering-surface.md
+++ b/docs/specs/proposals/harness-ui-steering-surface.md
@@ -92,7 +92,9 @@ Readable entries should expose raw `current_node` separately from the
 dashboard lifecycle state. The lifecycle states are `active`, `completed`,
 `idle`, `missing`, and `invalid`; ordinary idle without last-landed context
 stays `idle`, and invalid rows carry a reason such as `unreadable`,
-`not_git_workspace`, or `status_error`.
+`not_git_workspace`, or `status_error`. The read model should return stable
+lifecycle groups containing compact watched workspace entries rather than
+making the frontend derive grouping or field names from raw status payloads.
 
 ## Product Shape
 

--- a/docs/specs/proposals/harness-ui-steering-surface.md
+++ b/docs/specs/proposals/harness-ui-steering-surface.md
@@ -86,6 +86,14 @@ artifacts for the selected workspace. It should present those sources through
 one machine-local entrypoint and one dense document-oriented workspace surface
 instead of inventing new product-only state.
 
+The dashboard home should consume a read-only dashboard read model: a
+read-time projection over `watchlist.json` plus per-workspace harness status.
+Readable entries should expose raw `current_node` separately from the
+dashboard lifecycle state. The lifecycle states are `active`, `completed`,
+`idle`, `missing`, and `invalid`; ordinary idle without last-landed context
+stays `idle`, and invalid rows carry a reason such as `unreadable`,
+`not_git_workspace`, or `status_error`.
+
 ## Product Shape
 
 ### Entry Point
@@ -152,7 +160,7 @@ It should:
 - list watched workspaces
 - order them by recency using watchlist data
 - let the user enter a specific watched workspace
-- surface degraded watched entries such as missing or unreadable workspaces
+- surface degraded watched entries such as missing or invalid workspaces
 
 Workspace detail should live under `/workspace/<workspace_key>`.
 
@@ -339,7 +347,7 @@ It should:
 - default to the watched-workspace list instead of a specific repo
 - sort watched workspaces by watchlist recency
 - make the current workspace easy to find without requiring direct-open flags
-- present missing or unreadable watched entries as explicit degraded rows
+- present missing or invalid watched entries as explicit degraded rows
 
 The home page does not need a second dashboard-only workspace summary shell.
 Its job is to help the user pick a watched workspace and move into the
@@ -452,10 +460,10 @@ workspace's canonical path at read time. The URL should not expose the raw
 absolute path, and the watchlist should not grow a separate persisted
 route-only ID just to support the route family.
 
-### Missing, Unreadable, and Unknown Workspace Routes
+### Missing, Invalid, and Unknown Workspace Routes
 
 If a watched workspace is still in the watchlist but is currently missing or
-unreadable, `/workspace/<workspace_key>` should render a simple degraded page
+invalid, `/workspace/<workspace_key>` should render a simple degraded page
 instead of failing hard or silently redirecting away.
 
 That degraded page may offer one local cleanup action:

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -281,6 +281,50 @@ Invalid entries carry a reason such as `unreadable`, `not_git_workspace`, or
 `status_error`. The reason refines the `invalid` state; it does not expand the
 top-level lifecycle enum.
 
+## Dashboard Read Model Payload
+
+The dashboard read model should expose one compact result for the dashboard
+home. The concrete API route is implementation-owned, but the payload boundary
+should follow this shape:
+
+- `ok`: whether the dashboard read completed without a top-level watchlist
+  load failure
+- `command`: stable result label such as `dashboard`
+- `summary`: concise human-readable result summary
+- `groups`: dashboard lifecycle groups in stable order
+- `errors`: top-level watchlist or read-model errors when the watched set
+  cannot be loaded at all
+
+Each group contains:
+
+- `state`: one of `active`, `completed`, `idle`, `missing`, or `invalid`
+- `workspaces`: watched workspace entries in dashboard recency order
+
+Each workspace entry contains:
+
+- `workspace_key`: dashboard route key derived from canonical
+  `workspace_path`
+- `workspace_path`: canonical watched path from the watchlist record
+- `watched_at`: timestamp from the watchlist record
+- `last_seen_at`: timestamp from the watchlist record, used as the primary
+  dashboard recency signal
+- `dashboard_state`: same lifecycle value as the containing group
+- `invalid_reason`: present only when `dashboard_state` is `invalid`
+- `current_node`: raw harness workflow node for readable status entries
+- `summary`: compact row/card summary; for readable entries this should come
+  from harness status
+- `next_actions`: compact pass-through of the most relevant status next
+  actions for readable entries
+- `warnings`, `blockers`, and `errors`: compact pass-through or degraded-entry
+  diagnostics for the watched workspace
+- `artifacts`: stable status artifact handles needed for dashboard navigation
+  or display
+
+Readable entries should omit `invalid_reason`. Missing entries do not have
+`current_node` because there is no readable workspace status. Invalid entries
+may omit `current_node` unless a partial status result produced a trustworthy
+raw node before failing.
+
 In particular:
 
 - a harness plan moving through `archive` or back to `idle` does not remove

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -289,7 +289,7 @@ should follow this shape:
 
 - `ok`: whether the dashboard read completed without a top-level watchlist
   load failure
-- `command`: stable result label such as `dashboard`
+- `resource`: stable UI resource label such as `dashboard`
 - `summary`: concise human-readable result summary
 - `groups`: dashboard lifecycle groups in stable order
 - `errors`: top-level watchlist or read-model errors when the watched set

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -221,8 +221,9 @@ Derived at read time:
 - whether the workspace is the repository's primary checkout or a linked
   worktree
 - whether a watched workspace currently presents as `active`, `completed`,
-  `missing`, or another explicit degraded read-time state such as
-  `unreadable`
+  `idle`, `missing`, or `invalid`
+- invalid reason for degraded read failures, such as `unreadable`,
+  `not_git_workspace`, or `status_error`
 - live harness status or dashboard summary fields
 
 The contract prefers deriving these facts from the current filesystem and Git
@@ -246,25 +247,51 @@ deferred beyond this machine-local touch foundation.
 The first contract keeps dashboard lifecycle classification derived instead of
 persisted.
 
-At minimum, later read-model and UI work may classify a watched workspace as:
+The dashboard read model is a read-time projection over `watchlist.json` plus
+per-workspace harness status. It must not write the watchlist or workflow
+state while building dashboard entries.
+
+Readable dashboard entries expose the raw harness `current_node` separately
+from the dashboard lifecycle state. The lifecycle state is a compact
+dashboard classification, not a replacement for the raw workflow node.
+
+The dashboard lifecycle states are:
 
 - `active`
 - `completed`
+- `idle`
 - `missing`
-- `unreadable`
+- `invalid`
 
 These are read-time states for currently watched entries, not membership
 transitions stored in the watchlist file.
+
+Lifecycle classification:
+
+- `active`: status is readable and `current_node` is anything except `idle`
+- `completed`: status is readable, `current_node` is `idle`, and status
+  artifacts include last-landed context
+- `idle`: status is readable, `current_node` is `idle`, and no last-landed
+  context is present
+- `missing`: the watched path no longer exists
+- `invalid`: the watched path exists but cannot be treated as a valid readable
+  harness workspace
+
+Invalid entries carry a reason such as `unreadable`, `not_git_workspace`, or
+`status_error`. The reason refines the `invalid` state; it does not expand the
+top-level lifecycle enum.
 
 In particular:
 
 - a harness plan moving through `archive` or back to `idle` does not remove
   the workspace from the watchlist
+- ordinary idle without last-landed context remains `idle`; it must not be
+  presented as `completed`
 - deleting the local directory does not remove the workspace from the
   watchlist by itself; it instead becomes a `missing` watched workspace until
   later explicit membership-removal behavior exists and removes it
-- a permissions or probe failure may surface as `unreadable` without removing
-  the workspace from the watchlist
+- a permissions, Git probe, or status failure may surface as `invalid` without
+  removing the workspace from the watchlist
 
 ## No Automatic GC In V1
 
@@ -272,18 +299,18 @@ This first contract does not define silent automatic garbage collection.
 
 The watchlist is a remembered local set, not an auto-pruned mirror of the
 current filesystem. The combination of `last_seen_at`, derived `missing`
-status, and deferred explicit membership-removal behavior is enough for this
-touch-foundation slice.
+or `invalid` status, and deferred explicit membership-removal behavior is
+enough for this touch-foundation slice.
 
 Later work may add user-facing cleanup or stale-item policies, but v1 should
 not silently discard watched entries just because they have gone idle,
-unreadable, or missing.
+invalid, or missing.
 
 ## Dashboard Routing Outcomes
 
 For dashboard workspace-detail routing:
 
-- a watched workspace that is now `missing` or `unreadable` should still
+- a watched workspace that is now `missing` or `invalid` should still
   resolve to an explicit degraded workspace page rather than being silently
   dropped or redirected away
 - a route key that does not match any current watched workspace should be
@@ -325,7 +352,7 @@ This spec does not:
 
 - define when or how workspaces are added to the watchlist
 - define daemon versus on-demand backend architecture
-- define a dashboard read model beyond the persisted-versus-derived boundary
+- define dashboard UI rendering beyond the persisted-versus-derived boundary
 - merge separate local clones into one project because they share a remote
 - support non-git watched directories in the first slice
 - define any dashboard-local `hidden` state or secondary visibility layer

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -277,9 +277,9 @@ Lifecycle classification:
 - `invalid`: the watched path exists but cannot be treated as a valid readable
   harness workspace
 
-Invalid entries carry a reason such as `unreadable`, `not_git_workspace`, or
-`status_error`. The reason refines the `invalid` state; it does not expand the
-top-level lifecycle enum.
+Invalid entries carry a reason such as `unreadable`, `not_git_workspace`,
+`status_error`, `malformed_path`, or `route_key_collision`. The reason refines
+the `invalid` state; it does not expand the top-level lifecycle enum.
 
 ## Dashboard Read Model Payload
 
@@ -336,6 +336,10 @@ In particular:
   later explicit membership-removal behavior exists and removes it
 - a permissions, Git probe, or status failure may surface as `invalid` without
   removing the workspace from the watchlist
+- a malformed non-absolute `workspace_path` must surface as `invalid` before
+  any filesystem, Git, or status probe is attempted
+- a duplicate or otherwise colliding `workspace_key` must surface explicit
+  per-entry collision diagnostics rather than silently routing to one workspace
 
 ## No Automatic GC In V1
 

--- a/internal/contracts/dashboard.go
+++ b/internal/contracts/dashboard.go
@@ -1,0 +1,78 @@
+package contracts
+
+// DashboardResult is the read-only UI resource for the machine-local dashboard
+// home.
+type DashboardResult struct {
+	// OK reports whether the machine-local watchlist was loaded.
+	OK bool `json:"ok"`
+
+	// Resource is the stable UI resource identifier.
+	Resource string `json:"resource"`
+
+	// Summary is the concise human-readable explanation of the loaded
+	// dashboard model.
+	Summary string `json:"summary"`
+
+	// Groups lists watched workspaces grouped by dashboard lifecycle state.
+	Groups []DashboardGroup `json:"groups"`
+
+	// Errors lists hard failures that prevented dashboard loading.
+	Errors []ErrorDetail `json:"errors,omitempty"`
+}
+
+// DashboardGroup is one dashboard lifecycle group.
+type DashboardGroup struct {
+	// State is the dashboard lifecycle state for every workspace in the group.
+	State string `json:"state"`
+
+	// Workspaces lists watched workspace entries in dashboard recency order.
+	Workspaces []DashboardWorkspace `json:"workspaces"`
+}
+
+// DashboardWorkspace is one watched workspace summary for the dashboard home.
+type DashboardWorkspace struct {
+	// WorkspaceKey is the opaque deterministic route key derived from the
+	// watched workspace path.
+	WorkspaceKey string `json:"workspace_key"`
+
+	// WorkspacePath is the canonical watched path from the watchlist record.
+	WorkspacePath string `json:"workspace_path"`
+
+	// WatchedAt is the timestamp when the workspace first entered the
+	// watchlist.
+	WatchedAt string `json:"watched_at,omitempty"`
+
+	// LastSeenAt is the dashboard recency timestamp from the watchlist record.
+	LastSeenAt string `json:"last_seen_at,omitempty"`
+
+	// DashboardState is the read-time dashboard lifecycle state.
+	DashboardState string `json:"dashboard_state"`
+
+	// InvalidReason refines invalid entries without expanding the dashboard
+	// lifecycle state enum.
+	InvalidReason string `json:"invalid_reason,omitempty"`
+
+	// CurrentNode is the raw harness workflow node for readable status entries.
+	CurrentNode string `json:"current_node,omitempty"`
+
+	// Summary is the compact workspace summary for dashboard rows or cards.
+	Summary string `json:"summary"`
+
+	// NextAction lists the most relevant status follow-up steps for readable
+	// entries.
+	NextAction []NextAction `json:"next_actions,omitempty"`
+
+	// Warnings lists non-fatal degraded-state notes for this workspace.
+	Warnings []string `json:"warnings,omitempty"`
+
+	// Blockers lists state issues that block ordinary progression for this
+	// workspace.
+	Blockers []ErrorDetail `json:"blockers,omitempty"`
+
+	// Errors lists hard failures for this workspace entry.
+	Errors []ErrorDetail `json:"errors,omitempty"`
+
+	// Artifacts points to stable status artifact handles for navigation or
+	// display.
+	Artifacts *StatusArtifacts `json:"artifacts,omitempty"`
+}

--- a/internal/contracts/registry.go
+++ b/internal/contracts/registry.go
@@ -5,20 +5,29 @@ import "reflect"
 // SchemaEntry describes one generated JSON Schema and matching generated
 // reference doc entry.
 type SchemaEntry struct {
-	Key         string
-	Group       string
-	Path        string
-	Title       string
-	Description string
-	Shape       string
+	Key             string
+	Group           string
+	Path            string
+	Title           string
+	Description     string
+	Shape           string
 	HiddenFromIndex bool
-	Type        reflect.Type
+	Type            reflect.Type
 }
 
 // SchemaRegistry returns the generated schema/doc registry entries for the
 // current public contract surface.
 func SchemaRegistry() []SchemaEntry {
 	return []SchemaEntry{
+		{
+			Key:         "ui_resources.dashboard",
+			Group:       "ui_resources",
+			Path:        "schema/ui-resources/dashboard.schema.json",
+			Title:       "Dashboard UI resource",
+			Description: "Read-only JSON resource returned by the dashboard home API for `harness ui`.",
+			Shape:       "output",
+			Type:        reflect.TypeFor[DashboardResult](),
+		},
 		{
 			Key:         "ui_resources.plan",
 			Group:       "ui_resources",
@@ -182,24 +191,24 @@ func SchemaRegistry() []SchemaEntry {
 			Type:        reflect.TypeFor[LocalStateFile](),
 		},
 		{
-			Key:         "artifacts.review_manifest",
-			Group:       "artifacts",
-			Path:        "schema/artifacts/review-manifest.schema.json",
-			Title:       "Review manifest artifact",
-			Description: "Command-owned review manifest artifact for one review round.",
-			Shape:       "artifact",
+			Key:             "artifacts.review_manifest",
+			Group:           "artifacts",
+			Path:            "schema/artifacts/review-manifest.schema.json",
+			Title:           "Review manifest artifact",
+			Description:     "Command-owned review manifest artifact for one review round.",
+			Shape:           "artifact",
 			HiddenFromIndex: true,
-			Type:        reflect.TypeFor[ReviewManifest](),
+			Type:            reflect.TypeFor[ReviewManifest](),
 		},
 		{
-			Key:         "artifacts.review_ledger",
-			Group:       "artifacts",
-			Path:        "schema/artifacts/review-ledger.schema.json",
-			Title:       "Review ledger artifact",
-			Description: "Command-owned review ledger artifact for one review round.",
-			Shape:       "artifact",
+			Key:             "artifacts.review_ledger",
+			Group:           "artifacts",
+			Path:            "schema/artifacts/review-ledger.schema.json",
+			Title:           "Review ledger artifact",
+			Description:     "Command-owned review ledger artifact for one review round.",
+			Shape:           "artifact",
 			HiddenFromIndex: true,
-			Type:        reflect.TypeFor[ReviewLedger](),
+			Type:            reflect.TypeFor[ReviewLedger](),
 		},
 		{
 			Key:         "artifacts.review_submission",
@@ -211,14 +220,14 @@ func SchemaRegistry() []SchemaEntry {
 			Type:        reflect.TypeFor[ReviewSubmission](),
 		},
 		{
-			Key:         "artifacts.review_aggregate",
-			Group:       "artifacts",
-			Path:        "schema/artifacts/review-aggregate.schema.json",
-			Title:       "Review aggregate artifact",
-			Description: "Command-owned review aggregate artifact.",
-			Shape:       "artifact",
+			Key:             "artifacts.review_aggregate",
+			Group:           "artifacts",
+			Path:            "schema/artifacts/review-aggregate.schema.json",
+			Title:           "Review aggregate artifact",
+			Description:     "Command-owned review aggregate artifact.",
+			Shape:           "artifact",
 			HiddenFromIndex: true,
-			Type:        reflect.TypeFor[ReviewAggregate](),
+			Type:            reflect.TypeFor[ReviewAggregate](),
 		},
 		{
 			Key:         "artifacts.evidence_ci_record",

--- a/internal/contracts/registry.go
+++ b/internal/contracts/registry.go
@@ -24,7 +24,7 @@ func SchemaRegistry() []SchemaEntry {
 			Group:       "ui_resources",
 			Path:        "schema/ui-resources/dashboard.schema.json",
 			Title:       "Dashboard UI resource",
-			Description: "Read-only JSON resource returned by the dashboard home API for `harness ui`.",
+			Description: "Read-only JSON resource returned by the dashboard home API.",
 			Shape:       "output",
 			Type:        reflect.TypeFor[DashboardResult](),
 		},

--- a/internal/dashboard/service.go
+++ b/internal/dashboard/service.go
@@ -1,0 +1,237 @@
+package dashboard
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/catu-ai/easyharness/internal/contracts"
+	"github.com/catu-ai/easyharness/internal/status"
+	"github.com/catu-ai/easyharness/internal/watchlist"
+)
+
+const (
+	StateActive    = "active"
+	StateCompleted = "completed"
+	StateIdle      = "idle"
+	StateMissing   = "missing"
+	StateInvalid   = "invalid"
+
+	InvalidUnreadable      = "unreadable"
+	InvalidNotGitWorkspace = "not_git_workspace"
+	InvalidStatusError     = "status_error"
+)
+
+var dashboardStateOrder = []string{StateActive, StateCompleted, StateIdle, StateMissing, StateInvalid}
+
+type Service struct {
+	LookupEnv   func(string) (string, bool)
+	UserHomeDir func() (string, error)
+	ReadStatus  func(string) contracts.StatusResult
+	Stat        func(string) (os.FileInfo, error)
+}
+
+type Result = contracts.DashboardResult
+type Group = contracts.DashboardGroup
+type Workspace = contracts.DashboardWorkspace
+type ErrorDetail = contracts.ErrorDetail
+
+func (s Service) Read() Result {
+	file, err := watchlist.Service{
+		LookupEnv:   s.LookupEnv,
+		UserHomeDir: s.UserHomeDir,
+	}.Read()
+	if err != nil {
+		return Result{
+			OK:       false,
+			Resource: "dashboard",
+			Summary:  "Unable to load the machine-local watchlist.",
+			Groups:   emptyGroups(),
+			Errors:   []ErrorDetail{{Path: "watchlist", Message: err.Error()}},
+		}
+	}
+
+	entries := make([]Workspace, 0, len(file.Workspaces))
+	for _, watched := range file.Workspaces {
+		entries = append(entries, s.readWorkspace(watched))
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entryLess(entries[i], entries[j])
+	})
+
+	groups := groupEntries(entries)
+	return Result{
+		OK:       true,
+		Resource: "dashboard",
+		Summary:  fmt.Sprintf("Loaded %d watched workspace(s).", len(entries)),
+		Groups:   groups,
+	}
+}
+
+func (s Service) readWorkspace(watched watchlist.Workspace) Workspace {
+	path := strings.TrimSpace(watched.WorkspacePath)
+	entry := Workspace{
+		WorkspaceKey:   workspaceKey(path),
+		WorkspacePath:  path,
+		WatchedAt:      strings.TrimSpace(watched.WatchedAt),
+		LastSeenAt:     strings.TrimSpace(watched.LastSeenAt),
+		DashboardState: StateInvalid,
+		Summary:        "Watched workspace is invalid.",
+	}
+
+	if path == "" {
+		entry.InvalidReason = InvalidNotGitWorkspace
+		entry.Errors = []ErrorDetail{{Path: "workspace_path", Message: "watched workspace path is empty"}}
+		return entry
+	}
+
+	info, err := s.stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			entry.DashboardState = StateMissing
+			entry.Summary = "Watched workspace path is missing."
+			entry.Errors = []ErrorDetail{{Path: "workspace_path", Message: "watched workspace path is missing"}}
+			return entry
+		}
+		entry.InvalidReason = InvalidUnreadable
+		entry.Summary = "Watched workspace path is unreadable."
+		entry.Errors = []ErrorDetail{{Path: "workspace_path", Message: err.Error()}}
+		return entry
+	}
+	if !info.IsDir() {
+		entry.InvalidReason = InvalidNotGitWorkspace
+		entry.Summary = "Watched workspace path is not a Git workspace."
+		entry.Errors = []ErrorDetail{{Path: "workspace_path", Message: "watched workspace path is not a directory"}}
+		return entry
+	}
+	if err := requireGitWorkspace(path); err != nil {
+		if errors.Is(err, watchlist.ErrNotGitWorkspace) {
+			entry.InvalidReason = InvalidNotGitWorkspace
+			entry.Summary = "Watched workspace path is not a Git workspace."
+		} else {
+			entry.InvalidReason = InvalidUnreadable
+			entry.Summary = "Unable to inspect watched workspace Git metadata."
+		}
+		entry.Errors = []ErrorDetail{{Path: "git", Message: err.Error()}}
+		return entry
+	}
+
+	statusResult := s.readStatus(path)
+	if !statusResult.OK {
+		entry.InvalidReason = InvalidStatusError
+		entry.Summary = statusResult.Summary
+		entry.CurrentNode = statusResult.State.CurrentNode
+		entry.NextAction = statusResult.NextAction
+		entry.Warnings = statusResult.Warnings
+		entry.Blockers = statusResult.Blockers
+		entry.Errors = statusResult.Errors
+		entry.Artifacts = statusResult.Artifacts
+		return entry
+	}
+
+	entry.DashboardState = dashboardState(statusResult)
+	entry.Summary = statusResult.Summary
+	entry.CurrentNode = statusResult.State.CurrentNode
+	entry.NextAction = statusResult.NextAction
+	entry.Warnings = statusResult.Warnings
+	entry.Blockers = statusResult.Blockers
+	entry.Errors = statusResult.Errors
+	entry.Artifacts = statusResult.Artifacts
+	return entry
+}
+
+func (s Service) stat(path string) (os.FileInfo, error) {
+	if s.Stat != nil {
+		return s.Stat(path)
+	}
+	return os.Stat(path)
+}
+
+func (s Service) readStatus(path string) contracts.StatusResult {
+	if s.ReadStatus != nil {
+		return s.ReadStatus(path)
+	}
+	return status.Service{Workdir: path}.Read()
+}
+
+func dashboardState(result contracts.StatusResult) string {
+	if result.State.CurrentNode != "idle" {
+		return StateActive
+	}
+	if result.Artifacts != nil && strings.TrimSpace(result.Artifacts.LastLandedAt) != "" {
+		return StateCompleted
+	}
+	return StateIdle
+}
+
+func requireGitWorkspace(path string) error {
+	output, err := exec.Command("git", "-C", filepath.Clean(path), "rev-parse", "--show-toplevel").CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return fmt.Errorf("%w: %s", watchlist.ErrNotGitWorkspace, strings.TrimSpace(string(output)))
+		}
+		return fmt.Errorf("inspect git workspace: %w", err)
+	}
+	if strings.TrimSpace(string(output)) == "" {
+		return watchlist.ErrNotGitWorkspace
+	}
+	return nil
+}
+
+func workspaceKey(path string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(strings.TrimSpace(path))))
+	return "wk_" + hex.EncodeToString(sum[:])[:16]
+}
+
+func emptyGroups() []Group {
+	return groupEntries(nil)
+}
+
+func groupEntries(entries []Workspace) []Group {
+	byState := make(map[string][]Workspace, len(dashboardStateOrder))
+	for _, state := range dashboardStateOrder {
+		byState[state] = []Workspace{}
+	}
+	for _, entry := range entries {
+		state := entry.DashboardState
+		if _, ok := byState[state]; !ok {
+			state = StateInvalid
+			entry.DashboardState = StateInvalid
+			if entry.InvalidReason == "" {
+				entry.InvalidReason = InvalidStatusError
+			}
+		}
+		byState[state] = append(byState[state], entry)
+	}
+
+	groups := make([]Group, 0, len(dashboardStateOrder))
+	for _, state := range dashboardStateOrder {
+		groups = append(groups, Group{State: state, Workspaces: byState[state]})
+	}
+	return groups
+}
+
+func entryLess(a, b Workspace) bool {
+	at, aOK := parseTimestamp(a.LastSeenAt)
+	bt, bOK := parseTimestamp(b.LastSeenAt)
+	if aOK && bOK && !at.Equal(bt) {
+		return at.After(bt)
+	}
+	if aOK != bOK {
+		return aOK
+	}
+	return a.WorkspacePath < b.WorkspacePath
+}
+
+func parseTimestamp(value string) (time.Time, bool) {
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	return parsed, err == nil
+}

--- a/internal/dashboard/service.go
+++ b/internal/dashboard/service.go
@@ -188,12 +188,7 @@ func requireGitWorkspace(path string) error {
 			if message == "" {
 				message = err.Error()
 			}
-			lowerMessage := strings.ToLower(message)
-			if strings.Contains(lowerMessage, "not a git repository") ||
-				strings.Contains(lowerMessage, "not a git work tree") {
-				return fmt.Errorf("%w: %s", watchlist.ErrNotGitWorkspace, message)
-			}
-			return fmt.Errorf("inspect git workspace: %s", message)
+			return classifyGitProbeExit(path, message)
 		}
 		return fmt.Errorf("inspect git workspace: %w", err)
 	}
@@ -201,6 +196,23 @@ func requireGitWorkspace(path string) error {
 		return watchlist.ErrNotGitWorkspace
 	}
 	return nil
+}
+
+func classifyGitProbeExit(path, message string) error {
+	lowerMessage := strings.ToLower(message)
+	if strings.Contains(lowerMessage, "not a git repository") ||
+		strings.Contains(lowerMessage, "not a git work tree") {
+		if gitMarkerExists(path) {
+			return fmt.Errorf("inspect git workspace: %s", message)
+		}
+		return fmt.Errorf("%w: %s", watchlist.ErrNotGitWorkspace, message)
+	}
+	return fmt.Errorf("inspect git workspace: %s", message)
+}
+
+func gitMarkerExists(path string) bool {
+	_, err := os.Lstat(filepath.Join(path, ".git"))
+	return err == nil
 }
 
 func workspaceKey(path string) string {

--- a/internal/dashboard/service.go
+++ b/internal/dashboard/service.go
@@ -32,10 +32,11 @@ const (
 var dashboardStateOrder = []string{StateActive, StateCompleted, StateIdle, StateMissing, StateInvalid}
 
 type Service struct {
-	LookupEnv   func(string) (string, bool)
-	UserHomeDir func() (string, error)
-	ReadStatus  func(string) contracts.StatusResult
-	Stat        func(string) (os.FileInfo, error)
+	LookupEnv         func(string) (string, bool)
+	UserHomeDir       func() (string, error)
+	ReadStatus        func(string) contracts.StatusResult
+	Stat              func(string) (os.FileInfo, error)
+	CheckGitWorkspace func(string) error
 }
 
 type Result = contracts.DashboardResult
@@ -111,7 +112,7 @@ func (s Service) readWorkspace(watched watchlist.Workspace) Workspace {
 		entry.Errors = []ErrorDetail{{Path: "workspace_path", Message: "watched workspace path is not a directory"}}
 		return entry
 	}
-	if err := requireGitWorkspace(path); err != nil {
+	if err := s.checkGitWorkspace(path); err != nil {
 		if errors.Is(err, watchlist.ErrNotGitWorkspace) {
 			entry.InvalidReason = InvalidNotGitWorkspace
 			entry.Summary = "Watched workspace path is not a Git workspace."
@@ -154,11 +155,18 @@ func (s Service) stat(path string) (os.FileInfo, error) {
 	return os.Stat(path)
 }
 
+func (s Service) checkGitWorkspace(path string) error {
+	if s.CheckGitWorkspace != nil {
+		return s.CheckGitWorkspace(path)
+	}
+	return requireGitWorkspace(path)
+}
+
 func (s Service) readStatus(path string) contracts.StatusResult {
 	if s.ReadStatus != nil {
 		return s.ReadStatus(path)
 	}
-	return status.Service{Workdir: path}.Read()
+	return status.Service{Workdir: path}.ReadUnlocked()
 }
 
 func dashboardState(result contracts.StatusResult) string {
@@ -176,7 +184,16 @@ func requireGitWorkspace(path string) error {
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			return fmt.Errorf("%w: %s", watchlist.ErrNotGitWorkspace, strings.TrimSpace(string(output)))
+			message := strings.TrimSpace(string(output))
+			if message == "" {
+				message = err.Error()
+			}
+			lowerMessage := strings.ToLower(message)
+			if strings.Contains(lowerMessage, "not a git repository") ||
+				strings.Contains(lowerMessage, "not a git work tree") {
+				return fmt.Errorf("%w: %s", watchlist.ErrNotGitWorkspace, message)
+			}
+			return fmt.Errorf("inspect git workspace: %s", message)
 		}
 		return fmt.Errorf("inspect git workspace: %w", err)
 	}

--- a/internal/dashboard/service.go
+++ b/internal/dashboard/service.go
@@ -24,9 +24,11 @@ const (
 	StateMissing   = "missing"
 	StateInvalid   = "invalid"
 
-	InvalidUnreadable      = "unreadable"
-	InvalidNotGitWorkspace = "not_git_workspace"
-	InvalidStatusError     = "status_error"
+	InvalidUnreadable        = "unreadable"
+	InvalidNotGitWorkspace   = "not_git_workspace"
+	InvalidStatusError       = "status_error"
+	InvalidMalformedPath     = "malformed_path"
+	InvalidRouteKeyCollision = "route_key_collision"
 )
 
 var dashboardStateOrder = []string{StateActive, StateCompleted, StateIdle, StateMissing, StateInvalid}
@@ -63,6 +65,7 @@ func (s Service) Read() Result {
 	for _, watched := range file.Workspaces {
 		entries = append(entries, s.readWorkspace(watched))
 	}
+	markRouteKeyCollisions(entries)
 	sort.SliceStable(entries, func(i, j int) bool {
 		return entryLess(entries[i], entries[j])
 	})
@@ -88,8 +91,13 @@ func (s Service) readWorkspace(watched watchlist.Workspace) Workspace {
 	}
 
 	if path == "" {
-		entry.InvalidReason = InvalidNotGitWorkspace
+		entry.InvalidReason = InvalidMalformedPath
 		entry.Errors = []ErrorDetail{{Path: "workspace_path", Message: "watched workspace path is empty"}}
+		return entry
+	}
+	if !filepath.IsAbs(path) {
+		entry.InvalidReason = InvalidMalformedPath
+		entry.Errors = []ErrorDetail{{Path: "workspace_path", Message: "watched workspace path must be absolute"}}
 		return entry
 	}
 
@@ -146,6 +154,33 @@ func (s Service) readWorkspace(watched watchlist.Workspace) Workspace {
 	entry.Errors = statusResult.Errors
 	entry.Artifacts = statusResult.Artifacts
 	return entry
+}
+
+func markRouteKeyCollisions(entries []Workspace) {
+	byKey := make(map[string][]int, len(entries))
+	for index, entry := range entries {
+		byKey[entry.WorkspaceKey] = append(byKey[entry.WorkspaceKey], index)
+	}
+	for key, indexes := range byKey {
+		if len(indexes) < 2 {
+			continue
+		}
+		for _, index := range indexes {
+			entry := &entries[index]
+			entry.DashboardState = StateInvalid
+			entry.InvalidReason = InvalidRouteKeyCollision
+			entry.CurrentNode = ""
+			entry.NextAction = nil
+			entry.Warnings = nil
+			entry.Blockers = nil
+			entry.Artifacts = nil
+			entry.Summary = "Watched workspace route key collides with another watchlist record."
+			entry.Errors = append(entry.Errors, ErrorDetail{
+				Path:    "workspace_key",
+				Message: fmt.Sprintf("workspace_key %q is shared by %d watchlist records", key, len(indexes)),
+			})
+		}
+	}
 }
 
 func (s Service) stat(path string) (os.FileInfo, error) {

--- a/internal/dashboard/service_test.go
+++ b/internal/dashboard/service_test.go
@@ -283,6 +283,31 @@ func TestReadSurfacesGitProbeFailuresAsUnreadable(t *testing.T) {
 	}
 }
 
+func TestClassifyGitProbeExitDistinguishesNotGitFromUnreadableMetadata(t *testing.T) {
+	notGit := filepath.Join(t.TempDir(), "not-git")
+	if err := os.MkdirAll(notGit, 0o755); err != nil {
+		t.Fatalf("mkdir not-git: %v", err)
+	}
+	notGitMessage := "fatal: not a git repository (or any of the parent directories): .git"
+	if err := classifyGitProbeExit(notGit, notGitMessage); !errors.Is(err, watchlist.ErrNotGitWorkspace) {
+		t.Fatalf("expected no-marker not-git message to map to ErrNotGitWorkspace, got %v", err)
+	}
+
+	unreadableMetadata := filepath.Join(t.TempDir(), "unreadable-metadata")
+	if err := os.MkdirAll(filepath.Join(unreadableMetadata, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir git marker: %v", err)
+	}
+	err := classifyGitProbeExit(unreadableMetadata, notGitMessage)
+	if err == nil || errors.Is(err, watchlist.ErrNotGitWorkspace) {
+		t.Fatalf("expected existing git marker not-git message to stay unreadable, got %v", err)
+	}
+
+	permissionMessage := "fatal: cannot change to '/watched/workspace': Permission denied"
+	if err := classifyGitProbeExit(notGit, permissionMessage); err == nil || errors.Is(err, watchlist.ErrNotGitWorkspace) {
+		t.Fatalf("expected permission probe failure to stay unreadable, got %v", err)
+	}
+}
+
 func statusResult(node, summary string, artifacts *contracts.StatusArtifacts) contracts.StatusResult {
 	return contracts.StatusResult{
 		OK:        true,

--- a/internal/dashboard/service_test.go
+++ b/internal/dashboard/service_test.go
@@ -1,0 +1,339 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/catu-ai/easyharness/internal/contracts"
+	"github.com/catu-ai/easyharness/internal/watchlist"
+)
+
+func TestReadGroupsReadableWorkspaceStates(t *testing.T) {
+	home := t.TempDir()
+	active := seedGitWorkspace(t, "active")
+	completed := seedGitWorkspace(t, "completed")
+	idle := seedGitWorkspace(t, "idle")
+	writeWatchlist(t, home, []watchlist.Workspace{
+		workspaceRecord(active, "2026-04-22T12:00:00Z"),
+		workspaceRecord(completed, "2026-04-22T11:00:00Z"),
+		workspaceRecord(idle, "2026-04-22T10:00:00Z"),
+	})
+
+	result := Service{
+		LookupEnv: easyHome(home),
+		ReadStatus: func(path string) contracts.StatusResult {
+			switch path {
+			case active:
+				return statusResult("execution/finalize/await_merge", "Awaiting merge", nil)
+			case completed:
+				return statusResult("idle", "Landed", &contracts.StatusArtifacts{LastLandedAt: "2026-04-22T09:00:00Z"})
+			case idle:
+				return statusResult("idle", "No current plan", nil)
+			default:
+				t.Fatalf("unexpected status path %q", path)
+				return contracts.StatusResult{}
+			}
+		},
+	}.Read()
+
+	if !result.OK {
+		t.Fatalf("expected dashboard read to succeed, got %#v", result)
+	}
+	assertGroupPaths(t, result, StateActive, []string{active})
+	assertGroupPaths(t, result, StateCompleted, []string{completed})
+	assertGroupPaths(t, result, StateIdle, []string{idle})
+	activeEntry := findWorkspace(t, result, StateActive, active)
+	if activeEntry.CurrentNode != "execution/finalize/await_merge" || activeEntry.DashboardState != StateActive {
+		t.Fatalf("unexpected active entry: %#v", activeEntry)
+	}
+	completedEntry := findWorkspace(t, result, StateCompleted, completed)
+	if completedEntry.CurrentNode != "idle" || completedEntry.Artifacts == nil || completedEntry.Artifacts.LastLandedAt == "" {
+		t.Fatalf("unexpected completed entry: %#v", completedEntry)
+	}
+	idleEntry := findWorkspace(t, result, StateIdle, idle)
+	if idleEntry.CurrentNode != "idle" || idleEntry.InvalidReason != "" {
+		t.Fatalf("unexpected idle entry: %#v", idleEntry)
+	}
+}
+
+func TestReadSurfacesMissingAndInvalidEntries(t *testing.T) {
+	home := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "missing")
+	notGit := filepath.Join(t.TempDir(), "not-git")
+	if err := os.MkdirAll(notGit, 0o755); err != nil {
+		t.Fatalf("mkdir non-git workspace: %v", err)
+	}
+	statusError := seedGitWorkspace(t, "status-error")
+	writeWatchlist(t, home, []watchlist.Workspace{
+		workspaceRecord(missing, "2026-04-22T12:00:00Z"),
+		workspaceRecord(notGit, "2026-04-22T11:00:00Z"),
+		workspaceRecord(statusError, "2026-04-22T10:00:00Z"),
+	})
+
+	result := Service{
+		LookupEnv: easyHome(home),
+		ReadStatus: func(path string) contracts.StatusResult {
+			if path != statusError {
+				t.Fatalf("unexpected status path %q", path)
+			}
+			return contracts.StatusResult{
+				OK:      false,
+				Command: "status",
+				Summary: "Unable to read current worktree state.",
+				State:   contracts.StatusState{CurrentNode: "idle"},
+				Errors:  []contracts.ErrorDetail{{Path: "state", Message: "boom"}},
+			}
+		},
+	}.Read()
+
+	if !result.OK {
+		t.Fatalf("expected dashboard read to succeed, got %#v", result)
+	}
+	assertGroupPaths(t, result, StateMissing, []string{missing})
+	assertGroupPaths(t, result, StateInvalid, []string{notGit, statusError})
+	missingEntry := findWorkspace(t, result, StateMissing, missing)
+	if missingEntry.InvalidReason != "" || missingEntry.CurrentNode != "" {
+		t.Fatalf("unexpected missing entry: %#v", missingEntry)
+	}
+	notGitEntry := findWorkspace(t, result, StateInvalid, notGit)
+	if notGitEntry.InvalidReason != InvalidNotGitWorkspace {
+		t.Fatalf("expected not-git invalid reason, got %#v", notGitEntry)
+	}
+	statusErrorEntry := findWorkspace(t, result, StateInvalid, statusError)
+	if statusErrorEntry.InvalidReason != InvalidStatusError || statusErrorEntry.CurrentNode != "idle" {
+		t.Fatalf("expected status-error invalid reason with partial node, got %#v", statusErrorEntry)
+	}
+}
+
+func TestReadOrdersEntriesByRecencyWithDeterministicFallback(t *testing.T) {
+	home := t.TempDir()
+	root := t.TempDir()
+	newest := seedGitWorkspaceAt(t, root, "newest")
+	alpha := seedGitWorkspaceAt(t, root, "alpha")
+	beta := seedGitWorkspaceAt(t, root, "beta")
+	malformed := seedGitWorkspaceAt(t, root, "malformed")
+	writeWatchlist(t, home, []watchlist.Workspace{
+		workspaceRecord(beta, "2026-04-22T10:00:00Z"),
+		workspaceRecord(malformed, "not-a-time"),
+		workspaceRecord(newest, "2026-04-22T12:00:00Z"),
+		workspaceRecord(alpha, "2026-04-22T10:00:00Z"),
+	})
+
+	result := Service{
+		LookupEnv:  easyHome(home),
+		ReadStatus: func(string) contracts.StatusResult { return statusResult("plan", "Plan exists", nil) },
+	}.Read()
+
+	assertGroupPaths(t, result, StateActive, []string{newest, alpha, beta, malformed})
+}
+
+func TestReadReturnsTopLevelErrorForUnreadableWatchlist(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, "watchlist.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir watchlist dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":`), 0o644); err != nil {
+		t.Fatalf("write invalid watchlist: %v", err)
+	}
+
+	result := Service{LookupEnv: easyHome(home)}.Read()
+	if result.OK {
+		t.Fatalf("expected unreadable watchlist to fail top-level read, got %#v", result)
+	}
+	if result.Resource != "dashboard" || len(result.Errors) != 1 {
+		t.Fatalf("unexpected top-level error result: %#v", result)
+	}
+	assertGroupPaths(t, result, StateActive, nil)
+}
+
+func TestReadDoesNotRewriteWatchlist(t *testing.T) {
+	home := t.TempDir()
+	workspace := seedGitWorkspace(t, "idle")
+	writeWatchlist(t, home, []watchlist.Workspace{workspaceRecord(workspace, "2026-04-22T12:00:00Z")})
+	watchlistPath := filepath.Join(home, "watchlist.json")
+	fixedTime := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(watchlistPath, fixedTime, fixedTime); err != nil {
+		t.Fatalf("set watchlist timestamp: %v", err)
+	}
+	beforeInfo, err := os.Stat(watchlistPath)
+	if err != nil {
+		t.Fatalf("stat watchlist before read: %v", err)
+	}
+	beforeData, err := os.ReadFile(watchlistPath)
+	if err != nil {
+		t.Fatalf("read watchlist before read: %v", err)
+	}
+
+	result := Service{
+		LookupEnv:  easyHome(home),
+		ReadStatus: func(string) contracts.StatusResult { return statusResult("idle", "No current plan", nil) },
+	}.Read()
+	if !result.OK {
+		t.Fatalf("dashboard read failed: %#v", result)
+	}
+
+	afterInfo, err := os.Stat(watchlistPath)
+	if err != nil {
+		t.Fatalf("stat watchlist after read: %v", err)
+	}
+	afterData, err := os.ReadFile(watchlistPath)
+	if err != nil {
+		t.Fatalf("read watchlist after read: %v", err)
+	}
+	if string(afterData) != string(beforeData) {
+		t.Fatalf("expected dashboard read to preserve watchlist bytes")
+	}
+	if !afterInfo.ModTime().Equal(beforeInfo.ModTime()) {
+		t.Fatalf("expected dashboard read to preserve watchlist mtime, got %s want %s", afterInfo.ModTime(), beforeInfo.ModTime())
+	}
+}
+
+func TestReadUsesDefaultStatusService(t *testing.T) {
+	home := t.TempDir()
+	workspace := seedGitWorkspace(t, "default-status")
+	writeWatchlist(t, home, []watchlist.Workspace{workspaceRecord(workspace, "2026-04-22T12:00:00Z")})
+
+	result := Service{LookupEnv: easyHome(home)}.Read()
+	if !result.OK {
+		t.Fatalf("dashboard read failed: %#v", result)
+	}
+	entry := findWorkspace(t, result, StateIdle, workspace)
+	if entry.CurrentNode != "idle" || !strings.Contains(entry.Summary, "No current plan is active") {
+		t.Fatalf("expected default status service idle entry, got %#v", entry)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".local")); !os.IsNotExist(err) {
+		t.Fatalf("expected dashboard read to avoid creating workflow state, err=%v", err)
+	}
+}
+
+func statusResult(node, summary string, artifacts *contracts.StatusArtifacts) contracts.StatusResult {
+	return contracts.StatusResult{
+		OK:        true,
+		Command:   "status",
+		Summary:   summary,
+		State:     contracts.StatusState{CurrentNode: node},
+		Artifacts: artifacts,
+		NextAction: []contracts.NextAction{
+			{Command: nil, Description: "Keep going."},
+		},
+	}
+}
+
+func writeWatchlist(t *testing.T, home string, workspaces []watchlist.Workspace) {
+	t.Helper()
+	data, err := json.MarshalIndent(watchlist.File{Version: 1, Workspaces: workspaces}, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal watchlist: %v", err)
+	}
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir watchlist home: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "watchlist.json"), data, 0o644); err != nil {
+		t.Fatalf("write watchlist: %v", err)
+	}
+}
+
+func workspaceRecord(path, seenAt string) watchlist.Workspace {
+	return watchlist.Workspace{
+		WorkspacePath: path,
+		WatchedAt:     "2026-04-22T09:00:00Z",
+		LastSeenAt:    seenAt,
+	}
+}
+
+func easyHome(home string) func(string) (string, bool) {
+	return func(key string) (string, bool) {
+		if key == "EASYHARNESS_HOME" {
+			return home, true
+		}
+		return "", false
+	}
+}
+
+func seedGitWorkspace(t *testing.T, name string) string {
+	t.Helper()
+	return seedGitWorkspaceAt(t, t.TempDir(), name)
+}
+
+func seedGitWorkspaceAt(t *testing.T, parent, name string) string {
+	t.Helper()
+	root := filepath.Join(parent, name)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir git workspace: %v", err)
+	}
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.name", "Codex Test")
+	runGit(t, root, "config", "user.email", "codex@example.com")
+	return root
+}
+
+func runGit(t *testing.T, root string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func assertGroupPaths(t *testing.T, result Result, state string, want []string) {
+	t.Helper()
+	for _, group := range result.Groups {
+		if group.State != state {
+			continue
+		}
+		got := make([]string, 0, len(group.Workspaces))
+		for _, workspace := range group.Workspaces {
+			got = append(got, workspace.WorkspacePath)
+		}
+		if strings.Join(got, "\n") != strings.Join(want, "\n") {
+			t.Fatalf("unexpected %s group\n got: %#v\nwant: %#v", state, got, want)
+		}
+		return
+	}
+	t.Fatalf("missing group %q", state)
+}
+
+func findWorkspace(t *testing.T, result Result, state, path string) Workspace {
+	t.Helper()
+	for _, group := range result.Groups {
+		if group.State != state {
+			continue
+		}
+		for _, workspace := range group.Workspaces {
+			if workspace.WorkspacePath == path {
+				return workspace
+			}
+		}
+	}
+	t.Fatalf("missing workspace %q in state %q", path, state)
+	return Workspace{}
+}
+
+func TestReadSurfacesStatErrorsAsUnreadable(t *testing.T) {
+	home := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "unreadable")
+	writeWatchlist(t, home, []watchlist.Workspace{workspaceRecord(workspace, "2026-04-22T12:00:00Z")})
+
+	result := Service{
+		LookupEnv: easyHome(home),
+		Stat: func(path string) (os.FileInfo, error) {
+			if path != workspace {
+				t.Fatalf("unexpected stat path %q", path)
+			}
+			return nil, errors.New("permission denied")
+		},
+	}.Read()
+
+	entry := findWorkspace(t, result, StateInvalid, workspace)
+	if entry.InvalidReason != InvalidUnreadable {
+		t.Fatalf("expected unreadable invalid reason, got %#v", entry)
+	}
+}

--- a/internal/dashboard/service_test.go
+++ b/internal/dashboard/service_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/catu-ai/easyharness/internal/contracts"
+	"github.com/catu-ai/easyharness/internal/plan"
+	"github.com/catu-ai/easyharness/internal/runstate"
 	"github.com/catu-ai/easyharness/internal/watchlist"
 )
 
@@ -213,6 +215,74 @@ func TestReadUsesDefaultStatusService(t *testing.T) {
 	}
 }
 
+func TestReadUsesDefaultStatusServiceForActiveWorkspaceWithoutMutatingState(t *testing.T) {
+	home := t.TempDir()
+	workspace := seedGitWorkspace(t, "active-default-status")
+	relPlanPath := writeActivePlan(t, workspace)
+	if _, err := runstate.SaveCurrentPlan(workspace, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	planStem := strings.TrimSuffix(filepath.Base(relPlanPath), filepath.Ext(relPlanPath))
+	if _, err := runstate.SaveState(workspace, planStem, &runstate.State{
+		ExecutionStartedAt: "2026-04-22T09:00:00Z",
+		Revision:           1,
+	}); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	writeWatchlist(t, home, []watchlist.Workspace{workspaceRecord(workspace, "2026-04-22T12:00:00Z")})
+	currentPlanPath := filepath.Join(workspace, ".local", "harness", "current-plan.json")
+	statePath := filepath.Join(workspace, ".local", "harness", "plans", planStem, "state.json")
+	lockPath := filepath.Join(workspace, ".local", "harness", "plans", planStem, ".state-mutation.lock")
+	stateFiles := []string{currentPlanPath, statePath}
+	fixedTime := time.Date(2026, 4, 22, 8, 0, 0, 0, time.UTC)
+	before := make(map[string]fileSnapshot, len(stateFiles))
+	for _, path := range stateFiles {
+		if err := os.Chtimes(path, fixedTime, fixedTime); err != nil {
+			t.Fatalf("set state timestamp %s: %v", path, err)
+		}
+		before[path] = snapshotFile(t, path)
+	}
+
+	result := Service{LookupEnv: easyHome(home)}.Read()
+	if !result.OK {
+		t.Fatalf("dashboard read failed: %#v", result)
+	}
+	entry := findWorkspace(t, result, StateActive, workspace)
+	if entry.CurrentNode != "execution/step-1/implement" {
+		t.Fatalf("expected active execution node, got %#v", entry)
+	}
+	for _, path := range stateFiles {
+		assertFileUnchanged(t, path, before[path])
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected dashboard read to avoid creating state lock, err=%v", err)
+	}
+}
+
+func TestReadSurfacesGitProbeFailuresAsUnreadable(t *testing.T) {
+	home := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	writeWatchlist(t, home, []watchlist.Workspace{workspaceRecord(workspace, "2026-04-22T12:00:00Z")})
+
+	result := Service{
+		LookupEnv: easyHome(home),
+		CheckGitWorkspace: func(path string) error {
+			if path != workspace {
+				t.Fatalf("unexpected git probe path %q", path)
+			}
+			return errors.New("inspect git workspace: permission denied")
+		},
+	}.Read()
+
+	entry := findWorkspace(t, result, StateInvalid, workspace)
+	if entry.InvalidReason != InvalidUnreadable {
+		t.Fatalf("expected unreadable invalid reason, got %#v", entry)
+	}
+}
+
 func statusResult(node, summary string, artifacts *contracts.StatusArtifacts) contracts.StatusResult {
 	return contracts.StatusResult{
 		OK:        true,
@@ -224,6 +294,57 @@ func statusResult(node, summary string, artifacts *contracts.StatusArtifacts) co
 			{Command: nil, Description: "Keep going."},
 		},
 	}
+}
+
+type fileSnapshot struct {
+	data    []byte
+	modTime time.Time
+}
+
+func snapshotFile(t *testing.T, path string) fileSnapshot {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file %s: %v", path, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %s: %v", path, err)
+	}
+	return fileSnapshot{data: data, modTime: info.ModTime()}
+}
+
+func assertFileUnchanged(t *testing.T, path string, before fileSnapshot) {
+	t.Helper()
+	after := snapshotFile(t, path)
+	if string(after.data) != string(before.data) {
+		t.Fatalf("expected %s bytes to remain unchanged", path)
+	}
+	if !after.modTime.Equal(before.modTime) {
+		t.Fatalf("expected %s mtime to remain unchanged, got %s want %s", path, after.modTime, before.modTime)
+	}
+}
+
+func writeActivePlan(t *testing.T, root string) string {
+	t.Helper()
+	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title:      "Dashboard Active Plan",
+		Timestamp:  time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC),
+		SourceType: "direct_request",
+		Size:       "M",
+	})
+	if err != nil {
+		t.Fatalf("render plan: %v", err)
+	}
+	relPath := filepath.ToSlash(filepath.Join("docs", "plans", "active", "2026-04-22-dashboard-active-plan.md"))
+	path := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir plan dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+	return relPath
 }
 
 func writeWatchlist(t *testing.T, home string, workspaces []watchlist.Workspace) {

--- a/internal/dashboard/service_test.go
+++ b/internal/dashboard/service_test.go
@@ -113,6 +113,63 @@ func TestReadSurfacesMissingAndInvalidEntries(t *testing.T) {
 	}
 }
 
+func TestReadRejectsMalformedNonAbsoluteWorkspacePath(t *testing.T) {
+	home := t.TempDir()
+	relative := "relative-git"
+	writeWatchlist(t, home, []watchlist.Workspace{workspaceRecord(relative, "2026-04-22T12:00:00Z")})
+
+	result := Service{
+		LookupEnv: easyHome(home),
+		Stat: func(path string) (os.FileInfo, error) {
+			t.Fatalf("dashboard read should not stat malformed non-absolute path %q", path)
+			return nil, nil
+		},
+		CheckGitWorkspace: func(path string) error {
+			t.Fatalf("dashboard read should not probe git for malformed non-absolute path %q", path)
+			return nil
+		},
+		ReadStatus: func(path string) contracts.StatusResult {
+			t.Fatalf("dashboard read should not read status for malformed non-absolute path %q", path)
+			return contracts.StatusResult{}
+		},
+	}.Read()
+
+	entry := findWorkspace(t, result, StateInvalid, relative)
+	if entry.InvalidReason != InvalidMalformedPath || entry.WorkspaceKey == "" {
+		t.Fatalf("expected malformed invalid entry with route key, got %#v", entry)
+	}
+	if len(entry.Errors) != 1 || entry.Errors[0].Path != "workspace_path" {
+		t.Fatalf("expected workspace_path diagnostic, got %#v", entry.Errors)
+	}
+}
+
+func TestReadSurfacesRouteKeyCollisions(t *testing.T) {
+	home := t.TempDir()
+	workspace := seedGitWorkspace(t, "duplicate")
+	writeWatchlist(t, home, []watchlist.Workspace{
+		workspaceRecord(workspace, "2026-04-22T12:00:00Z"),
+		workspaceRecord(workspace, "2026-04-22T11:00:00Z"),
+	})
+
+	result := Service{
+		LookupEnv:  easyHome(home),
+		ReadStatus: func(string) contracts.StatusResult { return statusResult("execution/step-1/implement", "Active", nil) },
+	}.Read()
+
+	entries := findWorkspaces(t, result, StateInvalid, workspace)
+	if len(entries) != 2 {
+		t.Fatalf("expected both duplicate entries to be surfaced as invalid, got %d: %#v", len(entries), entries)
+	}
+	for _, entry := range entries {
+		if entry.InvalidReason != InvalidRouteKeyCollision || entry.CurrentNode != "" {
+			t.Fatalf("expected collision invalid entry without readable node, got %#v", entry)
+		}
+		if len(entry.Errors) == 0 || entry.Errors[len(entry.Errors)-1].Path != "workspace_key" {
+			t.Fatalf("expected workspace_key collision diagnostic, got %#v", entry.Errors)
+		}
+	}
+}
+
 func TestReadOrdersEntriesByRecencyWithDeterministicFallback(t *testing.T) {
 	home := t.TempDir()
 	root := t.TempDir()
@@ -449,18 +506,27 @@ func assertGroupPaths(t *testing.T, result Result, state string, want []string) 
 
 func findWorkspace(t *testing.T, result Result, state, path string) Workspace {
 	t.Helper()
+	entries := findWorkspaces(t, result, state, path)
+	if len(entries) == 0 {
+		t.Fatalf("missing workspace %q in state %q", path, state)
+	}
+	return entries[0]
+}
+
+func findWorkspaces(t *testing.T, result Result, state, path string) []Workspace {
+	t.Helper()
+	var matches []Workspace
 	for _, group := range result.Groups {
 		if group.State != state {
 			continue
 		}
 		for _, workspace := range group.Workspaces {
 			if workspace.WorkspacePath == path {
-				return workspace
+				matches = append(matches, workspace)
 			}
 		}
 	}
-	t.Fatalf("missing workspace %q in state %q", path, state)
-	return Workspace{}
+	return matches
 }
 
 func TestReadSurfacesStatErrorsAsUnreadable(t *testing.T) {

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/catu-ai/easyharness/internal/dashboard"
 	"github.com/catu-ai/easyharness/internal/planui"
 	"github.com/catu-ai/easyharness/internal/reviewui"
 	"github.com/catu-ai/easyharness/internal/status"
@@ -90,6 +91,13 @@ func NewHandler(workdir string) (http.Handler, error) {
 	}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("/api/dashboard", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		writeDashboardJSON(w, dashboard.Service{}.Read())
+	})
 	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -178,6 +186,14 @@ func serveIndex(staticFS fs.FS, workdir string, w http.ResponseWriter) {
 }
 
 func writeStatusJSON(w http.ResponseWriter, result status.Result) {
+	statusCode := http.StatusOK
+	if !result.OK {
+		statusCode = http.StatusServiceUnavailable
+	}
+	writeJSON(w, statusCode, result)
+}
+
+func writeDashboardJSON(w http.ResponseWriter, result dashboard.Result) {
 	statusCode := http.StatusOK
 	if !result.OK {
 		statusCode = http.StatusServiceUnavailable

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/runstate"
 	"github.com/catu-ai/easyharness/internal/timeline"
+	"github.com/catu-ai/easyharness/internal/watchlist"
 )
 
 func TestNewHandlerServesStatusJSON(t *testing.T) {
@@ -103,6 +104,95 @@ func TestUIReadSurfacesDoNotTouchWatchlist(t *testing.T) {
 			t.Fatalf("expected %s to avoid watchlist writes, err=%v", path, err)
 		}
 	}
+}
+
+func TestNewHandlerServesDashboardJSON(t *testing.T) {
+	home := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	seedGitWorkspace(t, workspace)
+	writeWatchlist(t, home, []watchlist.Workspace{{
+		WorkspacePath: workspace,
+		WatchedAt:     "2026-04-22T09:00:00Z",
+		LastSeenAt:    "2026-04-22T12:00:00Z",
+	}})
+	t.Setenv("EASYHARNESS_HOME", home)
+
+	handler, err := NewHandler(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/dashboard", nil)
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Fatalf("expected JSON content type, got %q", got)
+	}
+	var payload struct {
+		OK       bool                 `json:"ok"`
+		Resource string               `json:"resource"`
+		Groups   []dashboardTestGroup `json:"groups"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v\n%s", err, recorder.Body.String())
+	}
+	if !payload.OK || payload.Resource != "dashboard" {
+		t.Fatalf("unexpected dashboard payload: %#v", payload)
+	}
+	entry := dashboardWorkspaceInGroup(t, payload.Groups, "idle", workspace)
+	if entry.DashboardState != "idle" || entry.CurrentNode != "idle" {
+		t.Fatalf("unexpected dashboard entry: %#v", entry)
+	}
+}
+
+func TestNewHandlerRejectsDashboardNonGET(t *testing.T) {
+	handler, err := NewHandler(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/dashboard", nil)
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status 405, got %d", recorder.Code)
+	}
+}
+
+func TestNewHandlerDashboardDoesNotRewriteWatchlist(t *testing.T) {
+	home := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "missing")
+	writeWatchlist(t, home, []watchlist.Workspace{{
+		WorkspacePath: missing,
+		WatchedAt:     "2026-04-22T09:00:00Z",
+		LastSeenAt:    "2026-04-22T12:00:00Z",
+	}})
+	t.Setenv("EASYHARNESS_HOME", home)
+	watchlistPath := filepath.Join(home, "watchlist.json")
+	fixedTime := time.Date(2026, 4, 22, 9, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(watchlistPath, fixedTime, fixedTime); err != nil {
+		t.Fatalf("set watchlist timestamp: %v", err)
+	}
+	before := snapshotFile(t, watchlistPath)
+
+	handler, err := NewHandler(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/dashboard", nil)
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	assertFileUnchanged(t, watchlistPath, before)
 }
 
 func TestNewHandlerFallsBackToIndexForSPAPath(t *testing.T) {
@@ -946,6 +1036,83 @@ func renderPlanFixture(t *testing.T, title string) string {
 		t.Fatalf("render plan: %v", err)
 	}
 	return strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
+}
+
+type dashboardTestGroup struct {
+	State      string                   `json:"state"`
+	Workspaces []dashboardTestWorkspace `json:"workspaces"`
+}
+
+type dashboardTestWorkspace struct {
+	WorkspacePath  string `json:"workspace_path"`
+	DashboardState string `json:"dashboard_state"`
+	CurrentNode    string `json:"current_node"`
+}
+
+func dashboardWorkspaceInGroup(t *testing.T, groups []dashboardTestGroup, state, path string) dashboardTestWorkspace {
+	t.Helper()
+	for _, group := range groups {
+		if group.State != state {
+			continue
+		}
+		for _, workspace := range group.Workspaces {
+			if workspace.WorkspacePath == path {
+				return workspace
+			}
+		}
+	}
+	t.Fatalf("missing workspace %q in dashboard state %q", path, state)
+	return dashboardTestWorkspace{}
+}
+
+type fileSnapshot struct {
+	data    []byte
+	modTime time.Time
+}
+
+func snapshotFile(t *testing.T, path string) fileSnapshot {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file %s: %v", path, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %s: %v", path, err)
+	}
+	return fileSnapshot{data: data, modTime: info.ModTime()}
+}
+
+func assertFileUnchanged(t *testing.T, path string, before fileSnapshot) {
+	t.Helper()
+	after := snapshotFile(t, path)
+	if string(after.data) != string(before.data) {
+		t.Fatalf("expected %s bytes to remain unchanged", path)
+	}
+	if !after.modTime.Equal(before.modTime) {
+		t.Fatalf("expected %s mtime to remain unchanged, got %s want %s", path, after.modTime, before.modTime)
+	}
+}
+
+func writeWatchlist(t *testing.T, home string, workspaces []watchlist.Workspace) {
+	t.Helper()
+	payload := struct {
+		Version    int                   `json:"version"`
+		Workspaces []watchlist.Workspace `json:"workspaces"`
+	}{
+		Version:    1,
+		Workspaces: workspaces,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal watchlist: %v", err)
+	}
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("mkdir watchlist home: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "watchlist.json"), data, 0o644); err != nil {
+		t.Fatalf("write watchlist: %v", err)
+	}
 }
 
 type lockedBuffer struct {

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -192,6 +192,21 @@ func TestNewHandlerDashboardDoesNotRewriteWatchlist(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d: %s", recorder.Code, recorder.Body.String())
 	}
+	var payload struct {
+		OK       bool                 `json:"ok"`
+		Resource string               `json:"resource"`
+		Groups   []dashboardTestGroup `json:"groups"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v\n%s", err, recorder.Body.String())
+	}
+	if !payload.OK || payload.Resource != "dashboard" {
+		t.Fatalf("unexpected dashboard payload: %#v", payload)
+	}
+	entry := dashboardWorkspaceInGroup(t, payload.Groups, "missing", missing)
+	if entry.DashboardState != "missing" || entry.CurrentNode != "" {
+		t.Fatalf("expected missing degraded entry, got %#v", entry)
+	}
 	assertFileUnchanged(t, watchlistPath, before)
 }
 

--- a/internal/watchlist/watchlist.go
+++ b/internal/watchlist/watchlist.go
@@ -36,6 +36,14 @@ type Workspace struct {
 	LastSeenAt    string `json:"last_seen_at"`
 }
 
+func (s Service) Read() (File, error) {
+	home, err := s.easyharnessHome()
+	if err != nil {
+		return File{}, err
+	}
+	return loadFile(filepath.Join(home, "watchlist.json"))
+}
+
 func (s Service) Touch(workdir string) error {
 	if strings.TrimSpace(workdir) == "" {
 		return fmt.Errorf("resolve workspace: empty path")

--- a/internal/watchlist/watchlist_test.go
+++ b/internal/watchlist/watchlist_test.go
@@ -113,6 +113,48 @@ func TestReadMissingWatchlistReturnsEmptyFileWithoutCreatingIt(t *testing.T) {
 	}
 }
 
+func TestReadExistingWatchlistDoesNotRewriteFile(t *testing.T) {
+	userHome := t.TempDir()
+	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+	writeWatchlistFile(t, watchlistPath, File{
+		Version: version,
+		Workspaces: []Workspace{
+			{WorkspacePath: "/tmp/workspace-a", WatchedAt: "2026-04-19T01:00:00Z", LastSeenAt: "2026-04-19T02:00:00Z"},
+		},
+	})
+	fixedTime := time.Date(2026, 4, 19, 3, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(watchlistPath, fixedTime, fixedTime); err != nil {
+		t.Fatalf("set watchlist timestamp: %v", err)
+	}
+	beforeInfo, err := os.Stat(watchlistPath)
+	if err != nil {
+		t.Fatalf("stat watchlist before read: %v", err)
+	}
+	beforeData, err := os.ReadFile(watchlistPath)
+	if err != nil {
+		t.Fatalf("read watchlist before read: %v", err)
+	}
+
+	if _, err := (Service{UserHomeDir: func() (string, error) { return userHome, nil }}).Read(); err != nil {
+		t.Fatalf("read watchlist: %v", err)
+	}
+
+	afterInfo, err := os.Stat(watchlistPath)
+	if err != nil {
+		t.Fatalf("stat watchlist after read: %v", err)
+	}
+	afterData, err := os.ReadFile(watchlistPath)
+	if err != nil {
+		t.Fatalf("read watchlist after read: %v", err)
+	}
+	if string(afterData) != string(beforeData) {
+		t.Fatalf("expected read to preserve watchlist bytes\nbefore:\n%s\nafter:\n%s", beforeData, afterData)
+	}
+	if !afterInfo.ModTime().Equal(beforeInfo.ModTime()) {
+		t.Fatalf("expected read to preserve watchlist mtime, got %s want %s", afterInfo.ModTime(), beforeInfo.ModTime())
+	}
+}
+
 func TestReadReturnsParseErrorForInvalidWatchlist(t *testing.T) {
 	userHome := t.TempDir()
 	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")

--- a/internal/watchlist/watchlist_test.go
+++ b/internal/watchlist/watchlist_test.go
@@ -43,6 +43,103 @@ func TestTouchUsesDefaultEasyharnessHome(t *testing.T) {
 	}
 }
 
+func TestReadUsesDefaultEasyharnessHome(t *testing.T) {
+	userHome := t.TempDir()
+	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+	seed := File{
+		Version: version,
+		Workspaces: []Workspace{
+			{WorkspacePath: "/tmp/workspace-a", WatchedAt: "2026-04-19T01:00:00Z", LastSeenAt: "2026-04-19T02:00:00Z"},
+		},
+	}
+	writeWatchlistFile(t, watchlistPath, seed)
+
+	got, err := Service{UserHomeDir: func() (string, error) { return userHome, nil }}.Read()
+	if err != nil {
+		t.Fatalf("read watchlist: %v", err)
+	}
+	if got.Version != version || len(got.Workspaces) != 1 {
+		t.Fatalf("unexpected watchlist: %#v", got)
+	}
+	if got.Workspaces[0].WorkspacePath != "/tmp/workspace-a" {
+		t.Fatalf("expected persisted workspace path to survive read, got %#v", got.Workspaces[0])
+	}
+}
+
+func TestReadUsesEasyharnessHomeOverride(t *testing.T) {
+	userHome := t.TempDir()
+	customHome := filepath.Join(t.TempDir(), "custom-home")
+	writeWatchlistFile(t, filepath.Join(customHome, "watchlist.json"), File{
+		Version: version,
+		Workspaces: []Workspace{
+			{WorkspacePath: "/tmp/custom", WatchedAt: "2026-04-19T01:00:00Z", LastSeenAt: "2026-04-19T01:00:00Z"},
+		},
+	})
+
+	svc := Service{
+		LookupEnv: func(key string) (string, bool) {
+			if key == envHome {
+				return customHome, true
+			}
+			return "", false
+		},
+		UserHomeDir: func() (string, error) { return userHome, nil },
+	}
+	got, err := svc.Read()
+	if err != nil {
+		t.Fatalf("read watchlist: %v", err)
+	}
+	if len(got.Workspaces) != 1 || got.Workspaces[0].WorkspacePath != "/tmp/custom" {
+		t.Fatalf("expected custom home watchlist, got %#v", got)
+	}
+	if _, err := os.Stat(filepath.Join(userHome, ".easyharness", "watchlist.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected default home to remain untouched, err=%v", err)
+	}
+}
+
+func TestReadMissingWatchlistReturnsEmptyFileWithoutCreatingIt(t *testing.T) {
+	userHome := t.TempDir()
+	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+
+	got, err := Service{UserHomeDir: func() (string, error) { return userHome, nil }}.Read()
+	if err != nil {
+		t.Fatalf("read missing watchlist: %v", err)
+	}
+	if got.Version != version || len(got.Workspaces) != 0 {
+		t.Fatalf("expected empty watchlist file model, got %#v", got)
+	}
+	if _, err := os.Stat(watchlistPath); !os.IsNotExist(err) {
+		t.Fatalf("expected read to avoid creating watchlist, err=%v", err)
+	}
+}
+
+func TestReadReturnsParseErrorForInvalidWatchlist(t *testing.T) {
+	userHome := t.TempDir()
+	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+	if err := os.MkdirAll(filepath.Dir(watchlistPath), 0o755); err != nil {
+		t.Fatalf("mkdir watchlist dir: %v", err)
+	}
+	if err := os.WriteFile(watchlistPath, []byte(`{"version":`), 0o644); err != nil {
+		t.Fatalf("write invalid watchlist: %v", err)
+	}
+
+	_, err := Service{UserHomeDir: func() (string, error) { return userHome, nil }}.Read()
+	if err == nil || !strings.Contains(err.Error(), "parse watchlist.json") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestReadReturnsErrorForUnsupportedVersion(t *testing.T) {
+	userHome := t.TempDir()
+	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+	writeWatchlistFile(t, watchlistPath, File{Version: version + 1})
+
+	_, err := Service{UserHomeDir: func() (string, error) { return userHome, nil }}.Read()
+	if err == nil || !strings.Contains(err.Error(), "unsupported version") {
+		t.Fatalf("expected unsupported version error, got %v", err)
+	}
+}
+
 func TestTouchUsesEasyharnessHomeOverride(t *testing.T) {
 	customHome := filepath.Join(t.TempDir(), "custom-home")
 	workdir := filepath.Join(t.TempDir(), "workspace")
@@ -377,6 +474,20 @@ func readWatchlistFile(t *testing.T, path string) File {
 		t.Fatalf("decode watchlist file: %v\n%s", err, data)
 	}
 	return decoded
+}
+
+func writeWatchlistFile(t *testing.T, path string, file File) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir watchlist dir: %v", err)
+	}
+	payload, err := json.MarshalIndent(file, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal watchlist file: %v", err)
+	}
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatalf("write watchlist file: %v", err)
+	}
 }
 
 func seedGitWorkspace(t *testing.T, root string) {

--- a/schema/index.json
+++ b/schema/index.json
@@ -213,6 +213,16 @@
       "go_type": "github.com/catu-ai/easyharness/internal/contracts.NextAction"
     },
     {
+      "key": "ui_resources.dashboard",
+      "group": "ui_resources",
+      "surface": "public",
+      "title": "Dashboard UI resource",
+      "description": "Read-only JSON resource returned by the dashboard home API for `harness ui`.",
+      "path": "schema/ui-resources/dashboard.schema.json",
+      "id": "https://github.com/catu-ai/easyharness/tree/main/schema/ui-resources/dashboard.schema.json",
+      "go_type": "github.com/catu-ai/easyharness/internal/contracts.DashboardResult"
+    },
+    {
       "key": "ui_resources.plan",
       "group": "ui_resources",
       "surface": "public",

--- a/schema/index.json
+++ b/schema/index.json
@@ -217,7 +217,7 @@
       "group": "ui_resources",
       "surface": "public",
       "title": "Dashboard UI resource",
-      "description": "Read-only JSON resource returned by the dashboard home API for `harness ui`.",
+      "description": "Read-only JSON resource returned by the dashboard home API.",
       "path": "schema/ui-resources/dashboard.schema.json",
       "id": "https://github.com/catu-ai/easyharness/tree/main/schema/ui-resources/dashboard.schema.json",
       "go_type": "github.com/catu-ai/easyharness/internal/contracts.DashboardResult"

--- a/schema/ui-resources/dashboard.schema.json
+++ b/schema/ui-resources/dashboard.schema.json
@@ -1,0 +1,290 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/catu-ai/easyharness/tree/main/schema/ui-resources/dashboard.schema.json",
+  "$ref": "#/$defs/DashboardResult",
+  "$defs": {
+    "DashboardGroup": {
+      "properties": {
+        "state": {
+          "type": "string",
+          "description": "State is the dashboard lifecycle state for every workspace in the group."
+        },
+        "workspaces": {
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/DashboardWorkspace"
+              },
+              "type": "array",
+              "description": "Workspaces lists watched workspace entries in dashboard recency order."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Workspaces lists watched workspace entries in dashboard recency order."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "state",
+        "workspaces"
+      ],
+      "description": "DashboardGroup is one dashboard lifecycle group."
+    },
+    "DashboardResult": {
+      "properties": {
+        "ok": {
+          "type": "boolean",
+          "description": "OK reports whether the machine-local watchlist was loaded."
+        },
+        "resource": {
+          "type": "string",
+          "description": "Resource is the stable UI resource identifier."
+        },
+        "summary": {
+          "type": "string",
+          "description": "Summary is the concise human-readable explanation of the loaded dashboard model."
+        },
+        "groups": {
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/DashboardGroup"
+              },
+              "type": "array",
+              "description": "Groups lists watched workspaces grouped by dashboard lifecycle state."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Groups lists watched workspaces grouped by dashboard lifecycle state."
+        },
+        "errors": {
+          "items": {
+            "$ref": "#/$defs/ErrorDetail"
+          },
+          "type": "array",
+          "description": "Errors lists hard failures that prevented dashboard loading."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ok",
+        "resource",
+        "summary",
+        "groups"
+      ],
+      "description": "DashboardResult is the read-only UI resource for the machine-local dashboard home."
+    },
+    "DashboardWorkspace": {
+      "properties": {
+        "workspace_key": {
+          "type": "string",
+          "description": "WorkspaceKey is the opaque deterministic route key derived from the watched workspace path."
+        },
+        "workspace_path": {
+          "type": "string",
+          "description": "WorkspacePath is the canonical watched path from the watchlist record."
+        },
+        "watched_at": {
+          "type": "string",
+          "description": "WatchedAt is the timestamp when the workspace first entered the watchlist."
+        },
+        "last_seen_at": {
+          "type": "string",
+          "description": "LastSeenAt is the dashboard recency timestamp from the watchlist record."
+        },
+        "dashboard_state": {
+          "type": "string",
+          "description": "DashboardState is the read-time dashboard lifecycle state."
+        },
+        "invalid_reason": {
+          "type": "string",
+          "description": "InvalidReason refines invalid entries without expanding the dashboard lifecycle state enum."
+        },
+        "current_node": {
+          "type": "string",
+          "description": "CurrentNode is the raw harness workflow node for readable status entries."
+        },
+        "summary": {
+          "type": "string",
+          "description": "Summary is the compact workspace summary for dashboard rows or cards."
+        },
+        "next_actions": {
+          "items": {
+            "$ref": "#/$defs/NextAction"
+          },
+          "type": "array",
+          "description": "NextAction lists the most relevant status follow-up steps for readable entries."
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Warnings lists non-fatal degraded-state notes for this workspace."
+        },
+        "blockers": {
+          "items": {
+            "$ref": "#/$defs/ErrorDetail"
+          },
+          "type": "array",
+          "description": "Blockers lists state issues that block ordinary progression for this workspace."
+        },
+        "errors": {
+          "items": {
+            "$ref": "#/$defs/ErrorDetail"
+          },
+          "type": "array",
+          "description": "Errors lists hard failures for this workspace entry."
+        },
+        "artifacts": {
+          "$ref": "#/$defs/StatusArtifacts",
+          "description": "Artifacts points to stable status artifact handles for navigation or display."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "workspace_key",
+        "workspace_path",
+        "dashboard_state",
+        "summary"
+      ],
+      "description": "DashboardWorkspace is one watched workspace summary for the dashboard home."
+    },
+    "ErrorDetail": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path identifies the field, section, or artifact path associated with the error."
+        },
+        "message": {
+          "type": "string",
+          "description": "Message is the human-readable explanation of the problem."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path",
+        "message"
+      ],
+      "description": "ErrorDetail describes one machine-readable validation or execution problem in a command result."
+    },
+    "NextAction": {
+      "properties": {
+        "command": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Command is the suggested command line to run next when the next step is best expressed as a harness command."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Command is the suggested command line to run next when the next step is best expressed as a harness command."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description explains the suggested next step in plain language."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command",
+        "description"
+      ],
+      "description": "NextAction describes one concrete follow-up action that the caller should consider after reading a command result."
+    },
+    "ReviewSlot": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the human-readable dimension label."
+        },
+        "slot": {
+          "type": "string",
+          "description": "Slot is the stable slot identifier."
+        },
+        "instructions": {
+          "type": "string",
+          "description": "Instructions is the reviewer prompt for this slot."
+        },
+        "submission_path": {
+          "type": "string",
+          "description": "SubmissionPath is the target path for this slot's submission artifact."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "slot",
+        "instructions",
+        "submission_path"
+      ],
+      "description": "ReviewSlot describes one surfaced reviewer submission slot."
+    },
+    "StatusArtifacts": {
+      "properties": {
+        "project_root": {
+          "type": "string",
+          "description": "ProjectRoot is the repository root that anchors surfaced repo-facing paths."
+        },
+        "plan_path": {
+          "type": "string",
+          "description": "PlanPath is the active, archived, or last-landed plan path relevant to the current status resolution.",
+          "examples": [
+            "docs/plans/active/2026-03-31-centralize-contract-schemas-and-generated-reference-docs.md"
+          ]
+        },
+        "supplements_path": {
+          "type": "string",
+          "description": "SupplementsPath is the companion supplements directory for the current plan package when one exists.",
+          "examples": [
+            "docs/plans/active/supplements/2026-03-31-centralize-contract-schemas-and-generated-reference-docs"
+          ]
+        },
+        "review_round_id": {
+          "type": "string",
+          "description": "ReviewRoundID is the active review round identifier when review is in flight."
+        },
+        "review_slots": {
+          "items": {
+            "$ref": "#/$defs/ReviewSlot"
+          },
+          "type": "array",
+          "description": "ReviewSlots lists the active round's reviewer-owned slot handles when review is in flight."
+        },
+        "ci_record_id": {
+          "type": "string",
+          "description": "CIRecordID is the latest CI evidence record identifier when known."
+        },
+        "publish_record_id": {
+          "type": "string",
+          "description": "PublishRecordID is the latest publish evidence record identifier when known."
+        },
+        "sync_record_id": {
+          "type": "string",
+          "description": "SyncRecordID is the latest sync evidence record identifier when known."
+        },
+        "last_landed_at": {
+          "type": "string",
+          "description": "LastLandedAt is the timestamp of the most recent landed plan."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "StatusArtifacts lists stable paths or identifiers related to the current status result."
+    }
+  },
+  "title": "Dashboard UI resource",
+  "description": "Read-only JSON resource returned by the dashboard home API for `harness ui`."
+}

--- a/schema/ui-resources/dashboard.schema.json
+++ b/schema/ui-resources/dashboard.schema.json
@@ -286,5 +286,5 @@
     }
   },
   "title": "Dashboard UI resource",
-  "description": "Read-only JSON resource returned by the dashboard home API for `harness ui`."
+  "description": "Read-only JSON resource returned by the dashboard home API."
 }


### PR DESCRIPTION
## Summary

- add a read-only watchlist loader and dashboard read-model service for watched workspaces
- expose raw `current_node` alongside dashboard lifecycle groups: active, completed, idle, missing, invalid
- add `GET /api/dashboard`, dashboard contract/schema docs, and tests for degraded entries and no-write reads

## Validation

- `go test ./internal/watchlist -count=1`
- `go test ./internal/dashboard ./internal/watchlist ./internal/contractsync -count=1`
- `go test ./internal/ui ./internal/dashboard ./internal/watchlist -count=1`
- `go test ./internal/dashboard ./internal/watchlist ./internal/ui -count=1`
- `scripts/sync-contract-artifacts --check`
- `git diff --check`
- `go test ./internal/... -count=1`

## Harness

- Plan: `docs/plans/archived/2026-04-22-build-watchlist-dashboard-read-model.md`
- Finalize review: `review-011-full` passed with no findings

Closes #165
Updates #156
