### PR TITLE
Define read-only PR handoff identity

### DIFF
--- a/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
+++ b/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
@@ -234,7 +234,12 @@ as the fallback path.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added explicit `gh pr view <recorded-pr-url>` observation for recorded PR
+identity. The provider is mockable through `Service.RunCommand`, classifies
+missing `gh`, missing auth, unreadable PR, invalid JSON, and generic command
+failure as degraded observations, and never runs `gh pr list`. The identity
+snapshot remains local/recorded-evidence only and does not implicitly call
+`gh`. Validation: `go test ./internal/remote`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
+++ b/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
@@ -1,0 +1,283 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-18T23:44:43+08:00"
+approved_at: "2026-05-18T23:45:57+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/203
+size: M
+---
+
+# Define Read-Only PR Handoff Identity
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Resolve issue #203 by defining the read-only identity model that later
+remote-handoff work can rely on without guessing. The core contract is that a
+recorded publish evidence PR URL is the authoritative remote handoff anchor
+once a candidate has reached the publish phase.
+
+The end state should let future PR and CI status work observe a known PR with
+`gh` when available, degrade clearly when `gh` or auth is unavailable, and keep
+the existing manual evidence-submit workflow as the fallback. Local git and
+remote facts remain useful context, but they must not become a branch-based PR
+guessing system.
+
+## Scope
+
+### In Scope
+
+- Document that `publish` evidence `pr_url` is the authoritative remote
+  handoff identity for an archived candidate.
+- Document that local git branch, commit, remote, and GitHub owner/repo facts
+  are contextual observations rather than PR association authority.
+- Define degraded read states for missing recorded PR URL, invalid PR URL,
+  missing `gh`, missing `gh` auth, unreadable PR, unsupported or unavailable
+  remote context, detached HEAD, and mismatched contextual facts.
+- Add a small internal read-model skeleton that can load the current local git
+  context, parse a recorded GitHub PR URL, and call `gh` only to observe that
+  recorded PR.
+- Add tests for the read-only model, including success and degraded paths,
+  without requiring real GitHub network access or a real authenticated `gh`
+  session.
+
+### Out of Scope
+
+- Introducing `.harness` customization or any tracked configuration schema.
+- Discovering or guessing a PR from the current branch when publish evidence
+  does not already record a PR URL.
+- Reading CI/check status, merge policy, review state, or full PR readiness.
+- Adding `harness publish`, opening PRs, updating PRs, commenting, rerunning
+  checks, merging, or performing any git/GitHub write operation.
+- Changing `harness status` workflow-node progression to depend on live
+  GitHub reads.
+- Supporting non-GitHub hosts beyond explicit degraded states.
+
+## Acceptance Criteria
+
+- [ ] Specs identify recorded publish `pr_url` as the remote handoff anchor for
+      later PR and CI reads.
+- [ ] Specs clearly distinguish authoritative harness evidence from contextual
+      local git/remote observations.
+- [ ] The implementation does not perform branch-based PR discovery when no
+      recorded PR URL exists; it degrades to manual publish evidence fallback.
+- [ ] The read model uses `gh` only for read-only observation of a recorded PR
+      URL and treats missing `gh`, missing auth, network/API failure, and
+      unreadable PRs as degraded observations rather than workflow failures.
+- [ ] Tests cover recorded PR URL parsing, local git context success and
+      detached/missing-remote degradation, `gh` success, and `gh` degraded
+      paths using fake command execution.
+- [ ] Existing manual `harness evidence submit --kind publish|ci|sync` flows
+      continue to work unchanged.
+
+## Deferred Items
+
+- Add PR and CI fact reading for a recorded PR URL in issue #199.
+- Surface remote handoff facts and next actions through `harness status` in
+  issue #200.
+- Add repo-level `.harness` customization for complex remote mappings in
+  issue #71 or a follow-up customization slice.
+
+## Work Breakdown
+
+### Step 1: Specify the no-guess remote handoff contract
+
+- Done: [x]
+
+#### Objective
+
+Update the durable specs so future agents can tell which remote handoff facts
+are authoritative, which are contextual, and when the workflow should fall
+back to manual evidence rather than guessing.
+
+#### Details
+
+`docs/specs/state-model.md` should define the publish-phase identity rule:
+once publish evidence records a PR URL, that URL is the candidate's
+authoritative remote handoff anchor. Local git branch, commit, upstream,
+origin, and remote repository facts are context that may explain warnings but
+must not replace recorded evidence.
+
+`docs/specs/cli-contract.md` should describe the intended read-only boundary
+for later status integration: live `gh` reads may observe a recorded PR, but
+status must continue to degrade without failing local workflow state when
+`gh`, auth, or the network is unavailable. When no recorded PR URL exists, the
+next action should remain to open/update the PR and record publish evidence,
+not to discover or guess a PR from the current branch.
+
+#### Expected Files
+
+- `docs/specs/state-model.md`
+- `docs/specs/cli-contract.md`
+
+#### Validation
+
+- The specs are understandable without this plan or chat history.
+- `git diff --check` passes for the edited specs and plan.
+- `harness plan lint docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md` still passes after the edits.
+
+#### Execution Notes
+
+Updated `docs/specs/state-model.md` and `docs/specs/cli-contract.md` to define
+recorded publish `pr_url` as the remote handoff anchor, local git/remote facts
+as contextual observations, and `gh` as an optional read-through provider that
+must degrade without blocking local workflow state. Validation:
+`git diff --check -- docs/specs/state-model.md docs/specs/cli-contract.md
+docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md`;
+`harness plan lint
+docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 only records the approved no-guess handoff
+contract in specs; implementation and behavior tests begin in Step 2.
+
+### Step 2: Add the local and recorded-PR identity skeleton
+
+- Done: [ ]
+
+#### Objective
+
+Create the minimal internal read model for local git context and recorded PR
+URL identity without adding status output behavior or GitHub writes.
+
+#### Details
+
+Add a small internal package or equivalent local module that reports:
+
+- local git context for the current worktree, including branch when available,
+  HEAD commit when available, selected remote context when unambiguous, and
+  degraded states such as not-a-git-repository, detached HEAD, missing remote,
+  unsupported host, and ambiguous remote context
+- recorded PR identity parsed from a publish evidence PR URL, limited to
+  supported GitHub PR URLs
+- explicit degraded identity when no publish evidence PR URL exists
+
+The model should not infer PR identity from branch names. Any current-branch
+or remote information should be retained as context only, so later status work
+can produce warnings without turning context into authority.
+
+#### Expected Files
+
+- `internal/remote/...` or another clearly named internal read-model package
+- `internal/remote/..._test.go`
+- Supporting contract files only if needed for generated schemas or shared
+  result structs
+
+#### Validation
+
+- Unit tests cover URL parsing, unsupported URLs, missing recorded PR URL,
+  normal branch context, detached HEAD context, missing remote context, and
+  unsupported remote context.
+- Tests use temporary git repositories where local git behavior matters.
+- The implementation has no GitHub network dependency.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Add read-only `gh` observation with degraded paths
+
+- Done: [ ]
+
+#### Objective
+
+Add a mockable `gh` observation path for a recorded PR URL so later PR/CI work
+can build on a tested provider boundary.
+
+#### Details
+
+Use `gh` as the intended read-through provider for GitHub PR observation, but
+do not make it a hard workflow dependency. The provider should call `gh` only
+for read-only operations against a recorded PR URL, such as `gh pr view
+<url> --json ...`, and it should classify failures into clear degraded states.
+
+The execution boundary should allow tests to fake command execution so the
+suite does not require a real `gh` binary, real auth, or network access.
+Missing `gh`, auth errors, non-zero command exits, invalid JSON, and unreadable
+PRs should produce degraded observations and preserve manual evidence submit
+as the fallback path.
+
+#### Expected Files
+
+- `internal/remote/...`
+- `internal/remote/..._test.go`
+
+#### Validation
+
+- Unit tests cover `gh` success, missing binary, auth unavailable, unreadable
+  PR, invalid JSON, and generic command failure.
+- The provider does not call `gh pr list` or otherwise discover PRs from the
+  current branch.
+- The provider performs no git or GitHub write operation.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run focused Go tests for the new read-model package.
+- Run relevant status/evidence tests if shared contracts or evidence loading
+  behavior changes.
+- Run `go test ./...` unless the implementation remains narrowly isolated and
+  a faster package set is clearly sufficient.
+- Run `harness plan lint` for this plan after step closeout updates.
+- Run `git diff --check` before archive.
+
+## Risks
+
+- Risk: The implementation could accidentally reintroduce branch-based PR
+  guessing under the name of convenience.
+  - Mitigation: Keep the contract explicit, add tests proving no `gh pr list`
+    discovery is used, and require missing PR evidence to degrade to manual
+    fallback.
+- Risk: `gh` failure modes could become workflow failures and make local
+  harness status brittle on unauthenticated machines.
+  - Mitigation: Treat `gh` as an optional read-through provider and classify
+    missing auth, missing binary, and network/API failures as degraded
+    observations.
+- Risk: The skeleton could overfit the current issue and make later #199/#200
+  integration awkward.
+  - Mitigation: Keep the package focused on identity and provider boundaries,
+    not CI/readiness policy or status-node progression.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
+++ b/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
@@ -184,11 +184,18 @@ Added `internal/remote` local identity skeleton and tests. The package now
 parses recorded GitHub PR URLs, reports missing or unsupported recorded PR
 identity, inspects current worktree git context, records detached HEAD and
 remote degradation, and treats branch/remote facts as context only. Validation:
+`go test ./internal/remote`. After `review-001-delta`, added negative coverage
+and parsing guards so empty GitHub owner/repo path segments degrade instead of
+being accepted as recorded or supported identity. Validation:
 `go test ./internal/remote`.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` found one important correctness issue: malformed GitHub PR
