### PR TITLE
Stabilize dev bootstrap version marker

### DIFF
--- a/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
+++ b/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
@@ -165,25 +165,48 @@ warning.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+Validation covered the marker-selection unit path, the status/init drift path,
+the installed development binary, and the full Go test suite:
+
+- `go test ./internal/install -run 'TestInitUsesStableDevVersionMarkerWhenDevBuildHasVersion|TestInitUsesStableDevVersionMarkerAcrossCommitChanges|TestInitRefreshesVersionMarkersAcrossVersionChanges' -count=1`
+- `go test ./internal/status ./internal/install -count=1`
+- `scripts/install-dev-harness`
+- `harness --version`
+- `harness init --dry-run`
+- `harness status`
+- `go test ./... -count=1`
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Step-closeout delta review `review-001-delta` passed with no findings across
+`correctness` and `tests`. Finalize full review `review-002-full` passed
+`correctness` and `tests`, and found one docs-consistency archive-readiness
+issue: the durable archive summary sections still contained placeholders. This
+revision removes those placeholders and records the closeout summaries.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+The candidate is intended to archive as a standard tracked plan after the
+summary-placeholder repair receives a clean finalize review. There are no
+deferred items or follow-up issues for this slice.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Dev-mode bootstrap marker rendering now returns the stable `dev` marker even
+  when the dev binary exposes a diagnostic version such as `v0.2.5-dev`.
+- Release-mode bootstrap marker rendering continues to use concrete release
+  versions.
+- Regression coverage now proves the dev-build-with-version case remains noop
+  for managed bootstrap assets.
+- The repo-local dev binary was rebuilt and verified to keep `harness
+  --version` diagnostics while clearing the false `harness status` bootstrap
+  drift warning.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+No planned scope was left undelivered.
 
 ### Follow-Up Issues
 

--- a/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
+++ b/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
@@ -40,15 +40,15 @@ managed bootstrap instructions and skill packages continue to use the stable
 
 ## Acceptance Criteria
 
-- [ ] A dev binary with `mode: dev` and `version: v0.2.5-dev` keeps rendering
+- [x] A dev binary with `mode: dev` and `version: v0.2.5-dev` keeps rendering
       managed bootstrap version markers as `dev`.
-- [ ] Release binaries still render managed bootstrap markers from their
+- [x] Release binaries still render managed bootstrap markers from their
       concrete release version.
-- [ ] `harness init --dry-run` is all noop for the current clean dogfood
+- [x] `harness init --dry-run` is all noop for the current clean dogfood
       bootstrap outputs after reinstalling the dev binary.
-- [ ] `harness status` no longer emits the false stale bootstrap warning in the
+- [x] `harness status` no longer emits the false stale bootstrap warning in the
       current idle worktree after reinstalling the dev binary.
-- [ ] Focused tests cover the dev-build-with-version regression.
+- [x] Focused tests cover the dev-build-with-version regression.
 
 ## Deferred Items
 
