### PR TITLE
Keep workbench page payloads warm

### DIFF
--- a/docs/plans/active/2026-04-30-keep-workbench-page-payloads-warm.md
+++ b/docs/plans/active/2026-04-30-keep-workbench-page-payloads-warm.md
@@ -1,0 +1,229 @@
+---
+template_version: 0.2.0
+created_at: "2026-04-30T00:18:22+08:00"
+approved_at: "2026-04-30T00:20:14+08:00"
+source_type: issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/205
+size: XS
+---
+
+# Keep Workbench Page Payloads Warm
+
+## Goal
+
+Keep the last successful Plan, Timeline, and Review workbench payloads visible
+across tab switches so returning to an inactive page does not briefly show an
+empty or first-load state before the next refresh completes.
+
+The intended design is a small stale-while-revalidate extension to the existing
+front-end live resource hook: distinguish a resource that is invalid and should
+be cleared from a resource that is still valid but paused because its page is
+inactive.
+
+## Scope
+
+### In Scope
+
+- Add an explicit live-resource lifecycle shape that separates resource identity
+  from refresh activity.
+- Keep inactive Plan, Timeline, and Review resource data in memory while their
+  workspace remains the same and readable.
+- Refresh a retained page payload in the background when the user returns to
+  that page.
+- Preserve stale/error freshness semantics when a background refresh fails.
+- Reset retained page payloads when the resource identity changes, including
+  workspace changes.
+- Add focused hook and workbench integration tests for the no-empty-flicker
+  behavior.
+
+### Out of Scope
+
+- Introducing TanStack Query or another general query/cache library.
+- Adding cross-resource cache maps or persistence across reloads, browser tabs,
+  or sessions.
+- Keeping inactive tabs mounted in the DOM.
+- Polling inactive Plan, Timeline, or Review pages.
+- Redesigning the full workbench live-refresh policy or freshness UI.
+- Changing backend API contracts.
+
+## Acceptance Criteria
+
+- [x] Plan, Timeline, and Review keep their last successful payload visible
+      while switching away and back within the same workspace.
+- [x] Returning to a retained page triggers an immediate background refresh
+      without clearing the existing payload.
+- [x] If the background refresh fails after a successful payload exists, the old
+      payload remains visible and the resource reports a stale/error state.
+- [x] First-load failure without any retained payload still renders the existing
+      disconnected/empty behavior.
+- [x] Changing workspace or resource identity clears retained Plan, Timeline,
+      and Review payloads so data cannot bleed between workspaces.
+- [x] Inactive Plan, Timeline, and Review resources do not keep polling.
+- [x] Tests cover the hook lifecycle and the App-level tab-switch behavior.
+
+## Deferred Items
+
+- Broader workbench live-refresh transport changes such as websocket or SSE
+  updates.
+- Persistence of workbench page payloads across browser reloads or new tabs.
+
+## Work Breakdown
+
+### Step 1: Split Live Resource Identity From Refresh Activity
+
+- Done: [x]
+
+#### Objective
+
+Update `useLiveResource` so a resource can be valid but paused, while preserving
+the existing clear-on-invalid behavior for identity changes.
+
+#### Details
+
+Prefer a compact API such as:
+
+```ts
+useLiveResource({
+  resource: workspaceReadable
+    ? { key: `workspace:${workspaceKey}:plan`, path: `/api/workspace/${workspaceKey}/plan` }
+    : null,
+  mode: "live" | "paused",
+  formatError,
+})
+```
+
+`resource: null` means the resource is invalid and should clear data. A changed
+`resource.key` also clears data. `mode: "paused"` means stop polling and focus
+refresh listeners but keep the last successful payload and current freshness.
+`mode: "live"` means fetch now and install the usual polling/focus refresh
+behavior. When returning to live mode with retained data, keep rendering that
+data while the refresh is in flight.
+
+Keep the hook implementation small. A full query abstraction or broad reducer
+rewrite is unnecessary unless the current effect becomes harder to reason about
+after the lifecycle split.
+
+#### Expected Files
+
+- `web/src/live-resource.ts`
+- `web/src/types.ts` if a shared resource type is useful
+
+#### Validation
+
+- Add or update `web/src/live-resource.test.tsx` tests for paused retention,
+  paused no-polling, live resume refresh, stale-on-resume-failure, first-load
+  failure, and key-change clearing.
+
+#### Execution Notes
+
+Implemented `useLiveResource` around explicit `resource` identity plus
+`live`/`paused` refresh mode. `resource: null` and changed resource keys clear
+data, paused mode tears down refresh activity while preserving successful data,
+and live resume refreshes retained data in the background. Added hook tests for
+paused retention, no polling while paused, live resume refresh, stale-on-resume
+failure, first-load disconnected behavior, and invalid-resource clearing.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 and Step 2 were implemented and validated as one
+cohesive XS UI resource lifecycle slice; the complete candidate will receive
+full finalize review.
+
+### Step 2: Apply Paused Resources To Workbench Pages
+
+- Done: [x]
+
+#### Objective
+
+Use the new lifecycle shape for Plan, Timeline, and Review so inactive pages
+pause refresh without losing payloads.
+
+#### Details
+
+Status should keep its current live behavior while a workspace is readable
+because the topbar depends on it across workbench pages. Plan, Timeline, and
+Review should use the workspace/page identity as the resource key and switch
+between `live` and `paused` based on the active workbench page.
+
+Do not add App-level shadow caches for these payloads unless the hook approach
+cannot stay simple. The resource hook should own payload retention so future
+pages can opt into the same lifecycle without duplicating state.
+
+#### Expected Files
+
+- `web/src/main.tsx`
+
+#### Validation
+
+- Add or update `web/src/main.test.tsx` tests proving Plan, Timeline, and
+  Review render retained payloads immediately after tab switches and still
+  refresh in the background.
+- Include a workspace/resource identity reset assertion at either hook or App
+  level.
+
+#### Execution Notes
+
+Migrated App resource calls to the new identity/mode API. Dashboard, workspace
+route, and status resources remain live while valid. Plan, Timeline, and Review
+resources keep workspace-scoped identities and switch between live and paused
+based on the active workbench page. Added App integration tests that hold the
+return refresh pending and verify retained Plan, Timeline, and Review payloads
+render immediately with Updating freshness.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: The App migration depends directly on the Step 1 hook
+API and was validated in the same focused test/build loop; the complete
+candidate will receive full finalize review.
+
+## Validation Strategy
+
+- Run the targeted front-end tests:
+  `pnpm --dir web test -- live-resource.test.tsx main.test.tsx`.
+- Run the full front-end test suite when the targeted behavior is stable:
+  `pnpm --dir web test`.
+- Run the front-end type/build check:
+  `pnpm --dir web build`.
+- Run `harness status` before step closeout and before archive/finalize
+  decisions.
+
+## Risks
+
+- Risk: Retained data could briefly show under the wrong workspace if the reset
+  boundary is too loose.
+  - Mitigation: Treat `resource.key` changes and `resource: null` as hard reset
+    events, and cover this with tests.
+- Risk: The hook API could become too abstract for a small UI.
+  - Mitigation: Keep the API limited to resource identity plus live/paused
+    refresh mode, and avoid cache maps, persistence, or dependency-heavy query
+    abstractions.
+- Risk: Paused resources could accidentally keep polling.
+  - Mitigation: Ensure timers and focus/visibility listeners are installed only
+    in live mode, and test that paused mode does not fetch on interval.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-04-30-keep-workbench-page-payloads-warm.md
+++ b/docs/plans/active/2026-04-30-keep-workbench-page-payloads-warm.md
@@ -204,17 +204,20 @@ candidate will receive full finalize review.
 
 ## Validation Summary
 
