### PR TITLE
Keep workbench page state warm

### DIFF
--- a/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
+++ b/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
@@ -236,7 +236,10 @@ candidate. Follow-up review `review-002-full` found one remaining blocking
 test gap: continuity tests still relied on seeded state. The second repair
 added user-control remount tests for Plan, Timeline, and Review and reran
 `pnpm --dir web test`, `pnpm --dir web check`, and `pnpm --dir web build`
-successfully.
+successfully. Follow-up review `review-003-full` found that Review artifact
+selection still used default state; the third repair added a second artifact,
+clicked its artifact tab through the UI, and verified that selected artifact
+state survives remount. Full validation passed again.
 
 ## Archive Summary
 

--- a/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
+++ b/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
@@ -188,7 +188,9 @@ Added `web/src/main.test.tsx` coverage for Plan, Timeline, and Review tab
 switch continuity, plus fallback behavior for missing remembered review ids and
 artifact ids. Review repair added Plan fallback, Timeline fallback,
 supplements-only Plan selection, and post-return Plan refetch coverage. Focused
-and full frontend validation passed.
+and full frontend validation passed. A second repair added component-level
+control tests proving Plan, Timeline, and Review controls write lifted state
+through their actual UI handlers before remount continuity is asserted.
 
 #### Review Notes
 
@@ -230,7 +232,11 @@ Plan child selections and expand fallback/refetch test coverage. The repair
 fixed the supplements-only Plan fallback path and added focused regression
 coverage for Plan, Timeline, and Review fallback plus the Plan refetch claim.
 Fresh validation passed; a follow-up finalize review will verify the repaired
-candidate.
+candidate. Follow-up review `review-002-full` found one remaining blocking
+test gap: continuity tests still relied on seeded state. The second repair
+added user-control remount tests for Plan, Timeline, and Review and reran
+`pnpm --dir web test`, `pnpm --dir web check`, and `pnpm --dir web build`
+successfully.
 
 ## Archive Summary
 

--- a/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
+++ b/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
@@ -186,7 +186,9 @@ behavior clearly.
 
 Added `web/src/main.test.tsx` coverage for Plan, Timeline, and Review tab
 switch continuity, plus fallback behavior for missing remembered review ids and
-artifact ids. Focused and full frontend validation passed.
+artifact ids. Review repair added Plan fallback, Timeline fallback,
+supplements-only Plan selection, and post-return Plan refetch coverage. Focused
+and full frontend validation passed.
 
 #### Review Notes
 
@@ -223,7 +225,12 @@ Passed:
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Finalize review `review-001-full` requested changes: preserve supplements-only
+Plan child selections and expand fallback/refetch test coverage. The repair
+fixed the supplements-only Plan fallback path and added focused regression
+coverage for Plan, Timeline, and Review fallback plus the Plan refetch claim.
+Fresh validation passed; a follow-up finalize review will verify the repaired
+candidate.
 
 ## Archive Summary
 

--- a/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
+++ b/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
@@ -1,0 +1,244 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-28T15:45:53Z"
+approved_at: "2026-04-28T23:48:41+08:00"
+source_type: issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/172
+size: M
+---
+
+# Keep Workbench Page State Warm
+
+## Goal
+
+Keep the workbench feeling like one stable UI while users move between Plan,
+Timeline, and Review. When a user switches away from one of those pages and
+comes back, the page should remember the part they were looking at whenever
+that item still exists.
+
+This is a UI continuity pass, not a data-freezing pass. Live data may continue
+to refresh, and invalid selections should fall back to a sensible default.
+
+## Scope
+
+### In Scope
+
+- Preserve Plan page selection and expanded tree state across workbench tab
+  switches.
+- Preserve Timeline selected event and selected detail tab across workbench tab
+  switches.
+- Preserve Review selected round, selected detail tab, selected artifact, and
+  artifact panel visibility across workbench tab switches.
+- Keep live data refresh behavior working; do not freeze old payloads just to
+  preserve UI selection.
+- Fall back cleanly when refreshed data no longer contains the previously
+  selected item.
+- Add focused frontend tests for switching away and back without losing the
+  expected page-local state.
+
+### Out of Scope
+
+- Redesigning the workbench shell or rail.
+- Replacing the existing live resource system.
+- Persisting state across browser reloads, new tabs, or separate workspaces.
+- Stopping all refetching on tab switches.
+- Adding new Plan, Timeline, or Review features beyond state continuity.
+
+## Acceptance Criteria
+
+- [x] Plan remembers the selected document heading or supplement node across
+      workbench tab switches when the item still exists.
+- [x] Plan remembers expanded tree branches across workbench tab switches when
+      those branches still exist.
+- [x] Timeline remembers the selected event and detail tab across workbench tab
+      switches when they still exist.
+- [x] Review remembers the selected round, selected detail tab, selected
+      artifact, and artifact panel visibility across workbench tab switches
+      when they still exist.
+- [x] When refreshed data removes a remembered item, the affected page falls
+      back to the same kind of default it uses today instead of showing a broken
+      selection.
+- [x] Live refresh and freshness indicators still reflect current resource
+      state instead of treating preserved UI state as preserved data.
+- [x] Focused frontend tests cover the continuity behavior and the invalid
+      selection fallback.
+
+## Deferred Items
+
+- Persisting workbench page state across browser reloads.
+- A broader live refresh policy redesign for inactive pages.
+- Search, filtering, or new navigation affordances inside Plan, Timeline, or
+  Review.
+
+## Work Breakdown
+
+### Step 1: Define the remembered page state shape
+
+- Done: [x]
+
+#### Objective
+
+Move the remembered Plan, Timeline, and Review UI state to a workbench-level
+owner so tab switches no longer destroy it.
+
+#### Details
+
+Keep this state scoped to the current workspace route. The state should describe
+where the user is looking, not the loaded API payload. The implementation may
+use one small workbench state hook or local state in `App`, but it should avoid
+introducing a broad state-management layer.
+
+#### Expected Files
+
+- `web/src/main.tsx`
+- `web/src/pages.tsx`
+- `web/src/types.ts`
+
+#### Validation
+
+- Typecheck the frontend.
+- Confirm Plan, Timeline, and Review can receive controlled state from the
+  workbench owner without changing their visible layout.
+
+#### Execution Notes
+
+Added small page-specific state shapes for Plan, Timeline, and Review, then
+lifted their ownership into `App` so page components can be controlled across
+workbench tab switches. State is scoped to the current workspace key and reset
+when the workspace changes.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: completed as part of the combined approved slice; the
+integrated candidate is covered by the finalize review.
+
+### Step 2: Preserve state while keeping data refresh live
+
+- Done: [x]
+
+#### Objective
+
+Wire Plan, Timeline, and Review so their remembered state survives tab switches
+and is corrected only when refreshed data makes the remembered selection
+invalid.
+
+#### Details
+
+Do not freeze API payloads as the primary fix. If a page refetches when the user
+returns, preserve the user's selection through that refresh when possible. If
+the selected item is no longer present, reuse the page's current defaulting
+behavior.
+
+#### Expected Files
+
+- `web/src/main.tsx`
+- `web/src/pages.tsx`
+- `web/src/live-resource.ts`
+
+#### Validation
+
+- Typecheck the frontend.
+- Run the focused frontend test suite.
+- Manually exercise the UI in a browser if the implementation changes visible
+  workbench behavior in a way that unit tests cannot cover well.
+
+#### Execution Notes
+
+Wired Plan, Timeline, and Review to use the remembered state while continuing
+to fetch live resources normally. Selection, expanded branches, detail tabs,
+and artifact panel state are corrected only after loaded data proves the
+remembered id is no longer present.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: completed as part of the combined approved slice; the
+integrated candidate is covered by the finalize review.
+
+### Step 3: Lock continuity behavior with tests
+
+- Done: [x]
+
+#### Objective
+
+Add focused tests proving that tab switches preserve expected page state and
+that missing remembered items fall back cleanly.
+
+#### Details
+
+Prefer small jsdom tests around the frontend components or app shell. Add
+browser validation only where jsdom cannot express the routing and interaction
+behavior clearly.
+
+#### Expected Files
+
+- `web/src/pages.test.tsx`
+- `web/src/live-resource.test.tsx`
+- `web/src/main.test.tsx`
+
+#### Validation
+
+- `pnpm --dir web test`
+- `pnpm --dir web check`
+- `pnpm --dir web build`
+
+#### Execution Notes
+
+Added `web/src/main.test.tsx` coverage for Plan, Timeline, and Review tab
+switch continuity, plus fallback behavior for missing remembered review ids and
+artifact ids. Focused and full frontend validation passed.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: completed as part of the combined approved slice; the
+integrated candidate is covered by the finalize review.
+
+## Validation Strategy
+
+- Use focused frontend tests for the preserved-state behavior and fallback
+  behavior.
+- Run the full frontend check/build commands before archive.
+- Use browser validation if the implementation affects real routing or visual
+  behavior beyond what jsdom tests cover.
+
+## Risks
+
+- Risk: Preserved UI state could accidentally preserve stale data.
+  - Mitigation: Keep remembered state limited to selection, expansion, and panel
+    choices; keep API payloads and freshness separate.
+- Risk: Controlled state could make Plan, Timeline, or Review harder to follow.
+  - Mitigation: Keep the state shape small and page-specific instead of adding a
+    generic global store.
+- Risk: Refreshed data could remove a remembered item.
+  - Mitigation: Keep the existing default-selection behavior for invalid
+    remembered IDs.
+
+## Validation Summary
+
+Passed:
+
+- `pnpm --dir web test`
+- `pnpm --dir web check`
+- `pnpm --dir web build`
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
+++ b/docs/plans/active/2026-04-28-keep-workbench-page-state-warm.md
@@ -239,7 +239,10 @@ added user-control remount tests for Plan, Timeline, and Review and reran
 successfully. Follow-up review `review-003-full` found that Review artifact
 selection still used default state; the third repair added a second artifact,
 clicked its artifact tab through the UI, and verified that selected artifact