@@ -101,7 +101,7 @@ Step-closeout delta review `review-001-delta` passed with no findings across
 
 ### Step 2: Verify Real Dev Binary Behavior
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -132,11 +132,17 @@ direct command on PATH.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Reinstalled the repo-local dev binary with `scripts/install-dev-harness`.
+Verified the real `harness` command still reports `version: v0.2.5-dev` and
+`mode: dev`, while `harness init --dry-run` reports all noop actions and
+`harness status` no longer emits the stale bootstrap warning. Validation also
+passed with `go test ./internal/status ./internal/install -count=1` and
+`go test ./... -count=1`.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 2 only rebuilt and validated the dev binary after
+the Step 1 code change, and introduced no additional code or contract edits.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
+++ b/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
@@ -58,7 +58,7 @@ managed bootstrap instructions and skill packages continue to use the stable
 
 ### Step 1: Separate Dev Build Metadata From Bootstrap Markers
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -96,7 +96,8 @@ validation passed with `go test ./internal/install -run
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+Step-closeout delta review `review-001-delta` passed with no findings across
+`correctness` and `tests`.
 
 ### Step 2: Verify Real Dev Binary Behavior
 

--- a/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
+++ b/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
@@ -182,13 +182,24 @@ Step-closeout delta review `review-001-delta` passed with no findings across
 `correctness` and `tests`. Finalize full review `review-002-full` passed
 `correctness` and `tests`, and found one docs-consistency archive-readiness
 issue: the durable archive summary sections still contained placeholders. This
-revision removes those placeholders and records the closeout summaries.
+revision removed those placeholders and recorded the closeout summaries.
+Follow-up finalize full review `review-003-full` passed with no findings.
 
 ## Archive Summary
 
-The candidate is intended to archive as a standard tracked plan after the
-summary-placeholder repair receives a clean finalize review. There are no
-deferred items or follow-up issues for this slice.
+The candidate is ready to archive as a standard tracked plan after clean
+follow-up finalize review `review-003-full`. There are no deferred items or
+follow-up issues for this slice.
+
+- PR: pending post-archive publish handoff from branch
+  `codex/stabilize-dev-bootstrap-version-marker`.
+- Ready: Acceptance criteria are satisfied, step-closeout review
+  `review-001-delta` passed, finalize repair review `review-003-full` passed,
+  and validation includes the installed dev binary plus `go test ./... -count=1`.
+- Merge Handoff: Archive the active plan, commit the tracked archive move, push
+  branch `codex/stabilize-dev-bootstrap-version-marker`, open a PR, and record
+  publish/CI/sync evidence until `harness status` reaches
+  `execution/finalize/await_merge`.
 
 ## Outcome Summary
 

--- a/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
+++ b/docs/plans/active/2026-04-27-stabilize-dev-bootstrap-version-marker.md
@@ -1,0 +1,183 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-27T09:21:53+08:00"
+approved_at: "2026-04-27T09:23:20+08:00"
+source_type: direct_request
+source_refs: []
+size: XS
+---
+
+# Stabilize Dev Bootstrap Version Marker
+
+## Goal
+
+Fix the false bootstrap drift warning produced by dev-built `harness` binaries
+that expose a `vX.Y.Z-dev` build version. The direct `harness --version`
+metadata should keep reporting the dev build version for diagnostics, while
+managed bootstrap instructions and skill packages continue to use the stable
+`dev` marker in development mode.
+
+## Scope
+
+### In Scope
+
+- Keep bootstrap managed asset rendering stable when the running binary is in
+  dev mode, even if its build metadata includes a concrete `vX.Y.Z-dev`
+  version.
+- Add focused regression coverage for a dev build that has both `Mode: dev`
+  and a non-empty `Version`.
+- Reinstall the repo-local dev binary after the Go CLI change and verify the
+  real `harness` command no longer reports bootstrap drift on the clean
+  dogfood outputs.
+
+### Out of Scope
+
+- Changing the public `harness --version` output shape or removing dev build
+  version metadata.
+- Refreshing managed bootstrap files to `vX.Y.Z-dev` markers.
+- Changing release-mode bootstrap markers.
+- Redesigning the worktree-aware development wrapper.
+
+## Acceptance Criteria
+
+- [ ] A dev binary with `mode: dev` and `version: v0.2.5-dev` keeps rendering
+      managed bootstrap version markers as `dev`.
+- [ ] Release binaries still render managed bootstrap markers from their
+      concrete release version.
+- [ ] `harness init --dry-run` is all noop for the current clean dogfood
+      bootstrap outputs after reinstalling the dev binary.
+- [ ] `harness status` no longer emits the false stale bootstrap warning in the
+      current idle worktree after reinstalling the dev binary.
+- [ ] Focused tests cover the dev-build-with-version regression.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Separate Dev Build Metadata From Bootstrap Markers
+
+- Done: [ ]
+
+#### Objective
+
+Teach bootstrap marker selection to prefer the stable `dev` marker whenever
+the running harness binary is in dev mode.
+
+#### Details
+
+The regression appeared because `scripts/install-dev-harness` now injects
+`BuildVersion=vX.Y.Z-dev` for better `harness --version` diagnostics, while
+bootstrap marker rendering currently prefers any non-empty version before
+considering dev-mode stability. Keep the diagnostic version visible through
+`harness --version`, but prevent that diagnostic value from becoming a managed
+asset compatibility marker.
+
+#### Expected Files
+
+- `internal/install/service.go`
+- `internal/install/service_test.go`
+
+#### Validation
+
+- Add or update focused install tests covering `versioninfo.Info{Mode: "dev",
+  Version: "v0.2.5-dev"}`.
+- Run `go test ./internal/install -count=1`.
+
+#### Execution Notes
+
+Added a focused regression test that reproduces marker churn when a dev build
+has `Mode: dev` and `Version: v0.2.5-dev`, then updated bootstrap marker
+selection so dev mode always renders the stable `dev` marker. Focused
+validation passed with `go test ./internal/install -run
+'TestInitUsesStableDevVersionMarkerWhenDevBuildHasVersion|TestInitUsesStableDevVersionMarkerAcrossCommitChanges|TestInitRefreshesVersionMarkersAcrossVersionChanges'
+-count=1`.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Verify Real Dev Binary Behavior
+
+- Done: [ ]
+
+#### Objective
+
+Rebuild the repo-local dev binary and verify the real `harness` command no
+longer reports false bootstrap drift.
+
+#### Details
+
+Because the user-facing failure is visible through the installed worktree
+wrapper and repo-local binary, source-level `go run` validation is not enough.
+After the code change, rerun `scripts/install-dev-harness` and validate the
+direct command on PATH.
+
+#### Expected Files
+
+- `internal/install/service.go`
+- `internal/install/service_test.go`
+
+#### Validation
+
+- Run `scripts/install-dev-harness`.
+- Run `harness --version` and confirm it still reports a dev version.
+- Run `harness init --dry-run` and confirm all actions are `noop`.
+- Run `harness status` and confirm the stale bootstrap warning is absent.
+- Run a broader relevant test sweep such as `go test ./internal/status
+  ./internal/install -count=1`, with `go test ./... -count=1` preferred when
+  time permits.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+Use focused install tests to lock the marker-selection semantics, then validate
+the actual repo-local dev binary because this bug only became visible after the
+development installer injected build version metadata. Finish by checking the
+idle status path and init dry-run path that originally exposed the false
+warning.
+
+## Risks
+
+- Risk: Release bootstrap refresh behavior could accidentally lose concrete
+  release version markers.
+  - Mitigation: Keep existing release-version tests and add only a dev-mode
+    special case.
+- Risk: Source-level tests could pass while the installed wrapper still uses a
+  stale binary.
+  - Mitigation: Re-run `scripts/install-dev-harness` after the Go change and
+    validate with the actual `harness` command.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/archived/2026-04-27-stabilize-dev-bootstrap-version-marker.md
+++ b/docs/plans/archived/2026-04-27-stabilize-dev-bootstrap-version-marker.md
@@ -187,6 +187,8 @@ Follow-up finalize full review `review-003-full` passed with no findings.
 
 ## Archive Summary
 
+- Archived At: 2026-04-27T09:42:59+08:00
+- Revision: 1
 The candidate is ready to archive as a standard tracked plan after clean
 follow-up finalize review `review-003-full`. There are no deferred items or
 follow-up issues for this slice.

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -689,6 +689,9 @@ func (s Service) versionTag() string {
 	if info.Mode == "" && info.Commit == "" && info.Version == "" {
 		info = versioninfo.Current()
 	}
+	if strings.TrimSpace(info.Mode) == "dev" {
+		return "dev"
+	}
 	if strings.TrimSpace(info.Version) != "" {
 		return strings.TrimSpace(info.Version)
 	}

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -609,3 +609,47 @@ func TestInitUsesStableDevVersionMarkerAcrossCommitChanges(t *testing.T) {
 		t.Fatalf("expected stable dev skill marker, got:\n%s", skillData)
 	}
 }
+
+func TestInitUsesStableDevVersionMarkerWhenDevBuildHasVersion(t *testing.T) {
+	root := t.TempDir()
+
+	first := testService(root)
+	first.Version = versioninfo.Info{Mode: "dev", Commit: "before"}
+	if result := first.Init(Options{}); !result.OK {
+		t.Fatalf("initial dev init failed: %#v", result)
+	}
+
+	second := testService(root)
+	second.Version = versioninfo.Info{Version: "v0.2.5-dev", Mode: "dev", Commit: "abc123"}
+	result := second.Init(Options{})
+	if !result.OK {
+		t.Fatalf("repeat dev init failed: %#v", result)
+	}
+	for _, action := range result.Actions {
+		if action.Kind != ActionNoop {
+			t.Fatalf("expected dev build version to avoid marker churn, got %#v", result.Actions)
+		}
+	}
+
+	agentsData, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md after dev init: %v", err)
+	}
+	if strings.Contains(string(agentsData), `version="v0.2.5-dev"`) {
+		t.Fatalf("expected dev instructions marker to stay stable, got:\n%s", agentsData)
+	}
+	if !strings.Contains(string(agentsData), `<!-- easyharness:begin version="dev" -->`) {
+		t.Fatalf("expected dev instructions marker, got:\n%s", agentsData)
+	}
+
+	skillData, err := os.ReadFile(filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md"))
+	if err != nil {
+		t.Fatalf("read skill after dev init: %v", err)
+	}
+	if strings.Contains(string(skillData), "easyharness-version: v0.2.5-dev") {
+		t.Fatalf("expected dev skill marker to stay stable, got:\n%s", skillData)
+	}
+	if !strings.Contains(string(skillData), "easyharness-version: dev") {
+		t.Fatalf("expected dev skill marker, got:\n%s", skillData)
+	}
+}


### PR DESCRIPTION
## Summary

- Keep managed bootstrap version markers stable as `dev` whenever the running harness binary is in dev mode, even when `harness --version` reports a diagnostic `vX.Y.Z-dev` version.
- Add regression coverage for dev builds with both `Mode: dev` and a non-empty `Version`.
- Archive the tracked plan after clean step/finalize review.

## Validation

- `go test ./internal/install -run 'TestInitUsesStableDevVersionMarkerWhenDevBuildHasVersion|TestInitUsesStableDevVersionMarkerAcrossCommitChanges|TestInitRefreshesVersionMarkersAcrossVersionChanges' -count=1`
- `go test ./internal/status ./internal/install -count=1`
- `scripts/install-dev-harness`
- `harness --version`
- `harness init --dry-run`
- `harness status`
- `go test ./... -count=1`

## Review

- Step-closeout delta review `review-001-delta`: passed with no findings.
- Finalize full review `review-002-full`: found archive-summary placeholder debt.
- Finalize repair review `review-003-full`: passed with no findings.