-- `pnpm --dir web test -- live-resource.test.tsx main.test.tsx` passed with
-  25 tests.
-- `pnpm --dir web test` passed with 25 tests across 4 files.
-- `pnpm --dir web build` passed, including TypeScript and Vite production
-  build.
-- Finalize reviewers independently reran the same targeted, full, and build
-  validation commands.
+- Revision 2 finalize-fix validation:
+  `pnpm --dir web test -- live-resource.test.tsx main.test.tsx` passed with
+  26 tests.
+- Revision 2 finalize-fix validation: `pnpm --dir web test` passed with 26
+  tests across 4 files.
+- Revision 2 finalize-fix validation: `pnpm --dir web build` passed, including
+  TypeScript and Vite production build.
+- Revision 1 validation also passed the targeted front-end tests, full
+  front-end tests, and build before the initial archive.
 
 ## Review Summary
 
-- `review-001-full` passed with 0 blocking findings and 0 non-blocking
+- Revision 2 finalize-fix review is pending.
+- Revision 1 `review-001-full` passed with 0 blocking findings and 0 non-blocking
   findings.
 - Correctness review found no lifecycle, stale-data leak, transition, or
   freshness/error regressions.
@@ -222,6 +225,8 @@ candidate will receive full finalize review.
   inactive payload retention behavior.
 
 ## Archive Summary
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Archived At: 2026-04-30T00:30:39+08:00
 - Revision: 1
@@ -240,6 +245,10 @@ candidate will receive full finalize review.
   activity with `resource` plus `live`/`paused` mode.
 - Plan, Timeline, and Review workbench payloads stay warm across tab switches
   within the same readable workspace and refresh in the background on return.