-state survives remount. Full validation passed again.
+state survives remount. Review `review-004-full` tightened that assertion
+because the tab label could satisfy the old text check; the fourth repair now
+asserts both the selected artifact tab and the selected artifact body. Full
+validation passed again.
 
 ## Archive Summary
 

--- a/docs/plans/archived/2026-04-28-keep-workbench-page-state-warm.md
+++ b/docs/plans/archived/2026-04-28-keep-workbench-page-state-warm.md
@@ -242,22 +242,40 @@ clicked its artifact tab through the UI, and verified that selected artifact
 state survives remount. Review `review-004-full` tightened that assertion
 because the tab label could satisfy the old text check; the fourth repair now
 asserts both the selected artifact tab and the selected artifact body. Full
-validation passed again.
+validation passed again. Finalize review `review-005-full` passed with no
+findings.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-04-29T00:24:09+08:00
+- Revision: 1
+- PR: pending post-archive publish handoff from branch
+  `codex/keep-workbench-page-state-warm`.
+- Ready: Acceptance criteria satisfied; full validation passed; finalize review
+  `review-005-full` passed clean after repairs.
+- Merge Handoff: Archive the plan, commit archive closeout, push the branch,
+  open a PR for issue #172, record publish/CI/sync evidence, then wait for
+  human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+Plan, Timeline, and Review now keep page-local UI state warm across workbench
+tab switches/remounts while continuing to refetch live data. Remembered
+selection, expanded branches, detail tabs, and review artifact panel choices
+fall back cleanly when refreshed data no longer contains the remembered item.
+Focused tests cover continuity, fallback, user-driven state updates, and live
+Plan refetch behavior.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+Browser reload persistence, new-tab persistence, cross-workspace persistence,
+broader live-resource refresh redesign, and new Plan/Timeline/Review
+navigation/search/filter features stayed out of scope.
 
 ### Follow-Up Issues
 
-NONE
+No new GitHub issue opened. Deferred items remain intentionally out of scope
+for this issue: browser reload persistence, broader live refresh policy
+redesign, and Plan/Timeline/Review search/filter/navigation improvements.

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -1,8 +1,19 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { useState } from "preact/hooks";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { App } from "./main";
-import type { PlanResult, ReviewResult, StatusResult, TimelineResult, WorkspaceRouteResult } from "./types";
+import { PlanWorkspace, ReviewWorkspace, TimelineWorkspace } from "./pages";
+import type {
+  PlanResult,
+  PlanWorkspaceState,
+  ReviewResult,
+  ReviewWorkspaceState,
+  StatusResult,
+  TimelineResult,
+  TimelineWorkspaceState,
+  WorkspaceRouteResult,
+} from "./types";
 
 const workspaceResult: WorkspaceRouteResult = {
   ok: true,
@@ -162,6 +173,14 @@ function planFetchCount(): number {
   return vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === "/api/workspace/wk_alpha/plan").length;
 }
 
+function clickPlanTreeLabel(label: string) {
+  const target = Array.from(document.querySelectorAll<HTMLButtonElement>(".plan-tree-label")).find(
+    (nextElement) => nextElement.querySelector(".plan-tree-text")?.textContent === label,
+  );
+  if (!target) throw new Error(`Missing plan tree label ${label}`);
+  fireEvent.click(target);
+}
+
 function activeInspectorTabText(): string {
   return document.querySelector(".inspector-tab.is-active")?.textContent ?? "";
 }