+or remote URLs with empty repo segments could be accepted as valid identity.
+The repair adds negative tests for empty repo PR and remote URLs and rejects
+empty owner/repo segments before recording GitHub identity. Follow-up review is
+pending.
 
 ### Step 3: Add read-only `gh` observation with degraded paths
 

--- a/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
+++ b/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
@@ -140,7 +140,7 @@ contract in specs; implementation and behavior tests begin in Step 2.
 
 ### Step 2: Add the local and recorded-PR identity skeleton
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -194,8 +194,8 @@ being accepted as recorded or supported identity. Validation:
 `review-001-delta` found one important correctness issue: malformed GitHub PR
 or remote URLs with empty repo segments could be accepted as valid identity.
 The repair adds negative tests for empty repo PR and remote URLs and rejects
-empty owner/repo segments before recording GitHub identity. Follow-up review is
-pending.
+empty owner/repo segments before recording GitHub identity. `review-002-delta`
+passed with no findings after the repair.
 
 ### Step 3: Add read-only `gh` observation with degraded paths
 

--- a/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
+++ b/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
@@ -199,7 +199,7 @@ passed with no findings after the repair.
 
 ### Step 3: Add read-only `gh` observation with degraded paths
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -243,7 +243,10 @@ snapshot remains local/recorded-evidence only and does not implicitly call
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-003-delta` passed with no findings. The reviewer verified the provider
+uses explicit `gh pr view <recorded-pr-url>`, does not discover PRs from the
+current branch, keeps snapshots local/recorded-only, and validates degraded
+paths through fake command execution.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
+++ b/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
@@ -239,14 +239,20 @@ identity. The provider is mockable through `Service.RunCommand`, classifies
 missing `gh`, missing auth, unreadable PR, invalid JSON, and generic command
 failure as degraded observations, and never runs `gh pr list`. The identity
 snapshot remains local/recorded-evidence only and does not implicitly call
-`gh`. Validation: `go test ./internal/remote`.
+`gh`. Validation: `go test ./internal/remote`. After `review-004-full`, added
+a regression test and parser guard so scp-style GitHub remotes with extra repo
+path segments, such as `git@github.com:catu-ai/easyharness/extra.git`,
+degrade as unsupported remote context. Validation: `go test ./internal/remote`.
 
 #### Review Notes
 
 `review-003-delta` passed with no findings. The reviewer verified the provider
 uses explicit `gh pr view <recorded-pr-url>`, does not discover PRs from the
 current branch, keeps snapshots local/recorded-only, and validates degraded
-paths through fake command execution.
+paths through fake command execution. `review-004-full` later found one
+important finalize issue: scp-style GitHub remotes with extra path segments
+could be accepted as supported context. The repair rejects multi-segment
+scp-like repo paths and adds regression coverage; follow-up review is pending.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
+++ b/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
@@ -61,19 +61,19 @@ guessing system.
 
 ## Acceptance Criteria
 
-- [ ] Specs identify recorded publish `pr_url` as the remote handoff anchor for
+- [x] Specs identify recorded publish `pr_url` as the remote handoff anchor for
       later PR and CI reads.
-- [ ] Specs clearly distinguish authoritative harness evidence from contextual
+- [x] Specs clearly distinguish authoritative harness evidence from contextual
       local git/remote observations.
-- [ ] The implementation does not perform branch-based PR discovery when no
+- [x] The implementation does not perform branch-based PR discovery when no
       recorded PR URL exists; it degrades to manual publish evidence fallback.
-- [ ] The read model uses `gh` only for read-only observation of a recorded PR
+- [x] The read model uses `gh` only for read-only observation of a recorded PR
       URL and treats missing `gh`, missing auth, network/API failure, and
       unreadable PRs as degraded observations rather than workflow failures.
-- [ ] Tests cover recorded PR URL parsing, local git context success and
+- [x] Tests cover recorded PR URL parsing, local git context success and
       detached/missing-remote degradation, `gh` success, and `gh` degraded
       paths using fake command execution.
-- [ ] Existing manual `harness evidence submit --kind publish|ci|sync` flows
+- [x] Existing manual `harness evidence submit --kind publish|ci|sync` flows
       continue to work unchanged.
 
 ## Deferred Items
@@ -252,7 +252,9 @@ current branch, keeps snapshots local/recorded-only, and validates degraded
 paths through fake command execution. `review-004-full` later found one
 important finalize issue: scp-style GitHub remotes with extra path segments
 could be accepted as supported context. The repair rejects multi-segment
-scp-like repo paths and adds regression coverage; follow-up review is pending.
+scp-like repo paths and adds regression coverage. `review-005-delta` passed
+with no findings for that repair, and `review-006-full` passed with no
+findings for the repaired full candidate.
 
 ## Validation Strategy
 
@@ -283,26 +285,63 @@ scp-like repo paths and adds regression coverage; follow-up review is pending.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `go test ./internal/remote`
+- `go test -count=1 ./internal/remote`
+- `go test ./...`
+- `harness plan lint docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md`
+- `git diff --check`
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Step review:
+
+- Step 1 recorded `NO_STEP_REVIEW_NEEDED` because it only wrote the approved
+  contract into specs before behavior implementation began.
+- `review-001-delta` found one important issue: empty GitHub owner/repo path
+  segments could be accepted as recorded or supported identity.
+- `review-002-delta` passed after the empty-path repair.
+- `review-003-delta` passed for the explicit read-only `gh` observation
+  provider.
+
+Finalize review:
+
+- `review-004-full` found one important issue: scp-style GitHub remotes with
+  extra path segments could be accepted as supported context.
+- `review-005-delta` passed after the scp-style remote repair.
+- `review-006-full` passed with no findings for the repaired full candidate.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: NONE
+- Ready: The candidate satisfies the approved issue #203 scope and passed
+  repaired full finalize review.
+- Merge Handoff: Commit the archive move, push
+  `codex/read-only-pr-handoff-identity`, open or update the PR, then record
+  publish, CI, and sync evidence until `harness status` reaches
+  `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Specs now define recorded publish `pr_url` as the authoritative remote
+  handoff anchor and local git/remote facts as contextual observations.
+- Added `internal/remote` for local git context, recorded GitHub PR URL
+  parsing, and degraded identity states without branch-based PR discovery.
+- Added explicit mockable `gh pr view <recorded-pr-url>` observation that
+  degrades cleanly when `gh`, auth, provider output, or the PR read is
+  unavailable.
+- Added focused tests for supported and degraded PR URL parsing, git context,
+  malformed GitHub remote shapes, and fake-command `gh` observation paths.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- `.harness` customization, branch-based PR discovery, CI/check reads,
+  `harness status` remote fact surfacing, PR creation/update, GitHub writes,
+  and workflow-node progression changes remain out of scope.
 
 ### Follow-Up Issues
 