+- Fast return refreshes with retained payloads now keep the freshness pill on
+  `Live` through the existing update buffer instead of flashing `Updating`.
+- The topbar freshness pill now reserves stable width so `Live`/`Updating`
+  label changes do not shift the workspace path or summary metrics.
 - Stale/error behavior keeps retained data visible after failed resumed
   refreshes, while first-load failures still use disconnected empty behavior.
 - Resource invalidation and key changes clear retained data to prevent

--- a/docs/plans/archived/2026-04-30-keep-workbench-page-payloads-warm.md
+++ b/docs/plans/archived/2026-04-30-keep-workbench-page-payloads-warm.md
@@ -204,26 +204,59 @@ candidate will receive full finalize review.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `pnpm --dir web test -- live-resource.test.tsx main.test.tsx` passed with
+  25 tests.
+- `pnpm --dir web test` passed with 25 tests across 4 files.
+- `pnpm --dir web build` passed, including TypeScript and Vite production
+  build.
+- Finalize reviewers independently reran the same targeted, full, and build
+  validation commands.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- `review-001-full` passed with 0 blocking findings and 0 non-blocking
+  findings.
+- Correctness review found no lifecycle, stale-data leak, transition, or
+  freshness/error regressions.
+- Tests review found the hook and App coverage focused and sufficient for the
+  inactive payload retention behavior.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-04-30T00:30:39+08:00
+- Revision: 1
+- PR: NONE. The candidate has not been pushed or opened as a PR yet.
+- Ready: Acceptance criteria are satisfied locally, both tracked steps are done,
+  validation is green, and `review-001-full` passed cleanly.
+- Merge Handoff: Archive the plan, commit the tracked archive move, push branch
+  `codex/keep-workbench-page-payloads-warm`, open a PR for issue #205, then
+  record publish, CI, and sync evidence before waiting for human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- `useLiveResource` now models resource identity separately from refresh
+  activity with `resource` plus `live`/`paused` mode.
+- Plan, Timeline, and Review workbench payloads stay warm across tab switches
+  within the same readable workspace and refresh in the background on return.
+- Stale/error behavior keeps retained data visible after failed resumed
+  refreshes, while first-load failures still use disconnected empty behavior.
+- Resource invalidation and key changes clear retained data to prevent
+  cross-workspace payload bleed.
+- Tests now cover hook lifecycle edges and App-level pending-refresh tab
+  switches for Plan, Timeline, and Review.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No websocket/SSE or broader live-refresh policy redesign was added.
+- No payload persistence across reloads, browser tabs, or sessions was added.
+- No backend API contract changed.
 
 ### Follow-Up Issues
 
-NONE
+- #179 tracks broader workbench live-refresh policy tuning and any future
+  transport or stale-state UX expansion.
+- #206 tracks persistence of workbench page position across reloads and new
+  tabs; payload persistence remains out of scope for this slice unless that
+  future issue expands to include it.

--- a/docs/plans/archived/2026-04-30-keep-workbench-page-payloads-warm.md
+++ b/docs/plans/archived/2026-04-30-keep-workbench-page-payloads-warm.md
@@ -216,7 +216,11 @@ candidate will receive full finalize review.
 
 ## Review Summary
 
-- Revision 2 finalize-fix review is pending.
+- Revision 2 `review-002-delta` passed with 0 blocking findings and 0
+  non-blocking findings.
+- Revision 2 correctness review found the return-refresh buffer, preserved
+  stale/disconnected behavior, updated App expectations, and stable freshness
+  pill width to be low-risk.
 - Revision 1 `review-001-full` passed with 0 blocking findings and 0 non-blocking
   findings.
 - Correctness review found no lifecycle, stale-data leak, transition, or
@@ -226,16 +230,15 @@ candidate will receive full finalize review.
 
 ## Archive Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
-- Archived At: 2026-04-30T00:30:39+08:00
-- Revision: 1
-- PR: NONE. The candidate has not been pushed or opened as a PR yet.
-- Ready: Acceptance criteria are satisfied locally, both tracked steps are done,
-  validation is green, and `review-001-full` passed cleanly.
-- Merge Handoff: Archive the plan, commit the tracked archive move, push branch
-  `codex/keep-workbench-page-payloads-warm`, open a PR for issue #205, then
-  record publish, CI, and sync evidence before waiting for human merge approval.
+- Archived At: 2026-04-30T23:04:10+08:00
+- Revision: 2
+- PR: https://github.com/catu-ai/easyharness/pull/207
+- Ready: Acceptance criteria are satisfied locally, revision 2 validation is
+  green, `review-001-full` passed for the original candidate, and
+  `review-002-delta` passed for the finalize-fix repair.
+- Merge Handoff: Archive revision 2, commit and push the archive move plus
+  finalize-fix commit to PR #207, then record fresh publish, CI, and sync
+  evidence before waiting for human merge approval.
 
 ## Outcome Summary
 

