### PR TITLE
[codex] Define watchlist unwatch lifecycle

### DIFF
--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -290,6 +290,8 @@ tracked specs beyond this plan note.
 - `review-005-full` found one archive-readiness issue: final acceptance
   criteria and durable closeout sections were still placeholders. This update
   resolves that closeout gap before the archive retry.
+- `review-006-delta` passed after the closeout summaries and follow-up issue
+  handoff were filled.
 
 ## Archive Summary
 
@@ -300,8 +302,8 @@ tracked specs beyond this plan note.
 - Ready: Acceptance criteria are satisfied, the watchlist contract and UI
   proposal consistently define `completed` and `unwatch`, the isolated
   watchlist-level `Service.Unwatch` write path is implemented with focused
-  tests, issue #166 has a GitHub-visible handoff comment, and the only
-  finalize-review finding was this closeout placeholder update.
+  tests, issue #166 has a GitHub-visible handoff comment, and
+  `review-006-delta` passed after the finalize closeout repair.
 - Merge Handoff: After archive, commit the tracked plan move, push the branch,
   open the PR, record publish/CI/sync evidence, and stop at merge approval.
 

--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -56,27 +56,28 @@ state.
 
 ## Acceptance Criteria
 
-- [ ] The tracked specs consistently describe `completed` as a derived
+- [x] The tracked specs consistently describe `completed` as a derived
       dashboard lifecycle state rather than persisted watchlist state.
-- [ ] The tracked specs define `unwatch` as explicit watchlist membership
+- [x] The tracked specs define `unwatch` as explicit watchlist membership
       removal from `watchlist.json`.
-- [ ] The tracked specs clearly state that `unwatch` does not call or mean
+- [x] The tracked specs clearly state that `unwatch` does not call or mean
       `harness archive`.
-- [ ] The tracked specs state that completed workspaces do not automatically
+- [x] The tracked specs state that completed workspaces do not automatically
       age out or disappear in v1.
-- [ ] Any existing references to dashboard-local hide/archive semantics are
+- [x] Any existing references to dashboard-local hide/archive semantics are
       either removed or reframed as historical/deferred wording.
-- [ ] If implementation work is needed in this slice, focused watchlist or
+- [x] If implementation work is needed in this slice, focused watchlist or
       dashboard tests prove the new behavior without changing workflow state.
-- [ ] Issue #166 has a closeout comment or PR note summarizing the accepted
+- [x] Issue #166 has a closeout comment or PR note summarizing the accepted
       `unwatch` direction.
 
 ## Deferred Items
 
