### PR TITLE
Clarify status snapshot and mutation coordination

### DIFF
--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -150,7 +150,7 @@ and CLI contract. `review-002-delta` passed with no findings.
 
 ### Step 2: Refactor status snapshot APIs
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -187,7 +187,13 @@ rather than keeping wrappers that invite future misuse.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Replaced the ambiguous status `Read()`/`ReadUnlocked()` pair with a single
+read-only `status.Service.Snapshot()` API, removed the status-level
+`AfterSuccess` hook, and updated CLI timeline snapshots, dashboard status
+aggregation, UI status endpoints, and direct tests/callers. Validation:
+`rg` confirmed no status `Read()`/`ReadUnlocked()` callers remain; `go test
+./internal/status ./internal/cli ./internal/ui ./internal/dashboard
+./internal/lifecycle ./internal/review`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -61,24 +61,24 @@ the machine-local watchlist according to the existing watchlist contract.
 
 ## Acceptance Criteria
 
-- [ ] Specs state that read-model services are snapshot reads: they do not
+- [x] Specs state that read-model services are snapshot reads: they do not
       acquire mutation locks, write workflow state, append timeline events, or
       touch the watchlist.
-- [ ] Specs state that CLI `harness status` may wait briefly for a currently
+- [x] Specs state that CLI `harness status` may wait briefly for a currently
       held state mutation lock before resolving a snapshot, and reports a clear
       busy/error result if the lock remains held after the timeout.
-- [ ] Specs preserve the distinction that mutation commands fail fast on
+- [x] Specs preserve the distinction that mutation commands fail fast on
       mutation-lock contention, while status checkpoint reads may wait because
       harness commands are not expected to be long-running.
-- [ ] `status` package exposes a clearly named read-only snapshot API, and
+- [x] `status` package exposes a clearly named read-only snapshot API, and
       callers no longer rely on a lock-acquiring `Read()`/`ReadUnlocked()` pair.
-- [ ] UI and dashboard status reads use the snapshot API and have regression
+- [x] UI and dashboard status reads use the snapshot API and have regression
       coverage proving they do not create `.state-mutation.lock`, mutate
       workflow state, or touch the watchlist.
-- [ ] CLI `harness status` has regression coverage for the settle behavior:
+- [x] CLI `harness status` has regression coverage for the settle behavior:
       it waits through a short held lock when the lock releases, and returns a
       clear contention result when the lock stays held past the timeout.
-- [ ] Successful core CLI command watchlist registration still works, including
+- [x] Successful core CLI command watchlist registration still works, including
       `harness status`, while UI/API/dashboard polling remains excluded.
 
 ## Deferred Items
@@ -345,25 +345,56 @@ findings.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `git diff --check`
+- `harness plan lint
+  docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md`
+- `go test ./internal/status ./internal/runstate ./internal/cli ./internal/ui
+  ./internal/dashboard ./internal/watchlist -count=1`
+- Step-focused validation also covered `./internal/lifecycle` and
+  `./internal/review` after the status snapshot API rename.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step reviews: `review-001-delta` found and `review-002-delta` verified the
+  passive/non-destructive settle-contract repair; `review-003-delta`,
+  `review-004-delta`, and `review-005-delta` passed with no findings.
+- Finalize reviews: `review-006-full` found one blocking tests gap in the
+  positive CLI settle test. The repair made the test prove `harness status`
+  stays blocked while the state mutation lock is held and succeeds after
+  release. `review-007-full` passed with correctness and tests slots, both
+  with no findings.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: To be created after archive from this candidate branch.
+- Ready: The tracked steps are complete, the repair finalize review passed,
+  focused validation is green, and no follow-up issues are required.
+- Merge Handoff: After archive, commit the archive move, push the branch, open
+  the PR, record publish/CI/sync evidence, and wait for explicit human merge
+  approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Defined the durable read/write contract for status snapshots, CLI status
+  settlement, mutation-command lock contention, and watchlist ownership in the
+  state, CLI, and watchlist specs.
+- Replaced the ambiguous `status.Service.Read()`/`ReadUnlocked()` API with
+  read-only `status.Service.Snapshot()` callers and removed the status-level
+  success hook.
+- Added passive runstate lock probing and bounded CLI `harness status` settle
+  behavior that waits briefly for held mutation locks and reports a clear busy
+  status on timeout.
+- Added regression coverage for snapshot read purity, CLI settle wait/busy
+  behavior, UI/API/dashboard no-mutation reads, and intentional CLI
+  watchlist refresh.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No compatibility wrappers for the removed internal status read API.
+- No redesign of review, evidence, timeline, watchlist artifact formats, or
+  long-running command coordination.
 
 ### Follow-Up Issues
 

--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -89,7 +89,7 @@ the machine-local watchlist according to the existing watchlist contract.
 
 ### Step 1: Specify read and mutation coordination boundaries
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -136,10 +136,17 @@ Updated `docs/specs/state-model.md`, `docs/specs/cli-contract.md`, and
 and the CLI-only watchlist refresh boundary. Validation: `git diff --check`
 for the edited specs and plan; `harness plan lint
 docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md`.
+Follow-up repair after `review-001-delta` clarified that the status settle
+check must be passive and non-destructive: no missing lock-file creation, no
+mutation-lock ownership as a quiescence probe, and no mutation lock held while
+resolving the snapshot.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` found one blocking correctness issue: the initial settle
+contract did not explicitly forbid lock-owning or lock-file-creating probes.
+The repair added passive/non-destructive settle requirements to the state model
+and CLI contract. `review-002-delta` passed with no findings.
 
 ### Step 2: Refactor status snapshot APIs
 

--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -350,6 +350,10 @@ findings.
   docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md`
 - `go test ./internal/status ./internal/runstate ./internal/cli ./internal/ui
   ./internal/dashboard ./internal/watchlist -count=1`
+- `go test ./tests/e2e -run
+  TestArchivedRunstateInterleavingsIgnoreStaleEvidenceAndFailClearlyUnderLock
+  -count=1`
+- `go test ./...`
 - Step-focused validation also covered `./internal/lifecycle` and
   `./internal/review` after the status snapshot API rename.
 
@@ -363,14 +367,20 @@ findings.
   stays blocked while the state mutation lock is held and succeeds after
   release. `review-007-full` passed with correctness and tests slots, both
   with no findings.
+- Post-archive CI for revision `1` failed because an E2E concurrency test still
+  expected the old mutation-command lock contention wording for `harness
+  status`. Revision `2` updates that E2E expectation to the new status busy
+  wording and reruns the full local test suite before the fresh finalize
+  review.
 
 ## Archive Summary
 
 - Archived At: 2026-04-26T00:01:44+08:00
-- Revision: 1
-- PR: To be created after archive from this candidate branch.
-- Ready: The tracked steps are complete, the repair finalize review passed,
-  focused validation is green, and no follow-up issues are required.
+- Revision: 2 after post-archive CI repair.
+- PR: https://github.com/catu-ai/easyharness/pull/196
+- Ready: The tracked steps are complete, the revision `1` post-archive CI
+  failure has been repaired in revision `2`, full local validation is green,
+  and no follow-up issues are required.
 - Merge Handoff: After archive, commit the archive move, push the branch, open
   the PR, record publish/CI/sync evidence, and wait for explicit human merge
   approval.

--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -255,7 +255,8 @@ non-destructive probe boundary. Validation: `git diff --check`; `go test
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-004-delta` passed with correctness and tests slots, both with no
+findings.
 
 ### Step 4: Lock UI/API and watchlist boundaries with tests
 