--- a/web/src/live-resource.test.tsx
+++ b/web/src/live-resource.test.tsx
@@ -115,6 +115,39 @@ describe("useLiveResource", () => {
     await waitFor(() => expect(screen.getByTestId("value").textContent).toBe("alpha refreshed"));
   });
 
+  test("buffers updating freshness when paused data returns to live mode", async () => {
+    vi.useFakeTimers();
+    const refresh = { resolve: null as ((response: Response) => void) | null };
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, value: "alpha" }) } as Response)
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            refresh.resolve = resolve;
+          }),
+      );
+
+    const rendered = render(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} />);
+    await waitFor(() => expect(screen.getByTestId("freshness").textContent).toBe("live"));
+
+    rendered.rerender(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} mode="paused" />);
+    rendered.rerender(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} />);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("freshness").textContent).toBe("live");
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(screen.getByTestId("freshness").textContent).toBe("live");
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(screen.getByTestId("freshness").textContent).toBe("updating");
+
+    if (!refresh.resolve) throw new Error("Expected pending refresh");
+    refresh.resolve({ ok: true, json: async () => ({ ok: true, value: "alpha refreshed" }) } as Response);
+    await waitFor(() => expect(screen.getByTestId("freshness").textContent).toBe("live"));
+  });
+
   test("keeps retained data and reports stale when a resumed refresh fails", async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock

--- a/web/src/live-resource.test.tsx
+++ b/web/src/live-resource.test.tsx
@@ -1,14 +1,18 @@
-import { render, screen, waitFor } from "@testing-library/preact";
+import { cleanup, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { useLiveResource } from "./live-resource";
 
-function ResourceProbe(props: { path: string }) {
+function ResourceProbe(props: {
+  resource: { key: string; path: string } | null;
+  mode?: "live" | "paused";
+  intervalMs?: number;
+}) {
   const resource = useLiveResource<{ ok?: boolean; value?: string }>({
-    enabled: true,
-    path: props.path,
+    resource: props.resource,
+    mode: props.mode ?? "live",
     formatError: (result, statusCode) => result?.value || (statusCode ? `failed:${statusCode}` : "failed"),
-    intervalMs: 60_000,
+    intervalMs: props.intervalMs ?? 60_000,
   });
 
   return (
@@ -27,6 +31,8 @@ describe("useLiveResource", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
     vi.unstubAllGlobals();
   });
 
@@ -50,10 +56,10 @@ describe("useLiveResource", () => {
       return Promise.reject(new Error(`unexpected path ${path}`));
     });
 
-    const rendered = render(<ResourceProbe path="/api/workspace/alpha" />);
+    const rendered = render(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} />);
     await waitFor(() => expect(screen.getByTestId("value").textContent).toBe("alpha"));
 
-    rendered.rerender(<ResourceProbe path="/api/workspace/beta" />);
+    rendered.rerender(<ResourceProbe resource={{ key: "workspace:beta", path: "/api/workspace/beta" }} />);
 
     expect(screen.getByTestId("value").textContent).toBe("none");
     expect(screen.getByTestId("loading").textContent).toBe("true");
@@ -61,5 +67,92 @@ describe("useLiveResource", () => {
     await waitFor(() => expect(screen.getByTestId("freshness").textContent).toBe("disconnected"));
     expect(screen.getByTestId("value").textContent).toBe("none");
     expect(screen.getByTestId("error").textContent).toBe("beta missing");
+  });
+
+  test("retains successful data while paused without polling", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ ok: true, value: "alpha" }) } as Response);
+
+    const rendered = render(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} intervalMs={10} />);
+    await waitFor(() => expect(screen.getByTestId("value").textContent).toBe("alpha"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    rendered.rerender(
+      <ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} mode="paused" intervalMs={10} />,
+    );
+
+    expect(screen.getByTestId("value").textContent).toBe("alpha");
+    expect(screen.getByTestId("loading").textContent).toBe("false");
+
+    await new Promise((resolve) => window.setTimeout(resolve, 40));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("refreshes in the background when paused data returns to live mode", async () => {
+    const refresh = { resolve: null as ((response: Response) => void) | null };
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, value: "alpha" }) } as Response)
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            refresh.resolve = resolve;
+          }),
+      );
+
+    const rendered = render(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} />);
+    await waitFor(() => expect(screen.getByTestId("value").textContent).toBe("alpha"));
+
+    rendered.rerender(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} mode="paused" />);
+    rendered.rerender(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} />);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("value").textContent).toBe("alpha");
+    expect(screen.getByTestId("loading").textContent).toBe("false");
+
+    if (!refresh.resolve) throw new Error("Expected pending refresh");
+    refresh.resolve({ ok: true, json: async () => ({ ok: true, value: "alpha refreshed" }) } as Response);
+    await waitFor(() => expect(screen.getByTestId("value").textContent).toBe("alpha refreshed"));
+  });
+
+  test("keeps retained data and reports stale when a resumed refresh fails", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, value: "alpha" }) } as Response)
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({ ok: false, value: "refresh failed" }) } as Response);
+
+    const rendered = render(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} />);
+    await waitFor(() => expect(screen.getByTestId("value").textContent).toBe("alpha"));
+
+    rendered.rerender(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} mode="paused" />);
+    rendered.rerender(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} />);
+
+    await waitFor(() => expect(screen.getByTestId("freshness").textContent).toBe("stale"));
+    expect(screen.getByTestId("value").textContent).toBe("alpha");
+    expect(screen.getByTestId("error").textContent).toBe("refresh failed");
+  });
+
+  test("renders disconnected empty state when the first live load fails", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({ ok: false, value: "missing" }) } as Response);
+
+    render(<ResourceProbe resource={{ key: "workspace:missing", path: "/api/workspace/missing" }} />);
+
+    await waitFor(() => expect(screen.getByTestId("freshness").textContent).toBe("disconnected"));
+    expect(screen.getByTestId("value").textContent).toBe("none");
+    expect(screen.getByTestId("error").textContent).toBe("missing");
+  });
+
+  test("clears retained data when the resource becomes invalid", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ ok: true, value: "alpha" }) } as Response);
+
+    const rendered = render(<ResourceProbe resource={{ key: "workspace:alpha", path: "/api/workspace/alpha" }} />);
+    await waitFor(() => expect(screen.getByTestId("value").textContent).toBe("alpha"));
+
+    rendered.rerender(<ResourceProbe resource={null} />);
+
+    expect(screen.getByTestId("value").textContent).toBe("none");
+    expect(screen.getByTestId("freshness").textContent).toBe("idle");
   });
 });