@@ -172,6 +191,80 @@ function activeExplorerTitleText(): string {
 
 function explorerHasTitle(title: string): boolean {
   return Array.from(document.querySelectorAll(".explorer-item-title")).some((nextElement) => nextElement.textContent === title);
+}
+
+function clickExplorerItem(title: string) {
+  const target = Array.from(document.querySelectorAll<HTMLButtonElement>(".explorer-item")).find(
+    (nextElement) => nextElement.querySelector(".explorer-item-title")?.textContent === title,
+  );
+  if (!target) throw new Error(`Missing explorer item ${title}`);
+  fireEvent.click(target);
+}
+
+function PlanStateHarness() {
+  const [mounted, setMounted] = useState(true);
+  const [state, setState] = useState<PlanWorkspaceState>({ selectedNodeId: null, expandedNodeIds: null });
+  return (
+    <>
+      <button type="button" onClick={() => setMounted((current) => !current)}>
+        Toggle Plan
+      </button>
+      {mounted ? (
+        <PlanWorkspace
+          loading={false}
+          error={null}
+          summary={planResult.summary}
+          document={planResult.document ?? null}
+          supplements={planResult.supplements ?? null}
+          warnings={planResult.warnings ?? []}
+          state={state}
+          onStateChange={setState}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function TimelineStateHarness() {
+  const [mounted, setMounted] = useState(true);
+  const [state, setState] = useState<TimelineWorkspaceState>({ selectedEventId: null, selectedTab: "event" });
+  return (
+    <>
+      <button type="button" onClick={() => setMounted((current) => !current)}>
+        Toggle Timeline
+      </button>
+      {mounted ? <TimelineWorkspace loading={false} error={null} events={timelineResult.events ?? []} state={state} onStateChange={setState} /> : null}
+    </>
+  );
+}
+
+function ReviewStateHarness() {
+  const [mounted, setMounted] = useState(true);
+  const [state, setState] = useState<ReviewWorkspaceState>({
+    selectedRoundId: null,
+    selectedDetailTab: "summary",
+    selectedArtifactKey: null,
+    showArtifacts: false,
+  });
+  return (
+    <>
+      <button type="button" onClick={() => setMounted((current) => !current)}>
+        Toggle Review
+      </button>
+      {mounted ? (
+        <ReviewWorkspace
+          loading={false}
+          error={null}
+          summary={reviewResult.summary}
+          rounds={reviewResult.rounds ?? []}
+          warnings={reviewResult.warnings ?? []}
+          artifacts={[]}
+          state={state}
+          onStateChange={setState}
+        />
+      ) : null}
+    </>
+  );
 }
 
 describe("workbench page state continuity", () => {
@@ -278,6 +371,57 @@ describe("workbench page state continuity", () => {
     fireEvent.click(screen.getByLabelText("Review"));
 
     await waitFor(() => expect(explorerHasTitle("First review")).toBe(true));
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("First review"));
+    expect(activeInspectorTabText()).toBe("UI");
+    expect(screen.getAllByText("notes").length).toBeGreaterThan(0);
+  });
+
+  test("Plan controls write lifted state that survives page remount", async () => {
+    render(<PlanStateHarness />);
+
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    clickPlanTreeLabel("Scope");
+    await waitFor(() => expect(activePlanTreeText()).toBe("Scope"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Plan" }));
+    await waitFor(() => expect(document.querySelector(".plan-tree")).toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Plan" }));
+
+    await waitFor(() => expect(activePlanTreeText()).toBe("Scope"));
+  });
+
+  test("Timeline controls write lifted state that survives page remount", async () => {
+    render(<TimelineStateHarness />);
+
+    await waitFor(() => expect(explorerHasTitle("old event")).toBe(true));
+    clickExplorerItem("old event");
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("old event"));
+    fireEvent.click(screen.getByRole("tab", { name: "Input" }));
+    await waitFor(() => expect(activeInspectorTabText()).toBe("Input"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Timeline" }));
+    await waitFor(() => expect(document.querySelector(".explorer-list")).toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Timeline" }));
+
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("old event"));
+    expect(activeInspectorTabText()).toBe("Input");
+  });
+
+  test("Review controls write lifted state that survives page remount", async () => {
+    render(<ReviewStateHarness />);
+
+    await waitFor(() => expect(explorerHasTitle("First review")).toBe(true));
+    clickExplorerItem("First review");
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("First review"));
+    fireEvent.click(screen.getByRole("tab", { name: "UI" }));
+    await waitFor(() => expect(activeInspectorTabText()).toBe("UI"));
+    fireEvent.click(screen.getByRole("button", { name: "Artifacts" }));
+    await waitFor(() => expect(screen.getAllByText("notes").length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Review" }));
+    await waitFor(() => expect(document.querySelector(".explorer-list")).toBeNull());
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Review" }));
+
     await waitFor(() => expect(activeExplorerTitleText()).toBe("First review"));
     expect(activeInspectorTabText()).toBe("UI");
     expect(screen.getAllByText("notes").length).toBeGreaterThan(0);

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -137,7 +137,10 @@ const reviewResult: ReviewResult = {
       status: "passed",
       status_summary: "Passed.",
       reviewers: [{ slot: "ui", name: "UI", status: "submitted", summary: "Looks good." }],
-      artifacts: [{ label: "notes", path: ".local/review/notes.md", content_type: "text", content: "notes" }],
+      artifacts: [
+        { label: "notes", path: ".local/review/notes.md", content_type: "text", content: "notes" },
+        { label: "trace", path: ".local/review/trace.md", content_type: "text", content: "trace" },
+      ],
     },
   ],
 };
@@ -417,6 +420,8 @@ describe("workbench page state continuity", () => {
     await waitFor(() => expect(activeInspectorTabText()).toBe("UI"));
     fireEvent.click(screen.getByRole("button", { name: "Artifacts" }));
     await waitFor(() => expect(screen.getAllByText("notes").length).toBeGreaterThan(0));
+    fireEvent.click(screen.getByRole("tab", { name: "trace" }));
+    await waitFor(() => expect(screen.getAllByText("trace").length).toBeGreaterThan(0));
 
     fireEvent.click(screen.getByRole("button", { name: "Toggle Review" }));
     await waitFor(() => expect(document.querySelector(".explorer-list")).toBeNull());
@@ -424,7 +429,7 @@ describe("workbench page state continuity", () => {
 
     await waitFor(() => expect(activeExplorerTitleText()).toBe("First review"));
     expect(activeInspectorTabText()).toBe("UI");
-    expect(screen.getAllByText("notes").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("trace").length).toBeGreaterThan(0);
   });
 
   test("falls back cleanly when remembered Plan ids are no longer present", async () => {

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -47,6 +47,34 @@ const planResult: PlanResult = {
   supplements: null,
 };
 
+const supplementsOnlyPlanResult: PlanResult = {
+  ok: true,
+  resource: "plan",
+  summary: "Plan supplements loaded.",
+  warnings: [],
+  document: null,
+  supplements: {
+    id: "supplements",
+    kind: "directory",
+    label: "supplements",
+    path: "docs/plans/active/supplements",
+    children: [
+      {
+        id: "notes",
+        kind: "file",
+        label: "notes.md",
+        path: "docs/plans/active/supplements/notes.md",
+        preview: {
+          status: "supported",
+          content_type: "text",
+          content: "supplement notes",
+          byte_size: 16,
+        },
+      },
+    ],
+  },
+};
+
 const timelineResult: TimelineResult = {
   ok: true,
   resource: "timeline",
@@ -103,6 +131,8 @@ const reviewResult: ReviewResult = {
   ],
 };
 
+let currentPlanResult: PlanResult = planResult;
+
 function mockApi() {
   vi.stubGlobal(
     "fetch",
@@ -111,7 +141,7 @@ function mockApi() {
       const payloadByPath: Record<string, unknown> = {
         "/api/workspace/wk_alpha": workspaceResult,
         "/api/workspace/wk_alpha/status": statusResult,
-        "/api/workspace/wk_alpha/plan": planResult,
+        "/api/workspace/wk_alpha/plan": currentPlanResult,
         "/api/workspace/wk_alpha/timeline": timelineResult,
         "/api/workspace/wk_alpha/review": reviewResult,
       };
@@ -128,6 +158,10 @@ function activePlanTreeText(): string {
   return document.querySelector(".plan-tree-row.is-active .plan-tree-text")?.textContent ?? "";
 }
 
+function planFetchCount(): number {
+  return vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === "/api/workspace/wk_alpha/plan").length;
+}
+
 function activeInspectorTabText(): string {
   return document.querySelector(".inspector-tab.is-active")?.textContent ?? "";
 }
@@ -142,6 +176,7 @@ function explorerHasTitle(title: string): boolean {
 
 describe("workbench page state continuity", () => {
   beforeEach(() => {
+    currentPlanResult = planResult;
     mockApi();
   });
 
@@ -163,6 +198,7 @@ describe("workbench page state continuity", () => {
     );
 
     await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    const initialPlanFetches = planFetchCount();
     await waitFor(() => expect(activePlanTreeText()).toBe("Scope"));
 
     fireEvent.click(screen.getByLabelText("Timeline"));
@@ -170,8 +206,30 @@ describe("workbench page state continuity", () => {
     fireEvent.click(screen.getByLabelText("Plan"));
 
     await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    await waitFor(() => expect(planFetchCount()).toBeGreaterThan(initialPlanFetches));
     await waitFor(() => expect(activePlanTreeText()).toBe("Scope"));
-    expect(fetch).toHaveBeenCalledWith("/api/workspace/wk_alpha/plan", expect.any(Object));
+  });
+
+  test("keeps supplements-only Plan child selection warm across tab switches", async () => {
+    currentPlanResult = supplementsOnlyPlanResult;
+    window.history.pushState({}, "", "/workspace/wk_alpha/plan");
+    render(
+      <App
+        initialPlanWorkspaceState={{
+          selectedNodeId: "file:docs/plans/active/supplements/notes.md",
+          expandedNodeIds: ["directory:docs/plans/active/supplements"],
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("supplements"));
+    await waitFor(() => expect(activePlanTreeText()).toBe("notes.md"));
+
+    fireEvent.click(screen.getByLabelText("Timeline"));
+    await waitFor(() => expect(explorerHasTitle("new event")).toBe(true));
+    fireEvent.click(screen.getByLabelText("Plan"));
+
+    await waitFor(() => expect(activePlanTreeText()).toBe("notes.md"));
   });
 
   test("keeps Timeline event and detail tab warm across tab switches", async () => {
@@ -225,7 +283,38 @@ describe("workbench page state continuity", () => {
     expect(screen.getAllByText("notes").length).toBeGreaterThan(0);
   });
 
-  test("falls back cleanly when remembered page ids are no longer present", async () => {
+  test("falls back cleanly when remembered Plan ids are no longer present", async () => {
+    window.history.pushState({}, "", "/workspace/wk_alpha/plan");
+    render(
+      <App
+        initialPlanWorkspaceState={{
+          selectedNodeId: "heading:missing",
+          expandedNodeIds: ["document:docs/plans/active/warm.md", "heading:missing"],
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    await waitFor(() => expect(activePlanTreeText()).toBe("Warm Plan"));
+  });
+
+  test("falls back cleanly when remembered Timeline ids are no longer present", async () => {
+    window.history.pushState({}, "", "/workspace/wk_alpha/timeline");
+    render(
+      <App
+        initialTimelineWorkspaceState={{
+          selectedEventId: "missing-event",
+          selectedTab: "missing-tab",
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(explorerHasTitle("new event")).toBe(true));
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("new event"));
+    await waitFor(() => expect(activeInspectorTabText()).toBe("Event"));
+  });
+
+  test("falls back cleanly when remembered Review ids are no longer present", async () => {
     window.history.pushState({}, "", "/workspace/wk_alpha/review");
     render(
       <App

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -139,7 +139,7 @@ const reviewResult: ReviewResult = {
       reviewers: [{ slot: "ui", name: "UI", status: "submitted", summary: "Looks good." }],
       artifacts: [
         { label: "notes", path: ".local/review/notes.md", content_type: "text", content: "notes" },
-        { label: "trace", path: ".local/review/trace.md", content_type: "text", content: "trace" },
+        { label: "trace", path: ".local/review/trace.md", content_type: "text", content: "trace payload" },
       ],
     },
   ],
@@ -186,6 +186,14 @@ function clickPlanTreeLabel(label: string) {
 
 function activeInspectorTabText(): string {
   return document.querySelector(".inspector-tab.is-active")?.textContent ?? "";
+}
+
+function activeArtifactTabText(): string {
+  return Array.from(document.querySelectorAll(".raw-json-overlay .inspector-tab.is-active")).at(-1)?.textContent ?? "";
+}
+
+function activeArtifactBodyText(): string {
+  return document.querySelector(".raw-json-overlay .artifact-panel .inspector-json")?.textContent ?? "";
 }
 
 function activeExplorerTitleText(): string {
@@ -421,7 +429,8 @@ describe("workbench page state continuity", () => {
     fireEvent.click(screen.getByRole("button", { name: "Artifacts" }));
     await waitFor(() => expect(screen.getAllByText("notes").length).toBeGreaterThan(0));
     fireEvent.click(screen.getByRole("tab", { name: "trace" }));
-    await waitFor(() => expect(screen.getAllByText("trace").length).toBeGreaterThan(0));
+    await waitFor(() => expect(activeArtifactTabText()).toBe("trace"));
+    await waitFor(() => expect(activeArtifactBodyText()).toBe("trace payload"));
 
     fireEvent.click(screen.getByRole("button", { name: "Toggle Review" }));
     await waitFor(() => expect(document.querySelector(".explorer-list")).toBeNull());
@@ -429,7 +438,8 @@ describe("workbench page state continuity", () => {
 
     await waitFor(() => expect(activeExplorerTitleText()).toBe("First review"));
     expect(activeInspectorTabText()).toBe("UI");
-    expect(screen.getAllByText("trace").length).toBeGreaterThan(0);
+    expect(activeArtifactTabText()).toBe("trace");
+    expect(activeArtifactBodyText()).toBe("trace payload");
   });
 
   test("falls back cleanly when remembered Plan ids are no longer present", async () => {

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -1,0 +1,262 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { App } from "./main";
+import type { PlanResult, ReviewResult, StatusResult, TimelineResult, WorkspaceRouteResult } from "./types";
+
+const workspaceResult: WorkspaceRouteResult = {
+  ok: true,
+  resource: "workspace",
+  summary: "Workspace is active.",
+  watched: true,
+  workspace: {
+    workspace_key: "wk_alpha",
+    workspace_name: "alpha",
+    workspace_path: "/tmp/alpha",
+    dashboard_state: "active",
+    current_node: "execution/step-1/implement",
+    summary: "Alpha summary",
+  },
+};
+
+const statusResult: StatusResult = {
+  ok: true,
+  command: "status",
+  summary: "Step 1 is active.",
+  state: { current_node: "execution/step-1/implement" },
+  next_actions: [],
+  warnings: [],
+  blockers: [],
+  errors: [],
+};
+
+const planResult: PlanResult = {
+  ok: true,
+  resource: "plan",
+  summary: "Plan loaded.",
+  warnings: [],
+  document: {
+    title: "Warm Plan",
+    path: "docs/plans/active/warm.md",
+    markdown: "# Warm Plan\n\n## Scope\n\nKeep state.\n\n## Validation\n\nTest it.",
+    headings: [
+      { id: "scope", label: "Scope", level: 2, anchor: "scope" },
+      { id: "validation", label: "Validation", level: 2, anchor: "validation" },
+    ],
+  },
+  supplements: null,
+};
+
+const timelineResult: TimelineResult = {
+  ok: true,
+  resource: "timeline",
+  summary: "Timeline loaded.",
+  events: [
+    {
+      event_id: "event-new",
+      sequence: 2,
+      recorded_at: "2026-04-28T10:00:00Z",
+      kind: "execute",
+      command: "new event",
+      summary: "New event",
+      plan_stem: "warm",
+      input: { newer: true },
+    },
+    {
+      event_id: "event-old",
+      sequence: 1,
+      recorded_at: "2026-04-28T09:00:00Z",
+      kind: "plan",
+      command: "old event",
+      summary: "Old event",
+      plan_stem: "warm",
+      input: { older: true },
+    },
+  ],
+};
+
+const reviewResult: ReviewResult = {
+  ok: true,
+  resource: "review",
+  summary: "Review loaded.",
+  warnings: [],
+  artifacts: {},
+  rounds: [
+    {
+      round_id: "review-002-delta",
+      kind: "delta",
+      review_title: "Second review",
+      status: "passed",
+      status_summary: "Passed.",
+      reviewers: [{ slot: "tests", name: "Tests", status: "submitted", summary: "Looks good." }],
+      artifacts: [{ label: "submission", path: ".local/review/submission.json", content_type: "json", content: { ok: true } }],
+    },
+    {
+      round_id: "review-001-full",
+      kind: "full",
+      review_title: "First review",
+      status: "passed",
+      status_summary: "Passed.",
+      reviewers: [{ slot: "ui", name: "UI", status: "submitted", summary: "Looks good." }],
+      artifacts: [{ label: "notes", path: ".local/review/notes.md", content_type: "text", content: "notes" }],
+    },
+  ],
+};
+
+function mockApi() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const path = String(input);
+      const payloadByPath: Record<string, unknown> = {
+        "/api/workspace/wk_alpha": workspaceResult,
+        "/api/workspace/wk_alpha/status": statusResult,
+        "/api/workspace/wk_alpha/plan": planResult,
+        "/api/workspace/wk_alpha/timeline": timelineResult,
+        "/api/workspace/wk_alpha/review": reviewResult,
+      };
+      const payload = payloadByPath[path];
+      if (!payload) {
+        return Promise.reject(new Error(`unexpected path ${path}`));
+      }
+      return Promise.resolve({ ok: true, json: async () => payload } as Response);
+    }),
+  );
+}
+
+function activePlanTreeText(): string {
+  return document.querySelector(".plan-tree-row.is-active .plan-tree-text")?.textContent ?? "";
+}
+
+function activeInspectorTabText(): string {
+  return document.querySelector(".inspector-tab.is-active")?.textContent ?? "";
+}
+
+function activeExplorerTitleText(): string {
+  return document.querySelector(".explorer-item.is-active .explorer-item-title")?.textContent ?? "";
+}
+
+function explorerHasTitle(title: string): boolean {
+  return Array.from(document.querySelectorAll(".explorer-item-title")).some((nextElement) => nextElement.textContent === title);
+}
+
+describe("workbench page state continuity", () => {
+  beforeEach(() => {
+    mockApi();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    window.history.replaceState({}, "", "/");
+  });
+
+  test("keeps Plan selection warm across tab switches while refetching data", async () => {
+    window.history.pushState({}, "", "/workspace/wk_alpha/plan");
+    render(
+      <App
+        initialPlanWorkspaceState={{
+          selectedNodeId: "heading:scope",
+          expandedNodeIds: ["document:docs/plans/active/warm.md"],
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    await waitFor(() => expect(activePlanTreeText()).toBe("Scope"));
+
+    fireEvent.click(screen.getByLabelText("Timeline"));
+    await waitFor(() => expect(explorerHasTitle("new event")).toBe(true));
+    fireEvent.click(screen.getByLabelText("Plan"));
+
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    await waitFor(() => expect(activePlanTreeText()).toBe("Scope"));
+    expect(fetch).toHaveBeenCalledWith("/api/workspace/wk_alpha/plan", expect.any(Object));
+  });
+
+  test("keeps Timeline event and detail tab warm across tab switches", async () => {
+    window.history.pushState({}, "", "/workspace/wk_alpha/timeline");
+    render(
+      <App
+        initialTimelineWorkspaceState={{
+          selectedEventId: "event-old",
+          selectedTab: "input",
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(explorerHasTitle("old event")).toBe(true));
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("old event"));
+    await waitFor(() => expect(activeInspectorTabText()).toBe("Input"));
+
+    fireEvent.click(screen.getByLabelText("Plan"));
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    fireEvent.click(screen.getByLabelText("Timeline"));
+
+    await waitFor(() => expect(explorerHasTitle("old event")).toBe(true));
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("old event"));
+    expect(activeInspectorTabText()).toBe("Input");
+  });
+
+  test("keeps Review round, detail tab, and artifacts panel warm across tab switches", async () => {
+    window.history.pushState({}, "", "/workspace/wk_alpha/review");
+    render(
+      <App
+        initialReviewWorkspaceState={{
+          selectedRoundId: "review-001-full",
+          selectedDetailTab: "ui",
+          selectedArtifactKey: ".local/review/notes.md",
+          showArtifacts: true,
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(explorerHasTitle("First review")).toBe(true));
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("First review"));
+    await waitFor(() => expect(screen.getAllByText("notes").length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByLabelText("Plan"));
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    fireEvent.click(screen.getByLabelText("Review"));
+
+    await waitFor(() => expect(explorerHasTitle("First review")).toBe(true));
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("First review"));
+    expect(activeInspectorTabText()).toBe("UI");
+    expect(screen.getAllByText("notes").length).toBeGreaterThan(0);
+  });
+
+  test("falls back cleanly when remembered page ids are no longer present", async () => {
+    window.history.pushState({}, "", "/workspace/wk_alpha/review");
+    render(
+      <App
+        initialReviewWorkspaceState={{
+          selectedRoundId: "missing-round",
+          selectedDetailTab: "missing-tab",
+          selectedArtifactKey: "missing-artifact",
+          showArtifacts: true,
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(explorerHasTitle("Second review")).toBe(true));
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("Second review"));
+    await waitFor(() => expect(activeInspectorTabText()).toBe("Tests"));
+  });
+
+  test("falls back cleanly when a remembered review artifact id is no longer present", async () => {
+    window.history.pushState({}, "", "/workspace/wk_alpha/review");
+    render(
+      <App
+        initialReviewWorkspaceState={{
+          selectedRoundId: "review-001-full",
+          selectedDetailTab: "ui",
+          selectedArtifactKey: "missing-artifact",
+          showArtifacts: true,
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(activeExplorerTitleText()).toBe("First review"));
+    await waitFor(() => expect(screen.getAllByText("notes").length).toBeGreaterThan(0));
+  });
+});

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -22,9 +22,12 @@ import type {
   DashboardWorkspace,
   Page,
   PlanResult,
+  PlanWorkspaceState,
   ReviewResult,
+  ReviewWorkspaceState,
   StatusResult,
   TimelineResult,
+  TimelineWorkspaceState,
   WorkspaceRouteResult,
 } from "./types";
 import { buildWorkspaceUnwatchRequest } from "./workspace-actions";
@@ -44,6 +47,23 @@ type AppRoute =
       workspaceKey: string;
       page: Page;
     };
+
+const emptyPlanWorkspaceState = (): PlanWorkspaceState => ({
+  selectedNodeId: null,
+  expandedNodeIds: null,
+});
+
+const emptyTimelineWorkspaceState = (): TimelineWorkspaceState => ({
+  selectedEventId: null,
+  selectedTab: "event",
+});
+
+const emptyReviewWorkspaceState = (): ReviewWorkspaceState => ({
+  selectedRoundId: null,
+  selectedDetailTab: "summary",
+  selectedArtifactKey: null,
+  showArtifacts: false,
+});
 
 function isPage(value: string | null): value is Page {
   return value === "status" || value === "plan" || value === "timeline" || value === "review";
@@ -79,10 +99,21 @@ function formatTimelineResourceError(result: TimelineResult | null, statusCode?:
   return formatTimelineError(result?.summary, result?.errors, statusCode);
 }
 
-function App() {
+export function App(props: {
+  initialPlanWorkspaceState?: PlanWorkspaceState;
+  initialTimelineWorkspaceState?: TimelineWorkspaceState;
+  initialReviewWorkspaceState?: ReviewWorkspaceState;
+} = {}) {
   const [route, setRoute] = useState<AppRoute>(() => readRouteFromLocation());
   const [section, setSection] = useState<string>(() => readSectionFromLocation(readRouteFromLocation()));
   const [busyWorkspaceKey, setBusyWorkspaceKey] = useState<string | null>(null);
+  const [stateWorkspaceKey, setStateWorkspaceKey] = useState<string | null>(() => {
+    const initialRoute = readRouteFromLocation();
+    return initialRoute.kind === "workspace" ? initialRoute.workspaceKey : null;
+  });
+  const [planWorkspaceState, setPlanWorkspaceState] = useState<PlanWorkspaceState>(() => props.initialPlanWorkspaceState ?? emptyPlanWorkspaceState());
+  const [timelineWorkspaceState, setTimelineWorkspaceState] = useState<TimelineWorkspaceState>(() => props.initialTimelineWorkspaceState ?? emptyTimelineWorkspaceState());
+  const [reviewWorkspaceState, setReviewWorkspaceState] = useState<ReviewWorkspaceState>(() => props.initialReviewWorkspaceState ?? emptyReviewWorkspaceState());
 
   useEffect(() => {
     const onLocationChange = () => {
@@ -103,6 +134,15 @@ function App() {
       window.history.replaceState({}, "", `${workspacePageHref(route.workspaceKey, route.page)}#${sectionIDsForPage(route.page)[0]}`);
     }
   }, [route]);
+
+  useEffect(() => {
+    const nextWorkspaceKey = route.kind === "workspace" ? route.workspaceKey : null;
+    if (nextWorkspaceKey === stateWorkspaceKey) return;
+    setStateWorkspaceKey(nextWorkspaceKey);
+    setPlanWorkspaceState(emptyPlanWorkspaceState());
+    setTimelineWorkspaceState(emptyTimelineWorkspaceState());
+    setReviewWorkspaceState(emptyReviewWorkspaceState());
+  }, [route, stateWorkspaceKey]);
 
   const navigateToDashboard = () => {
     if (window.location.pathname !== "/dashboard") {
@@ -166,6 +206,9 @@ function App() {
   const { data: plan, error: planError, loading: planLoading, freshness: planFreshness } = planResource;
   const { data: timeline, error: timelineError, loading: timelineLoading, freshness: timelineFreshness } = timelineResource;
   const { data: review, error: reviewError, loading: reviewLoading, freshness: reviewFreshness } = reviewResource;
+  const planPageLoading = planLoading || (route.kind === "workspace" && route.page === "plan" && !plan && !planError);
+  const timelinePageLoading = timelineLoading || (route.kind === "workspace" && route.page === "timeline" && !timeline && !timelineError);
+  const reviewPageLoading = reviewLoading || (route.kind === "workspace" && route.page === "review" && !review && !reviewError);
 
   const activeStatus = useMemo(
     () => ({
@@ -344,23 +387,33 @@ function App() {
           <main class="main-stage">
             {route.page === "plan" ? (
               <PlanWorkspace
-                loading={planLoading}
+                loading={planPageLoading}
                 error={planError}
                 summary={activePlan.summary}
                 document={activePlan.document}
                 supplements={activePlan.supplements}
                 warnings={activePlan.warnings}
+                state={planWorkspaceState}
+                onStateChange={setPlanWorkspaceState}
               />
             ) : route.page === "timeline" ? (
-              <TimelineWorkspace loading={timelineLoading} error={timelineError} events={activeTimeline.events} />
+              <TimelineWorkspace
+                loading={timelinePageLoading}
+                error={timelineError}
+                events={activeTimeline.events}
+                state={timelineWorkspaceState}
+                onStateChange={setTimelineWorkspaceState}
+              />
             ) : route.page === "review" ? (
               <ReviewWorkspace
-                loading={reviewLoading}
+                loading={reviewPageLoading}
                 error={reviewError}
                 summary={activeReview.summary}
                 rounds={activeReview.rounds}
                 warnings={activeReview.warnings}
                 artifacts={activeReview.artifacts}
+                state={reviewWorkspaceState}
+                onStateChange={setReviewWorkspaceState}
               />
             ) : (
               <StatusWorkspace
@@ -406,4 +459,7 @@ function workspacePageHref(workspaceKey: string, page: Page): string {
   return `/workspace/${workspaceKey}/${page}`;
 }
 
-render(<App />, document.getElementById("app") as HTMLElement);
+const appElement = document.getElementById("app");
+if (appElement) {
+  render(<App />, appElement);
+}

--- a/web/src/pages.tsx
+++ b/web/src/pages.tsx
@@ -509,6 +509,7 @@ export function PlanWorkspace(props: {
   useEffect(() => {
     if (loading) return;
     if (!document) {
+      if (state.selectedNodeId && supplements && findSupplementNodeBySelectionId(supplements, state.selectedNodeId)) return;
       setSelectedNodeId(supplements ? planSupplementSelectionId(supplements) : "document");
       return;
     }

--- a/web/src/pages.tsx
+++ b/web/src/pages.tsx
@@ -44,13 +44,16 @@ import type {
   PlanDocument,
   PlanHeading,
   PlanNode,
+  PlanWorkspaceState,
   ReviewAggregateFinding,
   ReviewArtifact,
   ReviewFinding,
   ReviewRound,
   ReviewReviewer,
+  ReviewWorkspaceState,
   ReviewWorklog,
   TimelineEvent,
+  TimelineWorkspaceState,
   WorkspaceRouteResult,
 } from "./types";
 import {
@@ -454,6 +457,11 @@ export function StatusWorkspace(props: {
 }
 
 type FlattenedPlanHeading = PlanHeading & { nodeId: string };
+type StatePatch<T> = Partial<T> | ((current: T) => Partial<T>);
+
+function applyStatePatch<T>(current: T, patch: StatePatch<T>): T {
+  return { ...current, ...(typeof patch === "function" ? patch(current) : patch) };
+}
 
 export function PlanWorkspace(props: {
   loading: boolean;
@@ -462,33 +470,54 @@ export function PlanWorkspace(props: {
   document: PlanDocument | null;
   supplements: PlanNode | null;
   warnings: string[];
+  state: PlanWorkspaceState;
+  onStateChange: (updater: (current: PlanWorkspaceState) => PlanWorkspaceState) => void;
 }) {
-  const { loading, error, summary, document, supplements, warnings } = props;
+  const { loading, error, summary, document, supplements, warnings, state, onStateChange } = props;
   const documentRootId = document ? `document:${document.path}` : "document";
-  const [selectedNodeId, setSelectedNodeId] = useState<string>(documentRootId);
-  const [expandedNodeIds, setExpandedNodeIds] = useState<Set<string>>(new Set());
   const readerRef = useRef<HTMLDivElement | null>(null);
 
   const flattenedHeadings = useMemo(() => flattenPlanHeadings(document?.headings ?? []), [document?.headings]);
   const documentHTML = useMemo(() => (document ? markdownRenderer.render(document.markdown) : ""), [document]);
+  const defaultExpandedNodeIds = useMemo(() => buildDefaultPlanExpanded(documentRootId, document?.headings ?? [], supplements), [documentRootId, document?.headings, supplements]);
+  const defaultSelectedNodeId = document ? documentRootId : supplements ? planSupplementSelectionId(supplements) : "document";
+  const selectedNodeId = state.selectedNodeId ?? defaultSelectedNodeId;
+  const expandedNodeIds = useMemo(() => new Set(state.expandedNodeIds ?? Array.from(defaultExpandedNodeIds)), [defaultExpandedNodeIds, state.expandedNodeIds]);
+  const setPlanState = (patch: StatePatch<PlanWorkspaceState>) => onStateChange((current) => applyStatePatch(current, patch));
+  const setSelectedNodeId = (nextSelectedNodeId: string) => setPlanState({ selectedNodeId: nextSelectedNodeId });
+  const setExpandedNodeIds = (nextExpandedNodeIds: Set<string> | ((current: Set<string>) => Set<string>)) => {
+    setPlanState((current) => {
+      const currentSet = new Set(current.expandedNodeIds ?? Array.from(defaultExpandedNodeIds));
+      const nextSet = typeof nextExpandedNodeIds === "function" ? nextExpandedNodeIds(currentSet) : nextExpandedNodeIds;
+      return { expandedNodeIds: Array.from(nextSet) };
+    });
+  };
 
   useEffect(() => {
-    setExpandedNodeIds(buildDefaultPlanExpanded(documentRootId, document?.headings ?? [], supplements));
-  }, [documentRootId, document?.headings, supplements]);
+    if (loading || (!document && !supplements)) return;
+
+    const validExpandableNodeIds = collectPlanExpandableNodeIds(documentRootId, document?.headings ?? [], supplements);
+    setPlanState((current) => {
+      if (current.expandedNodeIds === null) {
+        return { expandedNodeIds: Array.from(defaultExpandedNodeIds) };
+      }
+      const nextExpandedNodeIds = current.expandedNodeIds.filter((nodeId) => validExpandableNodeIds.has(nodeId));
+      return nextExpandedNodeIds.length === current.expandedNodeIds.length ? {} : { expandedNodeIds: nextExpandedNodeIds };
+    });
+  }, [defaultExpandedNodeIds, document, documentRootId, loading, supplements]);
 
   useEffect(() => {
+    if (loading) return;
     if (!document) {
       setSelectedNodeId(supplements ? planSupplementSelectionId(supplements) : "document");
       return;
     }
 
-    setSelectedNodeId((current) => {
-      if (current === documentRootId) return current;
-      if (flattenedHeadings.some((heading) => heading.nodeId === current)) return current;
-      if (supplements && findSupplementNodeBySelectionId(supplements, current)) return current;
-      return documentRootId;
-    });
-  }, [document, documentRootId, flattenedHeadings, supplements]);
+    if (state.selectedNodeId === documentRootId) return;
+    if (state.selectedNodeId && flattenedHeadings.some((heading) => heading.nodeId === state.selectedNodeId)) return;
+    if (state.selectedNodeId && supplements && findSupplementNodeBySelectionId(supplements, state.selectedNodeId)) return;
+    setSelectedNodeId(documentRootId);
+  }, [document, documentRootId, flattenedHeadings, loading, state.selectedNodeId, supplements]);
 
   const selectedHeading = flattenedHeadings.find((heading) => heading.nodeId === selectedNodeId) ?? null;
   const selectedSupplementNode = supplements ? findSupplementNodeBySelectionId(supplements, selectedNodeId) : null;
@@ -799,6 +828,32 @@ function buildDefaultPlanExpanded(documentRootId: string, headings: PlanHeading[
   return expanded;
 }
 
+function collectPlanExpandableNodeIds(documentRootId: string, headings: PlanHeading[], supplements: PlanNode | null): Set<string> {
+  const nodeIds = new Set<string>();
+  if (headings.length > 0) {
+    nodeIds.add(documentRootId);
+  }
+  const visitHeadings = (items: PlanHeading[]) => {
+    items.forEach((item) => {
+      if (Array.isArray(item.children) && item.children.length > 0) {
+        nodeIds.add(planHeadingSelectionId(item));
+        visitHeadings(item.children);
+      }
+    });
+  };
+  const visitSupplements = (node: PlanNode) => {
+    if (Array.isArray(node.children) && node.children.length > 0) {
+      nodeIds.add(planSupplementSelectionId(node));
+      node.children.forEach(visitSupplements);
+    }
+  };
+  visitHeadings(headings);
+  if (supplements) {
+    visitSupplements(supplements);
+  }
+  return nodeIds;
+}
+
 function planHeadingSelectionId(heading: PlanHeading): string {
   return `heading:${heading.id}`;
 }
@@ -926,47 +981,49 @@ export function TimelineWorkspace(props: {
   loading: boolean;
   error: string | null;
   events: TimelineEvent[];
+  state: TimelineWorkspaceState;
+  onStateChange: (updater: (current: TimelineWorkspaceState) => TimelineWorkspaceState) => void;
 }) {
-  const { loading, error, events } = props;
+  const { loading, error, events, state, onStateChange } = props;
   const sortedEvents = useMemo(() => sortTimelineEvents(events), [events]);
-  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
+  const setTimelineState = (patch: StatePatch<TimelineWorkspaceState>) => onStateChange((current) => applyStatePatch(current, patch));
+  const setSelectedEventId = (selectedEventId: string | null) => setTimelineState({ selectedEventId });
+  const setSelectedTab = (selectedTab: string) => setTimelineState({ selectedTab });
   const selectedEvent = useMemo(() => {
     if (sortedEvents.length === 0) return null;
-    if (selectedEventId) {
-      const found = sortedEvents.find((event) => event.event_id === selectedEventId);
+    if (state.selectedEventId) {
+      const found = sortedEvents.find((event) => event.event_id === state.selectedEventId);
       if (found) return found;
     }
     return pickDefaultTimelineEvent(sortedEvents);
-  }, [selectedEventId, sortedEvents]);
-  const [selectedTab, setSelectedTab] = useState<string>("event");
+  }, [state.selectedEventId, sortedEvents]);
   const timelineTabs = useMemo(() => buildTimelineTabs(selectedEvent), [selectedEvent]);
 
   useEffect(() => {
+    if (loading) return;
     if (sortedEvents.length === 0) {
       setSelectedEventId(null);
       return;
     }
-    setSelectedEventId((current) => {
-      if (current && sortedEvents.some((event) => event.event_id === current)) {
-        return current;
-      }
-      return pickDefaultTimelineEvent(sortedEvents)?.event_id ?? null;
-    });
-  }, [sortedEvents]);
+    if (state.selectedEventId && sortedEvents.some((event) => event.event_id === state.selectedEventId)) return;
+    setSelectedEventId(pickDefaultTimelineEvent(sortedEvents)?.event_id ?? null);
+  }, [loading, sortedEvents, state.selectedEventId]);
 
   useEffect(() => {
+    if (loading) return;
     if (timelineTabs.length === 0) {
       setSelectedTab("event");
       return;
     }
-    setSelectedTab((current) => (timelineTabs.some((tab) => tab.id === current) ? current : timelineTabs[0].id));
-  }, [timelineTabs]);
+    if (timelineTabs.some((tab) => tab.id === state.selectedTab)) return;
+    setSelectedTab(timelineTabs[0].id);
+  }, [loading, state.selectedTab, timelineTabs]);
 
   const transitionLabel =
     selectedEvent && (selectedEvent.from_node || selectedEvent.to_node)
       ? `${selectedEvent.from_node || "unknown"} → ${selectedEvent.to_node || "unknown"}`
       : null;
-  const selectedTimelineTab = timelineTabs.find((tab) => tab.id === selectedTab) ?? timelineTabs[0];
+  const selectedTimelineTab = timelineTabs.find((tab) => tab.id === state.selectedTab) ?? timelineTabs[0];
 
   return (
     <WorkbenchFrame
@@ -1019,7 +1076,7 @@ export function TimelineWorkspace(props: {
             {transitionLabel ? <div class="inspector-transition">{transitionLabel}</div> : null}
             <InspectorTabs ariaLabel="Timeline event payloads">
               {timelineTabs.map((tab) => (
-                <InspectorTab key={tab.id} selected={selectedTab === tab.id} onSelect={() => setSelectedTab(tab.id)}>
+                <InspectorTab key={tab.id} selected={state.selectedTab === tab.id} onSelect={() => setSelectedTab(tab.id)}>
                   {tab.label}
                 </InspectorTab>
               ))}
@@ -1043,64 +1100,63 @@ export function ReviewWorkspace(props: {
   rounds: ReviewRound[];
   warnings: string[];
   artifacts: Array<[string, unknown]>;
+  state: ReviewWorkspaceState;
+  onStateChange: (updater: (current: ReviewWorkspaceState) => ReviewWorkspaceState) => void;
 }) {
-  const { loading, error, summary, rounds, warnings, artifacts } = props;
-  const [selectedRoundId, setSelectedRoundId] = useState<string | null>(null);
-  const [selectedDetailTab, setSelectedDetailTab] = useState<string>("summary");
-  const [selectedArtifactKey, setSelectedArtifactKey] = useState<string | null>(null);
-  const [showArtifacts, setShowArtifacts] = useState(false);
+  const { loading, error, summary, rounds, warnings, artifacts, state, onStateChange } = props;
+  const setReviewState = (patch: StatePatch<ReviewWorkspaceState>) => onStateChange((current) => applyStatePatch(current, patch));
+  const setSelectedRoundId = (selectedRoundId: string | null) =>
+    setReviewState({ selectedRoundId, selectedDetailTab: "summary", showArtifacts: false });
+  const setSelectedDetailTab = (selectedDetailTab: string) => setReviewState({ selectedDetailTab });
+  const setSelectedArtifactKey = (selectedArtifactKey: string | null) => setReviewState({ selectedArtifactKey });
+  const setShowArtifacts = (showArtifacts: boolean) => setReviewState({ showArtifacts });
 
   const selectedRound = useMemo(() => {
     if (rounds.length === 0) return null;
-    if (selectedRoundId) {
-      const found = rounds.find((round) => round.round_id === selectedRoundId);
+    if (state.selectedRoundId) {
+      const found = rounds.find((round) => round.round_id === state.selectedRoundId);
       if (found) return found;
     }
     return rounds[0];
-  }, [rounds, selectedRoundId]);
+  }, [rounds, state.selectedRoundId]);
 
   const reviewers = Array.isArray(selectedRound?.reviewers) ? selectedRound.reviewers ?? [] : [];
   const supportArtifacts = Array.isArray(selectedRound?.artifacts) ? selectedRound.artifacts ?? [] : [];
   const selectedReviewer = useMemo(() => {
-    if (reviewers.length === 0 || selectedDetailTab === "summary") return null;
-    return reviewers.find((reviewer) => reviewer.slot === selectedDetailTab) ?? null;
-  }, [reviewers, selectedDetailTab]);
+    if (reviewers.length === 0 || state.selectedDetailTab === "summary") return null;
+    return reviewers.find((reviewer) => reviewer.slot === state.selectedDetailTab) ?? null;
+  }, [reviewers, state.selectedDetailTab]);
 
   const blockingFindings = Array.isArray(selectedRound?.blocking_findings) ? selectedRound.blocking_findings ?? [] : [];
   const nonBlockingFindings = Array.isArray(selectedRound?.non_blocking_findings) ? selectedRound.non_blocking_findings ?? [] : [];
   const selectedRoundWarnings = Array.isArray(selectedRound?.warnings) ? selectedRound.warnings ?? [] : [];
 
   useEffect(() => {
+    if (loading) return;
     if (rounds.length === 0) {
       setSelectedRoundId(null);
       return;
     }
-    setSelectedRoundId((current) => (current && rounds.some((round) => round.round_id === current) ? current : rounds[0]?.round_id ?? null));
-  }, [rounds]);
+    if (state.selectedRoundId && rounds.some((round) => round.round_id === state.selectedRoundId)) return;
+    setSelectedRoundId(rounds[0]?.round_id ?? null);
+  }, [loading, rounds, state.selectedRoundId]);
 
   useEffect(() => {
-    setSelectedDetailTab("summary");
-    setShowArtifacts(false);
-  }, [selectedRound?.round_id]);
+    if (loading) return;
+    if (state.selectedDetailTab === "summary") return;
+    if (reviewers.some((reviewer) => reviewer.slot === state.selectedDetailTab)) return;
+    setSelectedDetailTab(reviewers[0]?.slot ?? "summary");
+  }, [loading, reviewers, state.selectedDetailTab]);
 
   useEffect(() => {
-    setSelectedDetailTab((current) => {
-      if (current === "summary") return "summary";
-      return reviewers.some((reviewer) => reviewer.slot === current) ? current : reviewers[0]?.slot ?? "summary";
-    });
-  }, [reviewers]);
-
-  useEffect(() => {
+    if (loading) return;
     if (supportArtifacts.length === 0) {
       setSelectedArtifactKey(null);
       return;
     }
-    setSelectedArtifactKey((current) =>
-      current && supportArtifacts.some((artifact, index) => reviewArtifactKey(artifact, index) === current)
-        ? current
-        : reviewArtifactKey(supportArtifacts[0], 0),
-    );
-  }, [supportArtifacts]);
+    if (state.selectedArtifactKey && supportArtifacts.some((artifact, index) => reviewArtifactKey(artifact, index) === state.selectedArtifactKey)) return;
+    setSelectedArtifactKey(reviewArtifactKey(supportArtifacts[0], 0));
+  }, [loading, state.selectedArtifactKey, supportArtifacts]);
 
   return (
     <WorkbenchFrame
@@ -1167,17 +1223,17 @@ export function ReviewWorkspace(props: {
           />
 
           <InspectorTabs ariaLabel="Review content tabs">
-            <InspectorTab selected={selectedDetailTab === "summary"} onSelect={() => setSelectedDetailTab("summary")}>
+            <InspectorTab selected={state.selectedDetailTab === "summary"} onSelect={() => setSelectedDetailTab("summary")}>
               Summary
             </InspectorTab>
             {reviewers.map((reviewer) => (
-              <InspectorTab key={reviewer.slot} selected={selectedDetailTab === reviewer.slot} onSelect={() => setSelectedDetailTab(reviewer.slot)}>
+              <InspectorTab key={reviewer.slot} selected={state.selectedDetailTab === reviewer.slot} onSelect={() => setSelectedDetailTab(reviewer.slot)}>
                 {reviewReviewerLabel(reviewer)}
               </InspectorTab>
             ))}
           </InspectorTabs>
 
-          {selectedDetailTab === "summary" ? (
+          {state.selectedDetailTab === "summary" ? (
             <div class="review-tab-panel">
               <section class="content-section">
                 <div class="section-head">
@@ -1277,12 +1333,12 @@ export function ReviewWorkspace(props: {
         <EmptyState>{summary || "No review rounds recorded yet for the current plan."}</EmptyState>
       )}
 
-      {selectedRound && showArtifacts ? (
+      {selectedRound && state.showArtifacts ? (
         <RoundArtifactsOverlay
           title={`${reviewRoundTitle(selectedRound)} artifacts`}
           artifacts={supportArtifacts}
           metadata={artifacts}
-          selectedArtifactKey={selectedArtifactKey}
+          selectedArtifactKey={state.selectedArtifactKey}
           onSelectArtifact={setSelectedArtifactKey}
           onClose={() => setShowArtifacts(false)}
         />

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -103,6 +103,11 @@ export type PlanResult = {
   errors?: ErrorDetail[] | null;
 };
 
+export type PlanWorkspaceState = {
+  selectedNodeId: string | null;
+  expandedNodeIds: string[] | null;
+};
+
 export type TimelineDetail = {
   key: string;
   value: string;
@@ -150,6 +155,11 @@ export type TimelineResult = {
   } | null;
   events?: TimelineEvent[] | null;
   errors?: ErrorDetail[] | null;
+};
+
+export type TimelineWorkspaceState = {
+  selectedEventId: string | null;
+  selectedTab: string;
 };
 
 export type ReviewArtifact = {
@@ -231,6 +241,13 @@ export type ReviewResult = {
   rounds?: ReviewRound[] | null;
   warnings?: string[] | null;
   errors?: ErrorDetail[] | null;
+};
+
+export type ReviewWorkspaceState = {
+  selectedRoundId: string | null;
+  selectedDetailTab: string;
+  selectedArtifactKey: string | null;
+  showArtifacts: boolean;
 };
 
 export type DashboardProgressNode = {


### PR DESCRIPTION
## Summary

- Keep Plan, Timeline, and Review page-local UI state warm across workbench tab switches/remounts.
- Preserve selection, expanded branches, detail tabs, and review artifact panel choices while live resources continue to refetch.
- Add focused coverage for continuity, fallback behavior, user-driven state writes, and Plan refetch behavior.

Closes #172

## Validation

- pnpm --dir web test
- pnpm --dir web check
- pnpm --dir web build
- harness plan lint docs/plans/archived/2026-04-28-keep-workbench-page-state-warm.md