--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -197,7 +197,8 @@ aggregation, UI status endpoints, and direct tests/callers. Validation:
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-003-delta` passed with correctness and tests slots, both with no
+findings.
 
 ### Step 3: Add CLI status settle behavior
 

--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -260,7 +260,7 @@ findings.
 
 ### Step 4: Lock UI/API and watchlist boundaries with tests
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -310,7 +310,8 @@ files or create `.state-mutation.lock`. Validation: `go test ./internal/ui
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-005-delta` passed with correctness and tests slots, both with no
+findings.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -1,0 +1,341 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-25T23:26:35+08:00"
+approved_at: "2026-04-25T23:27:52+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/189
+size: M
+---
+
+# Clarify Status Snapshot and Mutation Coordination
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Resolve issue #189 by turning status resolution and UI/API resource reads into
+clear read-only snapshots, while keeping agent-facing `harness status`
+conservative through an explicit short settle wait at the CLI boundary.
+
+The end state should remove the confusing split where `status.Service.Read()`
+sounds like a plain read but creates or competes for `.state-mutation.lock`.
+Mutation locks should belong to mutation coordination, read models should stay
+side-effect-free, and successful core CLI commands should continue refreshing
+the machine-local watchlist according to the existing watchlist contract.
+
+## Scope
+
+### In Scope
+
+- Update the normative state, CLI, and watchlist docs so future agents can tell
+  which reads are pure snapshots, which commands may wait for mutation
+  settlement, and which surfaces may refresh watchlist recency.
+- Refactor `status` service APIs so status snapshot resolution is read-only and
+  does not acquire state mutation locks, write workflow state, or own
+  watchlist/timeline side effects.
+- Add an explicit CLI `harness status` settle path that briefly waits for an
+  in-progress state mutation to release its advisory lock before reading a
+  snapshot, then returns a clear busy/error result if the timeout is exceeded.
+- Keep mutation commands on the existing fail-fast mutation-lock behavior unless
+  a command-specific contract explicitly says otherwise.
+- Ensure UI/API/dashboard status and workspace-detail reads use the read-only
+  snapshot path and never create `.state-mutation.lock` or touch watchlist
+  recency.
+- Preserve the accepted watchlist behavior that successful core CLI workflow
+  commands, including `harness status`, silently refresh `last_seen_at` through
+  the shared best-effort CLI postprocessor.
+
+### Out of Scope
+
+- Redesigning review, evidence, timeline, or watchlist artifact formats.
+- Removing `state.json`, `.local/harness/current-plan.json`, or the existing
+  mutation lock files.
+- Introducing long-running command coordination or background job tracking.
+- Changing dashboard product scope beyond keeping its read model pure.
+- Adding compatibility shims for the old ambiguous `status.Service.Read()` API.
+
+## Acceptance Criteria
+
+- [ ] Specs state that read-model services are snapshot reads: they do not
+      acquire mutation locks, write workflow state, append timeline events, or
+      touch the watchlist.
+- [ ] Specs state that CLI `harness status` may wait briefly for a currently
+      held state mutation lock before resolving a snapshot, and reports a clear
+      busy/error result if the lock remains held after the timeout.
+- [ ] Specs preserve the distinction that mutation commands fail fast on
+      mutation-lock contention, while status checkpoint reads may wait because
+      harness commands are not expected to be long-running.
+- [ ] `status` package exposes a clearly named read-only snapshot API, and
+      callers no longer rely on a lock-acquiring `Read()`/`ReadUnlocked()` pair.
+- [ ] UI and dashboard status reads use the snapshot API and have regression
+      coverage proving they do not create `.state-mutation.lock`, mutate
+      workflow state, or touch the watchlist.
+- [ ] CLI `harness status` has regression coverage for the settle behavior:
+      it waits through a short held lock when the lock releases, and returns a
+      clear contention result when the lock stays held past the timeout.
+- [ ] Successful core CLI command watchlist registration still works, including
+      `harness status`, while UI/API/dashboard polling remains excluded.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Specify read and mutation coordination boundaries
+
+- Done: [ ]
+
+#### Objective
+
+Document the durable contract for status snapshots, CLI status settlement,
+mutation lock contention, and watchlist touch boundaries.
+
+#### Details
+
+`docs/specs/state-model.md` already defines `state.json` as
+control-plane-only and mutation locks as write coordination. Extend it so
+read-model services are explicitly snapshot readers rather than lock owners.
+Describe the expected reader behavior when a snapshot observes temporarily
+incomplete artifact state: surface a degraded result or warning rather than
+hiding the possibility behind a read lock.
+
+`docs/specs/cli-contract.md` should carry the user-facing `harness status`
+contract: status is an agent-facing checkpoint and may briefly wait for an
+active state mutation to settle before resolving the snapshot. If the lock is
+still held after the short timeout, status should return a clear busy/error
+result instead of reading a likely in-flight state.
+
+`docs/specs/watchlist-contract.md` already says successful core workflow
+commands can refresh `last_seen_at` and UI/dashboard reads should not inflate
+recency. Cross-reference the read-model purity rule so future UI/API work does
+not reintroduce watchlist touches through polling surfaces.
+
+#### Expected Files
+
+- `docs/specs/state-model.md`
+- `docs/specs/cli-contract.md`
+- `docs/specs/watchlist-contract.md`
+
+#### Validation
+
+- The docs describe the read/write boundary without depending on this plan or
+  discovery chat.
+- `git diff --check` passes for the edited specs.
+
+#### Execution Notes
+
+Updated `docs/specs/state-model.md`, `docs/specs/cli-contract.md`, and
+`docs/specs/watchlist-contract.md` to define read-model purity, CLI
+`harness status` settle behavior, mutation-command fail-fast lock semantics,
+and the CLI-only watchlist refresh boundary. Validation: `git diff --check`
+for the edited specs and plan; `harness plan lint
+docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md`.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Refactor status snapshot APIs
+
+- Done: [ ]
+
+#### Objective
+
+Make status resolution a plainly named read-only snapshot service and remove
+the ambiguous lock-acquiring `Read()` API shape.
+
+#### Details
+
+Refactor `internal/status` so the primary service entrypoint is named for what
+it does, such as `Snapshot()` or `ResolveSnapshot()`. It should not acquire
+`.state-mutation.lock`, write `state.json`, append timeline events, touch the
+watchlist, or expose an `AfterSuccess` hook.
+
+Update internal callers to use the new snapshot API. UI, dashboard, timeline
+hooks, and other read-model callers should all consume the same pure snapshot
+path. Because this repository does not preserve compatibility for intermediate
+internal APIs by default, remove the confusing `Read()`/`ReadUnlocked()` pair
+rather than keeping wrappers that invite future misuse.
+
+#### Expected Files
+
+- `internal/status/service.go`
+- `internal/status/service_test.go`
+- `internal/dashboard/service.go`
+- `internal/cli/timeline_events.go`
+- other direct `status.Service` callers found by `rg`
+
+#### Validation
+
+- `rg "ReadUnlocked|status.Service\\{[^}]*\\}\\.Read\\(" internal` finds no
+  remaining status service calls.
+- Focused status tests prove snapshot resolution still derives the same nodes
+  without writing cache fields into `state.json`.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Add CLI status settle behavior
+
+- Done: [ ]
+
+#### Objective
+
+Move conservative mutation coordination to the `harness status` command
+boundary by waiting briefly for held state mutation locks before reading a
+snapshot.
+
+#### Details
+
+Add a runstate helper that can detect and wait for an actually held advisory
+state mutation lock for the current plan. Do not use lock-file existence as the
+signal because lock files may remain on disk after the lock is released. The
+helper should use the same plan-local lock primitive or a compatible
+non-destructive advisory-lock probe.
+
+`harness status` should detect the current plan, wait a short bounded interval
+for any held state mutation lock to release, and then call the pure status
+snapshot API. If the lock stays held past the timeout, return a clear status
+result explaining that another local state mutation is still in progress.
+
+Keep mutation commands fail-fast on lock contention. This settle behavior is
+for checkpoint reads, not for competing workflow mutations.
+
+#### Expected Files
+
+- `internal/runstate/state.go`
+- `internal/runstate/state_test.go`
+- `internal/cli/app.go`
+- `internal/cli/app_test.go`
+- `internal/status/service.go`
+
+#### Validation
+
+- Add tests where `harness status` succeeds after a held lock is released within
+  the settle timeout.
+- Add tests where `harness status` returns the busy/error result when the lock
+  remains held.
+- Existing mutation-command lock contention tests continue to prove fail-fast
+  behavior.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 4: Lock UI/API and watchlist boundaries with tests
+
+- Done: [ ]
+
+#### Objective
+
+Prove the issue #189 surfaces are fixed and the accepted watchlist recency
+contract still holds.
+
+#### Details
+
+Update UI handler status routes so top-level `/api/status` and workspace-detail
+`/api/workspace/<key>/status` use the pure snapshot API. Add active-plan
+regressions that snapshot workflow files before the request and assert that the
+request does not create `.state-mutation.lock`, rewrite `state.json`, rewrite
+`current-plan.json`, or touch the machine-local watchlist.
+
+Also preserve positive CLI watchlist coverage for successful core workflow
+commands, especially `harness status`, so read-model purity is not confused
+with removing the intentional command-level recency refresh.
+
+#### Expected Files
+
+- `internal/ui/server.go`
+- `internal/ui/server_test.go`
+- `internal/cli/app_test.go`
+- `internal/dashboard/service_test.go`
+- `docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md`
+
+#### Validation
+
+- Focused UI tests fail if status API polling creates `.state-mutation.lock` or
+  touches `watchlist.json`.
+- Focused CLI tests fail if successful `harness status` stops refreshing the
+  watchlist.
+- The final test run covers at least `./internal/status`, `./internal/runstate`,
+  `./internal/cli`, `./internal/ui`, `./internal/dashboard`, and
+  `./internal/watchlist`.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run `harness plan lint` on this plan before approval.
+- During execution, run focused Go tests for each touched package as behavior
+  lands.
+- Before archive, run the combined focused suite:
+  `go test ./internal/status ./internal/runstate ./internal/cli ./internal/ui ./internal/dashboard ./internal/watchlist -count=1`.
+- Run `git diff --check`.
+- If status service API renaming affects generated schemas or docs, run the
+  relevant contract-sync check named by the failing tests or nearby docs.
+
+## Risks
+
+- Risk: Removing the lock-acquiring status read could expose transient
+  multi-file mutation snapshots to CLI users.
+  - Mitigation: Keep the pure snapshot API for read models, but add bounded
+    settle behavior specifically to `harness status` before it resolves the
+    snapshot.
+- Risk: The status API rename could miss a caller and leave a hidden
+  lock-acquiring path alive.
+  - Mitigation: Use `rg` checks and package tests to prove the old
+    `Read()`/`ReadUnlocked()` pair is gone from status callers.
+- Risk: Watchlist recency behavior could be accidentally removed while making
+  read services pure.
+  - Mitigation: Keep watchlist touch at the CLI successful core-command
+    postprocessor boundary and preserve positive/negative watchlist tests.
+- Risk: Timeout-based status settle behavior could make tests flaky.
+  - Mitigation: Keep the wait helper injectable or use deterministic short
+    lock-release coordination in tests rather than relying on wall-clock races.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -202,7 +202,7 @@ findings.
 
 ### Step 3: Add CLI status settle behavior
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -245,7 +245,13 @@ for checkpoint reads, not for competing workflow mutations.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added runstate helpers for passive state-mutation lock probing and bounded
+settle waits. `harness status` now waits briefly for a held state mutation
+lock before calling the pure status snapshot resolver, returns a clear busy
+status if the lock remains held, and does not create `.state-mutation.lock`
+when no lock file exists. Adjusted the specs to describe the implementable
+non-destructive probe boundary. Validation: `git diff --check`; `go test
+./internal/runstate ./internal/cli ./internal/status`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -299,7 +299,14 @@ with removing the intentional command-level recency refresh.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added active-plan UI/API regressions for top-level `/api/status` and
+workspace-detail `/api/workspace/<key>/status`. The tests snapshot
+`current-plan.json`, plan-local `state.json`, and the machine-local
+watchlist when present, then assert status polling does not rewrite those
+files or create `.state-mutation.lock`. Validation: `go test ./internal/ui
+-count=1`; `go test ./internal/status ./internal/runstate ./internal/cli
+./internal/ui ./internal/dashboard ./internal/watchlist -count=1`; `git diff
+--check`.
 
 #### Review Notes
 

--- a/docs/plans/archived/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/archived/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -375,8 +375,8 @@ findings.
 
 ## Archive Summary
 
-- Archived At: 2026-04-26T00:01:44+08:00
-- Revision: 2 after post-archive CI repair.
+- Archived At: 2026-04-26T00:17:44+08:00
+- Revision: 2
 - PR: https://github.com/catu-ai/easyharness/pull/196
 - Ready: The tracked steps are complete, the revision `1` post-archive CI
   failure has been repaired in revision `2`, full local validation is green,

--- a/docs/plans/archived/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
+++ b/docs/plans/archived/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md
@@ -366,6 +366,8 @@ findings.
 
 ## Archive Summary
 
+- Archived At: 2026-04-26T00:01:44+08:00
+- Revision: 1
 - PR: To be created after archive from this candidate branch.
 - Ready: The tracked steps are complete, the repair finalize review passed,
   focused validation is green, and no follow-up issues are required.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -134,11 +134,11 @@ bounded wait, `harness status` should return a clear contention result instead
 of reading a likely in-flight state.
 
 The status settle check must be passive and non-destructive. It must not create
-`.state-mutation.lock` when the file is absent, must not acquire and hold the
-state mutation lock as its quiescence probe, and must not own any mutation lock
-while resolving the status snapshot. After the bounded settle check completes,
-`harness status` should call the same pure snapshot resolver used by UI/API
-read surfaces.
+`.state-mutation.lock` when the file is absent, must not use the ordinary
+mutation-lock acquisition helper as its probe, and must not hold any mutation
+lock while resolving the status snapshot. After the bounded settle check
+completes, `harness status` should call the same pure snapshot resolver used by
+UI/API read surfaces.
 
 This wait rule does not apply to ordinary mutation commands. Commands that
 mutate workflow state should continue to fail fast on mutation-lock contention

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -119,6 +119,24 @@ interrupted or overlapping writes.
 - fail with a clear contention error when that state lock is already held
   instead of waiting silently or risking a stale overwrite
 
+### Snapshot Reads and Checkpoint Settle
+
+Read-model services are side-effect-free snapshots as defined in
+[State Model](./state-model.md). They must not create mutation locks, rewrite
+workflow state, append timeline events, or refresh the watchlist merely because
+a UI/API/dashboard resource was polled.
+
+The CLI command boundary may add extra checkpoint behavior on top of a pure
+snapshot. `harness status` is the primary agent-facing checkpoint, so it may
+wait briefly for a currently held state mutation lock to release before
+resolving and returning the snapshot. If the lock remains held after the
+bounded wait, `harness status` should return a clear contention result instead
+of reading a likely in-flight state.
+
+This wait rule does not apply to ordinary mutation commands. Commands that
+mutate workflow state should continue to fail fast on mutation-lock contention
+unless their own command contract explicitly defines a different behavior.
+
 ## Shared Output Envelope
 
 Stateful commands share a common JSON envelope vocabulary, but not every
@@ -442,11 +460,17 @@ Contract:
 
 - detect the current plan artifact, whether it is a tracked active plan, a
   tracked standard archive, or a lightweight local archive
+- before resolving the status snapshot for a current plan, briefly wait for an
+  actively held state mutation lock to settle; if the lock remains held beyond
+  the bounded wait, return a clear local-mutation-in-progress result
 - resolve the canonical `state.current_node` from the current plan,
   execute-start milestones, review artifacts, append-only evidence, reopen
   milestones, archive state, and land milestones
 - return pure v0.2 JSON centered on `state.current_node`, selected `facts`,
   `artifacts`, `summary`, and `next_actions`
+- keep the underlying status snapshot read-only: the snapshot resolver must
+  not acquire mutation locks, rewrite `state.json`, append timeline events, or
+  touch watchlist recency
 - never emit legacy v0.1 fields such as `lifecycle`, `step_state`, or
   `handoff_state`
 - surface aggregated review failures as a concrete repair signal rather than

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -133,6 +133,13 @@ resolving and returning the snapshot. If the lock remains held after the
 bounded wait, `harness status` should return a clear contention result instead
 of reading a likely in-flight state.
 
+The status settle check must be passive and non-destructive. It must not create
+`.state-mutation.lock` when the file is absent, must not acquire and hold the
+state mutation lock as its quiescence probe, and must not own any mutation lock
+while resolving the status snapshot. After the bounded settle check completes,
+`harness status` should call the same pure snapshot resolver used by UI/API
+read surfaces.
+
 This wait rule does not apply to ordinary mutation commands. Commands that
 mutate workflow state should continue to fail fast on mutation-lock contention
 unless their own command contract explicitly defines a different behavior.
@@ -463,6 +470,9 @@ Contract:
 - before resolving the status snapshot for a current plan, briefly wait for an
   actively held state mutation lock to settle; if the lock remains held beyond
   the bounded wait, return a clear local-mutation-in-progress result
+- perform that settle wait with a passive, non-destructive advisory-lock check
+  that does not create a missing lock file and does not hold any mutation lock
+  while resolving the snapshot
 - resolve the canonical `state.current_node` from the current plan,
   execute-start milestones, review artifacts, append-only evidence, reopen
   milestones, archive state, and land milestones

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -84,9 +84,9 @@ read-model snapshot when their public contract calls for it. In particular,
 resolving a snapshot, as defined in [CLI Contract](./cli-contract.md). That
 settle behavior belongs to the CLI checkpoint command, not to the underlying
 status read model. The settle check must be passive and non-destructive: it
-must not create a missing lock file, acquire ownership of the mutation lock as
-a way to prove quiescence, or hold any mutation lock while resolving the
-snapshot.
+must not create a missing lock file, must not use the ordinary mutation-lock
+acquisition helper as its probe, and must not hold any mutation lock while
+resolving the snapshot.
 
 ### Durable Plan, Disposable Runtime
 

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -83,7 +83,10 @@ read-model snapshot when their public contract calls for it. In particular,
 `harness status` may briefly wait for a state mutation lock to settle before
 resolving a snapshot, as defined in [CLI Contract](./cli-contract.md). That
 settle behavior belongs to the CLI checkpoint command, not to the underlying
-status read model.
+status read model. The settle check must be passive and non-destructive: it
+must not create a missing lock file, acquire ownership of the mutation lock as
+a way to prove quiescence, or hold any mutation lock while resolving the
+snapshot.
 
 ### Durable Plan, Disposable Runtime
 

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -65,6 +65,26 @@ together or a process exits during persistence.
 - if the per-plan state lock is already held, the command should fail with a
   clear error rather than waiting silently or risking a stale overwrite
 
+### Read-Model Purity
+
+Read-model services resolve snapshots from the current tracked plan,
+CLI-owned runtime artifacts, and append-only evidence or review records. They
+must not acquire mutation locks, create lock files, rewrite workflow state,
+append timeline events, or refresh machine-local watchlist recency.
+
+This rule applies to status resolution as a library/read-model operation and
+to UI/API/dashboard resource reads. A read-model caller may observe a momentary
+multi-file transition while another command is mutating local artifacts. The
+reader should surface a conservative degraded result, warning, or error from
+the files it can read rather than hiding the possibility behind a read lock.
+
+Agent-facing CLI commands may add command-level coordination around a
+read-model snapshot when their public contract calls for it. In particular,
+`harness status` may briefly wait for a state mutation lock to settle before
+resolving a snapshot, as defined in [CLI Contract](./cli-contract.md). That
+settle behavior belongs to the CLI checkpoint command, not to the underlying
+status read model.
+
 ### Durable Plan, Disposable Runtime
 
 Tracked active plans remain the durable source of scope, step closeout, and
@@ -199,6 +219,12 @@ acquire the review mutation lock before the state mutation lock. Commands that
 only submit reviewer output should stay on the review-artifact path and should
 not acquire the state mutation lock just because the round also has local
 state.
+
+Mutation commands should remain fail-fast on mutation-lock contention unless a
+more specific command contract says otherwise. Waiting for a mutation lock is
+reserved for checkpoint reads such as `harness status`, where a short wait can
+avoid reporting an in-flight snapshot without letting two mutation commands
+silently queue behind each other.
 
 ## High-Level Resolution Order
 

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -103,6 +103,13 @@ routine successful workflow confirmations such as `harness status`,
 `harness review start`, or lifecycle/evidence commands can keep the recency
 signal fresh when they pass through one shared watchlist writer.
 
+Watchlist refresh is a CLI command success side effect, not a read-model side
+effect. UI/API/dashboard resource reads, including status polling, must not
+touch `watchlist.json` or inflate `last_seen_at`. The dashboard may read the
+watchlist and derive workspace status at request time, but recency changes
+belong to explicit watchlist-management actions or successful core CLI
+workflow commands.
+
 ## Path Normalization and Uniqueness
 
 Writers must normalize `workspace_path` before comparing or persisting records.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -759,7 +759,7 @@ func (a *App) runStatus(args []string) int {
 		return 1
 	}
 
-	result := status.Service{Workdir: workdir}.Read()
+	result := status.Service{Workdir: workdir}.Snapshot()
 	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
@@ -837,7 +837,7 @@ func (a *App) runReviewSubmit(args []string) int {
 		return 1
 	}
 	recordedAt := a.Now().Format(time.RFC3339)
-	beforeStatus := readUnlockedStatusSnapshot(workdir)
+	beforeStatus := readStatusSnapshot(workdir)
 	result := review.Service{
 		Workdir: workdir,
 		Now:     a.Now,

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/lifecycle"
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/review"
+	"github.com/catu-ai/easyharness/internal/runstate"
 	"github.com/catu-ai/easyharness/internal/status"
 	"github.com/catu-ai/easyharness/internal/ui"
 	versioninfo "github.com/catu-ai/easyharness/internal/version"
@@ -36,6 +37,9 @@ type App struct {
 	UserHomeDir func() (string, error)
 	Version     func() versioninfo.Info
 	RunUIServer func(context.Context, ui.Server) error
+
+	StatusSettleTimeout      time.Duration
+	StatusSettlePollInterval time.Duration
 }
 
 func New(stdout, stderr io.Writer) *App {
@@ -759,8 +763,53 @@ func (a *App) runStatus(args []string) int {
 		return 1
 	}
 
+	if result, settled := a.settleStatusSnapshot(workdir); !settled {
+		return a.writeJSONResultForWorkdir(workdir, result)
+	}
 	result := status.Service{Workdir: workdir}.Snapshot()
 	return a.writeJSONResultForWorkdir(workdir, result)
+}
+
+func (a *App) settleStatusSnapshot(workdir string) (status.Result, bool) {
+	planPath, err := plan.DetectCurrentPath(workdir)
+	if err != nil {
+		return status.Result{}, true
+	}
+	planStem := strings.TrimSuffix(filepath.Base(planPath), filepath.Ext(planPath))
+	timeout := a.StatusSettleTimeout
+	if timeout == 0 {
+		timeout = 2 * time.Second
+	}
+	pollInterval := a.StatusSettlePollInterval
+	if pollInterval == 0 {
+		pollInterval = 25 * time.Millisecond
+	}
+	held, err := runstate.WaitForStateMutationLockRelease(workdir, planStem, timeout, pollInterval)
+	if err != nil {
+		return status.Result{
+			OK:      false,
+			Command: "status",
+			Summary: "Unable to inspect local state mutation lock.",
+			Artifacts: &status.Artifacts{
+				ProjectRoot: workdir,
+				PlanPath:    normalizeRepoPath(workdir, planPath),
+			},
+			Errors: []status.StatusError{{Path: "state", Message: "Unable to inspect local state mutation lock."}},
+		}, false
+	}
+	if held {
+		return status.Result{
+			OK:      false,
+			Command: "status",
+			Summary: "Another local state mutation is still in progress.",
+			Artifacts: &status.Artifacts{
+				ProjectRoot: workdir,
+				PlanPath:    normalizeRepoPath(workdir, planPath),
+			},
+			Errors: []status.StatusError{{Path: "state", Message: "Another local state mutation is still in progress."}},
+		}, false
+	}
+	return status.Result{}, true
 }
 
 func (a *App) runReviewStart(args []string) int {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1605,7 +1605,7 @@ func TestReopenNewStepCommandReturnsJSON(t *testing.T) {
 		t.Fatalf("expected reopened current-plan pointer to move back to active path, got %#v", current)
 	}
 
-	statusResult := status.Service{Workdir: root}.Read()
+	statusResult := status.Service{Workdir: root}.Snapshot()
 	if !statusResult.OK {
 		t.Fatalf("expected status after reopen, got %#v", statusResult)
 	}
@@ -1665,7 +1665,7 @@ func TestReopenFinalizeFixCommandReturnsJSON(t *testing.T) {
 		t.Fatalf("expected finalize-fix reopen mode to persist, got %#v", state)
 	}
 
-	statusResult := status.Service{Workdir: root}.Read()
+	statusResult := status.Service{Workdir: root}.Snapshot()
 	if !statusResult.OK {
 		t.Fatalf("expected status after reopen, got %#v", statusResult)
 	}
@@ -1841,7 +1841,7 @@ func TestReopenCommandRejectsLandCleanupInProgress(t *testing.T) {
 		t.Fatalf("expected reopen failure during land cleanup, got %#v", payload)
 	}
 
-	statusResult := status.Service{Workdir: root}.Read()
+	statusResult := status.Service{Workdir: root}.Snapshot()
 	if !statusResult.OK || statusResult.State.CurrentNode != "land" {
 		t.Fatalf("expected land status to remain after failed reopen, got %#v", statusResult)
 	}
@@ -1886,7 +1886,7 @@ func TestLandCompleteCommandReturnsJSON(t *testing.T) {
 	}
 	assertLifecycleEnvelope(t, payload, "idle", 1)
 
-	statusResult := status.Service{Workdir: root}.Read()
+	statusResult := status.Service{Workdir: root}.Snapshot()
 	if !statusResult.OK || statusResult.State.CurrentNode != "idle" {
 		t.Fatalf("expected idle status after land complete, got %#v", statusResult)
 	}
@@ -1947,7 +1947,7 @@ func TestLandCommandRejectsActivePlanWithoutWritingLandedMarker(t *testing.T) {
 		t.Fatalf("expected no landed marker on failed command, got %#v", current)
 	}
 
-	statusResult := status.Service{Workdir: root}.Read()
+	statusResult := status.Service{Workdir: root}.Snapshot()
 	if !statusResult.OK {
 		t.Fatalf("expected active-plan status after failed land, got %#v", statusResult)
 	}

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -682,6 +682,120 @@ func TestStatusCommandIgnoresWatchlistWriteFailure(t *testing.T) {
 	}
 }
 
+func TestStatusCommandDoesNotCreateStateMutationLock(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+
+	outputPath := filepath.Join(root, "docs/plans/active/2026-03-18-test-plan.md")
+	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Status Passive Probe Plan", "--output", outputPath}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
+
+	stdout.Reset()
+	stderr.Reset()
+	if exitCode := app.Run([]string{"status"}); exitCode != 0 {
+		t.Fatalf("status command failed with %d: %s", exitCode, stderr.String())
+	}
+
+	lockPath := filepath.Join(root, ".local", "harness", "plans", "2026-03-18-test-plan", ".state-mutation.lock")
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected status settle probe not to create state lock, err=%v", err)
+	}
+}
+
+func TestStatusCommandWaitsForStateMutationLockRelease(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.StatusSettleTimeout = 500 * time.Millisecond
+	app.StatusSettlePollInterval = time.Millisecond
+
+	outputPath := filepath.Join(root, "docs/plans/active/2026-03-18-test-plan.md")
+	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Status Wait Plan", "--output", outputPath}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
+
+	release, err := runstate.AcquireStateMutationLock(root, "2026-03-18-test-plan")
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		release()
+		close(released)
+	}()
+
+	stdout.Reset()
+	stderr.Reset()
+	if exitCode := app.Run([]string{"status"}); exitCode != 0 {
+		t.Fatalf("expected status to wait for released state lock, got %d: %s", exitCode, stderr.String())
+	}
+	<-released
+
+	var payload struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode status payload: %v\n%s", err, stdout.String())
+	}
+	if !payload.OK {
+		t.Fatalf("expected OK status payload, got %s", stdout.String())
+	}
+}
+
+func TestStatusCommandReturnsBusyWhenStateMutationLockStaysHeld(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.StatusSettleTimeout = time.Millisecond
+	app.StatusSettlePollInterval = time.Millisecond
+
+	outputPath := filepath.Join(root, "docs/plans/active/2026-03-18-test-plan.md")
+	if exitCode := app.Run([]string{"plan", "template", "--title", "CLI Status Busy Plan", "--output", outputPath}); exitCode != 0 {
+		t.Fatalf("template command failed with %d: %s", exitCode, stderr.String())
+	}
+	approvePlanInFile(t, outputPath, "2026-03-18T14:55:00+08:00")
+
+	release, err := runstate.AcquireStateMutationLock(root, "2026-03-18-test-plan")
+	if err != nil {
+		t.Fatalf("acquire state lock: %v", err)
+	}
+	defer release()
+
+	stdout.Reset()
+	stderr.Reset()
+	if exitCode := app.Run([]string{"status"}); exitCode == 0 {
+		t.Fatalf("expected busy status to fail while state lock remains held, stdout=%s", stdout.String())
+	}
+
+	var payload struct {
+		OK      bool   `json:"ok"`
+		Summary string `json:"summary"`
+		Errors  []struct {
+			Path string `json:"path"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode status payload: %v\n%s", err, stdout.String())
+	}
+	if payload.OK || payload.Summary != "Another local state mutation is still in progress." {
+		t.Fatalf("unexpected busy status payload: %#v", payload)
+	}
+	if len(payload.Errors) != 1 || payload.Errors[0].Path != "state" {
+		t.Fatalf("expected state error, got %#v", payload.Errors)
+	}
+}
+
 func TestVersionCommandDoesNotTouchWatchlist(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -726,19 +727,33 @@ func TestStatusCommandWaitsForStateMutationLockRelease(t *testing.T) {
 	if err != nil {
 		t.Fatalf("acquire state lock: %v", err)
 	}
-	released := make(chan struct{})
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		release()
-		close(released)
-	}()
 
 	stdout.Reset()
 	stderr.Reset()
-	if exitCode := app.Run([]string{"status"}); exitCode != 0 {
+	statusStarted := make(chan struct{})
+	var closeStatusStarted sync.Once
+	app.Getwd = func() (string, error) {
+		closeStatusStarted.Do(func() {
+			close(statusStarted)
+		})
+		return root, nil
+	}
+	done := make(chan int, 1)
+	go func() {
+		done <- app.Run([]string{"status"})
+	}()
+
+	<-statusStarted
+	select {
+	case exitCode := <-done:
+		t.Fatalf("expected status to keep waiting while state lock is held, got exit code %d", exitCode)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	release()
+	if exitCode := <-done; exitCode != 0 {
 		t.Fatalf("expected status to wait for released state lock, got %d: %s", exitCode, stderr.String())
 	}
-	<-released
 
 	var payload struct {
 		OK bool `json:"ok"`

--- a/internal/cli/timeline_events.go
+++ b/internal/cli/timeline_events.go
@@ -15,15 +15,7 @@ import (
 )
 
 func readStatusSnapshot(workdir string) *status.Result {
-	result := status.Service{Workdir: workdir}.Read()
-	if !result.OK {
-		return nil
-	}
-	return &result
-}
-
-func readUnlockedStatusSnapshot(workdir string) *status.Result {
-	result := status.Service{Workdir: workdir}.ReadUnlocked()
+	result := status.Service{Workdir: workdir}.Snapshot()
 	if !result.OK {
 		return nil
 	}
@@ -77,7 +69,7 @@ func lifecycleTimelineHook(workdir string, before *status.Result, recordedAt str
 		return appendTimelineEvent(
 			workdir,
 			before,
-			readUnlockedStatusSnapshot(workdir),
+			readStatusSnapshot(workdir),
 			attachRawPayloads(timelineEventFromLifecycle(result), input, result, result.Artifacts),
 			recordedAt,
 		)
@@ -89,7 +81,7 @@ func reviewStartTimelineHook(workdir string, before *status.Result, recordedAt s
 		return appendTimelineEvent(
 			workdir,
 			before,
-			readUnlockedStatusSnapshot(workdir),
+			readStatusSnapshot(workdir),
 			attachRawPayloads(timelineEventFromReviewStart(result), input, result, result.Artifacts),
 			recordedAt,
 		)
@@ -101,7 +93,7 @@ func reviewSubmitTimelineHook(workdir string, before *status.Result, recordedAt 
 		return appendTimelineEvent(
 			workdir,
 			before,
-			readUnlockedStatusSnapshot(workdir),
+			readStatusSnapshot(workdir),
 			attachRawPayloads(timelineEventFromReviewSubmit(result), input, result, result.Artifacts),
 			recordedAt,
 		)
@@ -113,7 +105,7 @@ func reviewAggregateTimelineHook(workdir string, before *status.Result, recorded
 		return appendTimelineEvent(
 			workdir,
 			before,
-			readUnlockedStatusSnapshot(workdir),
+			readStatusSnapshot(workdir),
 			attachRawPayloads(timelineEventFromReviewAggregate(result), input, result, result.Artifacts),
 			recordedAt,
 		)
@@ -125,7 +117,7 @@ func evidenceTimelineHook(workdir string, before *status.Result, recordedAt, kin
 		return appendTimelineEvent(
 			workdir,
 			before,
-			readUnlockedStatusSnapshot(workdir),
+			readStatusSnapshot(workdir),
 			attachRawPayloads(timelineEventFromEvidence(result, kind), input, result, result.Artifacts),
 			recordedAt,
 		)

--- a/internal/dashboard/service.go
+++ b/internal/dashboard/service.go
@@ -289,7 +289,7 @@ func (s Service) readStatus(path string) contracts.StatusResult {
 	if s.ReadStatus != nil {
 		return s.ReadStatus(path)
 	}
-	return status.Service{Workdir: path}.ReadUnlocked()
+	return status.Service{Workdir: path}.Snapshot()
 }
 
 func dashboardState(result contracts.StatusResult) string {

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -1284,7 +1284,7 @@ func TestReopenNewStepRecordsModeAndStatusCue(t *testing.T) {
 		t.Fatalf("expected reopen to capture original step count, got %#v", state.Reopen)
 	}
 
-	statusResult := status.Service{Workdir: root}.Read()
+	statusResult := status.Service{Workdir: root}.Snapshot()
 	if !statusResult.OK {
 		t.Fatalf("expected status after reopen, got %#v", statusResult)
 	}
@@ -1510,7 +1510,7 @@ func TestLandCompleteWritesIdleMarkerForStatus(t *testing.T) {
 		t.Fatalf("unexpected current plan marker: %#v", current)
 	}
 
-	statusResult := status.Service{Workdir: root}.Read()
+	statusResult := status.Service{Workdir: root}.Snapshot()
 	if !statusResult.OK {
 		t.Fatalf("expected idle-after-land status, got %#v", statusResult)
 	}

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -141,7 +141,7 @@ func TestStartAcceptsExplicitEarlierStepFromFinalizeContext(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("save finalize-fix state: %v", err)
 	}
-	statusResult := status.Service{Workdir: root}.Read()
+	statusResult := status.Service{Workdir: root}.Snapshot()
 	if statusResult.State.CurrentNode != "execution/finalize/fix" {
 		t.Fatalf("expected fixture to resolve the real finalize-fix node before explicit repair, got %#v", statusResult.State)
 	}

--- a/internal/runstate/state.go
+++ b/internal/runstate/state.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/catu-ai/easyharness/internal/contracts"
 )
@@ -119,6 +120,35 @@ func AcquireStateMutationLock(workdir, planStem string) (func(), error) {
 		fmt.Sprintf("another command is already mutating local state for plan %q; retry after it finishes", planStem))
 }
 
+func StateMutationLockHeld(workdir, planStem string) (bool, error) {
+	return planFileLockHeld(workdir, planStem, ".state-mutation.lock")
+}
+
+func WaitForStateMutationLockRelease(workdir, planStem string, timeout, pollInterval time.Duration) (bool, error) {
+	if timeout <= 0 {
+		return StateMutationLockHeld(workdir, planStem)
+	}
+	if pollInterval <= 0 {
+		pollInterval = 25 * time.Millisecond
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		held, err := StateMutationLockHeld(workdir, planStem)
+		if err != nil || !held {
+			return held, err
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return true, nil
+		}
+		sleepFor := pollInterval
+		if remaining < sleepFor {
+			sleepFor = remaining
+		}
+		time.Sleep(sleepFor)
+	}
+}
+
 func AcquireTimelineMutationLock(workdir, planStem string) (func(), error) {
 	return acquirePlanFileLock(workdir, planStem, ".timeline-mutation.lock",
 		fmt.Sprintf("another command is already appending timeline events for plan %q; retry after it finishes", planStem))
@@ -186,6 +216,27 @@ func acquirePlanFileLock(workdir, planStem, lockFileName, contentionMessage stri
 		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
 		_ = file.Close()
 	}, nil
+}
+
+func planFileLockHeld(workdir, planStem, lockFileName string) (bool, error) {
+	lockPath := filepath.Join(workdir, ".local", "harness", "plans", planStem, lockFileName)
+	file, err := os.OpenFile(lockPath, os.O_RDWR, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer file.Close()
+
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return true, nil
+		}
+		return false, err
+	}
+	_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	return false, nil
 }
 
 func CurrentRevision(state *State) int {

--- a/internal/runstate/state_test.go
+++ b/internal/runstate/state_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestSaveCurrentPlanWritesExactJSON(t *testing.T) {
@@ -135,5 +136,91 @@ func TestWriteJSONAtomicPreservesOriginalFileWhenRenameFails(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].Name() != "current-plan.json" {
 		t.Fatalf("expected failed atomic write to clean up temp files, got %#v", entries)
+	}
+}
+
+func TestStateMutationLockHeldDoesNotCreateMissingLockFile(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-04-25-passive-lock-probe"
+	lockPath := filepath.Join(root, ".local", "harness", "plans", planStem, ".state-mutation.lock")
+
+	held, err := StateMutationLockHeld(root, planStem)
+	if err != nil {
+		t.Fatalf("StateMutationLockHeld: %v", err)
+	}
+	if held {
+		t.Fatal("expected missing lock to report not held")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected passive probe not to create lock file, err=%v", err)
+	}
+}
+
+func TestStateMutationLockHeldDetectsHeldAndReleasedLock(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-04-25-held-lock-probe"
+	release, err := AcquireStateMutationLock(root, planStem)
+	if err != nil {
+		t.Fatalf("AcquireStateMutationLock: %v", err)
+	}
+
+	held, err := StateMutationLockHeld(root, planStem)
+	if err != nil {
+		t.Fatalf("StateMutationLockHeld while held: %v", err)
+	}
+	if !held {
+		t.Fatal("expected held lock to report held")
+	}
+
+	release()
+	held, err = StateMutationLockHeld(root, planStem)
+	if err != nil {
+		t.Fatalf("StateMutationLockHeld after release: %v", err)
+	}
+	if held {
+		t.Fatal("expected released lock to report not held")
+	}
+}
+
+func TestWaitForStateMutationLockReleaseWaitsUntilReleased(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-04-25-wait-lock-release"
+	release, err := AcquireStateMutationLock(root, planStem)
+	if err != nil {
+		t.Fatalf("AcquireStateMutationLock: %v", err)
+	}
+
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		release()
+		close(released)
+	}()
+
+	held, err := WaitForStateMutationLockRelease(root, planStem, 500*time.Millisecond, time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForStateMutationLockRelease: %v", err)
+	}
+	if held {
+		t.Fatal("expected wait to observe released lock")
+	}
+	<-released
+}
+
+func TestWaitForStateMutationLockReleaseReportsHeldAfterTimeout(t *testing.T) {
+	root := t.TempDir()
+	planStem := "2026-04-25-wait-lock-timeout"
+	release, err := AcquireStateMutationLock(root, planStem)
+	if err != nil {
+		t.Fatalf("AcquireStateMutationLock: %v", err)
+	}
+	defer release()
+
+	held, err := WaitForStateMutationLockRelease(root, planStem, time.Millisecond, time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForStateMutationLockRelease: %v", err)
+	}
+	if !held {
+		t.Fatal("expected timeout to report lock still held")
 	}
 }

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -19,8 +19,7 @@ import (
 )
 
 type Service struct {
-	Workdir      string
-	AfterSuccess func(Result)
+	Workdir string
 }
 
 type Result = contracts.StatusResult
@@ -57,15 +56,7 @@ type missingStepCloseoutReminder struct {
 
 type latestStepCloseoutRound = stepcloseout.RoundRecord
 
-func (s Service) Read() Result {
-	return s.read(true)
-}
-
-func (s Service) ReadUnlocked() Result {
-	return s.read(false)
-}
-
-func (s Service) read(acquireLock bool) Result {
+func (s Service) Snapshot() Result {
 	currentPlan, err := runstate.LoadCurrentPlan(s.Workdir)
 	if err != nil {
 		return Result{
@@ -79,7 +70,7 @@ func (s Service) read(acquireLock bool) Result {
 	planPath, err := plan.DetectCurrentPath(s.Workdir)
 	if err != nil {
 		if errors.Is(err, plan.ErrNoCurrentPlan) {
-			return s.finalizeRead(idleResult(s.Workdir, currentPlan))
+			return idleResult(s.Workdir, currentPlan)
 		}
 		return Result{
 			OK:      false,
@@ -90,34 +81,6 @@ func (s Service) read(acquireLock bool) Result {
 	}
 
 	planStem := strings.TrimSuffix(filepath.Base(planPath), filepath.Ext(planPath))
-	release := func() {}
-	if acquireLock {
-		release, err = runstate.AcquireStateMutationLock(s.Workdir, planStem)
-		if err != nil {
-			return Result{
-				OK:      false,
-				Command: "status",
-				Summary: "Another local state mutation is already in progress.",
-				Artifacts: &Artifacts{
-					ProjectRoot: s.Workdir,
-					PlanPath:    repoFacingPath(s.Workdir, planPath),
-				},
-				Errors: []StatusError{{Path: "state", Message: "Another local state mutation is already in progress."}},
-			}
-		}
-		defer release()
-
-		planPath, err = plan.DetectCurrentPathLocked(s.Workdir, planStem)
-		if err != nil {
-			return Result{
-				OK:      false,
-				Command: "status",
-				Summary: "Unable to determine the current plan.",
-				Errors:  []StatusError{{Path: "plan", Message: "Unable to determine the current plan."}},
-			}
-		}
-	}
-
 	doc, err := plan.LoadFile(planPath)
 	if err != nil {
 		return Result{
@@ -279,14 +242,6 @@ func (s Service) read(acquireLock bool) Result {
 		result.Artifacts = nil
 	}
 
-	return s.finalizeRead(result)
-}
-
-func (s Service) finalizeRead(result Result) Result {
-	if !result.OK || s.AfterSuccess == nil {
-		return result
-	}
-	s.AfterSuccess(result)
 	return result
 }
 

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -27,7 +27,7 @@ func TestStatusPlanNodeForActivePlan(t *testing.T) {
 		return content
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected OK status result, got %#v", result)
 	}
@@ -64,7 +64,7 @@ func TestStatusPlanNodeForApprovedActivePlan(t *testing.T) {
 		return approvePlanContent(content, "2026-03-18T10:05:00+08:00")
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected OK status result, got %#v", result)
 	}
@@ -84,7 +84,7 @@ func TestStatusPlanNodeForTrackedLightweightPlan(t *testing.T) {
 		return strings.Replace(content, "size: M", "size: XXS", 1)
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected OK status result, got %#v", result)
 	}
@@ -113,7 +113,7 @@ func TestStatusSurfacesSupplementsDirectoryForCurrentPlanPackage(t *testing.T) {
 		t.Fatalf("write supplements file: %v", err)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected OK status result, got %#v", result)
 	}
@@ -140,7 +140,7 @@ func TestStatusSurfacesSupplementsDirectoryForArchivedPlanPackage(t *testing.T) 
 		t.Fatalf("write archived supplements file: %v", err)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected OK status result, got %#v", result)
 	}
@@ -162,7 +162,7 @@ func TestStatusLightweightPublishPromptsForBreadcrumb(t *testing.T) {
 		"revision": 1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/publish" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -207,7 +207,7 @@ func TestStatusLightweightArchivedPlanSurfacesSupplementsDirectory(t *testing.T)
 		t.Fatalf("write lightweight supplements file: %v", err)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected OK status result, got %#v", result)
 	}
@@ -225,7 +225,7 @@ func TestStatusExecutionStepImplementNode(t *testing.T) {
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-1/implement" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -243,7 +243,7 @@ func TestStatusExecutionStepImplementNode(t *testing.T) {
 	assertStateJSONLacksKeys(t, root, "2026-03-18-status-plan", "current_node")
 }
 
-func TestStatusRejectsWhenStateMutationLockIsHeld(t *testing.T) {
+func TestStatusSnapshotDoesNotCompeteForStateMutationLock(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/active/2026-03-18-status-plan.md", func(content string) string {
 		return content
@@ -255,18 +255,12 @@ func TestStatusRejectsWhenStateMutationLockIsHeld(t *testing.T) {
 	}
 	defer release()
 
-	result := status.Service{Workdir: root}.Read()
-	if result.OK {
-		t.Fatalf("expected status failure while state lock is held, got %#v", result)
+	result := status.Service{Workdir: root}.Snapshot()
+	if !result.OK {
+		t.Fatalf("expected status snapshot to remain read-only while state lock is held, got %#v", result)
 	}
-	if result.Summary != "Another local state mutation is already in progress." {
-		t.Fatalf("unexpected summary: %#v", result)
-	}
-	if len(result.Errors) != 1 || result.Errors[0].Path != "state" {
-		t.Fatalf("unexpected errors: %#v", result.Errors)
-	}
-	if result.Artifacts == nil || result.Artifacts.ProjectRoot != root || result.Artifacts.PlanPath != "docs/plans/active/2026-03-18-status-plan.md" {
-		t.Fatalf("expected repo-facing locked-status artifacts, got %#v", result.Artifacts)
+	if result.State.CurrentNode != "plan" {
+		t.Fatalf("unexpected node: %#v", result.State)
 	}
 }
 
@@ -285,7 +279,7 @@ func TestStatusIgnoresNonStructuralReviewFactsForCurrentStep(t *testing.T) {
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-1/implement" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -324,7 +318,7 @@ func TestStatusExecutionStepReviewNode(t *testing.T) {
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-1/review" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -358,7 +352,7 @@ func TestStatusStepReviewMatchesTargetWithoutMarkdownPunctuation(t *testing.T) {
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-1/review" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -391,7 +385,7 @@ func TestStatusDoesNotWarnForEarlierCompletedStepWithCleanFullReview(t *testing.
 		"decision": "pass",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected clean full step-closeout review to allow step 2, got %#v", result.State)
 	}
@@ -409,7 +403,7 @@ func TestStatusWarnsWhenEarlierCompletedStepLacksReviewCompleteCloseout(t *testi
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected later-step node to stay stable, got %#v", result.State)
 	}
@@ -449,7 +443,7 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutRoundIsNotClean(t *testing.T
 		"decision": "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
@@ -483,7 +477,7 @@ func TestStatusDoesNotWarnWhenLatestHistoricalStepCloseoutRepairsEarlierFailure(
 		"decision": "pass",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected clean latest historical closeout to allow step 2, got %#v", result.State)
 	}
@@ -514,7 +508,7 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutRoundIsStillInFlight(t *test
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
@@ -552,7 +546,7 @@ func TestStatusWarnsWhenLatestHistoricalStepCloseoutManifestIsUnreadable(t *test
 		"decision":     "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
@@ -591,7 +585,7 @@ func TestStatusWarnsWhenLatestUnreadableHistoricalCloseoutCannotBeMapped(t *test
 		"decision":     "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
@@ -641,7 +635,7 @@ func TestStatusWarnsWhenHistoricalCloseoutMissingRevisionIsIgnored(t *testing.T)
 		"decision":     "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
@@ -688,7 +682,7 @@ func TestStatusWarnsWhenHistoricalCloseoutStepIsOutOfRangeIsIgnored(t *testing.T
 		"decision":     "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
@@ -745,7 +739,7 @@ func TestStatusFinalizeArchiveSuppressesArchiveActionForUnscopedUnreadableHistor
 		"decision":     "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/archive" {
 		t.Fatalf("expected archive node to stay stable, got %#v", result.State)
 	}
@@ -804,7 +798,7 @@ func TestStatusDoesNotLetUnreadableHistoryForOneStepUnsatisfyAnother(t *testing.
 		"decision":     "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("expected finalize node to stay stable, got %#v", result.State)
 	}
@@ -839,7 +833,7 @@ func TestStatusWarnsInFinalizeWhenCompletedStepStillLacksCloseout(t *testing.T) 
 		"decision": "pass",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("expected finalize node to stay stable, got %#v", result.State)
 	}
@@ -887,7 +881,7 @@ func TestStatusFinalizeArchiveSummaryAndActionsDoNotPretendReadyWhenCloseoutDebt
 		"decision": "pass",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/archive" {
 		t.Fatalf("expected archive node to stay stable, got %#v", result.State)
 	}
@@ -934,7 +928,7 @@ func TestStatusFinalizeArchiveKeepsBlockerGuidanceWhenCloseoutDebtAndArchiveBloc
 		"decision": "pass",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/archive" {
 		t.Fatalf("expected archive node to stay stable, got %#v", result.State)
 	}
@@ -983,7 +977,7 @@ func TestStatusDoesNotSuggestSecondReviewWhileStepReviewIsInFlight(t *testing.T)
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/review" {
 		t.Fatalf("expected in-flight step review node, got %#v", result.State)
 	}
@@ -1033,7 +1027,7 @@ func TestStatusShowsExplicitEarlierStepRepairAsInFlightReview(t *testing.T) {
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-1/review" {
 		t.Fatalf("expected explicit earlier-step repair to show step 1 review in flight, got %#v", result.State)
 	}
@@ -1082,7 +1076,7 @@ func TestStatusDoesNotSuggestSecondReviewWhileFinalizeReviewIsInFlight(t *testin
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("expected in-flight finalize review node, got %#v", result.State)
 	}
@@ -1115,7 +1109,7 @@ func TestStatusSuppressesMissingReviewWarningWithNoReviewNeededMarker(t *testing
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node with suppressed warning, got %#v", result.State)
 	}
@@ -1142,7 +1136,7 @@ func TestStatusNoReviewNeededMarkerDoesNotHideLaterFailedCloseout(t *testing.T) 
 		"decision": "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
@@ -1166,7 +1160,7 @@ func TestStatusNoReviewNeededMarkerDoesNotHideLaterInFlightCloseout(t *testing.T
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
@@ -1193,7 +1187,7 @@ func TestStatusNoReviewNeededMarkerAllowsLaterCleanCloseoutToStaySatisfied(t *te
 		"decision": "pass",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("expected step 2 node to stay stable, got %#v", result.State)
 	}
@@ -1243,7 +1237,7 @@ func TestStatusUnreadableFinalizeManifestDoesNotMasqueradeAsStepDebt(t *testing.
 		t.Fatalf("write unreadable finalize manifest: %v", err)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("expected finalize review node to stay stable, got %#v", result.State)
 	}
@@ -1300,7 +1294,7 @@ func TestStatusFinalizeReviewUsesAggregateFirstGuidanceForUnscopedUnreadableHist
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("expected finalize review node to stay stable, got %#v", result.State)
 	}
@@ -1347,7 +1341,7 @@ func TestStatusFinalizeReviewSummaryForUnscopedUnreadableHistoryWithoutActiveRou
 		"decision":     "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("expected finalize review node to stay stable, got %#v", result.State)
 	}
@@ -1396,7 +1390,7 @@ func TestStatusFinalizeFixSummaryForUnscopedUnreadableHistory(t *testing.T) {
 		"decision":     "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/fix" {
 		t.Fatalf("expected finalize fix node to stay stable, got %#v", result.State)
 	}
@@ -1437,7 +1431,7 @@ func TestStatusFailedStepReviewUsesActiveReviewRoundWhenManifestIsMissing(t *tes
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-1/implement" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1470,7 +1464,7 @@ func TestStatusUnknownAggregatedReviewDecisionStaysConservative(t *testing.T) {
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-1/implement" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1502,7 +1496,7 @@ func TestStatusFailedStepReviewPinsReviewedStep(t *testing.T) {
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-1/implement" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1534,7 +1528,7 @@ func TestStatusAdvancesToNextStepAfterCleanStepReview(t *testing.T) {
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-2/implement" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1552,7 +1546,7 @@ func TestStatusFinalizeReviewNode(t *testing.T) {
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1581,7 +1575,7 @@ func TestStatusFinalizeReviewClearsPriorStepReviewFacts(t *testing.T) {
 		"revision":     1,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1608,7 +1602,7 @@ func TestStatusFinalizeReviewInFlightIncludesReviewFacts(t *testing.T) {
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1633,7 +1627,7 @@ func TestStatusFinalizeFixNodeAfterFailedFinalizeReview(t *testing.T) {
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/fix" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1658,7 +1652,7 @@ func TestStatusFinalizeArchiveNodeAfterCleanFinalizeReview(t *testing.T) {
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/archive" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1677,7 +1671,7 @@ func TestStatusArchivedPlanNeedsPublishEvidence(t *testing.T) {
 	})
 	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/publish" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1708,7 +1702,7 @@ func TestStatusWarnsInArchivedPublishWhenCompletedStepStillLacksCloseout(t *test
 		"decision": "pass",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/publish" {
 		t.Fatalf("expected publish node to stay stable, got %#v", result.State)
 	}
@@ -1757,7 +1751,7 @@ func TestStatusLightweightPublishPrioritizesRepairDebtBeforeBreadcrumb(t *testin
 		"decision": "pass",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/publish" {
 		t.Fatalf("expected publish node to stay stable, got %#v", result.State)
 	}
@@ -1829,7 +1823,7 @@ func TestStatusArchivedNodesRequireReopenForUnscopedUnreadableHistory(t *testing
 				}
 			}
 
-			result := status.Service{Workdir: root}.Read()
+			result := status.Service{Workdir: root}.Snapshot()
 			if result.State.CurrentNode != tc.expectedNode {
 				t.Fatalf("expected archived node %q, got %#v", tc.expectedNode, result.State)
 			}
@@ -1902,7 +1896,7 @@ func TestStatusArchivedPlanReadyForAwaitMerge(t *testing.T) {
 		t.Fatalf("sync evidence: %#v", result)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/await_merge" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -1945,7 +1939,7 @@ func TestStatusWarnsInAwaitMergeWhenCompletedStepStillLacksCloseout(t *testing.T
 		t.Fatalf("sync evidence: %#v", result)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/await_merge" {
 		t.Fatalf("expected await_merge node to stay stable, got %#v", result.State)
 	}
@@ -2002,7 +1996,7 @@ func TestStatusArchivedPlanReadyForAwaitMergeFromEvidenceArtifacts(t *testing.T)
 		t.Fatalf("sync evidence: %#v", result)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/await_merge" {
 		t.Fatalf("expected evidence artifacts to reach await_merge, got %#v", result.State)
 	}
@@ -2044,7 +2038,7 @@ func TestStatusArchivedPlanIgnoresOlderRevisionEvidenceArtifacts(t *testing.T) {
 		"revision": 2,
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/publish" {
 		t.Fatalf("expected older revision evidence to keep publish state, got %#v", result.State)
 	}
@@ -2076,7 +2070,7 @@ func TestStatusArchivedPlanReadyForAwaitMergeWithSyncNotApplied(t *testing.T) {
 		t.Fatalf("sync evidence: %#v", result)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/await_merge" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -2108,7 +2102,7 @@ func TestStatusArchivedPlanReadyForAwaitMergeWhenCIAndSyncAreBothNotApplied(t *t
 		t.Fatalf("sync evidence: %#v", result)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/await_merge" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -2143,7 +2137,7 @@ func TestStatusArchivedPlanStaysInPublishFromEvidenceArtifactsWhenDirty(t *testi
 		t.Fatalf("sync evidence: %#v", result)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/publish" {
 		t.Fatalf("expected dirty evidence artifacts to stay in publish, got %#v", result.State)
 	}
@@ -2186,7 +2180,7 @@ func TestStatusArchivedPlanStaysInPublishWhenEvidenceIsDirty(t *testing.T) {
 		t.Fatalf("sync evidence: %#v", result)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/publish" {
 		t.Fatalf("expected dirty evidence to stay in publish, got %#v", result.State)
 	}
@@ -2228,7 +2222,7 @@ func TestStatusArchivedPlanStaysInPublishWhenSyncIsDirty(t *testing.T) {
 		t.Fatalf("sync evidence: %#v", result)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/publish" {
 		t.Fatalf("expected dirty sync evidence to stay in publish, got %#v", result.State)
 	}
@@ -2261,7 +2255,7 @@ func TestStatusLandNode(t *testing.T) {
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "land" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -2298,7 +2292,7 @@ func TestStatusIdleNodeAfterLand(t *testing.T) {
 		"last_landed_at":        "2026-03-19T12:00:00Z",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected idle result, got %#v", result)
 	}
@@ -2320,7 +2314,7 @@ func TestStatusIdleSurfacesNonBlockingBootstrapReminderWhenManagedAssetsAreStale
 	staleManagedInstructions(t, root)
 	staleManagedSkill(t, root, "harness-discovery")
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected idle result, got %#v", result)
 	}
@@ -2350,7 +2344,7 @@ func TestStatusIdleSurfacesReminderWhenManagedInstructionsAreStale(t *testing.T)
 
 	staleManagedInstructions(t, root)
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected idle result, got %#v", result)
 	}
@@ -2368,7 +2362,7 @@ func TestStatusIdleSurfacesReminderWhenManagedSkillsAreStale(t *testing.T) {
 
 	staleManagedSkill(t, root, "harness-discovery")
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected idle result, got %#v", result)
 	}
@@ -2384,7 +2378,7 @@ func TestStatusIdleSkipsBootstrapReminderWhenManagedAssetsAreFresh(t *testing.T)
 		t.Fatalf("init failed: %#v", result)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected idle result, got %#v", result)
 	}
@@ -2409,7 +2403,7 @@ func TestStatusActivePlanDoesNotSurfaceIdleBootstrapReminder(t *testing.T) {
 		return content
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected plan result, got %#v", result)
 	}
@@ -2439,7 +2433,7 @@ func TestStatusActiveExecutionDoesNotSurfaceIdleBootstrapReminder(t *testing.T) 
 		"execution_started_at": "2026-03-18T10:05:00+08:00",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if !result.OK {
 		t.Fatalf("expected execution result, got %#v", result)
 	}
@@ -2467,7 +2461,7 @@ func TestStatusReopenedFinalizeFixNeedsReview(t *testing.T) {
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/fix" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -2490,7 +2484,7 @@ func TestStatusReopenedNewStepPendingPromptsForNewStep(t *testing.T) {
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/fix" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -2516,7 +2510,7 @@ func TestStatusReopenedNewStepPendingKeepsNewStepCueEvenWithMissingCloseoutWarni
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/fix" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -2546,7 +2540,7 @@ func TestStatusReopenedNewStepContinuesOnceStepExists(t *testing.T) {
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-3/implement" {
 		t.Fatalf("unexpected node: %#v", result.State)
 	}
@@ -2578,7 +2572,7 @@ func TestStatusReopenedNewStepKeepsLaterFrontierWhileEarlierCloseoutDebtExists(t
 		"decision": "changes_requested",
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-3/implement" {
 		t.Fatalf("expected reopened step 3 frontier to stay stable, got %#v", result.State)
 	}
@@ -2663,7 +2657,7 @@ func TestStatusReentersReviewedStepAfterFailedExplicitEarlierStepRepair(t *testi
 		t.Fatalf("expected failed explicit earlier-step repair aggregate, got %#v", aggregate)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-1/implement" {
 		t.Fatalf("expected failed explicit earlier-step repair to reenter step 1, got %#v", result.State)
 	}
@@ -2734,7 +2728,7 @@ func TestStatusReturnsToLaterFrontierAfterCleanExplicitEarlierStepRepair(t *test
 		t.Fatalf("expected clean explicit earlier-step repair aggregate, got %#v", aggregate)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/step-3/implement" {
 		t.Fatalf("expected clean explicit earlier-step repair to return to the later frontier, got %#v", result.State)
 	}
@@ -2804,7 +2798,7 @@ func TestStatusReturnsToFinalizeReviewAfterCleanExplicitEarlierStepRepair(t *tes
 		t.Fatalf("expected clean explicit earlier-step repair aggregate from finalize review, got %#v", aggregate)
 	}
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/review" {
 		t.Fatalf("expected clean explicit earlier-step repair to return to finalize review, got %#v", result.State)
 	}
@@ -2847,7 +2841,7 @@ func TestStatusConsumedReopenedNewStepDoesNotForceAnotherStepAfterLaterFinding(t
 		},
 	})
 
-	result := status.Service{Workdir: root}.Read()
+	result := status.Service{Workdir: root}.Snapshot()
 	if result.State.CurrentNode != "execution/finalize/fix" {
 		t.Fatalf("expected finalize fix node, got %#v", result.State)
 	}

--- a/internal/ui/server.go
+++ b/internal/ui/server.go
@@ -218,7 +218,7 @@ func NewHandler(workdir string) (http.Handler, error) {
 		workspacePath := workspaceResult.Workspace.WorkspacePath
 		switch resource {
 		case "status":
-			writeStatusJSON(w, status.Service{Workdir: workspacePath}.Read())
+			writeStatusJSON(w, status.Service{Workdir: workspacePath}.Snapshot())
 		case "plan":
 			writePlanJSON(w, planui.Service{Workdir: workspacePath}.Read())
 		case "timeline":
@@ -234,7 +234,7 @@ func NewHandler(workdir string) (http.Handler, error) {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		writeStatusJSON(w, status.Service{Workdir: workdir}.Read())
+		writeStatusJSON(w, status.Service{Workdir: workdir}.Snapshot())
 	})
 	mux.HandleFunc("/api/plan", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -262,7 +262,7 @@ func NewHandler(workdir string) (http.Handler, error) {
 }
 
 var (
-	errWorkspaceActionTargetNotFound = errors.New("workspace action target is not currently watched")
+	errWorkspaceActionTargetNotFound  = errors.New("workspace action target is not currently watched")
 	errWorkspaceActionTargetAmbiguous = errors.New("workspace route key is ambiguous; specify the exact workspace_path")
 )
 

--- a/internal/ui/server_test.go
+++ b/internal/ui/server_test.go
@@ -84,6 +84,48 @@ func TestNewHandlerStatusDoesNotTouchWatchlist(t *testing.T) {
 	}
 }
 
+func TestNewHandlerStatusForActivePlanDoesNotMutateWorkflowOrWatchlist(t *testing.T) {
+	workdir := filepath.Join(t.TempDir(), "workspace-active-status")
+	seedGitWorkspace(t, workdir)
+	home := t.TempDir()
+	t.Setenv("EASYHARNESS_HOME", home)
+	relPlanPath, planStem := writeUIActivePlan(t, workdir, "UI Active Status")
+	currentPlanPath, statePath, lockPath := seedUIActiveState(t, workdir, relPlanPath, planStem)
+	before := snapshotStateFiles(t, currentPlanPath, statePath)
+
+	handler, err := NewHandler(workdir)
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/status", nil)
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		OK    bool `json:"ok"`
+		State struct {
+			CurrentNode string `json:"current_node"`
+		} `json:"state"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v\n%s", err, recorder.Body.String())
+	}
+	if !payload.OK || payload.State.CurrentNode != "execution/step-1/implement" {
+		t.Fatalf("unexpected status payload: %#v", payload)
+	}
+	assertStateFilesUnchanged(t, before)
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected UI status request to avoid creating state lock, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "watchlist.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected UI status request to avoid watchlist writes, err=%v", err)
+	}
+}
+
 func TestUIReadSurfacesDoNotTouchWatchlist(t *testing.T) {
 	workdir := filepath.Join(t.TempDir(), "workspace")
 	seedGitWorkspace(t, workdir)
@@ -304,8 +346,8 @@ func TestNewHandlerServesWorkspaceLookupJSON(t *testing.T) {
 		t.Fatalf("expected status 200, got %d: %s", recorder.Code, recorder.Body.String())
 	}
 	var payload struct {
-		OK       bool `json:"ok"`
-		Watched  bool `json:"watched"`
+		OK        bool `json:"ok"`
+		Watched   bool `json:"watched"`
 		Workspace *struct {
 			WorkspacePath string `json:"workspace_path"`
 		} `json:"workspace"`
@@ -338,7 +380,7 @@ func TestNewHandlerServesWorkspaceStatusJSONByKey(t *testing.T) {
 		t.Fatalf("expected status 200, got %d: %s", recorder.Code, recorder.Body.String())
 	}
 	var payload struct {
-		OK      bool `json:"ok"`
+		OK      bool   `json:"ok"`
 		Command string `json:"command"`
 	}
 	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
@@ -346,6 +388,53 @@ func TestNewHandlerServesWorkspaceStatusJSONByKey(t *testing.T) {
 	}
 	if !payload.OK || payload.Command != "status" {
 		t.Fatalf("unexpected status payload: %#v", payload)
+	}
+}
+
+func TestNewHandlerWorkspaceStatusForActivePlanDoesNotMutateWorkflowOrWatchlist(t *testing.T) {
+	home := t.TempDir()
+	workspace := filepath.Join(t.TempDir(), "workspace-status-active")
+	seedGitWorkspace(t, workspace)
+	writeWatchlist(t, home, []watchlist.Workspace{workspaceRecord(workspace, "2026-04-22T12:00:00Z")})
+	t.Setenv("EASYHARNESS_HOME", home)
+	relPlanPath, planStem := writeUIActivePlan(t, workspace, "Workspace Active Status")
+	currentPlanPath, statePath, lockPath := seedUIActiveState(t, workspace, relPlanPath, planStem)
+	watchlistPath := filepath.Join(home, "watchlist.json")
+	fixedTime := time.Date(2026, 4, 22, 8, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(watchlistPath, fixedTime, fixedTime); err != nil {
+		t.Fatalf("set watchlist timestamp: %v", err)
+	}
+	before := snapshotStateFiles(t, currentPlanPath, statePath)
+	watchlistBefore := snapshotFile(t, watchlistPath)
+
+	handler, err := NewHandler(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewHandler: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/workspace/"+dashboard.WorkspaceKey(workspace)+"/status", nil)
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		OK    bool `json:"ok"`
+		State struct {
+			CurrentNode string `json:"current_node"`
+		} `json:"state"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v\n%s", err, recorder.Body.String())
+	}
+	if !payload.OK || payload.State.CurrentNode != "execution/step-1/implement" {
+		t.Fatalf("unexpected status payload: %#v", payload)
+	}
+	assertStateFilesUnchanged(t, before)
+	assertFileUnchanged(t, watchlistPath, watchlistBefore)
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected workspace status request to avoid creating state lock, err=%v", err)
 	}
 }
 
@@ -1434,6 +1523,59 @@ func renderPlanFixture(t *testing.T, title string) string {
 		t.Fatalf("render plan: %v", err)
 	}
 	return strings.Replace(rendered, "size: REPLACE_WITH_PLAN_SIZE", "size: M", 1)
+}
+
+func writeUIActivePlan(t *testing.T, root, title string) (string, string) {
+	t.Helper()
+	planStem := strings.ToLower(strings.ReplaceAll(title, " ", "-"))
+	relPath := filepath.ToSlash(filepath.Join("docs", "plans", "active", "2026-04-22-"+planStem+".md"))
+	path := filepath.Join(root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir plan dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(renderPlanFixture(t, title)), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+	return relPath, "2026-04-22-" + planStem
+}
+
+func seedUIActiveState(t *testing.T, root, relPlanPath, planStem string) (string, string, string) {
+	t.Helper()
+	currentPlanPath, err := runstate.SaveCurrentPlan(root, relPlanPath)
+	if err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	statePath, err := runstate.SaveState(root, planStem, &runstate.State{
+		ExecutionStartedAt: "2026-04-22T09:00:00Z",
+		Revision:           1,
+	})
+	if err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	fixedTime := time.Date(2026, 4, 22, 8, 0, 0, 0, time.UTC)
+	for _, path := range []string{currentPlanPath, statePath} {
+		if err := os.Chtimes(path, fixedTime, fixedTime); err != nil {
+			t.Fatalf("set state timestamp %s: %v", path, err)
+		}
+	}
+	lockPath := filepath.Join(root, ".local", "harness", "plans", planStem, ".state-mutation.lock")
+	return currentPlanPath, statePath, lockPath
+}
+
+func snapshotStateFiles(t *testing.T, paths ...string) map[string]fileSnapshot {
+	t.Helper()
+	before := make(map[string]fileSnapshot, len(paths))
+	for _, path := range paths {
+		before[path] = snapshotFile(t, path)
+	}
+	return before
+}
+
+func assertStateFilesUnchanged(t *testing.T, before map[string]fileSnapshot) {
+	t.Helper()
+	for path, snapshot := range before {
+		assertFileUnchanged(t, path, snapshot)
+	}
 }
 
 type dashboardTestGroup struct {

--- a/tests/e2e/runstate_concurrency_test.go
+++ b/tests/e2e/runstate_concurrency_test.go
@@ -104,7 +104,7 @@ func TestArchivedRunstateInterleavingsIgnoreStaleEvidenceAndFailClearlyUnderLock
 	support.RequireExitCode(t, lockedStatus, 1)
 	support.RequireNoStderr(t, lockedStatus)
 	lockedStatusPayload := support.RequireJSONResult[statusResult](t, lockedStatus)
-	if lockedStatusPayload.OK || lockedStatusPayload.Summary != "Another local state mutation is already in progress." {
+	if lockedStatusPayload.OK || lockedStatusPayload.Summary != "Another local state mutation is still in progress." {
 		t.Fatalf("expected locked status failure, got %#v", lockedStatusPayload)
 	}
 	if lockedStatusPayload.Artifacts.ProjectRoot == "" || lockedStatusPayload.Artifacts.PlanPath != postRearchiveStatus.Artifacts.PlanPath {


### PR DESCRIPTION
## Summary

- define status/read-model purity, passive CLI status settle behavior, mutation-command fail-fast behavior, and CLI-owned watchlist refresh in specs
- replace ambiguous `status.Service.Read()` / `ReadUnlocked()` with read-only `Snapshot()` and remove status-level success hooks
- add passive state-mutation lock probing plus bounded `harness status` settle behavior with busy reporting
- add regression coverage for CLI settle behavior, UI/API/dashboard no-mutation reads, and intentional CLI watchlist refresh

## Validation

- `git diff --check`
- `harness plan lint docs/plans/active/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md`
- `go test ./internal/status ./internal/runstate ./internal/cli ./internal/ui ./internal/dashboard ./internal/watchlist -count=1`
- finalize review `review-007-full` passed with correctness and tests slots, no findings

## Harness

Archived plan: `docs/plans/archived/2026-04-25-clarify-status-snapshot-and-mutation-coordination.md`

Closes #189