-NONE
+- #199: Add PR and CI fact reading for a recorded PR URL.
+- #200: Surface remote handoff facts and next actions through `harness status`.
+- #71: Add repo-level `.harness` customization for complex remote mappings.

--- a/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
+++ b/docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md
@@ -180,7 +180,11 @@ can produce warnings without turning context into authority.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added `internal/remote` local identity skeleton and tests. The package now
+parses recorded GitHub PR URLs, reports missing or unsupported recorded PR
+identity, inspects current worktree git context, records detached HEAD and
+remote degradation, and treats branch/remote facts as context only. Validation:
+`go test ./internal/remote`.
 
 #### Review Notes
 

--- a/docs/plans/archived/2026-05-18-define-read-only-pr-handoff-identity.md
+++ b/docs/plans/archived/2026-05-18-define-read-only-pr-handoff-identity.md
@@ -312,6 +312,8 @@ Finalize review:
 
 ## Archive Summary
 
+- Archived At: 2026-05-19T00:17:47+08:00
+- Revision: 1
 - PR: NONE
 - Ready: The candidate satisfies the approved issue #203 scope and passed
   repaired full finalize review.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -495,6 +495,16 @@ Contract:
   instead of making the controller learn them only from `harness archive`
 - surface stale or unknown remote freshness as warnings and next actions rather
   than as a derived state layer
+- treat recorded publish evidence as the authoritative remote handoff identity:
+  when the latest publish evidence has a PR URL, later read-only remote
+  observation should anchor on that PR URL; when it does not, status should
+  steer the controller to open or update the PR and record publish evidence
+  rather than guessing a PR from the current branch
+- keep live remote observation optional and read-only: `gh` may be used to
+  observe a recorded PR URL when available, but missing `gh`, missing auth,
+  network/API failure, an unreadable PR, or mismatched local git context should
+  degrade to warnings or manual evidence guidance instead of failing local
+  workflow state
 - if no current plan is active but `.local/harness/current-plan.json` records a
   landed candidate, return `state.current_node: idle` with landed context in
   `artifacts`
@@ -796,6 +806,21 @@ Post-archive merge readiness additionally requires:
 - publish evidence with a PR URL
 - CI good enough or explicit `not_applied`
 - sync freshness or explicit `not_applied`