--- a/web/src/live-resource.ts
+++ b/web/src/live-resource.ts
@@ -13,20 +13,28 @@ export type LiveResourceResult<T> = {
   freshness: LiveFreshness;
 };
 
-export function useLiveResource<T>(options: {
-  enabled: boolean;
+export type LiveResourceDescriptor = {
+  key: string;
   path: string;
+};
+
+export function useLiveResource<T>(options: {
+  resource: LiveResourceDescriptor | null;
+  mode?: "live" | "paused";
   formatError: (result: T | null, statusCode?: number) => string;
   intervalMs?: number;
 }): LiveResourceResult<T> {
-  const { enabled, path, formatError, intervalMs = LIVE_REFRESH_INTERVAL_MS } = options;
+  const { resource, mode = "live", formatError, intervalMs = LIVE_REFRESH_INTERVAL_MS } = options;
+  const resourceKey = resource?.key ?? null;
+  const resourcePath = resource?.path ?? null;
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [freshness, setFreshness] = useState<LiveFreshness>(() => describeLiveFreshness(enabled ? "connecting" : "idle"));
+  const [freshness, setFreshness] = useState<LiveFreshness>(() => describeLiveFreshness(resource && mode === "live" ? "connecting" : "idle"));
   const inFlightRef = useRef(false);
   const lastSuccessAtRef = useRef<string | null>(null);
   const hasSuccessfulLoadRef = useRef(false);
+  const resourceKeyRef = useRef<string | null>(null);
   const formatErrorRef = useRef(formatError);
 
   useEffect(() => {
@@ -34,7 +42,8 @@ export function useLiveResource<T>(options: {
   }, [formatError]);
 
   useEffect(() => {
-    if (!enabled) {
+    if (!resourceKey) {
+      resourceKeyRef.current = null;
       hasSuccessfulLoadRef.current = false;
       lastSuccessAtRef.current = null;
       setData(null);
@@ -44,12 +53,18 @@ export function useLiveResource<T>(options: {
       return;
     }
 
+    if (resourceKeyRef.current === resourceKey) return;
+    resourceKeyRef.current = resourceKey;
     hasSuccessfulLoadRef.current = false;
     lastSuccessAtRef.current = null;
     setData(null);
     setError(null);
-    setLoading(true);
-    setFreshness(describeLiveFreshness("connecting"));
+    setLoading(mode === "live");
+    setFreshness(describeLiveFreshness(mode === "live" ? "connecting" : "idle"));
+  }, [mode, resourceKey]);
+
+  useEffect(() => {
+    if (!resourcePath || mode !== "live") return;
 
     let disposed = false;
     let activeController: AbortController | null = null;
@@ -80,16 +95,20 @@ export function useLiveResource<T>(options: {
       inFlightRef.current = true;
       clearUpdatingIndicator();
       if (hasLiveData) {
-        updatingIndicatorTimeoutID = window.setTimeout(() => {
-          updatingIndicatorTimeoutID = null;
-          if (disposed || controller.signal.aborted) return;
+        if (trigger === "initial") {
           setFreshness(describeLiveFreshness("updating", lastSuccessAtRef.current));
-        }, LIVE_REFRESH_ACTIVITY_BUFFER_MS);
+        } else {
+          updatingIndicatorTimeoutID = window.setTimeout(() => {
+            updatingIndicatorTimeoutID = null;
+            if (disposed || controller.signal.aborted) return;
+            setFreshness(describeLiveFreshness("updating", lastSuccessAtRef.current));
+          }, LIVE_REFRESH_ACTIVITY_BUFFER_MS);
+        }
       } else {
         setFreshness(describeLiveFreshness("connecting", lastSuccessAtRef.current));
       }
 
-      fetch(path, { signal: controller.signal })
+      fetch(resourcePath, { signal: controller.signal })
         .then(async (response) => {
           const payload = (await response.json()) as T & { ok?: boolean };
           if (!response.ok || payload.ok === false) {
@@ -111,7 +130,7 @@ export function useLiveResource<T>(options: {
         .catch((nextError: unknown) => {
           if (disposed || controller.signal.aborted) return;
           clearUpdatingIndicator();
-          const message = nextError instanceof Error ? nextError.message : `Unable to load ${path}`;
+          const message = nextError instanceof Error ? nextError.message : `Unable to load ${resourcePath}`;
           setError(message);
           setLoading(false);
           if (!hasSuccessfulLoadRef.current) {
@@ -150,7 +169,7 @@ export function useLiveResource<T>(options: {
       activeController?.abort();
       inFlightRef.current = false;
     };
-  }, [enabled, intervalMs, path]);
+  }, [intervalMs, mode, resourceKey, resourcePath]);
 
   return { data, error, loading, freshness };
 }

--- a/web/src/live-resource.ts
+++ b/web/src/live-resource.ts
@@ -95,15 +95,11 @@ export function useLiveResource<T>(options: {
       inFlightRef.current = true;
       clearUpdatingIndicator();
       if (hasLiveData) {
-        if (trigger === "initial") {
+        updatingIndicatorTimeoutID = window.setTimeout(() => {
+          updatingIndicatorTimeoutID = null;
+          if (disposed || controller.signal.aborted) return;
           setFreshness(describeLiveFreshness("updating", lastSuccessAtRef.current));
-        } else {
-          updatingIndicatorTimeoutID = window.setTimeout(() => {
-            updatingIndicatorTimeoutID = null;
-            if (disposed || controller.signal.aborted) return;
-            setFreshness(describeLiveFreshness("updating", lastSuccessAtRef.current));
-          }, LIVE_REFRESH_ACTIVITY_BUFFER_MS);
-        }
+        }, LIVE_REFRESH_ACTIVITY_BUFFER_MS);
       } else {
         setFreshness(describeLiveFreshness("connecting", lastSuccessAtRef.current));
       }

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -176,6 +176,48 @@ function planFetchCount(): number {
   return vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === "/api/workspace/wk_alpha/plan").length;
 }
 
+function apiFetchCount(path: string): number {
+  return vi.mocked(fetch).mock.calls.filter(([input]) => String(input) === path).length;
+}
+
+function mockApiWithPendingRefresh(pathWithPendingRefresh: string) {
+  let fetchesForPendingPath = 0;
+  let resolveRefresh: ((response: Response) => void) | null = null;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const path = String(input);
+      const payloadByPath: Record<string, unknown> = {
+        "/api/workspace/wk_alpha": workspaceResult,
+        "/api/workspace/wk_alpha/status": statusResult,
+        "/api/workspace/wk_alpha/plan": currentPlanResult,
+        "/api/workspace/wk_alpha/timeline": timelineResult,
+        "/api/workspace/wk_alpha/review": reviewResult,
+      };
+      const payload = payloadByPath[path];
+      if (!payload) {
+        return Promise.reject(new Error(`unexpected path ${path}`));
+      }
+      if (path === pathWithPendingRefresh) {
+        fetchesForPendingPath += 1;
+        if (fetchesForPendingPath > 1) {
+          return new Promise<Response>((resolve) => {
+            resolveRefresh = resolve;
+          });
+        }
+      }
+      return Promise.resolve({ ok: true, json: async () => payload } as Response);
+    }),
+  );
+
+  return {
+    resolveRefresh(payload: unknown) {
+      if (!resolveRefresh) throw new Error(`No pending refresh for ${pathWithPendingRefresh}`);
+      resolveRefresh({ ok: true, json: async () => payload } as Response);
+    },
+  };
+}
+
 function clickPlanTreeLabel(label: string) {
   const target = Array.from(document.querySelectorAll<HTMLButtonElement>(".plan-tree-label")).find(
     (nextElement) => nextElement.querySelector(".plan-tree-text")?.textContent === label,
@@ -314,6 +356,28 @@ describe("workbench page state continuity", () => {
     await waitFor(() => expect(activePlanTreeText()).toBe("Scope"));
   });
 
+  test("keeps Plan payload visible while the return refresh is pending", async () => {
+    const pending = mockApiWithPendingRefresh("/api/workspace/wk_alpha/plan");
+    window.history.pushState({}, "", "/workspace/wk_alpha/plan");
+    render(<App />);
+
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+
+    fireEvent.click(screen.getByLabelText("Timeline"));
+    await waitFor(() => expect(explorerHasTitle("new event")).toBe(true));
+    fireEvent.click(screen.getByLabelText("Plan"));
+
+    await waitFor(() => expect(apiFetchCount("/api/workspace/wk_alpha/plan")).toBe(2));
+    expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan");
+    expect(document.querySelector(".topbar-freshness-label")?.textContent).toBe("Updating");
+
+    pending.resolveRefresh({
+      ...planResult,
+      document: planResult.document ? { ...planResult.document, title: "Refreshed Plan", markdown: "# Refreshed Plan" } : null,
+    });
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Refreshed Plan"));
+  });
+
   test("keeps supplements-only Plan child selection warm across tab switches", async () => {
     currentPlanResult = supplementsOnlyPlanResult;
     window.history.pushState({}, "", "/workspace/wk_alpha/plan");
@@ -360,6 +424,23 @@ describe("workbench page state continuity", () => {
     expect(activeInspectorTabText()).toBe("Input");
   });
 
+  test("keeps Timeline payload visible while the return refresh is pending", async () => {
+    mockApiWithPendingRefresh("/api/workspace/wk_alpha/timeline");
+    window.history.pushState({}, "", "/workspace/wk_alpha/timeline");
+    render(<App />);
+
+    await waitFor(() => expect(explorerHasTitle("new event")).toBe(true));
+
+    fireEvent.click(screen.getByLabelText("Plan"));
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    fireEvent.click(screen.getByLabelText("Timeline"));
+
+    await waitFor(() => expect(apiFetchCount("/api/workspace/wk_alpha/timeline")).toBe(2));
+    expect(explorerHasTitle("new event")).toBe(true);
+    expect(activeExplorerTitleText()).toBe("new event");
+    expect(document.querySelector(".topbar-freshness-label")?.textContent).toBe("Updating");
+  });
+
   test("keeps Review round, detail tab, and artifacts panel warm across tab switches", async () => {
     window.history.pushState({}, "", "/workspace/wk_alpha/review");
     render(
@@ -385,6 +466,23 @@ describe("workbench page state continuity", () => {
     await waitFor(() => expect(activeExplorerTitleText()).toBe("First review"));
     expect(activeInspectorTabText()).toBe("UI");
     expect(screen.getAllByText("notes").length).toBeGreaterThan(0);
+  });
+
+  test("keeps Review payload visible while the return refresh is pending", async () => {
+    mockApiWithPendingRefresh("/api/workspace/wk_alpha/review");
+    window.history.pushState({}, "", "/workspace/wk_alpha/review");
+    render(<App />);
+
+    await waitFor(() => expect(explorerHasTitle("Second review")).toBe(true));
+
+    fireEvent.click(screen.getByLabelText("Plan"));
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    fireEvent.click(screen.getByLabelText("Review"));
+
+    await waitFor(() => expect(apiFetchCount("/api/workspace/wk_alpha/review")).toBe(2));
+    expect(explorerHasTitle("Second review")).toBe(true);
+    expect(activeExplorerTitleText()).toBe("Second review");
+    expect(document.querySelector(".topbar-freshness-label")?.textContent).toBe("Updating");
   });
 
   test("Plan controls write lifted state that survives page remount", async () => {

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -369,7 +369,7 @@ describe("workbench page state continuity", () => {
 
     await waitFor(() => expect(apiFetchCount("/api/workspace/wk_alpha/plan")).toBe(2));
     expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan");
-    expect(document.querySelector(".topbar-freshness-label")?.textContent).toBe("Updating");
+    expect(document.querySelector(".topbar-freshness-label")?.textContent).toBe("Live");
 
     pending.resolveRefresh({
       ...planResult,
@@ -438,7 +438,7 @@ describe("workbench page state continuity", () => {
     await waitFor(() => expect(apiFetchCount("/api/workspace/wk_alpha/timeline")).toBe(2));
     expect(explorerHasTitle("new event")).toBe(true);
     expect(activeExplorerTitleText()).toBe("new event");
-    expect(document.querySelector(".topbar-freshness-label")?.textContent).toBe("Updating");
+    expect(document.querySelector(".topbar-freshness-label")?.textContent).toBe("Live");
   });
 
   test("keeps Review round, detail tab, and artifacts panel warm across tab switches", async () => {
@@ -482,7 +482,7 @@ describe("workbench page state continuity", () => {
     await waitFor(() => expect(apiFetchCount("/api/workspace/wk_alpha/review")).toBe(2));
     expect(explorerHasTitle("Second review")).toBe(true);
     expect(activeExplorerTitleText()).toBe("Second review");
-    expect(document.querySelector(".topbar-freshness-label")?.textContent).toBe("Updating");
+    expect(document.querySelector(".topbar-freshness-label")?.textContent).toBe("Live");
   });
 
   test("Plan controls write lifted state that survives page remount", async () => {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -161,14 +161,13 @@ export function App(props: {
     setSection(nextSection);
   };
 
+  const workspaceKey = route.kind === "workspace" ? route.workspaceKey : null;
   const dashboardResource = useLiveResource<DashboardResult>({
-    enabled: route.kind === "dashboard",
-    path: "/api/dashboard",
+    resource: route.kind === "dashboard" ? { key: "dashboard", path: "/api/dashboard" } : null,
     formatError: (result, statusCode) => result?.summary?.trim() || (statusCode ? `GET /api/dashboard failed with ${statusCode}` : "Unable to load dashboard"),
   });
   const workspaceResource = useLiveResource<WorkspaceRouteResult>({
-    enabled: route.kind === "workspace",
-    path: route.kind === "workspace" ? `/api/workspace/${route.workspaceKey}` : "/api/workspace/_",
+    resource: workspaceKey ? { key: `workspace:${workspaceKey}`, path: `/api/workspace/${workspaceKey}` } : null,
     formatError: formatDashboardError,
   });
 
@@ -181,23 +180,22 @@ export function App(props: {
     selectedWorkspace.dashboard_state !== "invalid";
 
   const statusResource = useLiveResource<StatusResult>({
-    enabled: workspaceReadable,
-    path: route.kind === "workspace" ? `/api/workspace/${route.workspaceKey}/status` : "/api/workspace/_/status",
+    resource: workspaceReadable && workspaceKey ? { key: `workspace:${workspaceKey}:status`, path: `/api/workspace/${workspaceKey}/status` } : null,
     formatError: formatStatusError,
   });
   const planResource = useLiveResource<PlanResult>({
-    enabled: workspaceReadable && route.kind === "workspace" && route.page === "plan",
-    path: route.kind === "workspace" ? `/api/workspace/${route.workspaceKey}/plan` : "/api/workspace/_/plan",
+    resource: workspaceReadable && workspaceKey ? { key: `workspace:${workspaceKey}:plan`, path: `/api/workspace/${workspaceKey}/plan` } : null,
+    mode: route.kind === "workspace" && route.page === "plan" ? "live" : "paused",
     formatError: formatPlanError,
   });
   const timelineResource = useLiveResource<TimelineResult>({
-    enabled: workspaceReadable && route.kind === "workspace" && route.page === "timeline",
-    path: route.kind === "workspace" ? `/api/workspace/${route.workspaceKey}/timeline` : "/api/workspace/_/timeline",
+    resource: workspaceReadable && workspaceKey ? { key: `workspace:${workspaceKey}:timeline`, path: `/api/workspace/${workspaceKey}/timeline` } : null,
+    mode: route.kind === "workspace" && route.page === "timeline" ? "live" : "paused",
     formatError: formatTimelineResourceError,
   });
   const reviewResource = useLiveResource<ReviewResult>({
-    enabled: workspaceReadable && route.kind === "workspace" && route.page === "review",
-    path: route.kind === "workspace" ? `/api/workspace/${route.workspaceKey}/review` : "/api/workspace/_/review",
+    resource: workspaceReadable && workspaceKey ? { key: `workspace:${workspaceKey}:review`, path: `/api/workspace/${workspaceKey}/review` } : null,
+    mode: route.kind === "workspace" && route.page === "review" ? "live" : "paused",
     formatError: formatReviewError,
   });
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -119,7 +119,9 @@ code {
 .topbar-freshness {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.38rem;
+  min-width: 6.75rem;
   min-height: 1.55rem;
   padding: 0 0.45rem;
   border: 1px solid var(--border-soft);


### PR DESCRIPTION
## Summary

- Split `useLiveResource` resource identity from refresh activity with `resource` plus `live`/`paused` mode.
- Keep Plan, Timeline, and Review payloads warm across workbench tab switches while refreshing in the background on return.
- Add hook and App tests for paused retention, stale/error behavior, identity reset, no inactive polling, and pending return refreshes.

## Validation

- `pnpm --dir web test -- live-resource.test.tsx main.test.tsx`
- `pnpm --dir web test`
- `pnpm --dir web build`
- Finalize review `review-001-full` passed with 0 findings.

Closes #205.