-- Implement the concrete dashboard/API `unwatch` write path if this slice only
-  lands the normative contract.
-- Add the frontend control that lets a user unwatch a completed workspace from
-  the dashboard home.
+- Wire the new watchlist-level `Service.Unwatch` method into the future
+  dashboard/API/UI surface, tracked by
+  [#167](https://github.com/catu-ai/easyharness/issues/167).
+- Add the frontend control that lets a user unwatch a completed, missing, or
+  invalid workspace from the dashboard home or degraded workspace page.
 
 ## Work Breakdown
 
@@ -258,26 +259,86 @@ tracked specs beyond this plan note.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `harness plan lint docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md`
+  passed after planning, step closeout updates, and final closeout updates.
+- `git diff --check -- docs/specs/watchlist-contract.md docs/specs/proposals/harness-ui-steering-surface.md docs/specs/index.md`
+  passed for the Step 1 docs contract update.
+- `rg -n "membership-removal behavior|hidden state|dashboard-local archive|age out|age-out|automatic"
+  docs/specs/watchlist-contract.md docs/specs/proposals/harness-ui-steering-surface.md`
+  confirmed the stale membership-removal wording was removed and remaining
+  hidden/archive/automatic references are non-goal or rejected-semantics
+  wording.
+- Red/green watchlist validation was used for Step 2: `go test
+  ./internal/watchlist -run Unwatch -count=1` failed before
+  `Service.Unwatch` existed, and `go test ./internal/watchlist -count=1`
+  passed after implementation and review fixes.
+- Final focused validation passed with `go test ./internal/watchlist
+  ./internal/dashboard -count=1`; the finalize correctness reviewer also ran
+  `go test ./internal/watchlist ./internal/dashboard ./internal/ui -count=1`
+  successfully.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- `review-001-delta` found one docs-consistency issue: a Missing or Unreadable
+  Workspaces paragraph still used old deferred membership-removal wording.
+- `review-002-delta` passed after that paragraph was changed to explicit
+  `unwatch` terminology.
+- `review-003-delta` found one tests issue: `Unwatch` lacked
+  `EASYHARNESS_HOME` / configured-home coverage.
+- `review-004-delta` passed after adding
+  `TestUnwatchUsesEasyharnessHomeOverride`.
+- `review-005-full` found one archive-readiness issue: final acceptance
+  criteria and durable closeout sections were still placeholders. This update
+  resolves that closeout gap before the archive retry.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: pending `harness archive`
+- Revision: 1
+- PR: not opened yet; publish closeout should create a PR from branch
+  `codex/issue-166-unwatch-lifecycle` and include `Closes #166`.
+- Ready: Acceptance criteria are satisfied, the watchlist contract and UI
+  proposal consistently define `completed` and `unwatch`, the isolated
+  watchlist-level `Service.Unwatch` write path is implemented with focused
+  tests, issue #166 has a GitHub-visible handoff comment, and the only
+  finalize-review finding was this closeout placeholder update.
+- Merge Handoff: After archive, commit the tracked plan move, push the branch,
+  open the PR, record publish/CI/sync evidence, and stop at merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Updated `docs/specs/watchlist-contract.md` so `completed` is clearly a
+  derived dashboard lifecycle state, `unwatch` is explicit watchlist
+  membership removal, completed/missing/invalid entries remain watched until
+  explicit `unwatch`, and v1 has no hidden state, dashboard-local archive
+  bucket, or automatic GC.
+- Updated `docs/specs/proposals/harness-ui-steering-surface.md` so the
+  dashboard proposal uses the same completed/unwatch terminology and states
+  that `Unwatch` is not `harness archive`, workflow mutation, or checkout
+  deletion.
+- Added `watchlist.Service.Unwatch`, reusing watchlist home resolution,
+  locking, loading, and atomic-write helpers while preserving unrelated
+  records and treating absent records as no-ops.
+- Added watchlist tests for removing a selected workspace, preserving
+  unrelated records, nested workspace canonicalization, missing watched paths,
+  absent-record idempotence, no watchlist creation for absent no-op removal,
+  and configured `EASYHARNESS_HOME` resolution.
+- Posted the #166 handoff comment:
+  https://github.com/catu-ai/easyharness/issues/166#issuecomment-4301163030
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Dashboard frontend/API wiring for invoking `Service.Unwatch`; that belongs
+  with the dashboard UI follow-up.
+- Automatic cleanup, age-out, background monitoring, or garbage collection for
+  completed, idle, missing, invalid, or stale watched workspaces.
+- Any change to `harness archive`, harness workflow state, checkout deletion,
+  tracked plan deletion, or `.local/harness` artifact cleanup semantics.
 
 ### Follow-Up Issues
 
-NONE
+- [#167 Ship a minimal watchlist dashboard UI](https://github.com/catu-ai/easyharness/issues/167)
+  should wire a user-facing `Unwatch` control to the new watchlist-level
+  removal behavior.

--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -82,7 +82,7 @@ state.
 
 ### Step 1: Tighten the completed and unwatch contract
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -129,11 +129,7 @@ docs/specs/proposals/harness-ui-steering-surface.md`.
 `review-001-delta` requested one docs-consistency fix: the Missing or
 Unreadable Workspaces section still used old deferred membership-removal
 wording. Reworded that section to say entries remain until explicit `unwatch`
-removes them. Follow-up validation: `git diff --check -- docs/specs/watchlist-contract.md
-docs/specs/proposals/harness-ui-steering-surface.md docs/specs/index.md`;
-`rg -n "membership-removal behavior|hidden state|dashboard-local archive|age out|age-out|automatic"
-docs/specs/watchlist-contract.md
-docs/specs/proposals/harness-ui-steering-surface.md`.
+removes them. `review-002-delta` passed with no findings.
 
 ### Step 2: Decide whether this slice needs a tiny unwatch write path
 

--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -189,7 +189,7 @@ untouched. `review-004-delta` passed with no findings.
 
 ### Step 3: Close the GitHub-facing handoff
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -220,11 +220,17 @@ The closeout note should state the final terms plainly:
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Posted the GitHub-facing #166 closeout comment documenting the accepted
+`unwatch` direction, the derived `completed` rule, the explicit
+non-relationship to `harness archive`, the absence of automatic GC, and the
+new watchlist-level `Service.Unwatch` write path:
+https://github.com/catu-ai/easyharness/issues/166#issuecomment-4301163030
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 3 only published the already-reviewed decision and
+implementation summary to issue #166; it did not change repository behavior or
+tracked specs beyond this plan note.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -181,7 +181,11 @@ no-op refinement.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-003-delta` requested one tests fix: add `Unwatch` coverage for
+`EASYHARNESS_HOME` / configured home resolution. Added
+`TestUnwatchUsesEasyharnessHomeOverride`, which proves `Unwatch` removes from
+the configured custom watchlist and leaves the default user-home watchlist
+untouched. Validation: `go test ./internal/watchlist -count=1`.
 
 ### Step 3: Close the GitHub-facing handoff
 

--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -292,6 +292,7 @@ tracked specs beyond this plan note.
   resolves that closeout gap before the archive retry.
 - `review-006-delta` passed after the closeout summaries and follow-up issue
   handoff were filled.
+- `review-007-full` passed cleanly with no blocking or non-blocking findings.
 
 ## Archive Summary
 
@@ -303,7 +304,7 @@ tracked specs beyond this plan note.
   proposal consistently define `completed` and `unwatch`, the isolated
   watchlist-level `Service.Unwatch` write path is implemented with focused
   tests, issue #166 has a GitHub-visible handoff comment, and
-  `review-006-delta` passed after the finalize closeout repair.
+  `review-007-full` passed cleanly.
 - Merge Handoff: After archive, commit the tracked plan move, push the branch,
   open the PR, record publish/CI/sync evidence, and stop at merge approval.
 

--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -133,7 +133,7 @@ removes them. `review-002-delta` passed with no findings.
 
 ### Step 2: Decide whether this slice needs a tiny unwatch write path
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -185,7 +185,7 @@ no-op refinement.
 `EASYHARNESS_HOME` / configured home resolution. Added
 `TestUnwatchUsesEasyharnessHomeOverride`, which proves `Unwatch` removes from
 the configured custom watchlist and leaves the default user-home watchlist
-untouched. Validation: `go test ./internal/watchlist -count=1`.
+untouched. `review-004-delta` passed with no findings.
 
 ### Step 3: Close the GitHub-facing handoff
 

--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -126,7 +126,14 @@ docs/specs/proposals/harness-ui-steering-surface.md`.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` requested one docs-consistency fix: the Missing or
+Unreadable Workspaces section still used old deferred membership-removal
+wording. Reworded that section to say entries remain until explicit `unwatch`
+removes them. Follow-up validation: `git diff --check -- docs/specs/watchlist-contract.md
+docs/specs/proposals/harness-ui-steering-surface.md docs/specs/index.md`;
+`rg -n "membership-removal behavior|hidden state|dashboard-local archive|age out|age-out|automatic"
+docs/specs/watchlist-contract.md
+docs/specs/proposals/harness-ui-steering-surface.md`.
 
 ### Step 2: Decide whether this slice needs a tiny unwatch write path
 

--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -1,0 +1,261 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-23T09:36:00+08:00"
+approved_at: "2026-04-23T09:38:14+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/166
+size: S
+---
+
+# Define Watchlist Unwatch Lifecycle
+
+## Goal
+
+Close the completed-versus-hidden lifecycle gap for watched worktrees by
+settling on explicit `unwatch` terminology and behavior. A watched workspace
+may be classified as `completed` by the dashboard read model, but clearing it
+from the dashboard-owned watched set should be an explicit watchlist
+membership-removal action, not a hidden dashboard state and not a harness
+workflow archive.
+
+This slice should leave future dashboard UI and API work with one durable
+contract: `completed` is derived from harness status, while `unwatch` removes a
+workspace from the machine-local watchlist without mutating harness workflow
+state.
+
+## Scope
+
+### In Scope
+
+- Tighten the watchlist and dashboard specs so #166 consistently uses
+  `unwatch` rather than `hidden`, `hide`, or dashboard-local `archive`.
+- Confirm that the dashboard `completed` rule remains the current read-model
+  rule: readable status, `current_node: "idle"`, and last-landed context.
+- Define `unwatch` as an explicit user action that removes a workspace record
+  from `watchlist.json`.
+- State that `unwatch` is dashboard/watchlist membership behavior only; it
+  must not run `harness archive`, alter tracked plans, delete worktrees, or
+  change workflow state.
+- Add or adjust focused tests if existing docs or contracts are backed by
+  generated schema, contract sync, or dashboard/watchlist behavior assertions.
+- Leave a GitHub-visible closeout note for #166 explaining the accepted
+  terminology and any deferred implementation surface.
+
+### Out of Scope
+
+- Building the dashboard frontend UI.
+- Adding the `harness dashboard` CLI entrypoint.
+- Implementing a full workspace detail route.
+- Automatically removing completed, stale, missing, or invalid workspaces.
+- Introducing a persisted `hidden` flag or any separate hidden lifecycle
+  state.
+- Changing harness workflow semantics, including `harness archive`.
+- Deleting local repositories, git worktrees, plan files, or `.local/harness`
+  artifacts.
+
+## Acceptance Criteria
+
+- [ ] The tracked specs consistently describe `completed` as a derived
+      dashboard lifecycle state rather than persisted watchlist state.
+- [ ] The tracked specs define `unwatch` as explicit watchlist membership
+      removal from `watchlist.json`.
+- [ ] The tracked specs clearly state that `unwatch` does not call or mean
+      `harness archive`.
+- [ ] The tracked specs state that completed workspaces do not automatically
+      age out or disappear in v1.
+- [ ] Any existing references to dashboard-local hide/archive semantics are
+      either removed or reframed as historical/deferred wording.
+- [ ] If implementation work is needed in this slice, focused watchlist or
+      dashboard tests prove the new behavior without changing workflow state.
+- [ ] Issue #166 has a closeout comment or PR note summarizing the accepted
+      `unwatch` direction.
+
+## Deferred Items
+
+- Implement the concrete dashboard/API `unwatch` write path if this slice only
+  lands the normative contract.
+- Add the frontend control that lets a user unwatch a completed workspace from
+  the dashboard home.
+
+## Work Breakdown
+
+### Step 1: Tighten the completed and unwatch contract
+
+- Done: [ ]
+
+#### Objective
+
+Update the durable watchlist/dashboard documentation so a future agent can
+understand #166 without reading discovery chat.
+
+#### Details
+
+Keep the existing completed classification rule from the dashboard read model:
+`completed` is derived when status is readable, `current_node` is `idle`, and
+status artifacts include last-landed context. Replace any remaining dashboard
+`hidden`, `hide`, or `archive` language with `unwatch` unless the wording is
+explicitly describing a rejected alternative.
+
+`Unwatch` should be specified as membership removal from the machine-local
+watchlist. It should not become another lifecycle enum value, because removed
+items are no longer watched entries in the dashboard read model.
+
+#### Expected Files
+
+- `docs/specs/watchlist-contract.md`
+- `docs/specs/proposals/harness-ui-steering-surface.md`
+- `docs/specs/index.md` if the specs index needs a wording update
+
+#### Validation
+
+- `git diff --check -- docs/specs/watchlist-contract.md docs/specs/proposals/harness-ui-steering-surface.md docs/specs/index.md`
+- Reread the updated docs and confirm the terms `hidden` and dashboard-local
+  `archive` are not used as current behavior for watched workspace clearing.
+
+#### Execution Notes
+
+Updated the watchlist contract and dashboard steering proposal so `completed`
+remains a derived dashboard lifecycle state, completed entries stay watched
+until explicit `unwatch`, and `unwatch` is defined as watchlist membership
+removal only. Validation: `git diff --check -- docs/specs/watchlist-contract.md
+docs/specs/proposals/harness-ui-steering-surface.md docs/specs/index.md`;
+`rg -n "hidden|hide|dashboard-local archive|age out|age-out|automatic"
+docs/specs/watchlist-contract.md
+docs/specs/proposals/harness-ui-steering-surface.md`.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Decide whether this slice needs a tiny unwatch write path
+
+- Done: [ ]
+
+#### Objective
+
+Either implement the smallest watchlist-level `unwatch` behavior now or record
+the exact follow-up implementation issue if the contract-only closeout is the
+right boundary.
+
+#### Details
+
+Prefer implementation only if the existing code shape makes the write path
+truly small and isolated: a watchlist service method that removes one canonical
+workspace record from `watchlist.json`, preserves unrelated records, uses the
+same home resolution and lock/atomic-write discipline as `Touch`, and does not
+touch workflow state.
+
+If that expands beyond a small isolated watchlist change, defer it explicitly
+and leave #166 as the contract-definition closeout rather than smuggling UI or
+CLI work into this plan.
+
+#### Expected Files
+
+- `internal/watchlist/watchlist.go` if implementing
+- `internal/watchlist/watchlist_test.go` if implementing
+- GitHub issue or PR body note if deferring implementation
+
+#### Validation
+
+- If implementing: `go test ./internal/watchlist -count=1`
+- If deferring: a concrete follow-up issue or PR note names the intended
+  `unwatch` implementation surface and explains why #166 remains
+  contract-only.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Close the GitHub-facing handoff
+
+- Done: [ ]
+
+#### Objective
+
+Make the accepted `unwatch` decision visible on #166 or in the PR body so the
+issue does not depend on hidden chat context.
+
+#### Details
+
+The closeout note should state the final terms plainly:
+
+- `completed` is derived from status returning to `idle` with last-landed
+  context.
+- completed entries remain watched until explicit user action.
+- that action is called `unwatch`.
+- `unwatch` removes watchlist membership only and is unrelated to
+  `harness archive`.
+- v1 has no automatic age-out or garbage collection.
+
+#### Expected Files
+
+- No repository files are required for this step unless the PR body is the
+  chosen handoff surface.
+
+#### Validation
+
+- The issue comment or PR note can be read without discovery chat and explains
+  why #166 is ready to close or what implementation issue remains.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Lint the tracked plan before approval.
+- Run doc whitespace checks for touched markdown specs.
+- If a watchlist write path is implemented, run focused watchlist tests and
+  include regression cases for preserving unrelated records, idempotent
+  removal of absent records, and no workflow-state mutation.
+- Before archive, reread the issue and updated specs to confirm #166's
+  acceptance criteria are answered by tracked artifacts rather than chat.
+
+## Risks
+
+- Risk: `unwatch` could be confused with workflow archival or worktree
+  deletion.
+  - Mitigation: Keep the contract wording explicit that `unwatch` only removes
+    watchlist membership and does not mutate harness workflow state or files in
+    the watched repository.
+- Risk: A hidden-state compromise could creep back in as a persisted flag.
+  - Mitigation: State that removed items are no longer in the watched set, and
+    do not add a `hidden` lifecycle value.
+- Risk: The plan could expand into dashboard UI work.
+  - Mitigation: Keep UI controls and routing out of scope unless a later
+    approved plan takes them on.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -168,7 +168,16 @@ CLI work into this plan.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Implemented the small isolated watchlist write path in this slice:
+`watchlist.Service.Unwatch` removes one selected workspace record from
+`watchlist.json`, preserves unrelated records, uses the same home resolution,
+lock, and atomic rewrite helpers as `Touch`, supports missing workspace rows
+by matching their persisted path, leaves absent records as no-ops without
+creating an empty watchlist, and does not touch harness workflow state.
+Validation: red `go test ./internal/watchlist -run Unwatch -count=1` failed
+before implementation because `Service.Unwatch` did not exist; green
+`go test ./internal/watchlist -count=1` passed after implementation and the
+no-op refinement.
 
 #### Review Notes
 

--- a/docs/plans/archived/2026-04-23-define-watchlist-unwatch-lifecycle.md
+++ b/docs/plans/archived/2026-04-23-define-watchlist-unwatch-lifecycle.md
@@ -296,7 +296,7 @@ tracked specs beyond this plan note.
 
 ## Archive Summary
 
-- Archived At: pending `harness archive`
+- Archived At: 2026-04-23T09:58:33+08:00
 - Revision: 1
 - PR: not opened yet; publish closeout should create a PR from branch
   `codex/issue-166-unwatch-lifecycle` and include `Closes #166`.

--- a/docs/specs/proposals/harness-ui-steering-surface.md
+++ b/docs/specs/proposals/harness-ui-steering-surface.md
@@ -95,6 +95,10 @@ stays `idle`, and invalid rows carry a reason such as `unreadable`,
 `not_git_workspace`, or `status_error`. The read model should return stable
 lifecycle groups containing compact watched workspace entries rather than
 making the frontend derive grouping or field names from raw status payloads.
+Completed rows should remain watched until the user explicitly removes
+watchlist membership with `Unwatch`; the dashboard should not invent a
+separate hidden state or use dashboard-local archive terminology for that
+action.
 
 ## Product Shape
 
@@ -472,6 +476,10 @@ That degraded page may offer one local cleanup action:
 
 - `Unwatch`
 
+`Unwatch` removes the workspace from the machine-local watchlist only. It is
+not `harness archive`, does not alter harness workflow state, and does not
+delete the local checkout or git worktree.
+
 If the key does not match any currently watched workspace, the route should be
 treated as not currently watched. The product does not need extra tombstone or
 history state just to distinguish "never existed" from "used to be watched."
@@ -492,6 +500,8 @@ Ship:
 Defer:
 
 - direct action triggers beyond minimal refresh, open, or `Unwatch`
+- automatic cleanup or age-out of completed, missing, invalid, or stale watched
+  workspaces
 
 ### Phase 2: Contextual Steering Actions
 

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -231,16 +231,33 @@ state instead of persisting copies that can drift.
 
 ## Membership and User Action
 
-Watchlist membership is binary in this first contract:
+Watchlist membership is binary in this contract:
 
 - a workspace is watched because a record exists in `watchlist.json`
-- this touch-foundation slice does not yet define a membership-removal command
+- a workspace is no longer watched once that record is removed from
+  `watchlist.json`
 
 This contract does not define a separate dashboard-local `hidden` state.
+There is no persisted visibility flag, archive bucket, or secondary lifecycle
+layer for clearing rows from the main dashboard.
 
-Future work may add an explicit local action such as `unwatch` to remove a
-workspace record from `watchlist.json`, but that user-facing removal path is
-deferred beyond this machine-local touch foundation.
+The explicit user-facing membership-removal action is `unwatch`.
+
+`Unwatch` means:
+
+- remove the selected workspace record from the machine-local watchlist
+- preserve unrelated workspace records in the same watchlist file
+- leave the watched repository, git worktree, tracked plan files, and
+  `.local/harness` workflow artifacts untouched
+
+`Unwatch` does not mean `harness archive`. It must not advance, reopen,
+archive, land, or otherwise mutate harness workflow state. It also must not
+delete a local checkout or git worktree.
+
+Once a workspace is unwatched, it is absent from ordinary dashboard lifecycle
+groups because it is no longer a watched entry. The first dashboard slice does
+not need tombstone or history state to distinguish "never watched" from
+"previously watched and later unwatched."
 
 ## Derived Lifecycle States
 
@@ -331,9 +348,10 @@ In particular:
   the workspace from the watchlist
 - ordinary idle without last-landed context remains `idle`; it must not be
   presented as `completed`
+- completed watched workspaces remain visible until explicit `unwatch`
 - deleting the local directory does not remove the workspace from the
   watchlist by itself; it instead becomes a `missing` watched workspace until
-  later explicit membership-removal behavior exists and removes it
+  explicit `unwatch` removes it
 - a permissions, Git probe, or status failure may surface as `invalid` without
   removing the workspace from the watchlist
 - a malformed non-absolute `workspace_path` must surface as `invalid` before
@@ -347,8 +365,8 @@ This first contract does not define silent automatic garbage collection.
 
 The watchlist is a remembered local set, not an auto-pruned mirror of the
 current filesystem. The combination of `last_seen_at`, derived `missing`
-or `invalid` status, and deferred explicit membership-removal behavior is
-enough for this touch-foundation slice.
+or `invalid` status, and explicit `unwatch` behavior is enough for this
+contract.
 
 Later work may add user-facing cleanup or stale-item policies, but v1 should
 not silently discard watched entries just because they have gone idle,
@@ -365,6 +383,9 @@ For dashboard workspace-detail routing:
   treated as "not currently watched"
 - the first dashboard slice does not need extra watchlist history state just
   to distinguish "never watched" from "used to be watched and later unwatched"
+
+If a workspace has been unwatched, its old route key should resolve the same
+way as any other key that does not match the current watchlist.
 
 ## Write Expectations
 
@@ -405,3 +426,5 @@ This spec does not:
 - support non-git watched directories in the first slice
 - define any dashboard-local `hidden` state or secondary visibility layer
   beyond explicit `unwatch`
+- define automatic cleanup for completed, idle, missing, invalid, or stale
+  watched workspaces

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -176,8 +176,8 @@ If a previously watched `workspace_path` later becomes:
 - unreadable
 - no longer a valid Git-backed workspace
 
-the watchlist record should remain present until later explicit
-membership-removal behavior exists and removes it.
+the watchlist record should remain present until explicit `unwatch` removes
+it.
 
 Read-model and UI layers should surface those entries as explicit degraded
 states rather than silently dropping them from the watched set.

--- a/internal/watchlist/watchlist.go
+++ b/internal/watchlist/watchlist.go
@@ -83,6 +83,45 @@ func (s Service) Touch(workdir string) error {
 	return writeJSONAtomic(path, payload, 0o644)
 }
 
+func (s Service) Unwatch(workdir string) error {
+	canonicalPath, err := unwatchWorkspacePath(workdir)
+	if err != nil {
+		return err
+	}
+
+	home, err := s.easyharnessHome()
+	if err != nil {
+		return err
+	}
+
+	release, err := acquireLock(home)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	path := filepath.Join(home, "watchlist.json")
+	data, err := loadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var removed bool
+	data.Workspaces, removed = removeWorkspace(data.Workspaces, canonicalPath)
+	if !removed {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal watchlist.json: %w", err)
+	}
+	return writeJSONAtomic(path, payload, 0o644)
+}
+
 func (s Service) easyharnessHome() (string, error) {
 	if lookup := s.LookupEnv; lookup != nil {
 		if value, ok := lookup(envHome); ok && strings.TrimSpace(value) != "" {
@@ -205,6 +244,19 @@ func upsertWorkspace(workspaces []Workspace, canonicalPath, seenAt string) []Wor
 	return next
 }
 
+func removeWorkspace(workspaces []Workspace, canonicalPath string) ([]Workspace, bool) {
+	next := make([]Workspace, 0, len(workspaces))
+	removed := false
+	for _, workspace := range workspaces {
+		if strings.TrimSpace(workspace.WorkspacePath) == canonicalPath {
+			removed = true
+			continue
+		}
+		next = append(next, workspace)
+	}
+	return next, removed
+}
+
 func canonicalWorkspacePath(workdir string) (string, error) {
 	root, err := gitWorkspaceRoot(workdir)
 	if err != nil {
@@ -219,6 +271,24 @@ func canonicalWorkspacePath(workdir string) (string, error) {
 		return "", fmt.Errorf("resolve workspace symlinks: %w", err)
 	}
 	return filepath.Clean(resolved), nil
+}
+
+func unwatchWorkspacePath(workdir string) (string, error) {
+	workdir = strings.TrimSpace(workdir)
+	if workdir == "" {
+		return "", fmt.Errorf("resolve workspace: empty path")
+	}
+	if canonical, err := canonicalWorkspacePath(workdir); err == nil {
+		return canonical, nil
+	}
+	absolute, err := filepath.Abs(workdir)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace absolute path: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		return filepath.Clean(resolved), nil
+	}
+	return filepath.Clean(absolute), nil
 }
 
 func gitWorkspaceRoot(workdir string) (string, error) {

--- a/internal/watchlist/watchlist_test.go
+++ b/internal/watchlist/watchlist_test.go
@@ -505,6 +505,108 @@ func TestTouchRegistersLinkedGitWorktree(t *testing.T) {
 	}
 }
 
+func TestUnwatchRemovesWorkspaceAndPreservesUnrelatedRecords(t *testing.T) {
+	userHome := t.TempDir()
+	root := t.TempDir()
+	first := filepath.Join(root, "workspace-a")
+	second := filepath.Join(root, "workspace-b")
+	for _, path := range []string{first, second} {
+		seedGitWorkspace(t, path)
+	}
+	nested := filepath.Join(first, "docs", "plans")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested workspace path: %v", err)
+	}
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	if err := svc.Touch(first); err != nil {
+		t.Fatalf("touch first workspace: %v", err)
+	}
+	if err := svc.Touch(second); err != nil {
+		t.Fatalf("touch second workspace: %v", err)
+	}
+	if err := svc.Unwatch(nested); err != nil {
+		t.Fatalf("unwatch nested workspace path: %v", err)
+	}
+
+	got := readWatchlistFile(t, filepath.Join(userHome, ".easyharness", "watchlist.json"))
+	canonicalSecond, err := filepath.EvalSymlinks(second)
+	if err != nil {
+		t.Fatalf("resolve second workspace: %v", err)
+	}
+	if len(got.Workspaces) != 1 {
+		t.Fatalf("expected only unrelated workspace to remain, got %#v", got.Workspaces)
+	}
+	if got.Workspaces[0].WorkspacePath != canonicalSecond {
+		t.Fatalf("expected second workspace to remain, got %#v", got.Workspaces[0])
+	}
+}
+
+func TestUnwatchRemovesMissingWorkspaceByPersistedPath(t *testing.T) {
+	userHome := t.TempDir()
+	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+	missing := filepath.Join(t.TempDir(), "missing-workspace")
+	remaining := filepath.Join(t.TempDir(), "remaining-workspace")
+	writeWatchlistFile(t, watchlistPath, File{
+		Version: version,
+		Workspaces: []Workspace{
+			{WorkspacePath: missing, WatchedAt: "2026-04-19T01:00:00Z", LastSeenAt: "2026-04-19T01:00:00Z"},
+			{WorkspacePath: remaining, WatchedAt: "2026-04-19T02:00:00Z", LastSeenAt: "2026-04-19T02:00:00Z"},
+		},
+	})
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	if err := svc.Unwatch(missing); err != nil {
+		t.Fatalf("unwatch missing workspace: %v", err)
+	}
+
+	got := readWatchlistFile(t, watchlistPath)
+	if len(got.Workspaces) != 1 {
+		t.Fatalf("expected missing workspace to be removed, got %#v", got.Workspaces)
+	}
+	if got.Workspaces[0].WorkspacePath != remaining {
+		t.Fatalf("expected remaining workspace to survive, got %#v", got.Workspaces[0])
+	}
+}
+
+func TestUnwatchAbsentWorkspaceIsIdempotent(t *testing.T) {
+	userHome := t.TempDir()
+	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	absent := filepath.Join(t.TempDir(), "absent-workspace")
+	writeWatchlistFile(t, watchlistPath, File{
+		Version: version,
+		Workspaces: []Workspace{
+			{WorkspacePath: workspace, WatchedAt: "2026-04-19T01:00:00Z", LastSeenAt: "2026-04-19T01:00:00Z"},
+		},
+	})
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	if err := svc.Unwatch(absent); err != nil {
+		t.Fatalf("unwatch absent workspace: %v", err)
+	}
+
+	got := readWatchlistFile(t, watchlistPath)
+	if len(got.Workspaces) != 1 || got.Workspaces[0].WorkspacePath != workspace {
+		t.Fatalf("expected existing workspace to survive idempotent unwatch, got %#v", got.Workspaces)
+	}
+}
+
+func TestUnwatchMissingWatchlistDoesNotCreateFile(t *testing.T) {
+	userHome := t.TempDir()
+	absent := filepath.Join(t.TempDir(), "absent-workspace")
+
+	svc := Service{UserHomeDir: func() (string, error) { return userHome, nil }}
+	if err := svc.Unwatch(absent); err != nil {
+		t.Fatalf("unwatch absent workspace without watchlist: %v", err)
+	}
+
+	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+	if _, err := os.Stat(watchlistPath); !os.IsNotExist(err) {
+		t.Fatalf("expected absent unwatch to avoid creating watchlist, err=%v", err)
+	}
+}
+
 func readWatchlistFile(t *testing.T, path string) File {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/watchlist/watchlist_test.go
+++ b/internal/watchlist/watchlist_test.go
@@ -569,6 +569,48 @@ func TestUnwatchRemovesMissingWorkspaceByPersistedPath(t *testing.T) {
 	}
 }
 
+func TestUnwatchUsesEasyharnessHomeOverride(t *testing.T) {
+	userHome := t.TempDir()
+	customHome := filepath.Join(t.TempDir(), "custom-home")
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	defaultWorkspace := filepath.Join(t.TempDir(), "default-workspace")
+	writeWatchlistFile(t, filepath.Join(customHome, "watchlist.json"), File{
+		Version: version,
+		Workspaces: []Workspace{
+			{WorkspacePath: workspace, WatchedAt: "2026-04-19T01:00:00Z", LastSeenAt: "2026-04-19T01:00:00Z"},
+		},
+	})
+	defaultWatchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")
+	writeWatchlistFile(t, defaultWatchlistPath, File{
+		Version: version,
+		Workspaces: []Workspace{
+			{WorkspacePath: defaultWorkspace, WatchedAt: "2026-04-19T02:00:00Z", LastSeenAt: "2026-04-19T02:00:00Z"},
+		},
+	})
+
+	svc := Service{
+		LookupEnv: func(key string) (string, bool) {
+			if key == envHome {
+				return customHome, true
+			}
+			return "", false
+		},
+		UserHomeDir: func() (string, error) { return userHome, nil },
+	}
+	if err := svc.Unwatch(workspace); err != nil {
+		t.Fatalf("unwatch custom home workspace: %v", err)
+	}
+
+	customGot := readWatchlistFile(t, filepath.Join(customHome, "watchlist.json"))
+	if len(customGot.Workspaces) != 0 {
+		t.Fatalf("expected custom home workspace to be removed, got %#v", customGot.Workspaces)
+	}
+	defaultGot := readWatchlistFile(t, defaultWatchlistPath)
+	if len(defaultGot.Workspaces) != 1 || defaultGot.Workspaces[0].WorkspacePath != defaultWorkspace {
+		t.Fatalf("expected default watchlist to remain untouched, got %#v", defaultGot.Workspaces)
+	}
+}
+
 func TestUnwatchAbsentWorkspaceIsIdempotent(t *testing.T) {
 	userHome := t.TempDir()
 	watchlistPath := filepath.Join(userHome, ".easyharness", "watchlist.json")


### PR DESCRIPTION
## Summary

- define the watched-worktree clearing action as `Unwatch`, not hide/archive
- document `completed` as a derived dashboard lifecycle state and exclude automatic GC
- add `watchlist.Service.Unwatch` with focused watchlist tests
- archive the tracked harness plan and record #166/#167 handoff comments

Closes #166.

## Validation

- `harness plan lint docs/plans/active/2026-04-23-define-watchlist-unwatch-lifecycle.md`
- `harness plan lint docs/plans/archived/2026-04-23-define-watchlist-unwatch-lifecycle.md`
- `go test ./internal/watchlist -count=1`
- `go test ./internal/watchlist ./internal/dashboard -count=1`
- reviewer validation also ran `go test ./internal/watchlist ./internal/dashboard ./internal/ui -count=1`

## Review

- Step reviews passed after fixing stale terminology and adding configured-home test coverage.
- Final clean full review `review-007-full` passed with no findings.