+
+The PR URL recorded in publish evidence is the remote handoff anchor for later
+read-only PR and CI observation. Local branch, commit, upstream, and remote
+repository facts are context only; they may explain why a controller needs to
+repair or refresh evidence, but they must not replace the explicit PR URL or
+trigger branch-based PR discovery. If no PR URL has been recorded, the
+controller should continue the existing manual publish path and record evidence
+once the PR or handoff target exists.
+
+When a future status implementation observes a recorded PR through `gh`, it
+must treat `gh` as an optional read-through provider rather than a hard
+workflow dependency. Missing `gh`, missing auth, network or API errors, invalid
+provider output, and unreadable PRs should produce degraded remote facts or
+next-action guidance while preserving the local status result and the manual
+`harness evidence submit --kind publish|ci|sync` fallback.
 
 ### `harness execute start`
 

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -377,6 +377,25 @@ Rules:
 - freshness belongs to `execution/finalize/publish`, not to pre-archive
   readiness
 
+### Remote Handoff Identity
+
+The recorded `publish` evidence is the authoritative identity source for the
+remote handoff candidate. When the latest applicable publish evidence records
+a PR URL, that URL is the candidate's remote handoff anchor for later PR and
+CI reads.
+
+Local git and remote facts are contextual observations, not replacement
+identity. The current worktree branch, HEAD commit, upstream, `origin`, and
+derived GitHub owner/repo can help explain warnings or guide manual follow-up,
+but they must not be used to guess a PR when publish evidence has not recorded
+one.
+
+If publish evidence has no PR URL, the workflow remains in manual handoff:
+open or update the PR outside harness, then record publish evidence. Harness
+should not infer a PR from the current branch as a substitute for that explicit
+handoff record. Future repository customization may define more complex remote
+mapping, but the core model stays evidence-first.
+
 ## Reopen Rules
 
 `harness reopen` is the mechanical reversal of archive-time assumptions and

--- a/internal/remote/gh_test.go
+++ b/internal/remote/gh_test.go
@@ -1,0 +1,168 @@
+package remote
+
+import (
+	"errors"
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func TestObserveRecordedPRUsesGhView(t *testing.T) {
+	var calls []commandCall
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			calls = append(calls, commandCall{Name: name, Args: args})
+			return CommandResult{Stdout: `{
+				"url": "https://github.com/catu-ai/easyharness/pull/203",
+				"number": 203,
+				"state": "OPEN",
+				"headRefName": "codex/read-only-pr-handoff-identity",
+				"headRefOid": "abc123",
+				"baseRefName": "main"
+			}`}
+		},
+	}
+
+	observation := svc.ObserveRecordedPR(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/203"))
+
+	if observation.Status != PRObservationAvailable {
+		t.Fatalf("expected available observation, got %#v", observation)
+	}
+	if observation.State != "OPEN" || observation.HeadRefName != "codex/read-only-pr-handoff-identity" || observation.BaseRefName != "main" {
+		t.Fatalf("unexpected observation: %#v", observation)
+	}
+	want := []commandCall{{
+		Name: "gh",
+		Args: []string{
+			"pr", "view", "https://github.com/catu-ai/easyharness/pull/203",
+			"--json", "url,number,state,headRefName,headRefOid,baseRefName",
+		},
+	}}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("unexpected gh calls:\nwant %#v\ngot  %#v", want, calls)
+	}
+}
+
+func TestSnapshotDoesNotObserveRecordedPRImplicitly(t *testing.T) {
+	root := seedGitRepo(t)
+	called := false
+	svc := Service{
+		Workdir: root,
+		RunCommand: func(name string, args ...string) CommandResult {
+			called = true
+			return CommandResult{}
+		},
+	}
+
+	snapshot := svc.Snapshot("https://github.com/catu-ai/easyharness/pull/203")
+
+	if called {
+		t.Fatal("snapshot should not call gh; PR observation is explicit")
+	}
+	if snapshot.PR.Status != PRStatusRecorded {
+		t.Fatalf("expected recorded PR identity, got %#v", snapshot.PR)
+	}
+}
+
+func TestObserveRecordedPRDoesNotCallGhWhenNoRecordedPR(t *testing.T) {
+	called := false
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			called = true
+			return CommandResult{}
+		},
+	}
+
+	observation := svc.ObserveRecordedPR(ParseRecordedPRURL(""))
+
+	if called {
+		t.Fatal("did not expect gh to run without a recorded PR URL")
+	}
+	if observation.Status != PRObservationUnavailable || observation.Degraded.Code != DegradedMissingPRURL {
+		t.Fatalf("expected missing PR degradation, got %#v", observation)
+	}
+}
+
+func TestObserveRecordedPRDegradesWhenGhMissing(t *testing.T) {
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			return CommandResult{Err: exec.ErrNotFound}
+		},
+	}
+
+	observation := svc.ObserveRecordedPR(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/203"))
+
+	if observation.Status != PRObservationUnavailable || observation.Degraded.Code != DegradedGhMissing {
+		t.Fatalf("expected missing gh degradation, got %#v", observation)
+	}
+}
+
+func TestObserveRecordedPRDegradesWhenGhAuthUnavailable(t *testing.T) {
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			return CommandResult{
+				Stderr: "gh: To get started with GitHub CLI, please run: gh auth login",
+				Err:    errors.New("exit status 4"),
+			}
+		},
+	}
+
+	observation := svc.ObserveRecordedPR(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/203"))
+
+	if observation.Status != PRObservationUnavailable || observation.Degraded.Code != DegradedGhAuthUnavailable {
+		t.Fatalf("expected gh auth degradation, got %#v", observation)
+	}
+}
+
+func TestObserveRecordedPRDegradesForUnreadablePR(t *testing.T) {
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			return CommandResult{
+				Stderr: "GraphQL: Could not resolve to a PullRequest with the number of 203.",
+				Err:    errors.New("exit status 1"),
+			}
+		},
+	}
+
+	observation := svc.ObserveRecordedPR(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/203"))
+
+	if observation.Status != PRObservationUnavailable || observation.Degraded.Code != DegradedPRUnreadable {
+		t.Fatalf("expected unreadable PR degradation, got %#v", observation)
+	}
+}
+
+func TestObserveRecordedPRDegradesForInvalidJSON(t *testing.T) {
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			return CommandResult{Stdout: `{not-json`}
+		},
+	}
+
+	observation := svc.ObserveRecordedPR(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/203"))
+
+	if observation.Status != PRObservationUnavailable || observation.Degraded.Code != DegradedGhInvalidJSON {
+		t.Fatalf("expected invalid JSON degradation, got %#v", observation)
+	}
+}
+
+func TestObserveRecordedPRDegradesForGenericGhFailure(t *testing.T) {
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			return CommandResult{
+				Stderr: "temporary failure",
+				Err:    errors.New("exit status 1"),
+			}
+		},
+	}
+
+	observation := svc.ObserveRecordedPR(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/203"))
+
+	if observation.Status != PRObservationUnavailable || observation.Degraded.Code != DegradedGhCommandFailed {
+		t.Fatalf("expected generic gh failure degradation, got %#v", observation)
+	}
+}
+
+type commandCall struct {
+	Name string
+	Args []string
+}

--- a/internal/remote/identity.go
+++ b/internal/remote/identity.go
@@ -280,7 +280,7 @@ func parseGitHubRemote(name, raw string) Remote {
 
 	if match := scpLikeGitHubRemote.FindStringSubmatch(trimmed); len(match) == 3 {
 		repo := strings.TrimSuffix(match[2], ".git")
-		if match[1] == "" || repo == "" {
+		if match[1] == "" || repo == "" || strings.Contains(repo, "/") {
 			return remote
 		}
 		remote.Host = "github.com"

--- a/internal/remote/identity.go
+++ b/internal/remote/identity.go
@@ -1,6 +1,8 @@
 package remote
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os/exec"
@@ -15,6 +17,9 @@ const (
 	PRStatusMissing     = "missing"
 	PRStatusUnsupported = "unsupported"
 
+	PRObservationAvailable   = "available"
+	PRObservationUnavailable = "unavailable"
+
 	DegradedMissingPRURL      = "missing_pr_url"
 	DegradedUnsupportedPRURL  = "unsupported_pr_url"
 	DegradedNotGitRepository  = "not_git_repository"
@@ -22,12 +27,26 @@ const (
 	DegradedMissingRemote     = "missing_remote"
 	DegradedUnsupportedRemote = "unsupported_remote"
 	DegradedAmbiguousRemote   = "ambiguous_remote"
+	DegradedGhMissing         = "gh_missing"
+	DegradedGhAuthUnavailable = "gh_auth_unavailable"
+	DegradedPRUnreadable      = "pr_unreadable"
+	DegradedGhInvalidJSON     = "gh_invalid_json"
+	DegradedGhCommandFailed   = "gh_command_failed"
 )
 
 var scpLikeGitHubRemote = regexp.MustCompile(`^git@github\.com:([^/]+)/(.+?)(?:\.git)?$`)
 
 type Service struct {
-	Workdir string
+	Workdir    string
+	RunCommand CommandRunner
+}
+
+type CommandRunner func(name string, args ...string) CommandResult
+
+type CommandResult struct {
+	Stdout string
+	Stderr string
+	Err    error
 }
 
 type Snapshot struct {
@@ -63,6 +82,17 @@ type PRIdentity struct {
 	Degraded Degradation `json:"degraded,omitempty"`
 }
 
+type PRObservation struct {
+	Status      string      `json:"status"`
+	URL         string      `json:"url,omitempty"`
+	Number      int         `json:"number,omitempty"`
+	State       string      `json:"state,omitempty"`
+	HeadRefName string      `json:"head_ref_name,omitempty"`
+	HeadRefOID  string      `json:"head_ref_oid,omitempty"`
+	BaseRefName string      `json:"base_ref_name,omitempty"`
+	Degraded    Degradation `json:"degraded,omitempty"`
+}
+
 type Degradation struct {
 	Code    string `json:"code"`
 	Message string `json:"message,omitempty"`
@@ -72,6 +102,51 @@ func (s Service) Snapshot(recordedPRURL string) Snapshot {
 	return Snapshot{
 		Local: InspectLocal(s.Workdir),
 		PR:    ParseRecordedPRURL(recordedPRURL),
+	}
+}
+
+func (s Service) ObserveRecordedPR(identity PRIdentity) PRObservation {
+	if identity.Status != PRStatusRecorded {
+		return PRObservation{
+			Status:   PRObservationUnavailable,
+			Degraded: identity.Degraded,
+		}
+	}
+
+	result := s.run("gh", "pr", "view", identity.URL, "--json", "url,number,state,headRefName,headRefOid,baseRefName")
+	if result.Err != nil {
+		return PRObservation{
+			Status:   PRObservationUnavailable,
+			Degraded: classifyGhFailure(result),
+		}
+	}
+
+	var parsed struct {
+		URL         string `json:"url"`
+		Number      int    `json:"number"`
+		State       string `json:"state"`
+		HeadRefName string `json:"headRefName"`
+		HeadRefOID  string `json:"headRefOid"`
+		BaseRefName string `json:"baseRefName"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &parsed); err != nil {
+		return PRObservation{
+			Status: PRObservationUnavailable,
+			Degraded: Degradation{
+				Code:    DegradedGhInvalidJSON,
+				Message: "gh returned invalid JSON for recorded PR observation",
+			},
+		}
+	}
+
+	return PRObservation{
+		Status:      PRObservationAvailable,
+		URL:         parsed.URL,
+		Number:      parsed.Number,
+		State:       parsed.State,
+		HeadRefName: parsed.HeadRefName,
+		HeadRefOID:  parsed.HeadRefOID,
+		BaseRefName: parsed.BaseRefName,
 	}
 }
 
@@ -252,6 +327,49 @@ func gitOutput(workdir string, args ...string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+func (s Service) run(name string, args ...string) CommandResult {
+	if s.RunCommand != nil {
+		return s.RunCommand(name, args...)
+	}
+	cmd := exec.Command(name, args...)
+	output, err := cmd.Output()
+	stderr := ""
+	if exitErr := new(exec.ExitError); errors.As(err, &exitErr) {
+		stderr = string(exitErr.Stderr)
+	}
+	return CommandResult{
+		Stdout: string(output),
+		Stderr: stderr,
+		Err:    err,
+	}
+}
+
+func classifyGhFailure(result CommandResult) Degradation {
+	text := strings.ToLower(result.Stderr + "\n" + result.Err.Error())
+	switch {
+	case errors.Is(result.Err, exec.ErrNotFound):
+		return Degradation{
+			Code:    DegradedGhMissing,
+			Message: "gh is not available",
+		}
+	case strings.Contains(text, "auth") || strings.Contains(text, "authentication") || strings.Contains(text, "401"):
+		return Degradation{
+			Code:    DegradedGhAuthUnavailable,
+			Message: "gh authentication is unavailable",
+		}
+	case strings.Contains(text, "could not resolve to a pullrequest") || strings.Contains(text, "not found"):
+		return Degradation{
+			Code:    DegradedPRUnreadable,
+			Message: "recorded PR could not be read through gh",
+		}
+	default:
+		return Degradation{
+			Code:    DegradedGhCommandFailed,
+			Message: "gh failed while observing the recorded PR",
+		}
+	}
 }
 
 func splitPath(path string) []string {

--- a/internal/remote/identity.go
+++ b/internal/remote/identity.go
@@ -1,0 +1,264 @@
+package remote
+
+import (
+	"fmt"
+	"net/url"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	PRStatusRecorded    = "recorded"
+	PRStatusMissing     = "missing"
+	PRStatusUnsupported = "unsupported"
+
+	DegradedMissingPRURL      = "missing_pr_url"
+	DegradedUnsupportedPRURL  = "unsupported_pr_url"
+	DegradedNotGitRepository  = "not_git_repository"
+	DegradedDetachedHead      = "detached_head"
+	DegradedMissingRemote     = "missing_remote"
+	DegradedUnsupportedRemote = "unsupported_remote"
+	DegradedAmbiguousRemote   = "ambiguous_remote"
+)
+
+var scpLikeGitHubRemote = regexp.MustCompile(`^git@github\.com:([^/]+)/(.+?)(?:\.git)?$`)
+
+type Service struct {
+	Workdir string
+}
+
+type Snapshot struct {
+	Local LocalContext `json:"local"`
+	PR    PRIdentity   `json:"pr"`
+}
+
+type LocalContext struct {
+	InGitRepo bool          `json:"in_git_repo"`
+	Root      string        `json:"root,omitempty"`
+	Branch    string        `json:"branch,omitempty"`
+	Detached  bool          `json:"detached,omitempty"`
+	Head      string        `json:"head,omitempty"`
+	Remote    *Remote       `json:"remote,omitempty"`
+	Degraded  []Degradation `json:"degraded,omitempty"`
+}
+
+type Remote struct {
+	Name      string `json:"name"`
+	URL       string `json:"url"`
+	Host      string `json:"host,omitempty"`
+	Owner     string `json:"owner,omitempty"`
+	Repo      string `json:"repo,omitempty"`
+	Supported bool   `json:"supported"`
+}
+
+type PRIdentity struct {
+	Status   string      `json:"status"`
+	URL      string      `json:"url,omitempty"`
+	Owner    string      `json:"owner,omitempty"`
+	Repo     string      `json:"repo,omitempty"`
+	Number   int         `json:"number,omitempty"`
+	Degraded Degradation `json:"degraded,omitempty"`
+}
+
+type Degradation struct {
+	Code    string `json:"code"`
+	Message string `json:"message,omitempty"`
+}
+
+func (s Service) Snapshot(recordedPRURL string) Snapshot {
+	return Snapshot{
+		Local: InspectLocal(s.Workdir),
+		PR:    ParseRecordedPRURL(recordedPRURL),
+	}
+}
+
+func ParseRecordedPRURL(raw string) PRIdentity {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return PRIdentity{
+			Status: PRStatusMissing,
+			Degraded: Degradation{
+				Code:    DegradedMissingPRURL,
+				Message: "publish evidence has no recorded PR URL",
+			},
+		}
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme != "https" || parsed.Host != "github.com" {
+		return unsupportedPRURL(trimmed)
+	}
+	parts := splitPath(parsed.Path)
+	if len(parts) != 4 || parts[2] != "pull" {
+		return unsupportedPRURL(trimmed)
+	}
+	number, err := strconv.Atoi(parts[3])
+	if err != nil || number <= 0 {
+		return unsupportedPRURL(trimmed)
+	}
+
+	return PRIdentity{
+		Status: PRStatusRecorded,
+		URL:    trimmed,
+		Owner:  parts[0],
+		Repo:   parts[1],
+		Number: number,
+	}
+}
+
+func InspectLocal(workdir string) LocalContext {
+	root, err := gitOutput(workdir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return LocalContext{
+			Degraded: []Degradation{{
+				Code:    DegradedNotGitRepository,
+				Message: "workdir is not inside a git repository",
+			}},
+		}
+	}
+
+	local := LocalContext{
+		InGitRepo: true,
+		Root:      root,
+	}
+	if head, err := gitOutput(root, "rev-parse", "--verify", "HEAD"); err == nil {
+		local.Head = head
+	}
+	if branch, err := gitOutput(root, "symbolic-ref", "--quiet", "--short", "HEAD"); err == nil {
+		local.Branch = branch
+	} else {
+		local.Detached = true
+		local.Degraded = append(local.Degraded, Degradation{
+			Code:    DegradedDetachedHead,
+			Message: "worktree HEAD is detached",
+		})
+	}
+
+	remote, degradation := inspectRemote(root, local.Branch)
+	if remote != nil {
+		local.Remote = remote
+	}
+	if degradation.Code != "" {
+		local.Degraded = append(local.Degraded, degradation)
+	}
+
+	return local
+}
+
+func inspectRemote(root, branch string) (*Remote, Degradation) {
+	remoteName := ""
+	if branch != "" {
+		if upstream, err := gitOutput(root, "config", "--get", "branch."+branch+".remote"); err == nil && upstream != "." {
+			remoteName = upstream
+		}
+	}
+	if remoteName == "" {
+		if _, err := gitOutput(root, "remote", "get-url", "origin"); err == nil {
+			remoteName = "origin"
+		}
+	}
+	if remoteName == "" {
+		remotes, err := gitOutput(root, "remote")
+		if err != nil || strings.TrimSpace(remotes) == "" {
+			return nil, Degradation{
+				Code:    DegradedMissingRemote,
+				Message: "no git remote is configured",
+			}
+		}
+		names := splitLines(remotes)
+		if len(names) == 1 {
+			remoteName = names[0]
+		} else {
+			return nil, Degradation{
+				Code:    DegradedAmbiguousRemote,
+				Message: "multiple git remotes are configured and no unambiguous remote was selected",
+			}
+		}
+	}
+
+	rawURL, err := gitOutput(root, "remote", "get-url", remoteName)
+	if err != nil {
+		return nil, Degradation{
+			Code:    DegradedMissingRemote,
+			Message: fmt.Sprintf("unable to read git remote %q", remoteName),
+		}
+	}
+	remote := parseGitHubRemote(remoteName, rawURL)
+	if !remote.Supported {
+		return &remote, Degradation{
+			Code:    DegradedUnsupportedRemote,
+			Message: fmt.Sprintf("git remote %q is not a supported GitHub remote", remoteName),
+		}
+	}
+	return &remote, Degradation{}
+}
+
+func parseGitHubRemote(name, raw string) Remote {
+	trimmed := strings.TrimSpace(raw)
+	remote := Remote{Name: name, URL: trimmed}
+
+	if match := scpLikeGitHubRemote.FindStringSubmatch(trimmed); len(match) == 3 {
+		remote.Host = "github.com"
+		remote.Owner = match[1]
+		remote.Repo = strings.TrimSuffix(match[2], ".git")
+		remote.Supported = true
+		return remote
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Host != "github.com" {
+		return remote
+	}
+	parts := splitPath(parsed.Path)
+	if len(parts) != 2 {
+		return remote
+	}
+	remote.Host = "github.com"
+	remote.Owner = parts[0]
+	remote.Repo = strings.TrimSuffix(parts[1], ".git")
+	remote.Supported = true
+	return remote
+}
+
+func unsupportedPRURL(raw string) PRIdentity {
+	return PRIdentity{
+		Status: PRStatusUnsupported,
+		URL:    raw,
+		Degraded: Degradation{
+			Code:    DegradedUnsupportedPRURL,
+			Message: "recorded PR URL is not a supported GitHub pull request URL",
+		},
+	}
+}
+
+func gitOutput(workdir string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", filepath.Clean(workdir)}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func splitPath(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
+}
+
+func splitLines(input string) []string {
+	lines := strings.Split(input, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/internal/remote/identity.go
+++ b/internal/remote/identity.go
@@ -95,6 +95,9 @@ func ParseRecordedPRURL(raw string) PRIdentity {
 	if len(parts) != 4 || parts[2] != "pull" {
 		return unsupportedPRURL(trimmed)
 	}
+	if parts[0] == "" || parts[1] == "" {
+		return unsupportedPRURL(trimmed)
+	}
 	number, err := strconv.Atoi(parts[3])
 	if err != nil || number <= 0 {
 		return unsupportedPRURL(trimmed)
@@ -201,9 +204,13 @@ func parseGitHubRemote(name, raw string) Remote {
 	remote := Remote{Name: name, URL: trimmed}
 
 	if match := scpLikeGitHubRemote.FindStringSubmatch(trimmed); len(match) == 3 {
+		repo := strings.TrimSuffix(match[2], ".git")
+		if match[1] == "" || repo == "" {
+			return remote
+		}
 		remote.Host = "github.com"
 		remote.Owner = match[1]
-		remote.Repo = strings.TrimSuffix(match[2], ".git")
+		remote.Repo = repo
 		remote.Supported = true
 		return remote
 	}
@@ -216,9 +223,13 @@ func parseGitHubRemote(name, raw string) Remote {
 	if len(parts) != 2 {
 		return remote
 	}
+	repo := strings.TrimSuffix(parts[1], ".git")
+	if parts[0] == "" || repo == "" {
+		return remote
+	}
 	remote.Host = "github.com"
 	remote.Owner = parts[0]
-	remote.Repo = strings.TrimSuffix(parts[1], ".git")
+	remote.Repo = repo
 	remote.Supported = true
 	return remote
 }

--- a/internal/remote/identity_test.go
+++ b/internal/remote/identity_test.go
@@ -1,0 +1,165 @@
+package remote
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRecordedPRURLSupportsGitHub(t *testing.T) {
+	identity := ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/203")
+
+	if identity.Status != PRStatusRecorded {
+		t.Fatalf("expected recorded status, got %#v", identity)
+	}
+	if identity.Owner != "catu-ai" || identity.Repo != "easyharness" || identity.Number != 203 {
+		t.Fatalf("unexpected parsed identity: %#v", identity)
+	}
+	if identity.URL != "https://github.com/catu-ai/easyharness/pull/203" {
+		t.Fatalf("expected canonical URL to preserve input, got %q", identity.URL)
+	}
+}
+
+func TestParseRecordedPRURLDegradesWhenMissingOrUnsupported(t *testing.T) {
+	missing := ParseRecordedPRURL("")
+	if missing.Status != PRStatusMissing || missing.Degraded.Code != DegradedMissingPRURL {
+		t.Fatalf("expected missing PR URL degradation, got %#v", missing)
+	}
+
+	unsupported := ParseRecordedPRURL("https://gitlab.com/catu-ai/easyharness/-/merge_requests/1")
+	if unsupported.Status != PRStatusUnsupported || unsupported.Degraded.Code != DegradedUnsupportedPRURL {
+		t.Fatalf("expected unsupported PR URL degradation, got %#v", unsupported)
+	}
+}
+
+func TestSnapshotReportsBranchAndGitHubRemoteContext(t *testing.T) {
+	root := seedGitRepo(t)
+	runGit(t, root, "remote", "add", "origin", "git@github.com:catu-ai/easyharness.git")
+
+	snapshot := Service{Workdir: root}.Snapshot("https://github.com/catu-ai/easyharness/pull/203")
+
+	if snapshot.PR.Status != PRStatusRecorded {
+		t.Fatalf("expected recorded PR identity, got %#v", snapshot.PR)
+	}
+	if !snapshot.Local.InGitRepo || snapshot.Local.Branch == "" || snapshot.Local.Detached {
+		t.Fatalf("expected branch context, got %#v", snapshot.Local)
+	}
+	if snapshot.Local.Remote == nil {
+		t.Fatalf("expected remote context, got %#v", snapshot.Local)
+	}
+	if snapshot.Local.Remote.Name != "origin" || snapshot.Local.Remote.Owner != "catu-ai" || snapshot.Local.Remote.Repo != "easyharness" {
+		t.Fatalf("unexpected remote context: %#v", snapshot.Local.Remote)
+	}
+}
+
+func TestLocalContextDegradesForDetachedHead(t *testing.T) {
+	root := seedGitRepo(t)
+	head := runGit(t, root, "rev-parse", "HEAD")
+	runGit(t, root, "checkout", "--detach", head)
+
+	local := InspectLocal(root)
+
+	if !local.Detached || local.Branch != "" {
+		t.Fatalf("expected detached local context, got %#v", local)
+	}
+	if !hasDegradation(local.Degraded, DegradedDetachedHead) {
+		t.Fatalf("expected detached degradation, got %#v", local.Degraded)
+	}
+}
+
+func TestLocalContextDegradesForMissingRemote(t *testing.T) {
+	root := seedGitRepo(t)
+
+	local := InspectLocal(root)
+
+	if local.Remote != nil {
+		t.Fatalf("expected no remote context, got %#v", local.Remote)
+	}
+	if !hasDegradation(local.Degraded, DegradedMissingRemote) {
+		t.Fatalf("expected missing remote degradation, got %#v", local.Degraded)
+	}
+}
+
+func TestLocalContextDegradesForUnsupportedRemote(t *testing.T) {
+	root := seedGitRepo(t)
+	runGit(t, root, "remote", "add", "origin", "ssh://git@example.com/catu-ai/easyharness.git")
+
+	local := InspectLocal(root)
+
+	if local.Remote == nil || local.Remote.Supported {
+		t.Fatalf("expected unsupported remote context, got %#v", local.Remote)
+	}
+	if !hasDegradation(local.Degraded, DegradedUnsupportedRemote) {
+		t.Fatalf("expected unsupported remote degradation, got %#v", local.Degraded)
+	}
+}
+
+func TestLocalContextReportsNotGitRepository(t *testing.T) {
+	local := InspectLocal(t.TempDir())
+
+	if local.InGitRepo {
+		t.Fatalf("expected non-git context, got %#v", local)
+	}
+	if !hasDegradation(local.Degraded, DegradedNotGitRepository) {
+		t.Fatalf("expected not-git degradation, got %#v", local.Degraded)
+	}
+}
+
+func seedGitRepo(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	runGit(t, root, "init", "-b", "main")
+	runGit(t, root, "config", "user.name", "Codex Test")
+	runGit(t, root, "config", "user.email", "codex@example.com")
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("test repo\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-m", "fixture")
+	return root
+}
+
+func runGit(t *testing.T, root string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
+	}
+	return string(bytesTrimSpace(output))
+}
+
+func hasDegradation(degraded []Degradation, code string) bool {
+	for _, item := range degraded {
+		if item.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func bytesTrimSpace(input []byte) []byte {
+	for len(input) > 0 {
+		switch input[0] {
+		case ' ', '\n', '\r', '\t':
+			input = input[1:]
+		default:
+			goto trimRight
+		}
+	}
+	return input
+
+trimRight:
+	for len(input) > 0 {
+		switch input[len(input)-1] {
+		case ' ', '\n', '\r', '\t':
+			input = input[:len(input)-1]
+		default:
+			return input
+		}
+	}
+	return input
+}

--- a/internal/remote/identity_test.go
+++ b/internal/remote/identity_test.go
@@ -100,6 +100,20 @@ func TestLocalContextDegradesForUnsupportedRemote(t *testing.T) {
 	}
 }
 
+func TestLocalContextDegradesForScpLikeGitHubRemoteWithExtraPath(t *testing.T) {
+	root := seedGitRepo(t)
+	runGit(t, root, "remote", "add", "origin", "git@github.com:catu-ai/easyharness/extra.git")
+
+	local := InspectLocal(root)
+
+	if local.Remote == nil || local.Remote.Supported {
+		t.Fatalf("expected unsupported multi-segment scp-like remote context, got %#v", local.Remote)
+	}
+	if !hasDegradation(local.Degraded, DegradedUnsupportedRemote) {
+		t.Fatalf("expected unsupported remote degradation, got %#v", local.Degraded)
+	}
+}
+
 func TestLocalContextDegradesForEmptyGitHubRemoteRepo(t *testing.T) {
 	root := seedGitRepo(t)
 	runGit(t, root, "remote", "add", "origin", "https://github.com/catu-ai/.git")

--- a/internal/remote/identity_test.go
+++ b/internal/remote/identity_test.go
@@ -31,6 +31,11 @@ func TestParseRecordedPRURLDegradesWhenMissingOrUnsupported(t *testing.T) {
 	if unsupported.Status != PRStatusUnsupported || unsupported.Degraded.Code != DegradedUnsupportedPRURL {
 		t.Fatalf("expected unsupported PR URL degradation, got %#v", unsupported)
 	}
+
+	emptyRepo := ParseRecordedPRURL("https://github.com/catu-ai//pull/203")
+	if emptyRepo.Status != PRStatusUnsupported || emptyRepo.Degraded.Code != DegradedUnsupportedPRURL {
+		t.Fatalf("expected empty repo PR URL degradation, got %#v", emptyRepo)
+	}
 }
 
 func TestSnapshotReportsBranchAndGitHubRemoteContext(t *testing.T) {
@@ -89,6 +94,20 @@ func TestLocalContextDegradesForUnsupportedRemote(t *testing.T) {
 
 	if local.Remote == nil || local.Remote.Supported {
 		t.Fatalf("expected unsupported remote context, got %#v", local.Remote)
+	}
+	if !hasDegradation(local.Degraded, DegradedUnsupportedRemote) {
+		t.Fatalf("expected unsupported remote degradation, got %#v", local.Degraded)
+	}
+}
+
+func TestLocalContextDegradesForEmptyGitHubRemoteRepo(t *testing.T) {
+	root := seedGitRepo(t)
+	runGit(t, root, "remote", "add", "origin", "https://github.com/catu-ai/.git")
+
+	local := InspectLocal(root)
+
+	if local.Remote == nil || local.Remote.Supported {
+		t.Fatalf("expected unsupported empty-repo remote context, got %#v", local.Remote)
 	}
 	if !hasDegradation(local.Degraded, DegradedUnsupportedRemote) {
 		t.Fatalf("expected unsupported remote degradation, got %#v", local.Degraded)


### PR DESCRIPTION
## Summary

- Define recorded publish `pr_url` as the authoritative remote handoff anchor in the specs.
- Add `internal/remote` local git context and recorded GitHub PR URL identity parsing with degraded states.
- Add explicit, mockable `gh pr view <recorded-pr-url>` observation without branch-based PR discovery.

Closes #203.

## Validation

- `go test ./internal/remote`
- `go test -count=1 ./internal/remote`
- `go test ./...`
- `harness plan lint docs/plans/active/2026-05-18-define-read-only-pr-handoff-identity.md`
- `harness plan lint docs/plans/archived/2026-05-18-define-read-only-pr-handoff-identity.md`
- `git diff --check`

## Harness Handoff

- Plan: `docs/plans/archived/2026-05-18-define-read-only-pr-handoff-identity.md`
- Workflow profile: standard
- Archive state: archived and ready for publish/CI/sync evidence
- Merge approval: wait for `harness status` to reach `execution/finalize/await_merge`
