### PR TITLE
Add refresh for remote handoff evidence

### DIFF
--- a/docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md
+++ b/docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md
@@ -157,7 +157,7 @@ is needed.
 
 ### Step 2: Add `harness evidence refresh`
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -200,7 +200,18 @@ workflow state outside the normal evidence append and timeline mechanics.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added `harness evidence refresh` as an explicit mutating command. The command
+loads the latest publish evidence PR URL, observes that recorded PR through the
+remote read model, and appends `ci` and `sync` evidence independently when
+the corresponding remote facts are clear. Manual `harness evidence submit`
+fallback remains available for missing PR URLs, unsupported PR URLs, missing
+`gh`/auth, unreadable remote data, or per-domain degraded facts. Added
+service-level and CLI-level tests for full refresh, missing recorded PR, and
+partial domain refresh; wired help text, timeline events, watchlist touch, and
+generated contract schema output for the new result shape. Validation:
+`go test ./internal/evidence ./internal/cli`; `go test ./internal/remote
+./internal/evidence ./internal/cli ./internal/contractsync`;
+`scripts/sync-contract-artifacts`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md
+++ b/docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md
@@ -150,7 +150,10 @@ docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md`.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 1 closeout was covered by `review-001-delta`
+and the clean repair follow-up `review-002-delta`; those rounds were recorded
+after the plan frontier advanced, so no additional duplicate step-local review
+is needed.
 
 ### Step 2: Add `harness evidence refresh`
 

--- a/docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md
+++ b/docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md
@@ -1,0 +1,299 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-21T23:53:12+08:00"
+approved_at: "2026-05-21T23:54:41+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/199
+size: M
+---
+
+# Refresh Remote Handoff Evidence
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Resolve issue #199 by adding a read-only remote PR and CI read model, then
+using it to refresh local `ci` and `sync` evidence for an archived candidate
+with a recorded PR URL.
+
+The end state should let a controller run a single harness command after
+publish evidence exists and have harness read GitHub through `gh`, classify PR
+checks and merge freshness, and append the corresponding local evidence. The
+existing `harness evidence submit --kind publish|ci|sync` commands remain the
+manual fallback when `gh`, auth, network access, or provider output is
+unavailable.
+
+## Scope
+
+### In Scope
+
+- Extend the recorded-PR remote read model from issue #203 so it can observe
+  PR state, check status, and merge-readiness signals for a recorded GitHub PR.
+- Add `harness evidence refresh` as an explicit mutating command that reads the
+  recorded PR URL from latest publish evidence and appends `ci` and `sync`
+  evidence when the remote facts are clear enough.
+- Keep `gh` optional: missing `gh`, missing auth, network/API failures,
+  unreadable PRs, invalid JSON, or unsupported provider output must return
+  degraded command results without blocking manual evidence fallback.
+- Preserve the no-guess identity rule: if publish evidence does not already
+  contain a PR URL, refresh must not discover or infer a PR from the branch.
+- Update CLI contracts, state-model contracts, generated schemas or command
+  registry entries as needed for the new command surface.
+- Add unit and focused CLI tests covering successful refresh and degraded read
+  paths without requiring a real `gh` binary, auth, or network access.
+
+### Out of Scope
+
+- Surfacing live remote handoff facts and richer next actions through
+  `harness status`; that belongs to issue #200.
+- Opening, updating, commenting on, labeling, reviewing, rerunning checks for,
+  or merging PRs.
+- Guessing a PR from the current branch when publish evidence lacks a PR URL.
+- Replacing the manual `harness evidence submit` fallback.
+- Fetching full CI logs or deciding repository-specific merge policy beyond
+  the compact evidence states already understood by harness.
+- Introducing `.harness` customization or non-GitHub provider support.
+
+## Acceptance Criteria
+
+- [ ] A remote read model can classify recorded GitHub PR observation,
+      aggregate check status, and merge freshness/conflict state using mockable
+      command execution.
+- [ ] `harness evidence refresh` reads the latest publish evidence PR URL and
+      appends both `ci` and `sync` evidence when remote facts are clear.
+- [ ] Refresh maps passing checks to `ci: success`, pending checks to
+      `ci: pending`, failing/cancelled checks to `ci: failed`, clean/current
+      merge state to `sync: fresh`, stale/behind/unknown-but-readable merge
+      state to `sync: stale`, and conflict state to `sync: conflicted`.
+- [ ] Missing recorded PR URL, unsupported PR URL, missing `gh`, missing auth,
+      unreadable PRs, network/API failures, and invalid provider output degrade
+      without writing misleading success evidence.
+- [ ] Existing manual `harness evidence submit --kind publish|ci|sync` flows
+      continue to work unchanged and remain the documented fallback.
+- [ ] Tests cover success and degraded refresh paths, including the no-guess
+      missing-PR case and partial evidence behavior when only one domain can be
+      refreshed confidently.
+
+## Deferred Items
+
+- Issue #200: surface remote handoff facts and next actions in `harness
+  status` without mutating workflow state.
+- Issue #202: update controller docs and skills after the remote handoff
+  command and status surfaces settle.
+- Future customization work may define repository-specific remote mappings,
+  but this slice keeps the core model evidence-first and GitHub-only.
+
+## Work Breakdown
+
+### Step 1: Specify refresh semantics and extend the remote read model
+
+- Done: [x]
+
+#### Objective
+
+Define and implement the read-only provider boundary that turns a recorded PR
+URL into normalized PR, checks, and merge-state observations.
+
+#### Details
+
+The read model should build on `internal/remote` from issue #203. It must keep
+recorded publish `pr_url` as the only PR identity source and use `gh` only for
+read operations against that recorded URL. The command execution boundary must
+stay injectable so tests can simulate `gh pr view`, `gh pr checks`, missing
+auth, invalid JSON, pending checks, failing checks, and conflict states.
+
+The model should expose normalized outcomes instead of leaking raw `gh`
+shapes throughout the codebase. If GitHub exposes both PR-level fields and
+check rows, the implementation may use the smallest stable `gh` surface that
+can distinguish passing, pending, failing, cancelled, unavailable, fresh,
+stale, and conflicted outcomes.
+
+#### Expected Files
+
+- `internal/remote/...`
+- `internal/remote/..._test.go`
+- `docs/specs/state-model.md`
+- `docs/specs/cli-contract.md`
+- Contract schema or registry files if the read model affects public command
+  output types
+
+#### Validation
+
+- Unit tests cover normalized PR/check/sync observation success and degraded
+  paths using fake command execution.
+- Tests assert that no branch-based PR discovery runs when recorded PR URL is
+  missing.
+- Specs explain that refresh is the mutating evidence command, while status
+  remains read-only.
+
+#### Execution Notes
+
+Extended `internal/remote` with a normalized handoff observation that reads a
+recorded PR through `gh pr view`, reads checks through `gh pr checks`, and
+maps clear provider facts to local evidence statuses for later refresh:
+`ci: success|pending|failed` and `sync: fresh|stale|conflicted`. The read
+model keeps command execution injectable for tests, does not discover PRs from
+branches, and degrades per domain when checks or merge state are unavailable.
+Updated `docs/specs/state-model.md` and `docs/specs/cli-contract.md` to define
+`harness evidence refresh` as the explicit mutating bridge while keeping
+`harness status` read-only. Validation: `go test ./internal/remote`;
+`harness plan lint
+docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md`; `git diff
+--check -- internal/remote docs/specs
+docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md`.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Add `harness evidence refresh`
+
+- Done: [ ]
+
+#### Objective
+
+Add the explicit command that observes the recorded PR and writes append-only
+`ci` and `sync` evidence for the current archived candidate.
+
+#### Details
+
+`harness evidence refresh` should only operate when the current plan is an
+archived candidate in the publish/await-merge phase. It should load latest
+publish evidence for the current revision, parse the recorded PR URL, observe
+remote PR/check state, and append evidence records for domains whose facts are
+clear enough.
+
+The command should be all-or-clear per evidence domain rather than inventing
+success when data is unavailable. For example, if checks are readable but merge
+state is unavailable, refresh may write `ci` evidence and report degraded
+`sync` refresh; if neither domain is clear, it should write no evidence and
+steer the controller to manual `harness evidence submit`. The command must not
+write publish evidence, mutate GitHub, update PRs, rerun checks, or alter local
+workflow state outside the normal evidence append and timeline mechanics.
+
+#### Expected Files
+
+- `internal/evidence/...`
+- `internal/cli/...`
+- `internal/contracts/...`
+- `internal/inputschema/...` or generated schema files if needed
+- `docs/specs/cli-contract.md`
+
+#### Validation
+
+- CLI tests exercise successful refresh that writes both `ci` and `sync`
+  evidence and causes existing status resolution to reach
+  `execution/finalize/await_merge` when publish evidence is already recorded.
+- CLI tests cover missing publish PR URL, unsupported PR URL, `gh` unavailable,
+  auth unavailable, unreadable PR, invalid JSON, pending checks, failing
+  checks, stale merge state, and conflicted merge state.
+- Tests verify manual `evidence submit` commands still pass unchanged.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Close contracts, generated surfaces, and regression coverage
+
+- Done: [ ]
+
+#### Objective
+
+Make the new refresh behavior durable across docs, schemas, help text, and
+end-to-end workflow expectations.
+
+#### Details
+
+Refresh should appear in the public CLI contract as the automatic evidence
+path for recorded PR handoff, with manual submit preserved as the fallback.
+Any generated contract snapshots, command schemas, help text, or docs that
+enumerate evidence commands must be updated together so future agents do not
+learn conflicting command shapes.
+
+Keep issue #200 out of scope: this step may add minimal next-action text that
+points from publish-phase guidance toward `harness evidence refresh`, but it
+should not build the richer status remote-facts surface.
+
+#### Expected Files
+
+- `docs/specs/cli-contract.md`
+- `docs/specs/state-model.md`
+- Contract registry/schema snapshots if generated by the repository workflow
+- CLI/help tests and targeted workflow tests
+
+#### Validation
+
+- `go test ./internal/remote ./internal/evidence ./internal/cli`
+- Broader `go test ./...` unless a narrower failure is justified in execution
+  notes.
+- `harness plan lint docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md`
+- `git diff --check`
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+Validation should start with focused unit tests for the normalized remote read
+model, then exercise the command through CLI-level tests that verify evidence
+records are appended exactly when facts are clear. The full candidate should
+run the relevant package tests plus `go test ./...` before archive because
+evidence refresh touches command routing, public contracts, and status
+progression indirectly through existing evidence reads.
+
+## Risks
+
+- Risk: Refresh could accidentally make `gh` a hard dependency for normal
+  harness status or merge-readiness work.
+  - Mitigation: Keep refresh as an explicit command, preserve submit fallback,
+    and test missing `gh`/auth degraded results.
+- Risk: Mapping GitHub merge/check states too aggressively could write
+  misleading evidence.
+  - Mitigation: Normalize only clear outcomes, degrade instead of guessing, and
+    cover ambiguous provider output with negative tests.
+- Risk: The new command could blur the #199/#200 boundary by adding a large
+  status surface.
+  - Mitigation: Limit status changes to existing evidence-driven behavior and
+    defer richer remote facts/next actions to issue #200.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+- https://github.com/catu-ai/easyharness/issues/200
+- https://github.com/catu-ai/easyharness/issues/202

--- a/docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md
+++ b/docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md
@@ -215,11 +215,18 @@ generated contract schema output for the new result shape. Validation:
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-003-delta` found four important findings: refresh could leave
+unreported CI evidence if a later sync write failed, refresh accepted
+non-`recorded` publish evidence with a `pr_url`, the top-level CLI contract
+command list omitted `harness evidence refresh`, and CLI-level degraded/help
+coverage was too narrow. The repair requires publish status `recorded`,
+preallocates/rolls back evidence writes, updates the command list, and expands
+CLI degraded/non-success/help coverage. `review-004-delta` passed with no
+findings after the repair.
 
 ### Step 3: Close contracts, generated surfaces, and regression coverage
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -255,11 +262,18 @@ should not build the richer status remote-facts surface.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Completed the contract and regression closeout for the refresh command. The
+dev harness was reinstalled after CLI changes, contract artifacts were checked
+with `scripts/sync-contract-artifacts --check`, focused packages passed with
+`go test -count=1 ./internal/remote ./internal/evidence ./internal/cli
+./internal/contractsync`, and full validation passed with `go test ./...`
+including `tests/smoke` after a long smoke run.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 3 is validation and contract closeout for the
+candidate and will be covered by the required full finalize review before
+archive.
 
 ## Validation Strategy
 

--- a/docs/plans/archived/2026-05-21-refresh-remote-handoff-evidence.md
+++ b/docs/plans/archived/2026-05-21-refresh-remote-handoff-evidence.md
@@ -62,21 +62,21 @@ unavailable.
 
 ## Acceptance Criteria
 
-- [ ] A remote read model can classify recorded GitHub PR observation,
+- [x] A remote read model can classify recorded GitHub PR observation,
       aggregate check status, and merge freshness/conflict state using mockable
       command execution.
-- [ ] `harness evidence refresh` reads the latest publish evidence PR URL and
+- [x] `harness evidence refresh` reads the latest publish evidence PR URL and
       appends both `ci` and `sync` evidence when remote facts are clear.
-- [ ] Refresh maps passing checks to `ci: success`, pending checks to
+- [x] Refresh maps passing checks to `ci: success`, pending checks to
       `ci: pending`, failing/cancelled checks to `ci: failed`, clean/current
       merge state to `sync: fresh`, stale/behind/unknown-but-readable merge
       state to `sync: stale`, and conflict state to `sync: conflicted`.
-- [ ] Missing recorded PR URL, unsupported PR URL, missing `gh`, missing auth,
+- [x] Missing recorded PR URL, unsupported PR URL, missing `gh`, missing auth,
       unreadable PRs, network/API failures, and invalid provider output degrade
       without writing misleading success evidence.
-- [ ] Existing manual `harness evidence submit --kind publish|ci|sync` flows
+- [x] Existing manual `harness evidence submit --kind publish|ci|sync` flows
       continue to work unchanged and remain the documented fallback.
-- [ ] Tests cover success and degraded refresh paths, including the no-guess
+- [x] Tests cover success and degraded refresh paths, including the no-guess
       missing-PR case and partial evidence behavior when only one domain can be
       refreshed confidently.
 
@@ -301,25 +301,72 @@ progression indirectly through existing evidence reads.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+Validation passed for the archive candidate.
+
+- Reinstalled the dev harness after CLI changes with
+  `scripts/install-dev-harness`.
+- Ran focused package validation:
+  `go test -count=1 ./internal/remote ./internal/evidence ./internal/cli ./internal/status ./internal/contractsync`.
+- Ran full validation: `go test ./...`, including the slower smoke package.
+- Verified generated contracts with `scripts/sync-contract-artifacts --check`.
+- Verified whitespace/diff health with `git diff --check`.
+- Verified plan shape with
+  `harness plan lint docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md`.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Reviewed through step and finalize harness rounds.
+
+- Step 1 was covered by `review-001-delta`; `review-002-delta` passed after
+  remote observation test and contract repairs.
+- Step 2 was covered by `review-003-delta`; `review-004-delta` passed after
+  refresh rollback, publish-status, command-list, and degraded CLI coverage
+  repairs.
+- Finalize `review-005-full` requested fallback/status guidance repairs;
+  `review-006-delta` passed after missing/unsupported PR, partial refresh, and
+  status refresh guidance repairs.
+- Finalize `review-007-full` requested refresh guidance for non-ready
+  recorded-PR handoffs; `review-008-delta` passed after pending-CI and
+  stale-sync refresh guidance repairs.
+- Finalize `review-009-full` requested explicit manual fallback commands for
+  non-ready recorded-PR handoffs; `review-010-delta` passed after preserving
+  CI/sync submit fallback commands in those states.
+- Final archive-candidate `review-011-full` passed with zero blocking and zero
+  non-blocking findings.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-05-22T01:21:23+08:00
+- Revision: 1
+- PR: To be opened after archive commit and push.
+- Ready: The tracked plan has completed implementation, validation, and final
+  full review; archive is ready once this closeout update is frozen.
+- Merge Handoff: After PR creation, record publish evidence with the PR URL,
+  then use `harness evidence refresh` to record CI and sync evidence from that
+  recorded PR when checks and merge state are ready.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added a recorded-PR-only GitHub handoff observation model that classifies PR
+  checks and merge state through injectable `gh` command execution.
+- Added `harness evidence refresh` to append CI and sync evidence from the
+  latest recorded publish PR URL without guessing from the current branch.
+- Preserved manual `harness evidence submit --kind publish|ci|sync` fallback
+  for missing identity, unsupported providers, missing `gh`/auth, unreadable
+  remote data, partial refresh, and non-ready handoff states.
+- Updated CLI contracts, state-model docs, generated command schema registry,
+  CLI help, timeline/watchlist handling, status next actions, and regression
+  tests for successful and degraded refresh paths.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No `.harness` customization was introduced.
+- No non-GitHub provider support was added.
+- No PR creation/update, check rerun, commenting, labeling, reviewing, merging,
+  or CI-log fetching was added.
+- Rich live remote facts in `harness status` remain deferred to issue #200.
 
 ### Follow-Up Issues
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -36,6 +36,7 @@ The current command surface is:
 - `harness instructions uninstall`
 - `harness execute start`
 - `harness evidence submit`
+- `harness evidence refresh`
 - `harness status`
 - `harness dashboard`
 - `harness ui`

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -508,9 +508,10 @@ Contract:
   workflow state
 - never append evidence from `harness status`; automatic remote-to-evidence
   updates belong to the explicit `harness evidence refresh` command
-- when recorded publish evidence has a PR URL but CI or sync evidence is still
-  missing, include `harness evidence refresh` in status next actions while
-  preserving manual `harness evidence submit` fallback commands
+- when recorded publish evidence has a PR URL but CI or sync evidence is
+  missing or still non-ready (`ci: pending` or `sync: stale`), include
+  `harness evidence refresh` in status next actions while preserving manual
+  `harness evidence submit` fallback commands
 - if no current plan is active but `.local/harness/current-plan.json` records a
   landed candidate, return `state.current_node: idle` with landed context in
   `artifacts`

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -508,6 +508,9 @@ Contract:
   workflow state
 - never append evidence from `harness status`; automatic remote-to-evidence
   updates belong to the explicit `harness evidence refresh` command
+- when recorded publish evidence has a PR URL but CI or sync evidence is still
+  missing, include `harness evidence refresh` in status next actions while
+  preserving manual `harness evidence submit` fallback commands
 - if no current plan is active but `.local/harness/current-plan.json` records a
   landed candidate, return `state.current_node: idle` with landed context in
   `artifacts`

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -505,6 +505,8 @@ Contract:
   network/API failure, an unreadable PR, or mismatched local git context should
   degrade to warnings or manual evidence guidance instead of failing local
   workflow state
+- never append evidence from `harness status`; automatic remote-to-evidence
+  updates belong to the explicit `harness evidence refresh` command
 - if no current plan is active but `.local/harness/current-plan.json` records a
   landed candidate, return `state.current_node: idle` with landed context in
   `artifacts`
@@ -998,6 +1000,36 @@ Contract:
   `state.json`
 - preserve trajectory by never editing older evidence artifacts in place
 - accept explicit `not_applied` payloads when a domain truly does not apply
+
+### `harness evidence refresh`
+
+Purpose:
+
+- observe the recorded PR URL from latest publish evidence and append derived
+  `ci` and `sync` evidence for the current archived candidate
+
+Contract:
+
+- require the current plan to already be archived before refreshing evidence
+- require latest publish evidence to record a supported PR URL; if it does not,
+  do not infer a PR from the current branch and steer the controller to
+  publish or manual evidence submit
+- use `gh` only for read operations against the recorded PR URL
+- classify readable PR checks into `ci` evidence: passing checks become
+  `success`, pending checks become `pending`, and failing or cancelled checks
+  become `failed`
+- classify readable PR merge state into `sync` evidence: clean/current state
+  becomes `fresh`, stale/behind/blocked/unknown-but-readable state becomes
+  `stale`, and conflict state becomes `conflicted`
+- append evidence independently per domain: if CI facts are clear but sync
+  facts degrade, write only CI evidence and return clear degraded sync
+  guidance, and vice versa
+- never write misleading success evidence when `gh`, auth, network/API access,
+  provider output, checks, or merge state are unavailable
+- preserve `harness evidence submit --kind publish|ci|sync` as the manual
+  fallback for every degraded refresh path
+- never create or update PRs, rerun checks, comment, label, review, merge, or
+  perform GitHub writes
 
 ### `harness land --pr <url> [--commit <sha>]`
 

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -371,7 +371,8 @@ The repository standardizes three command-owned evidence domains:
 
 Rules:
 
-- all three domains are recorded through `harness evidence submit`
+- all three domains may be recorded manually through
+  `harness evidence submit`
 - when publish evidence already records a supported PR URL,
   `harness evidence refresh` may observe that PR through a read-only provider
   and record derived `ci` and `sync` evidence

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -372,6 +372,9 @@ The repository standardizes three command-owned evidence domains:
 Rules:
 
 - all three domains are recorded through `harness evidence submit`
+- when publish evidence already records a supported PR URL,
+  `harness evidence refresh` may observe that PR through a read-only provider
+  and record derived `ci` and `sync` evidence
 - missing evidence never means success or not-applicable
 - `not_applied` must be recorded explicitly when a domain truly does not apply
 - freshness belongs to `execution/finalize/publish`, not to pre-archive
@@ -395,6 +398,25 @@ open or update the PR outside harness, then record publish evidence. Harness
 should not infer a PR from the current branch as a substitute for that explicit
 handoff record. Future repository customization may define more complex remote
 mapping, but the core model stays evidence-first.
+
+### Remote Evidence Refresh
+
+`harness evidence refresh` is the explicit mutating bridge from remote
+observation to local evidence. It may use `gh` to read the PR recorded in
+publish evidence, classify PR checks as `ci` evidence, and classify merge
+freshness or conflicts as `sync` evidence. It must not create or update PRs,
+rerun checks, comment, label, review, merge, or perform other GitHub writes.
+
+Refresh writes evidence only for domains whose remote facts are clear enough.
+If checks are unreadable but merge state is clear, refresh may write `sync`
+evidence while degrading `ci`; the reverse is also allowed. If a domain is
+unavailable, ambiguous, or unsupported, refresh should leave that evidence
+domain untouched and guide the controller back to manual
+`harness evidence submit`.
+
+`harness status` remains a read-only snapshot resolver. Status may recommend a
+refresh or manual evidence submit, but it must not append evidence merely
+because it can observe remote facts.
 
 ## Reopen Rules
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/install"
 	"github.com/catu-ai/easyharness/internal/lifecycle"
 	"github.com/catu-ai/easyharness/internal/plan"
+	"github.com/catu-ai/easyharness/internal/remote"
 	"github.com/catu-ai/easyharness/internal/review"
 	"github.com/catu-ai/easyharness/internal/runstate"
 	"github.com/catu-ai/easyharness/internal/status"
@@ -37,6 +38,7 @@ type App struct {
 	UserHomeDir func() (string, error)
 	Version     func() versioninfo.Info
 	RunUIServer func(context.Context, ui.Server) error
+	RunCommand  remote.CommandRunner
 
 	StatusSettleTimeout      time.Duration
 	StatusSettlePollInterval time.Duration
@@ -203,6 +205,8 @@ func (a *App) runEvidence(args []string) int {
 	switch args[0] {
 	case "submit":
 		return a.runEvidenceSubmit(args[1:])
+	case "refresh":
+		return a.runEvidenceRefresh(args[1:])
 	case "-h", "--help", "help":
 		a.printEvidenceUsage()
 		return 0
@@ -279,6 +283,40 @@ func (a *App) runEvidenceSubmit(args []string) int {
 			"input": json.RawMessage(inputBytes),
 		}),
 	}.Submit(*kind, inputBytes)
+	return a.writeJSONResultForWorkdir(workdir, result)
+}
+
+func (a *App) runEvidenceRefresh(args []string) int {
+	fs := flag.NewFlagSet("harness evidence refresh", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(a.Stderr, "Usage: harness evidence refresh")
+		fmt.Fprintln(a.Stderr)
+		fmt.Fprintln(a.Stderr, "Observe the recorded PR URL and append CI and sync evidence when remote facts are clear.")
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+	workdir, err := a.Getwd()
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
+		return 1
+	}
+	recordedAt := a.Now().Format(time.RFC3339)
+	beforeStatus := readStatusSnapshot(workdir)
+	result := evidence.Service{
+		Workdir:      workdir,
+		Now:          a.Now,
+		RunCommand:   a.RunCommand,
+		AfterRefresh: evidenceRefreshTimelineHook(workdir, beforeStatus, recordedAt),
+	}.Refresh()
 	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
@@ -1097,6 +1135,7 @@ func (a *App) printRootUsage() {
 	fmt.Fprintln(a.Stderr, "  plan approve    Record explicit human approval for the current plan")
 	fmt.Fprintln(a.Stderr, "  execute start   Record the execution-start milestone")
 	fmt.Fprintln(a.Stderr, "  evidence submit Record append-only CI, publish, or sync evidence")
+	fmt.Fprintln(a.Stderr, "  evidence refresh Refresh CI and sync evidence from a recorded PR")
 	fmt.Fprintln(a.Stderr, "  review start    Create a deterministic review round")
 	fmt.Fprintln(a.Stderr, "  review submit   Record one reviewer submission")
 	fmt.Fprintln(a.Stderr, "  review aggregate Aggregate reviewer submissions")
@@ -1142,6 +1181,7 @@ func (a *App) printEvidenceUsage() {
 	fmt.Fprintln(a.Stderr)
 	fmt.Fprintln(a.Stderr, "Subcommands:")
 	fmt.Fprintln(a.Stderr, "  submit     Record append-only CI, publish, or sync evidence")
+	fmt.Fprintln(a.Stderr, "  refresh    Refresh CI and sync evidence from a recorded PR")
 }
 
 func (a *App) printSkillsUsage() {
@@ -1240,6 +1280,10 @@ func (a *App) writeJSONResult(value any) int {
 		if result.OK {
 			return 0
 		}
+	case evidence.RefreshResult:
+		if result.OK {
+			return 0
+		}
 	case lifecycle.Result:
 		if result.OK {
 			return 0
@@ -1254,7 +1298,7 @@ func (a *App) writeJSONResult(value any) int {
 
 func watchlistTouchEnabled(value any) bool {
 	switch value.(type) {
-	case evidence.Result, lifecycle.Result, review.AggregateResult, review.StartResult, review.SubmitResult, status.Result:
+	case evidence.Result, evidence.RefreshResult, lifecycle.Result, review.AggregateResult, review.StartResult, review.SubmitResult, status.Result:
 		return true
 	default:
 		return false

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1188,12 +1188,18 @@ func TestEvidenceRefreshCommandDegradesWithoutRecordedPR(t *testing.T) {
 		Errors []struct {
 			Path string `json:"path"`
 		} `json:"errors"`
+		NextActions []struct {
+			Command *string `json:"command"`
+		} `json:"next_actions"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("expected JSON evidence refresh output: %v\n%s", err, stdout.String())
 	}
 	if payload.OK || len(payload.Errors) == 0 || payload.Errors[0].Path != "publish.pr_url" {
 		t.Fatalf("expected publish.pr_url error, got %#v", payload)
+	}
+	if !jsonNextActionsContain(payload.NextActions, "harness evidence submit --kind publish --input <json>") {
+		t.Fatalf("expected publish fallback guidance, got %#v", payload.NextActions)
 	}
 }
 
@@ -1258,6 +1264,19 @@ func TestEvidenceRefreshCommandDegradesForRemoteFailures(t *testing.T) {
 			exitCode := app.Run([]string{"evidence", "refresh"})
 			if exitCode != 1 {
 				t.Fatalf("expected degraded refresh failure, got %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+			}
+			if tt.name == "unsupported PR URL" {
+				var payload struct {
+					NextActions []struct {
+						Command *string `json:"command"`
+					} `json:"next_actions"`
+				}
+				if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+					t.Fatalf("expected JSON evidence refresh output: %v\n%s", err, stdout.String())
+				}
+				if !jsonNextActionsContain(payload.NextActions, "harness evidence submit --kind publish --input <json>") {
+					t.Fatalf("expected publish fallback guidance, got %#v", payload.NextActions)
+				}
 			}
 			if ci, err := evidence.LoadLatestCI(root, "2026-03-18-landed-plan", 1); err != nil || ci != nil {
 				t.Fatalf("expected no CI evidence, got %#v err=%v", ci, err)
@@ -2579,6 +2598,17 @@ func assertWatchlistContainsWorkspace(t *testing.T, home, root string) {
 	if len(payload.Workspaces) != 1 || payload.Workspaces[0].WorkspacePath != canonicalRoot {
 		t.Fatalf("unexpected watchlist payload: %#v", payload)
 	}
+}
+
+func jsonNextActionsContain(actions []struct {
+	Command *string `json:"command"`
+}, command string) bool {
+	for _, action := range actions {
+		if action.Command != nil && *action.Command == command {
+			return true
+		}
+	}
+	return false
 }
 
 func seedGitWorkspace(t *testing.T, root string) {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/cli"
 	"github.com/catu-ai/easyharness/internal/evidence"
 	"github.com/catu-ai/easyharness/internal/plan"
+	"github.com/catu-ai/easyharness/internal/remote"
 	"github.com/catu-ai/easyharness/internal/runstate"
 	"github.com/catu-ai/easyharness/internal/status"
 	"github.com/catu-ai/easyharness/internal/timeline"
@@ -1116,6 +1117,86 @@ func TestEvidenceSubmitIgnoresWatchlistWriteFailure(t *testing.T) {
 	}
 }
 
+func TestEvidenceRefreshCommandWritesEvidenceAndUpdatesStatus(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	home := t.TempDir()
+	seedGitWorkspace(t, root)
+	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return home, nil }
+	app.Now = func() time.Time {
+		return time.Date(2026, 3, 18, 6, 0, 0, 0, time.UTC)
+	}
+	app.RunCommand = fakeCLIRefreshCommands(`"CLEAN"`, `[{"name":"Go Test","bucket":"pass","state":"SUCCESS","link":"https://ci.example/run"}]`)
+
+	writeArchivedPlanForCLI(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
+		t.Fatalf("seed publish evidence: %#v", result)
+	}
+
+	exitCode := app.Run([]string{"evidence", "refresh"})
+	if exitCode != 0 {
+		t.Fatalf("evidence refresh command failed with %d: %s", exitCode, stderr.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON evidence refresh output: %v\n%s", err, stdout.String())
+	}
+	if payload["command"] != "evidence refresh" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	statusResult := status.Service{Workdir: root}.Snapshot()
+	if !statusResult.OK || statusResult.State.CurrentNode != "execution/finalize/await_merge" {
+		t.Fatalf("expected refresh to satisfy merge-ready evidence, got %#v", statusResult)
+	}
+	assertLastTimelineEventCommand(t, root, "evidence refresh")
+	assertWatchlistContainsWorkspace(t, home, root)
+}
+
+func TestEvidenceRefreshCommandDegradesWithoutRecordedPR(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	called := false
+	app.RunCommand = func(name string, args ...string) remote.CommandResult {
+		called = true
+		return remote.CommandResult{}
+	}
+
+	writeArchivedPlanForCLI(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+
+	exitCode := app.Run([]string{"evidence", "refresh"})
+	if exitCode != 1 {
+		t.Fatalf("expected evidence refresh failure without PR, got %d: %s", exitCode, stderr.String())
+	}
+	if called {
+		t.Fatal("refresh should not call gh without recorded publish PR URL")
+	}
+	var payload struct {
+		OK     bool `json:"ok"`
+		Errors []struct {
+			Path string `json:"path"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON evidence refresh output: %v\n%s", err, stdout.String())
+	}
+	if payload.OK || len(payload.Errors) == 0 || payload.Errors[0].Path != "publish.pr_url" {
+		t.Fatalf("expected publish.pr_url error, got %#v", payload)
+	}
+}
+
 func TestEvidenceSubmitCommandReturnsSchemaValidationErrors(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -2101,6 +2182,29 @@ func seedMergeReadyEvidenceForCLI(t *testing.T, root string) {
 	}
 	if result := svc.Submit("sync", []byte(`{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`)); !result.OK {
 		t.Fatalf("seed sync evidence: %#v", result)
+	}
+}
+
+func fakeCLIRefreshCommands(mergeStateJSON, checksJSON string) remote.CommandRunner {
+	return func(name string, args ...string) remote.CommandResult {
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "view" {
+			return remote.CommandResult{Stdout: `{
+				"url":"https://github.com/catu-ai/easyharness/pull/99",
+				"number":99,
+				"state":"OPEN",
+				"isDraft":false,
+				"mergeStateStatus":` + mergeStateJSON + `,
+				"mergeable":"MERGEABLE",
+				"reviewDecision":"APPROVED",
+				"headRefName":"codex/test",
+				"headRefOid":"abc123",
+				"baseRefName":"main"
+			}`}
+		}
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "checks" {
+			return remote.CommandResult{Stdout: checksJSON}
+		}
+		return remote.CommandResult{}
 	}
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1197,6 +1197,145 @@ func TestEvidenceRefreshCommandDegradesWithoutRecordedPR(t *testing.T) {
 	}
 }
 
+func TestEvidenceRefreshCommandDegradesForRemoteFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		prURL      string
+		runCommand remote.CommandRunner
+	}{
+		{
+			name:  "unsupported PR URL",
+			prURL: "https://gitlab.com/catu-ai/easyharness/-/merge_requests/99",
+		},
+		{
+			name:  "gh missing",
+			prURL: "https://github.com/catu-ai/easyharness/pull/99",
+			runCommand: func(name string, args ...string) remote.CommandResult {
+				return remote.CommandResult{Err: exec.ErrNotFound}
+			},
+		},
+		{
+			name:  "auth unavailable",
+			prURL: "https://github.com/catu-ai/easyharness/pull/99",
+			runCommand: func(name string, args ...string) remote.CommandResult {
+				return remote.CommandResult{Stderr: "authentication required", Err: errors.New("exit status 4")}
+			},
+		},
+		{
+			name:  "unreadable PR",
+			prURL: "https://github.com/catu-ai/easyharness/pull/99",
+			runCommand: func(name string, args ...string) remote.CommandResult {
+				return remote.CommandResult{Stderr: "GraphQL: Could not resolve to a PullRequest", Err: errors.New("exit status 1")}
+			},
+		},
+		{
+			name:  "invalid PR JSON",
+			prURL: "https://github.com/catu-ai/easyharness/pull/99",
+			runCommand: func(name string, args ...string) remote.CommandResult {
+				return remote.CommandResult{Stdout: "{not-json"}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := new(bytes.Buffer)
+			stderr := new(bytes.Buffer)
+			app := cli.New(stdout, stderr)
+			root := t.TempDir()
+			app.Getwd = func() (string, error) { return root, nil }
+			app.RunCommand = tt.runCommand
+
+			writeArchivedPlanForCLI(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+			if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+				t.Fatalf("save current plan: %v", err)
+			}
+			input := `{"status":"recorded","pr_url":"` + tt.prURL + `"}`
+			if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(input)); !result.OK {
+				t.Fatalf("seed publish evidence: %#v", result)
+			}
+
+			exitCode := app.Run([]string{"evidence", "refresh"})
+			if exitCode != 1 {
+				t.Fatalf("expected degraded refresh failure, got %d stdout=%s stderr=%s", exitCode, stdout.String(), stderr.String())
+			}
+			if ci, err := evidence.LoadLatestCI(root, "2026-03-18-landed-plan", 1); err != nil || ci != nil {
+				t.Fatalf("expected no CI evidence, got %#v err=%v", ci, err)
+			}
+			if sync, err := evidence.LoadLatestSync(root, "2026-03-18-landed-plan", 1); err != nil || sync != nil {
+				t.Fatalf("expected no sync evidence, got %#v err=%v", sync, err)
+			}
+		})
+	}
+}
+
+func TestEvidenceRefreshCommandMapsNonSuccessRemoteStates(t *testing.T) {
+	tests := []struct {
+		name       string
+		mergeState string
+		checks     string
+		wantCI     string
+		wantSync   string
+	}{
+		{name: "pending checks", mergeState: `"CLEAN"`, checks: `[{"name":"Go Test","bucket":"pending","state":"IN_PROGRESS"}]`, wantCI: "pending", wantSync: "fresh"},
+		{name: "failing checks", mergeState: `"CLEAN"`, checks: `[{"name":"Go Test","bucket":"fail","state":"FAILURE"}]`, wantCI: "failed", wantSync: "fresh"},
+		{name: "stale merge", mergeState: `"BEHIND"`, checks: `[{"name":"Go Test","bucket":"pass","state":"SUCCESS"}]`, wantCI: "success", wantSync: "stale"},
+		{name: "conflicted merge", mergeState: `"DIRTY"`, checks: `[{"name":"Go Test","bucket":"pass","state":"SUCCESS"}]`, wantCI: "success", wantSync: "conflicted"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := new(bytes.Buffer)
+			stderr := new(bytes.Buffer)
+			app := cli.New(stdout, stderr)
+			root := t.TempDir()
+			app.Getwd = func() (string, error) { return root, nil }
+			app.RunCommand = fakeCLIRefreshCommands(tt.mergeState, tt.checks)
+
+			writeArchivedPlanForCLI(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+			if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+				t.Fatalf("save current plan: %v", err)
+			}
+			if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
+				t.Fatalf("seed publish evidence: %#v", result)
+			}
+
+			if exitCode := app.Run([]string{"evidence", "refresh"}); exitCode != 0 {
+				t.Fatalf("expected refresh success, got %d: %s", exitCode, stderr.String())
+			}
+			ci, err := evidence.LoadLatestCI(root, "2026-03-18-landed-plan", 1)
+			if err != nil || ci == nil || ci.Status != tt.wantCI {
+				t.Fatalf("expected CI %q, got %#v err=%v", tt.wantCI, ci, err)
+			}
+			sync, err := evidence.LoadLatestSync(root, "2026-03-18-landed-plan", 1)
+			if err != nil || sync == nil || sync.Status != tt.wantSync {
+				t.Fatalf("expected sync %q, got %#v err=%v", tt.wantSync, sync, err)
+			}
+		})
+	}
+}
+
+func TestEvidenceRefreshHelpSurfaces(t *testing.T) {
+	tests := [][]string{
+		{"--help"},
+		{"evidence", "--help"},
+		{"evidence", "refresh", "--help"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			stdout := new(bytes.Buffer)
+			stderr := new(bytes.Buffer)
+			app := cli.New(stdout, stderr)
+			if exitCode := app.Run(args); exitCode != 0 {
+				t.Fatalf("help failed with %d: %s", exitCode, stderr.String())
+			}
+			help := stderr.String()
+			if !strings.Contains(help, "refresh") || !strings.Contains(help, "CI and sync evidence") {
+				t.Fatalf("expected help to mention evidence refresh, got %q", help)
+			}
+		})
+	}
+}
+
 func TestEvidenceSubmitCommandReturnsSchemaValidationErrors(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/cli/timeline_events.go
+++ b/internal/cli/timeline_events.go
@@ -124,6 +124,18 @@ func evidenceTimelineHook(workdir string, before *status.Result, recordedAt, kin
 	}
 }
 
+func evidenceRefreshTimelineHook(workdir string, before *status.Result, recordedAt string) func(evidence.RefreshResult) error {
+	return func(result evidence.RefreshResult) error {
+		return appendTimelineEvent(
+			workdir,
+			before,
+			readStatusSnapshot(workdir),
+			attachRawPayloads(timelineEventFromEvidenceRefresh(result), nil, result, result.Artifacts),
+			recordedAt,
+		)
+	}
+}
+
 func timelineEventFromLifecycle(result lifecycle.Result) timeline.Event {
 	event := timeline.Event{
 		Kind:    "lifecycle",
@@ -233,6 +245,27 @@ func timelineEventFromEvidence(result evidence.Result, kind string) timeline.Eve
 		event.ArtifactRefs = append(event.ArtifactRefs,
 			pathRef("plan_path", result.Artifacts.PlanPath),
 			valueRef("record_id", result.Artifacts.RecordID),
+		)
+	}
+	return pruneTimelineEvent(event)
+}
+
+func timelineEventFromEvidenceRefresh(result evidence.RefreshResult) timeline.Event {
+	event := timeline.Event{
+		Kind:    "evidence",
+		Command: result.Command,
+		Summary: result.Summary,
+		Details: []timeline.Detail{
+			{Key: "evidence_kind", Value: "refresh"},
+		},
+	}
+	if result.Artifacts != nil {
+		event.PlanPath = result.Artifacts.PlanPath
+		event.ArtifactRefs = append(event.ArtifactRefs,
+			pathRef("plan_path", result.Artifacts.PlanPath),
+			valueRef("pr_url", result.Artifacts.PRURL),
+			valueRef("ci_record_id", result.Artifacts.CIRecordID),
+			valueRef("sync_record_id", result.Artifacts.SyncRecordID),
 		)
 	}
 	return pruneTimelineEvent(event)

--- a/internal/contracts/evidence.go
+++ b/internal/contracts/evidence.go
@@ -22,6 +22,32 @@ type EvidenceSubmitResult struct {
 	Errors []ErrorDetail `json:"errors,omitempty"`
 }
 
+// EvidenceRefreshResult is the JSON result returned by `harness evidence
+// refresh`.
+type EvidenceRefreshResult struct {
+	// OK reports whether at least one evidence domain was refreshed.
+	OK bool `json:"ok"`
+
+	// Command is the stable command identifier for the result payload.
+	Command string `json:"command"`
+
+	// Summary is the concise human-readable outcome description.
+	Summary string `json:"summary"`
+
+	// Artifacts points to the evidence records created by the command.
+	Artifacts *EvidenceRefreshArtifacts `json:"artifacts,omitempty"`
+
+	// NextAction lists the most relevant follow-up steps in priority order.
+	NextAction []NextAction `json:"next_actions"`
+
+	// Warnings lists degraded domains that did not prevent other evidence from
+	// being refreshed.
+	Warnings []string `json:"warnings,omitempty"`
+
+	// Errors lists hard failures that prevented any evidence refresh.
+	Errors []ErrorDetail `json:"errors,omitempty"`
+}
+
 // EvidenceArtifacts lists the evidence-related paths and identifiers touched by
 // `harness evidence submit`.
 type EvidenceArtifacts struct {
@@ -33,6 +59,24 @@ type EvidenceArtifacts struct {
 
 	// Kind is the evidence kind such as ci, publish, or sync.
 	Kind string `json:"kind"`
+}
+
+// EvidenceRefreshArtifacts lists evidence records touched by `harness evidence
+// refresh`.
+type EvidenceRefreshArtifacts struct {
+	// PlanPath is the archived plan path associated with the evidence records.
+	PlanPath string `json:"plan_path"`
+
+	// PRURL is the recorded pull request URL used for remote observation.
+	PRURL string `json:"pr_url,omitempty"`
+
+	// CIRecordID is the created CI evidence record identifier when CI was
+	// refreshed.
+	CIRecordID string `json:"ci_record_id,omitempty"`
+
+	// SyncRecordID is the created sync evidence record identifier when sync was
+	// refreshed.
+	SyncRecordID string `json:"sync_record_id,omitempty"`
 }
 
 // EvidenceCIInput is the JSON input consumed by `harness evidence submit --kind

--- a/internal/contracts/registry.go
+++ b/internal/contracts/registry.go
@@ -119,6 +119,15 @@ func SchemaRegistry() []SchemaEntry {
 			Type:        reflect.TypeFor[EvidenceSubmitResult](),
 		},
 		{
+			Key:         "commands.evidence.refresh.result",
+			Group:       "command_results",
+			Path:        "schema/commands/evidence.refresh.result.schema.json",
+			Title:       "Evidence refresh command result",
+			Description: "JSON output for `harness evidence refresh`.",
+			Shape:       "output",
+			Type:        reflect.TypeFor[EvidenceRefreshResult](),
+		},
+		{
 			Key:         "inputs.review.spec",
 			Group:       "command_inputs",
 			Path:        "schema/inputs/review.spec.schema.json",

--- a/internal/evidence/service.go
+++ b/internal/evidence/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/contracts"
 	"github.com/catu-ai/easyharness/internal/inputschema"
 	"github.com/catu-ai/easyharness/internal/plan"
+	"github.com/catu-ai/easyharness/internal/remote"
 	"github.com/catu-ai/easyharness/internal/runstate"
 )
 
@@ -23,11 +24,15 @@ type Service struct {
 	Workdir       string
 	Now           func() time.Time
 	AfterMutation func(Result) error
+	AfterRefresh  func(RefreshResult) error
 	AfterSuccess  func(Result)
+	RunCommand    remote.CommandRunner
 }
 
 type Result = contracts.EvidenceSubmitResult
+type RefreshResult = contracts.EvidenceRefreshResult
 type Artifacts = contracts.EvidenceArtifacts
+type RefreshArtifacts = contracts.EvidenceRefreshArtifacts
 type NextAction = contracts.NextAction
 type CommandError = contracts.ErrorDetail
 type CIInput = contracts.EvidenceCIInput
@@ -146,6 +151,121 @@ func (s Service) Submit(kind string, inputBytes []byte) Result {
 			Message: "kind must be one of: ci, publish, sync",
 		}})
 	}
+}
+
+func (s Service) Refresh() RefreshResult {
+	now := s.now().Format(time.RFC3339)
+	_, relPlanPath, planStem, state, _, release, result := s.loadCurrentArchivedPlan()
+	if result != nil {
+		return refreshErrorResult("Evidence refresh requires the current archived candidate.", result.Errors)
+	}
+	defer release()
+
+	revision := runstate.CurrentRevision(state)
+	publish, err := LoadLatestPublish(s.Workdir, planStem, revision)
+	if err != nil {
+		return refreshErrorResult("Unable to read publish evidence for refresh.", []CommandError{{Path: "publish", Message: err.Error()}})
+	}
+	if publish == nil || strings.TrimSpace(publish.PRURL) == "" {
+		return refreshErrorResult("Publish evidence has no recorded PR URL to refresh from.", []CommandError{{
+			Path:    "publish.pr_url",
+			Message: "record publish evidence with a PR URL before refreshing CI and sync evidence",
+		}})
+	}
+
+	identity := remote.ParseRecordedPRURL(publish.PRURL)
+	if identity.Status != remote.PRStatusRecorded {
+		return refreshErrorResult("Publish evidence PR URL is not supported for refresh.", []CommandError{{
+			Path:    "publish.pr_url",
+			Message: identity.Degraded.Message,
+		}})
+	}
+
+	observation := remote.Service{Workdir: s.Workdir, RunCommand: s.RunCommand}.ObserveHandoff(identity)
+	artifacts := &RefreshArtifacts{
+		PlanPath: relPlanPath,
+		PRURL:    identity.URL,
+	}
+	warnings := make([]string, 0, 2)
+	rollbackPaths := make([]string, 0, 2)
+
+	if observation.CI.Status == remote.RemoteCIAvailable {
+		recordID, recordPath, err := nextRecordLocation(s.Workdir, planStem, "ci")
+		if err != nil {
+			return refreshErrorResult("Unable to determine the next CI evidence record ID.", []CommandError{{Path: "ci.record_id", Message: err.Error()}})
+		}
+		record := CIRecord{
+			RecordID:   recordID,
+			Kind:       "ci",
+			PlanPath:   relPlanPath,
+			PlanStem:   planStem,
+			Revision:   revision,
+			RecordedAt: now,
+			Status:     observation.CI.EvidenceStatus,
+			Provider:   "github-actions",
+			URL:        firstCheckURL(observation.CI.Checks),
+			Reason:     "Refreshed from recorded pull request checks.",
+		}
+		if err := writeJSONFile(recordPath, record); err != nil {
+			return refreshErrorResult("Unable to persist CI evidence refresh.", []CommandError{{Path: "ci.record", Message: err.Error()}})
+		}
+		artifacts.CIRecordID = recordID
+		rollbackPaths = append(rollbackPaths, recordPath)
+	} else {
+		warnings = append(warnings, degradedWarning("CI refresh unavailable", observation.CI.Degraded))
+	}
+
+	if observation.Sync.Status == remote.RemoteSyncAvailable {
+		recordID, recordPath, err := nextRecordLocation(s.Workdir, planStem, "sync")
+		if err != nil {
+			return refreshErrorResult("Unable to determine the next sync evidence record ID.", []CommandError{{Path: "sync.record_id", Message: err.Error()}})
+		}
+		record := SyncRecord{
+			RecordID:   recordID,
+			Kind:       "sync",
+			PlanPath:   relPlanPath,
+			PlanStem:   planStem,
+			Revision:   revision,
+			RecordedAt: now,
+			Status:     observation.Sync.EvidenceStatus,
+			BaseRef:    observation.PR.BaseRefName,
+			HeadRef:    observation.PR.HeadRefName,
+			Reason:     "Refreshed from recorded pull request merge state.",
+		}
+		if err := writeJSONFile(recordPath, record); err != nil {
+			return refreshErrorResult("Unable to persist sync evidence refresh.", []CommandError{{Path: "sync.record", Message: err.Error()}})
+		}
+		artifacts.SyncRecordID = recordID
+		rollbackPaths = append(rollbackPaths, recordPath)
+	} else {
+		warnings = append(warnings, degradedWarning("Sync refresh unavailable", observation.Sync.Degraded))
+	}
+
+	if artifacts.CIRecordID == "" && artifacts.SyncRecordID == "" {
+		return RefreshResult{
+			OK:       false,
+			Command:  "evidence refresh",
+			Summary:  "Remote evidence refresh could not write CI or sync evidence.",
+			Warnings: warnings,
+			Errors: []CommandError{{
+				Path:    "remote",
+				Message: "remote PR facts were unavailable; use manual harness evidence submit fallback",
+			}},
+			NextAction: manualRefreshFallbackActions(),
+		}
+	}
+
+	resultOut := RefreshResult{
+		OK:        true,
+		Command:   "evidence refresh",
+		Summary:   refreshSummary(artifacts),
+		Artifacts: artifacts,
+		Warnings:  warnings,
+		NextAction: []NextAction{
+			{Command: nil, Description: "Run harness status to refresh the archived candidate summary and next actions."},
+		},
+	}
+	return s.finalizeRefreshMutation(resultOut, rollbackPaths)
 }
 
 func LoadLatestCI(workdir, planStem string, revision int) (*CIRecord, error) {
@@ -344,6 +464,16 @@ func errorResult(command, summary string, errors []CommandError) Result {
 	}
 }
 
+func refreshErrorResult(summary string, errors []CommandError) RefreshResult {
+	return RefreshResult{
+		OK:         false,
+		Command:    "evidence refresh",
+		Summary:    summary,
+		Errors:     errors,
+		NextAction: manualRefreshFallbackActions(),
+	}
+}
+
 func (s Service) finalizeMutation(result Result, rollback func() []CommandError) Result {
 	if !result.OK || s.AfterMutation == nil {
 		if result.OK && s.AfterSuccess != nil {
@@ -362,6 +492,64 @@ func (s Service) finalizeMutation(result Result, rollback func() []CommandError)
 		s.AfterSuccess(result)
 	}
 	return result
+}
+
+func (s Service) finalizeRefreshMutation(result RefreshResult, rollbackPaths []string) RefreshResult {
+	if !result.OK || s.AfterRefresh == nil {
+		return result
+	}
+	if err := s.AfterRefresh(result); err != nil {
+		issues := []CommandError{{Path: "timeline", Message: err.Error()}}
+		for _, path := range rollbackPaths {
+			issues = append(issues, rollbackEvidenceMutation(path)...)
+		}
+		return refreshErrorResult("Unable to record the timeline event for the successful evidence refresh.", issues)
+	}
+	return result
+}
+
+func firstCheckURL(checks []remote.CheckRun) string {
+	for _, check := range checks {
+		if strings.TrimSpace(check.Link) != "" {
+			return strings.TrimSpace(check.Link)
+		}
+	}
+	return ""
+}
+
+func degradedWarning(prefix string, degradation remote.Degradation) string {
+	message := strings.TrimSpace(degradation.Message)
+	if message == "" {
+		message = strings.TrimSpace(degradation.Code)
+	}
+	if message == "" {
+		message = "remote facts are unavailable"
+	}
+	return prefix + ": " + message
+}
+
+func refreshSummary(artifacts *RefreshArtifacts) string {
+	switch {
+	case artifacts != nil && artifacts.CIRecordID != "" && artifacts.SyncRecordID != "":
+		return "Refreshed CI and sync evidence from the recorded pull request."
+	case artifacts != nil && artifacts.CIRecordID != "":
+		return "Refreshed CI evidence from the recorded pull request; sync evidence still needs manual follow-up."
+	case artifacts != nil && artifacts.SyncRecordID != "":
+		return "Refreshed sync evidence from the recorded pull request; CI evidence still needs manual follow-up."
+	default:
+		return "Remote evidence refresh did not write evidence."
+	}
+}
+
+func manualRefreshFallbackActions() []NextAction {
+	return []NextAction{
+		{Command: strPtr("harness evidence submit --kind ci --input <json>"), Description: "Manually record CI evidence when remote checks cannot be refreshed."},
+		{Command: strPtr("harness evidence submit --kind sync --input <json>"), Description: "Manually record sync evidence when remote merge state cannot be refreshed."},
+	}
+}
+
+func strPtr(value string) *string {
+	return &value
 }
 
 func writeJSONFile(path string, value any) error {

--- a/internal/evidence/service.go
+++ b/internal/evidence/service.go
@@ -170,7 +170,7 @@ func (s Service) Refresh() RefreshResult {
 		return refreshErrorResult("Publish evidence has no recorded PR URL to refresh from.", []CommandError{{
 			Path:    "publish.pr_url",
 			Message: "record publish evidence with a PR URL before refreshing CI and sync evidence",
-		}})
+		}}, publishRefreshFallbackActions())
 	}
 
 	identity := remote.ParseRecordedPRURL(publish.PRURL)
@@ -178,7 +178,7 @@ func (s Service) Refresh() RefreshResult {
 		return refreshErrorResult("Publish evidence PR URL is not supported for refresh.", []CommandError{{
 			Path:    "publish.pr_url",
 			Message: identity.Degraded.Message,
-		}})
+		}}, publishRefreshFallbackActions())
 	}
 
 	observation := remote.Service{Workdir: s.Workdir, RunCommand: s.RunCommand}.ObserveHandoff(identity)
@@ -270,15 +270,23 @@ func (s Service) Refresh() RefreshResult {
 		}
 	}
 
+	nextActions := []NextAction{
+		{Command: nil, Description: "Run harness status to refresh the archived candidate summary and next actions."},
+	}
+	if artifacts.CIRecordID == "" {
+		nextActions = append(nextActions, ciRefreshFallbackAction())
+	}
+	if artifacts.SyncRecordID == "" {
+		nextActions = append(nextActions, syncRefreshFallbackAction())
+	}
+
 	resultOut := RefreshResult{
-		OK:        true,
-		Command:   "evidence refresh",
-		Summary:   refreshSummary(artifacts),
-		Artifacts: artifacts,
-		Warnings:  warnings,
-		NextAction: []NextAction{
-			{Command: nil, Description: "Run harness status to refresh the archived candidate summary and next actions."},
-		},
+		OK:         true,
+		Command:    "evidence refresh",
+		Summary:    refreshSummary(artifacts),
+		Artifacts:  artifacts,
+		Warnings:   warnings,
+		NextAction: nextActions,
 	}
 	return s.finalizeRefreshMutation(resultOut, rollbackPaths)
 }
@@ -479,13 +487,17 @@ func errorResult(command, summary string, errors []CommandError) Result {
 	}
 }
 
-func refreshErrorResult(summary string, errors []CommandError) RefreshResult {
+func refreshErrorResult(summary string, errors []CommandError, actions ...[]NextAction) RefreshResult {
+	nextActions := manualRefreshFallbackActions()
+	if len(actions) > 0 {
+		nextActions = actions[0]
+	}
 	return RefreshResult{
 		OK:         false,
 		Command:    "evidence refresh",
 		Summary:    summary,
 		Errors:     errors,
-		NextAction: manualRefreshFallbackActions(),
+		NextAction: nextActions,
 	}
 }
 
@@ -558,8 +570,30 @@ func refreshSummary(artifacts *RefreshArtifacts) string {
 
 func manualRefreshFallbackActions() []NextAction {
 	return []NextAction{
-		{Command: strPtr("harness evidence submit --kind ci --input <json>"), Description: "Manually record CI evidence when remote checks cannot be refreshed."},
-		{Command: strPtr("harness evidence submit --kind sync --input <json>"), Description: "Manually record sync evidence when remote merge state cannot be refreshed."},
+		ciRefreshFallbackAction(),
+		syncRefreshFallbackAction(),
+	}
+}
+
+func publishRefreshFallbackActions() []NextAction {
+	return []NextAction{
+		{Command: strPtr("harness evidence submit --kind publish --input <json>"), Description: "Record publish evidence with a PR URL before refreshing remote CI and sync facts."},
+		ciRefreshFallbackAction(),
+		syncRefreshFallbackAction(),
+	}
+}
+
+func ciRefreshFallbackAction() NextAction {
+	return NextAction{
+		Command:     strPtr("harness evidence submit --kind ci --input <json>"),
+		Description: "Manually record CI evidence when remote checks cannot be refreshed.",
+	}
+}
+
+func syncRefreshFallbackAction() NextAction {
+	return NextAction{
+		Command:     strPtr("harness evidence submit --kind sync --input <json>"),
+		Description: "Manually record sync evidence when remote merge state cannot be refreshed.",
 	}
 }
 

--- a/internal/evidence/service.go
+++ b/internal/evidence/service.go
@@ -166,7 +166,7 @@ func (s Service) Refresh() RefreshResult {
 	if err != nil {
 		return refreshErrorResult("Unable to read publish evidence for refresh.", []CommandError{{Path: "publish", Message: err.Error()}})
 	}
-	if publish == nil || strings.TrimSpace(publish.PRURL) == "" {
+	if publish == nil || publish.Status != "recorded" || strings.TrimSpace(publish.PRURL) == "" {
 		return refreshErrorResult("Publish evidence has no recorded PR URL to refresh from.", []CommandError{{
 			Path:    "publish.pr_url",
 			Message: "record publish evidence with a PR URL before refreshing CI and sync evidence",
@@ -188,13 +188,17 @@ func (s Service) Refresh() RefreshResult {
 	}
 	warnings := make([]string, 0, 2)
 	rollbackPaths := make([]string, 0, 2)
+	var ciRecord *CIRecord
+	ciRecordPath := ""
+	var syncRecord *SyncRecord
+	syncRecordPath := ""
 
 	if observation.CI.Status == remote.RemoteCIAvailable {
 		recordID, recordPath, err := nextRecordLocation(s.Workdir, planStem, "ci")
 		if err != nil {
 			return refreshErrorResult("Unable to determine the next CI evidence record ID.", []CommandError{{Path: "ci.record_id", Message: err.Error()}})
 		}
-		record := CIRecord{
+		ciRecord = &CIRecord{
 			RecordID:   recordID,
 			Kind:       "ci",
 			PlanPath:   relPlanPath,
@@ -206,11 +210,7 @@ func (s Service) Refresh() RefreshResult {
 			URL:        firstCheckURL(observation.CI.Checks),
 			Reason:     "Refreshed from recorded pull request checks.",
 		}
-		if err := writeJSONFile(recordPath, record); err != nil {
-			return refreshErrorResult("Unable to persist CI evidence refresh.", []CommandError{{Path: "ci.record", Message: err.Error()}})
-		}
-		artifacts.CIRecordID = recordID
-		rollbackPaths = append(rollbackPaths, recordPath)
+		ciRecordPath = recordPath
 	} else {
 		warnings = append(warnings, degradedWarning("CI refresh unavailable", observation.CI.Degraded))
 	}
@@ -220,7 +220,7 @@ func (s Service) Refresh() RefreshResult {
 		if err != nil {
 			return refreshErrorResult("Unable to determine the next sync evidence record ID.", []CommandError{{Path: "sync.record_id", Message: err.Error()}})
 		}
-		record := SyncRecord{
+		syncRecord = &SyncRecord{
 			RecordID:   recordID,
 			Kind:       "sync",
 			PlanPath:   relPlanPath,
@@ -232,13 +232,28 @@ func (s Service) Refresh() RefreshResult {
 			HeadRef:    observation.PR.HeadRefName,
 			Reason:     "Refreshed from recorded pull request merge state.",
 		}
-		if err := writeJSONFile(recordPath, record); err != nil {
-			return refreshErrorResult("Unable to persist sync evidence refresh.", []CommandError{{Path: "sync.record", Message: err.Error()}})
-		}
-		artifacts.SyncRecordID = recordID
-		rollbackPaths = append(rollbackPaths, recordPath)
+		syncRecordPath = recordPath
 	} else {
 		warnings = append(warnings, degradedWarning("Sync refresh unavailable", observation.Sync.Degraded))
+	}
+
+	if ciRecord != nil {
+		if err := writeJSONFile(ciRecordPath, *ciRecord); err != nil {
+			return refreshErrorResult("Unable to persist CI evidence refresh.", []CommandError{{Path: "ci.record", Message: err.Error()}})
+		}
+		artifacts.CIRecordID = ciRecord.RecordID
+		rollbackPaths = append(rollbackPaths, ciRecordPath)
+	}
+	if syncRecord != nil {
+		if err := writeJSONFile(syncRecordPath, *syncRecord); err != nil {
+			issues := []CommandError{{Path: "sync.record", Message: err.Error()}}
+			for _, path := range rollbackPaths {
+				issues = append(issues, rollbackEvidenceMutation(path)...)
+			}
+			return refreshErrorResult("Unable to persist sync evidence refresh.", issues)
+		}
+		artifacts.SyncRecordID = syncRecord.RecordID
+		rollbackPaths = append(rollbackPaths, syncRecordPath)
 	}
 
 	if artifacts.CIRecordID == "" && artifacts.SyncRecordID == "" {

--- a/internal/evidence/service_test.go
+++ b/internal/evidence/service_test.go
@@ -125,6 +125,37 @@ func TestRefreshRejectsMissingRecordedPRWithoutGuessing(t *testing.T) {
 	}
 }
 
+func TestRefreshRejectsNotAppliedPublishPRURL(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{
+		"status":"not_applied",
+		"pr_url":"https://github.com/catu-ai/easyharness/pull/99",
+		"reason":"remote handoff is not available"
+	}`)); !result.OK {
+		t.Fatalf("seed not_applied publish evidence: %#v", result)
+	}
+	called := false
+
+	result := evidence.Service{
+		Workdir: root,
+		RunCommand: func(name string, args ...string) remote.CommandResult {
+			called = true
+			return remote.CommandResult{}
+		},
+	}.Refresh()
+
+	if result.OK {
+		t.Fatalf("expected not_applied publish refresh failure, got %#v", result)
+	}
+	if called {
+		t.Fatal("refresh should not call gh for publish status not_applied")
+	}
+}
+
 func TestRefreshWritesOnlyClearDomainEvidence(t *testing.T) {
 	root := t.TempDir()
 	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
@@ -152,6 +183,36 @@ func TestRefreshWritesOnlyClearDomainEvidence(t *testing.T) {
 	}
 	if sync, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1); err != nil || sync != nil {
 		t.Fatalf("expected no sync evidence, got %#v err=%v", sync, err)
+	}
+}
+
+func TestRefreshDoesNotLeaveCIWhenSyncRecordLocationFails(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
+		t.Fatalf("seed publish evidence: %#v", result)
+	}
+	syncPath := filepath.Join(root, ".local", "harness", "plans", "2026-03-21-evidence-plan", "evidence", "sync")
+	if err := os.MkdirAll(filepath.Dir(syncPath), 0o755); err != nil {
+		t.Fatalf("mkdir evidence dir: %v", err)
+	}
+	if err := os.WriteFile(syncPath, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write sync path blocker: %v", err)
+	}
+
+	result := evidence.Service{
+		Workdir:    root,
+		RunCommand: fakeRefreshCommands(`"CLEAN"`, `[{"name":"Go Test","bucket":"pass","state":"SUCCESS"}]`),
+	}.Refresh()
+
+	if result.OK {
+		t.Fatalf("expected sync record-location failure, got %#v", result)
+	}
+	if ci, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 1); err != nil || ci != nil {
+		t.Fatalf("expected no unreported CI evidence, got %#v err=%v", ci, err)
 	}
 }
 

--- a/internal/evidence/service_test.go
+++ b/internal/evidence/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/catu-ai/easyharness/internal/evidence"
 	"github.com/catu-ai/easyharness/internal/plan"
+	"github.com/catu-ai/easyharness/internal/remote"
 	"github.com/catu-ai/easyharness/internal/runstate"
 )
 
@@ -47,6 +48,110 @@ func TestSubmitCIEvidenceWritesArtifactWithoutStateCache(t *testing.T) {
 	}
 	if record == nil || record.Status != "success" || record.Provider != "buildkite" {
 		t.Fatalf("unexpected CI record: %#v", record)
+	}
+}
+
+func TestRefreshWritesCIAndSyncEvidenceFromRecordedPR(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	svc := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 21, 10, 0, 0, 0, time.UTC)
+		},
+	}
+	if result := svc.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
+		t.Fatalf("seed publish evidence: %#v", result)
+	}
+
+	refresh := evidence.Service{
+		Workdir:    root,
+		Now:        svc.Now,
+		RunCommand: fakeRefreshCommands(`"CLEAN"`, `[{"name":"Go Test","bucket":"pass","state":"SUCCESS","link":"https://ci.example/run"}]`),
+	}.Refresh()
+
+	if !refresh.OK {
+		t.Fatalf("expected refresh success, got %#v", refresh)
+	}
+	if refresh.Artifacts == nil || refresh.Artifacts.CIRecordID != "ci-001" || refresh.Artifacts.SyncRecordID != "sync-001" {
+		t.Fatalf("unexpected refresh artifacts: %#v", refresh.Artifacts)
+	}
+	ci, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 1)
+	if err != nil {
+		t.Fatalf("load CI: %v", err)
+	}
+	if ci == nil || ci.Status != "success" || ci.Provider != "github-actions" || ci.URL != "https://ci.example/run" {
+		t.Fatalf("unexpected CI record: %#v", ci)
+	}
+	sync, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1)
+	if err != nil {
+		t.Fatalf("load sync: %v", err)
+	}
+	if sync == nil || sync.Status != "fresh" || sync.BaseRef != "main" || sync.HeadRef != "codex/test" {
+		t.Fatalf("unexpected sync record: %#v", sync)
+	}
+}
+
+func TestRefreshRejectsMissingRecordedPRWithoutGuessing(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	called := false
+
+	result := evidence.Service{
+		Workdir: root,
+		RunCommand: func(name string, args ...string) remote.CommandResult {
+			called = true
+			return remote.CommandResult{}
+		},
+	}.Refresh()
+
+	if result.OK {
+		t.Fatalf("expected missing PR refresh failure, got %#v", result)
+	}
+	if called {
+		t.Fatal("refresh should not call gh without recorded publish PR URL")
+	}
+	if len(result.Errors) == 0 || result.Errors[0].Path != "publish.pr_url" {
+		t.Fatalf("expected publish.pr_url error, got %#v", result.Errors)
+	}
+	if ci, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 1); err != nil || ci != nil {
+		t.Fatalf("expected no CI evidence, got %#v err=%v", ci, err)
+	}
+}
+
+func TestRefreshWritesOnlyClearDomainEvidence(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	svc := evidence.Service{Workdir: root}
+	if result := svc.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
+		t.Fatalf("seed publish evidence: %#v", result)
+	}
+
+	result := evidence.Service{
+		Workdir:    root,
+		RunCommand: fakeRefreshCommands(`""`, `[{"name":"Go Test","bucket":"pass","state":"SUCCESS"}]`),
+	}.Refresh()
+
+	if !result.OK {
+		t.Fatalf("expected partial refresh success, got %#v", result)
+	}
+	if result.Artifacts == nil || result.Artifacts.CIRecordID != "ci-001" || result.Artifacts.SyncRecordID != "" {
+		t.Fatalf("unexpected partial refresh artifacts: %#v", result.Artifacts)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatalf("expected degraded sync warning, got %#v", result)
+	}
+	if sync, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1); err != nil || sync != nil {
+		t.Fatalf("expected no sync evidence, got %#v err=%v", sync, err)
 	}
 }
 
@@ -458,6 +563,29 @@ func assertStateFileAbsent(t *testing.T, root, planStem string) {
 	path := filepath.Join(root, ".local", "harness", "plans", planStem, "state.json")
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("expected state.json to stay absent, got %v", err)
+	}
+}
+
+func fakeRefreshCommands(mergeStateJSON, checksJSON string) remote.CommandRunner {
+	return func(name string, args ...string) remote.CommandResult {
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "view" {
+			return remote.CommandResult{Stdout: `{
+				"url":"https://github.com/catu-ai/easyharness/pull/99",
+				"number":99,
+				"state":"OPEN",
+				"isDraft":false,
+				"mergeStateStatus":` + mergeStateJSON + `,
+				"mergeable":"MERGEABLE",
+				"reviewDecision":"APPROVED",
+				"headRefName":"codex/test",
+				"headRefOid":"abc123",
+				"baseRefName":"main"
+			}`}
+		}
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "checks" {
+			return remote.CommandResult{Stdout: checksJSON}
+		}
+		return remote.CommandResult{}
 	}
 }
 

--- a/internal/evidence/service_test.go
+++ b/internal/evidence/service_test.go
@@ -120,6 +120,9 @@ func TestRefreshRejectsMissingRecordedPRWithoutGuessing(t *testing.T) {
 	if len(result.Errors) == 0 || result.Errors[0].Path != "publish.pr_url" {
 		t.Fatalf("expected publish.pr_url error, got %#v", result.Errors)
 	}
+	if !refreshResultHasNextAction(result, "harness evidence submit --kind publish --input <json>") {
+		t.Fatalf("expected publish fallback guidance, got %#v", result.NextAction)
+	}
 	if ci, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 1); err != nil || ci != nil {
 		t.Fatalf("expected no CI evidence, got %#v err=%v", ci, err)
 	}
@@ -180,6 +183,9 @@ func TestRefreshWritesOnlyClearDomainEvidence(t *testing.T) {
 	}
 	if len(result.Warnings) == 0 {
 		t.Fatalf("expected degraded sync warning, got %#v", result)
+	}
+	if !refreshResultHasNextAction(result, "harness evidence submit --kind sync --input <json>") {
+		t.Fatalf("expected sync fallback guidance, got %#v", result.NextAction)
 	}
 	if sync, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1); err != nil || sync != nil {
 		t.Fatalf("expected no sync evidence, got %#v err=%v", sync, err)
@@ -648,6 +654,15 @@ func fakeRefreshCommands(mergeStateJSON, checksJSON string) remote.CommandRunner
 		}
 		return remote.CommandResult{}
 	}
+}
+
+func refreshResultHasNextAction(result evidence.RefreshResult, command string) bool {
+	for _, action := range result.NextAction {
+		if action.Command != nil && *action.Command == command {
+			return true
+		}
+	}
+	return false
 }
 
 func writeArchivedPlan(t *testing.T, root, relPath string) string {

--- a/internal/remote/gh_test.go
+++ b/internal/remote/gh_test.go
@@ -89,6 +89,47 @@ func TestObserveHandoffMapsPassingChecksAndCleanMergeState(t *testing.T) {
 	if len(calls) != 2 {
 		t.Fatalf("expected pr view and pr checks calls, got %#v", calls)
 	}
+	want := []commandCall{{
+		Name: "gh",
+		Args: []string{
+			"pr", "view", "https://github.com/catu-ai/easyharness/pull/199",
+			"--json", "url,number,state,isDraft,mergeStateStatus,mergeable,reviewDecision,headRefName,headRefOid,baseRefName",
+		},
+	}, {
+		Name: "gh",
+		Args: []string{
+			"pr", "checks", "https://github.com/catu-ai/easyharness/pull/199",
+			"--json", "name,workflow,bucket,state,link",
+		},
+	}}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("unexpected gh calls:\nwant %#v\ngot  %#v", want, calls)
+	}
+}
+
+func TestObserveHandoffDoesNotCallGhWhenNoRecordedPR(t *testing.T) {
+	called := false
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			called = true
+			return CommandResult{}
+		},
+	}
+
+	observation := svc.ObserveHandoff(ParseRecordedPRURL(""))
+
+	if called {
+		t.Fatal("did not expect gh to run without a recorded PR URL")
+	}
+	if observation.Status != HandoffObservationUnavailable {
+		t.Fatalf("expected unavailable handoff observation, got %#v", observation)
+	}
+	if observation.CI.Status != RemoteCIUnavailable || observation.CI.Degraded.Code != DegradedMissingPRURL {
+		t.Fatalf("expected CI missing PR degradation, got %#v", observation.CI)
+	}
+	if observation.Sync.Status != RemoteSyncUnavailable || observation.Sync.Degraded.Code != DegradedMissingPRURL {
+		t.Fatalf("expected sync missing PR degradation, got %#v", observation.Sync)
+	}
 }
 
 func TestObserveHandoffMapsPendingChecks(t *testing.T) {
@@ -162,6 +203,21 @@ func TestObserveHandoffDegradesWhenChecksAreUnreadableButMergeIsClear(t *testing
 	}
 	if observation.Sync.Status != RemoteSyncAvailable || observation.Sync.EvidenceStatus != "fresh" {
 		t.Fatalf("expected sync to remain refreshable, got %#v", observation.Sync)
+	}
+}
+
+func TestObserveHandoffDegradesWhenMergeIsUnreadableButChecksAreClear(t *testing.T) {
+	svc := Service{RunCommand: fakePRAndChecks(`{"mergeStateStatus":""}`, `[
+		{"name":"Go Test","bucket":"pass","state":"SUCCESS"}
+	]`)}
+
+	observation := svc.ObserveHandoff(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/199"))
+
+	if observation.CI.Status != RemoteCIAvailable || observation.CI.EvidenceStatus != "success" {
+		t.Fatalf("expected CI to remain refreshable, got %#v", observation.CI)
+	}
+	if observation.Sync.Status != RemoteSyncUnavailable || observation.Sync.Degraded.Code != DegradedMergeUnreadable {
+		t.Fatalf("expected degraded sync observation, got %#v", observation.Sync)
 	}
 }
 

--- a/internal/remote/gh_test.go
+++ b/internal/remote/gh_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -35,11 +36,132 @@ func TestObserveRecordedPRUsesGhView(t *testing.T) {
 		Name: "gh",
 		Args: []string{
 			"pr", "view", "https://github.com/catu-ai/easyharness/pull/203",
-			"--json", "url,number,state,headRefName,headRefOid,baseRefName",
+			"--json", "url,number,state,isDraft,mergeStateStatus,mergeable,reviewDecision,headRefName,headRefOid,baseRefName",
 		},
 	}}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("unexpected gh calls:\nwant %#v\ngot  %#v", want, calls)
+	}
+}
+
+func TestObserveHandoffMapsPassingChecksAndCleanMergeState(t *testing.T) {
+	var calls []commandCall
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			calls = append(calls, commandCall{Name: name, Args: args})
+			switch {
+			case len(args) >= 3 && args[0] == "pr" && args[1] == "view":
+				return CommandResult{Stdout: `{
+					"url": "https://github.com/catu-ai/easyharness/pull/199",
+					"number": 199,
+					"state": "OPEN",
+					"isDraft": false,
+					"mergeStateStatus": "CLEAN",
+					"mergeable": "MERGEABLE",
+					"reviewDecision": "APPROVED",
+					"headRefName": "codex/refresh",
+					"headRefOid": "abc123",
+					"baseRefName": "main"
+				}`}
+			case len(args) >= 3 && args[0] == "pr" && args[1] == "checks":
+				return CommandResult{Stdout: `[
+					{"name":"Go Test","workflow":"Go Test","bucket":"pass","state":"SUCCESS","link":"https://ci.example/1"},
+					{"name":"Lint","workflow":"Go Test","bucket":"skipping","state":"SKIPPED"}
+				]`}
+			default:
+				t.Fatalf("unexpected command %s %v", name, args)
+				return CommandResult{}
+			}
+		},
+	}
+
+	observation := svc.ObserveHandoff(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/199"))
+
+	if observation.Status != HandoffObservationAvailable {
+		t.Fatalf("expected available handoff observation, got %#v", observation)
+	}
+	if observation.CI.Status != RemoteCIAvailable || observation.CI.EvidenceStatus != "success" {
+		t.Fatalf("expected successful CI observation, got %#v", observation.CI)
+	}
+	if observation.Sync.Status != RemoteSyncAvailable || observation.Sync.EvidenceStatus != "fresh" {
+		t.Fatalf("expected fresh sync observation, got %#v", observation.Sync)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected pr view and pr checks calls, got %#v", calls)
+	}
+}
+
+func TestObserveHandoffMapsPendingChecks(t *testing.T) {
+	svc := Service{RunCommand: fakePRAndChecks(`{"mergeStateStatus":"CLEAN"}`, `[
+		{"name":"Go Test","bucket":"pass","state":"SUCCESS"},
+		{"name":"Smoke","bucket":"pending","state":"IN_PROGRESS"}
+	]`)}
+
+	observation := svc.ObserveHandoff(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/199"))
+
+	if observation.CI.Status != RemoteCIAvailable || observation.CI.EvidenceStatus != "pending" {
+		t.Fatalf("expected pending CI observation, got %#v", observation.CI)
+	}
+}
+
+func TestObserveHandoffMapsFailingAndCancelledChecks(t *testing.T) {
+	for _, bucket := range []string{"fail", "cancel"} {
+		t.Run(bucket, func(t *testing.T) {
+			svc := Service{RunCommand: fakePRAndChecks(`{"mergeStateStatus":"CLEAN"}`, `[
+				{"name":"Go Test","bucket":"`+bucket+`","state":"FAILURE"}
+			]`)}
+
+			observation := svc.ObserveHandoff(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/199"))
+
+			if observation.CI.Status != RemoteCIAvailable || observation.CI.EvidenceStatus != "failed" {
+				t.Fatalf("expected failed CI observation, got %#v", observation.CI)
+			}
+		})
+	}
+}
+
+func TestObserveHandoffMapsMergeStateToSyncEvidence(t *testing.T) {
+	tests := []struct {
+		name       string
+		mergeState string
+		want       string
+	}{
+		{name: "clean", mergeState: "CLEAN", want: "fresh"},
+		{name: "behind", mergeState: "BEHIND", want: "stale"},
+		{name: "blocked", mergeState: "BLOCKED", want: "stale"},
+		{name: "unknown", mergeState: "UNKNOWN", want: "stale"},
+		{name: "dirty", mergeState: "DIRTY", want: "conflicted"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := Service{RunCommand: fakePRAndChecks(`{"mergeStateStatus":"`+tt.mergeState+`"}`, `[
+				{"name":"Go Test","bucket":"pass","state":"SUCCESS"}
+			]`)}
+
+			observation := svc.ObserveHandoff(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/199"))
+
+			if observation.Sync.Status != RemoteSyncAvailable || observation.Sync.EvidenceStatus != tt.want {
+				t.Fatalf("expected sync %q, got %#v", tt.want, observation.Sync)
+			}
+		})
+	}
+}
+
+func TestObserveHandoffDegradesWhenChecksAreUnreadableButMergeIsClear(t *testing.T) {
+	svc := Service{RunCommand: func(name string, args ...string) CommandResult {
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "view" {
+			return CommandResult{Stdout: `{"mergeStateStatus":"CLEAN"}`}
+		}
+		return CommandResult{Err: exec.ErrNotFound}
+	}}
+
+	observation := svc.ObserveHandoff(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/199"))
+
+	if observation.CI.Status != RemoteCIUnavailable || observation.CI.Degraded.Code != DegradedGhMissing {
+		t.Fatalf("expected degraded CI observation, got %#v", observation.CI)
+	}
+	if observation.Sync.Status != RemoteSyncAvailable || observation.Sync.EvidenceStatus != "fresh" {
+		t.Fatalf("expected sync to remain refreshable, got %#v", observation.Sync)
 	}
 }
 
@@ -165,4 +287,30 @@ func TestObserveRecordedPRDegradesForGenericGhFailure(t *testing.T) {
 type commandCall struct {
 	Name string
 	Args []string
+}
+
+func fakePRAndChecks(prFields, checksJSON string) CommandRunner {
+	return func(name string, args ...string) CommandResult {
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "view" {
+			fields := strings.TrimSpace(prFields)
+			fields = strings.TrimPrefix(fields, "{")
+			fields = strings.TrimSuffix(fields, "}")
+			return CommandResult{Stdout: `{
+				"url": "https://github.com/catu-ai/easyharness/pull/199",
+				"number": 199,
+				"state": "OPEN",
+				"isDraft": false,
+				"mergeable": "MERGEABLE",
+				"reviewDecision": "APPROVED",
+				"headRefName": "codex/refresh",
+				"headRefOid": "abc123",
+				"baseRefName": "main",
+				` + fields + `
+			}`}
+		}
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "checks" {
+			return CommandResult{Stdout: checksJSON}
+		}
+		return CommandResult{Err: errors.New("unexpected command")}
+	}
 }

--- a/internal/remote/identity.go
+++ b/internal/remote/identity.go
@@ -20,6 +20,16 @@ const (
 	PRObservationAvailable   = "available"
 	PRObservationUnavailable = "unavailable"
 
+	HandoffObservationAvailable   = "available"
+	HandoffObservationUnavailable = "unavailable"
+	HandoffObservationDegraded    = "degraded"
+
+	RemoteCIAvailable   = "available"
+	RemoteCIUnavailable = "unavailable"
+
+	RemoteSyncAvailable   = "available"
+	RemoteSyncUnavailable = "unavailable"
+
 	DegradedMissingPRURL      = "missing_pr_url"
 	DegradedUnsupportedPRURL  = "unsupported_pr_url"
 	DegradedNotGitRepository  = "not_git_repository"
@@ -30,6 +40,8 @@ const (
 	DegradedGhMissing         = "gh_missing"
 	DegradedGhAuthUnavailable = "gh_auth_unavailable"
 	DegradedPRUnreadable      = "pr_unreadable"
+	DegradedChecksUnreadable  = "checks_unreadable"
+	DegradedMergeUnreadable   = "merge_unreadable"
 	DegradedGhInvalidJSON     = "gh_invalid_json"
 	DegradedGhCommandFailed   = "gh_command_failed"
 )
@@ -83,14 +95,48 @@ type PRIdentity struct {
 }
 
 type PRObservation struct {
-	Status      string      `json:"status"`
-	URL         string      `json:"url,omitempty"`
-	Number      int         `json:"number,omitempty"`
-	State       string      `json:"state,omitempty"`
-	HeadRefName string      `json:"head_ref_name,omitempty"`
-	HeadRefOID  string      `json:"head_ref_oid,omitempty"`
-	BaseRefName string      `json:"base_ref_name,omitempty"`
-	Degraded    Degradation `json:"degraded,omitempty"`
+	Status           string      `json:"status"`
+	URL              string      `json:"url,omitempty"`
+	Number           int         `json:"number,omitempty"`
+	State            string      `json:"state,omitempty"`
+	IsDraft          bool        `json:"is_draft,omitempty"`
+	MergeStateStatus string      `json:"merge_state_status,omitempty"`
+	Mergeable        string      `json:"mergeable,omitempty"`
+	ReviewDecision   string      `json:"review_decision,omitempty"`
+	HeadRefName      string      `json:"head_ref_name,omitempty"`
+	HeadRefOID       string      `json:"head_ref_oid,omitempty"`
+	BaseRefName      string      `json:"base_ref_name,omitempty"`
+	Degraded         Degradation `json:"degraded,omitempty"`
+}
+
+type HandoffObservation struct {
+	Status   string                `json:"status"`
+	PR       PRObservation         `json:"pr"`
+	CI       RemoteCIObservation   `json:"ci"`
+	Sync     RemoteSyncObservation `json:"sync"`
+	Degraded []Degradation         `json:"degraded,omitempty"`
+}
+
+type RemoteCIObservation struct {
+	Status         string      `json:"status"`
+	EvidenceStatus string      `json:"evidence_status,omitempty"`
+	Checks         []CheckRun  `json:"checks,omitempty"`
+	Degraded       Degradation `json:"degraded,omitempty"`
+}
+
+type RemoteSyncObservation struct {
+	Status         string      `json:"status"`
+	EvidenceStatus string      `json:"evidence_status,omitempty"`
+	MergeState     string      `json:"merge_state,omitempty"`
+	Degraded       Degradation `json:"degraded,omitempty"`
+}
+
+type CheckRun struct {
+	Name     string `json:"name,omitempty"`
+	Workflow string `json:"workflow,omitempty"`
+	Bucket   string `json:"bucket,omitempty"`
+	State    string `json:"state,omitempty"`
+	Link     string `json:"link,omitempty"`
 }
 
 type Degradation struct {
@@ -113,7 +159,7 @@ func (s Service) ObserveRecordedPR(identity PRIdentity) PRObservation {
 		}
 	}
 
-	result := s.run("gh", "pr", "view", identity.URL, "--json", "url,number,state,headRefName,headRefOid,baseRefName")
+	result := s.run("gh", "pr", "view", identity.URL, "--json", "url,number,state,isDraft,mergeStateStatus,mergeable,reviewDecision,headRefName,headRefOid,baseRefName")
 	if result.Err != nil {
 		return PRObservation{
 			Status:   PRObservationUnavailable,
@@ -122,12 +168,16 @@ func (s Service) ObserveRecordedPR(identity PRIdentity) PRObservation {
 	}
 
 	var parsed struct {
-		URL         string `json:"url"`
-		Number      int    `json:"number"`
-		State       string `json:"state"`
-		HeadRefName string `json:"headRefName"`
-		HeadRefOID  string `json:"headRefOid"`
-		BaseRefName string `json:"baseRefName"`
+		URL              string `json:"url"`
+		Number           int    `json:"number"`
+		State            string `json:"state"`
+		IsDraft          bool   `json:"isDraft"`
+		MergeStateStatus string `json:"mergeStateStatus"`
+		Mergeable        string `json:"mergeable"`
+		ReviewDecision   string `json:"reviewDecision"`
+		HeadRefName      string `json:"headRefName"`
+		HeadRefOID       string `json:"headRefOid"`
+		BaseRefName      string `json:"baseRefName"`
 	}
 	if err := json.Unmarshal([]byte(result.Stdout), &parsed); err != nil {
 		return PRObservation{
@@ -140,14 +190,163 @@ func (s Service) ObserveRecordedPR(identity PRIdentity) PRObservation {
 	}
 
 	return PRObservation{
-		Status:      PRObservationAvailable,
-		URL:         parsed.URL,
-		Number:      parsed.Number,
-		State:       parsed.State,
-		HeadRefName: parsed.HeadRefName,
-		HeadRefOID:  parsed.HeadRefOID,
-		BaseRefName: parsed.BaseRefName,
+		Status:           PRObservationAvailable,
+		URL:              parsed.URL,
+		Number:           parsed.Number,
+		State:            parsed.State,
+		IsDraft:          parsed.IsDraft,
+		MergeStateStatus: parsed.MergeStateStatus,
+		Mergeable:        parsed.Mergeable,
+		ReviewDecision:   parsed.ReviewDecision,
+		HeadRefName:      parsed.HeadRefName,
+		HeadRefOID:       parsed.HeadRefOID,
+		BaseRefName:      parsed.BaseRefName,
 	}
+}
+
+func (s Service) ObserveHandoff(identity PRIdentity) HandoffObservation {
+	pr := s.ObserveRecordedPR(identity)
+	if pr.Status != PRObservationAvailable {
+		degradation := pr.Degraded
+		return HandoffObservation{
+			Status:   HandoffObservationUnavailable,
+			PR:       pr,
+			CI:       unavailableCI(degradation),
+			Sync:     unavailableSync(degradation),
+			Degraded: degradationList(degradation),
+		}
+	}
+
+	ci := s.observeChecks(identity.URL)
+	sync := classifyMergeState(pr.MergeStateStatus)
+	degraded := make([]Degradation, 0, 2)
+	if ci.Status == RemoteCIUnavailable {
+		degraded = append(degraded, ci.Degraded)
+	}
+	if sync.Status == RemoteSyncUnavailable {
+		degraded = append(degraded, sync.Degraded)
+	}
+
+	status := HandoffObservationAvailable
+	if len(degraded) > 0 {
+		status = HandoffObservationDegraded
+	}
+	return HandoffObservation{
+		Status:   status,
+		PR:       pr,
+		CI:       ci,
+		Sync:     sync,
+		Degraded: degraded,
+	}
+}
+
+func (s Service) observeChecks(prURL string) RemoteCIObservation {
+	result := s.run("gh", "pr", "checks", prURL, "--json", "name,workflow,bucket,state,link")
+	if result.Err != nil && strings.TrimSpace(result.Stdout) == "" {
+		return unavailableCI(classifyGhFailure(result))
+	}
+
+	var checks []CheckRun
+	if err := json.Unmarshal([]byte(result.Stdout), &checks); err != nil {
+		return unavailableCI(Degradation{
+			Code:    DegradedGhInvalidJSON,
+			Message: "gh returned invalid JSON for recorded PR checks",
+		})
+	}
+	if len(checks) == 0 {
+		return unavailableCI(Degradation{
+			Code:    DegradedChecksUnreadable,
+			Message: "recorded PR checks are unavailable",
+		})
+	}
+
+	status, ok := classifyChecks(checks)
+	if !ok {
+		return unavailableCI(Degradation{
+			Code:    DegradedChecksUnreadable,
+			Message: "recorded PR checks could not be classified",
+		})
+	}
+	return RemoteCIObservation{
+		Status:         RemoteCIAvailable,
+		EvidenceStatus: status,
+		Checks:         checks,
+	}
+}
+
+func classifyChecks(checks []CheckRun) (string, bool) {
+	hasPending := false
+	hasPassing := false
+	for _, check := range checks {
+		switch strings.ToLower(strings.TrimSpace(check.Bucket)) {
+		case "fail", "cancel":
+			return "failed", true
+		case "pending":
+			hasPending = true
+		case "pass":
+			hasPassing = true
+		case "skipping":
+		default:
+			return "", false
+		}
+	}
+	if hasPending {
+		return "pending", true
+	}
+	if hasPassing {
+		return "success", true
+	}
+	return "", false
+}
+
+func classifyMergeState(raw string) RemoteSyncObservation {
+	mergeState := strings.ToUpper(strings.TrimSpace(raw))
+	switch mergeState {
+	case "CLEAN":
+		return RemoteSyncObservation{
+			Status:         RemoteSyncAvailable,
+			EvidenceStatus: "fresh",
+			MergeState:     mergeState,
+		}
+	case "DIRTY":
+		return RemoteSyncObservation{
+			Status:         RemoteSyncAvailable,
+			EvidenceStatus: "conflicted",
+			MergeState:     mergeState,
+		}
+	case "BEHIND", "BLOCKED", "DRAFT", "HAS_HOOKS", "UNKNOWN", "UNSTABLE":
+		return RemoteSyncObservation{
+			Status:         RemoteSyncAvailable,
+			EvidenceStatus: "stale",
+			MergeState:     mergeState,
+		}
+	default:
+		return unavailableSync(Degradation{
+			Code:    DegradedMergeUnreadable,
+			Message: "recorded PR merge state is unavailable",
+		})
+	}
+}
+
+func unavailableCI(degradation Degradation) RemoteCIObservation {
+	return RemoteCIObservation{
+		Status:   RemoteCIUnavailable,
+		Degraded: degradation,
+	}
+}
+
+func unavailableSync(degradation Degradation) RemoteSyncObservation {
+	return RemoteSyncObservation{
+		Status:   RemoteSyncUnavailable,
+		Degraded: degradation,
+	}
+}
+
+func degradationList(degradation Degradation) []Degradation {
+	if degradation.Code == "" {
+		return nil
+	}
+	return []Degradation{degradation}
 }
 
 func ParseRecordedPRURL(raw string) PRIdentity {

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -924,6 +924,11 @@ func buildPublishNextActions(facts *Facts) []NextAction {
 			Command:     nil,
 			Description: "Publish was marked not_applied, but v0.2 land still requires a PR URL; record publish evidence with a PR URL or reopen if the workflow changed.",
 		})
+	case strings.TrimSpace(facts.PRURL) != "" && (facts.CIStatus == "" || facts.SyncStatus == ""):
+		actions = append(actions, NextAction{
+			Command:     strPtr("harness evidence refresh"),
+			Description: "Refresh CI and sync evidence from the recorded PR URL.",
+		})
 	}
 
 	switch {

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -939,8 +939,8 @@ func buildPublishNextActions(facts *Facts) []NextAction {
 		})
 	case facts.CIStatus == "pending":
 		actions = append(actions, NextAction{
-			Command:     nil,
-			Description: "Wait for the relevant post-archive CI to finish, then record the updated result if it changes.",
+			Command:     strPtr("harness evidence submit --kind ci --input <json>"),
+			Description: "Wait for the relevant post-archive CI to finish, then manually record the updated result if refresh is unavailable.",
 		})
 	case facts.CIStatus == "failed":
 		actions = append(actions, NextAction{
@@ -957,8 +957,8 @@ func buildPublishNextActions(facts *Facts) []NextAction {
 		})
 	case facts.SyncStatus == "stale":
 		actions = append(actions, NextAction{
-			Command:     nil,
-			Description: "Refresh the branch against the merge base, then record a fresh sync result before merge approval.",
+			Command:     strPtr("harness evidence submit --kind sync --input <json>"),
+			Description: "Refresh the branch against the merge base, then manually record a fresh sync result if refresh is unavailable.",
 		})
 	case facts.SyncStatus == "conflicted":
 		actions = append(actions, NextAction{

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -924,10 +924,10 @@ func buildPublishNextActions(facts *Facts) []NextAction {
 			Command:     nil,
 			Description: "Publish was marked not_applied, but v0.2 land still requires a PR URL; record publish evidence with a PR URL or reopen if the workflow changed.",
 		})
-	case strings.TrimSpace(facts.PRURL) != "" && (facts.CIStatus == "" || facts.SyncStatus == ""):
+	case shouldSuggestEvidenceRefresh(facts):
 		actions = append(actions, NextAction{
 			Command:     strPtr("harness evidence refresh"),
-			Description: "Refresh CI and sync evidence from the recorded PR URL.",
+			Description: "Refresh CI and sync evidence from the recorded PR URL, including re-checking pending CI or non-fresh sync state.",
 		})
 	}
 
@@ -973,6 +973,16 @@ func buildPublishNextActions(facts *Facts) []NextAction {
 	})
 
 	return actions
+}
+
+func shouldSuggestEvidenceRefresh(facts *Facts) bool {
+	if facts == nil || facts.PublishStatus != "recorded" || strings.TrimSpace(facts.PRURL) == "" {
+		return false
+	}
+	return facts.CIStatus == "" ||
+		facts.CIStatus == "pending" ||
+		facts.SyncStatus == "" ||
+		facts.SyncStatus == "stale"
 }
 
 func idleResult(workdir string, currentPlan *runstate.CurrentPlan) Result {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -1715,22 +1715,25 @@ func TestStatusArchivedPlanWithRecordedPRSuggestsEvidenceRefresh(t *testing.T) {
 
 func TestStatusArchivedPlanKeepsEvidenceRefreshForNonReadyRecordedPR(t *testing.T) {
 	tests := []struct {
-		name       string
-		ciInput    string
-		syncInput  string
-		wantStatus string
+		name            string
+		ciInput         string
+		syncInput       string
+		wantStatus      string
+		fallbackCommand string
 	}{
 		{
-			name:       "pending CI",
-			ciInput:    `{"status":"pending","provider":"github-actions","url":"https://ci.example/run"}`,
-			syncInput:  `{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`,
-			wantStatus: "pending",
+			name:            "pending CI",
+			ciInput:         `{"status":"pending","provider":"github-actions","url":"https://ci.example/run"}`,
+			syncInput:       `{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`,
+			wantStatus:      "pending",
+			fallbackCommand: "harness evidence submit --kind ci --input <json>",
 		},
 		{
-			name:       "stale sync",
-			ciInput:    `{"status":"success","provider":"github-actions","url":"https://ci.example/run"}`,
-			syncInput:  `{"status":"stale","base_ref":"main","head_ref":"codex/test"}`,
-			wantStatus: "stale",
+			name:            "stale sync",
+			ciInput:         `{"status":"success","provider":"github-actions","url":"https://ci.example/run"}`,
+			syncInput:       `{"status":"stale","base_ref":"main","head_ref":"codex/test"}`,
+			wantStatus:      "stale",
+			fallbackCommand: "harness evidence submit --kind sync --input <json>",
 		},
 	}
 
@@ -1759,6 +1762,9 @@ func TestStatusArchivedPlanKeepsEvidenceRefreshForNonReadyRecordedPR(t *testing.
 			}
 			if !statusNextActionsContain(result, "harness evidence refresh") {
 				t.Fatalf("expected evidence refresh guidance for %s handoff, got %#v", tt.wantStatus, result.NextAction)
+			}
+			if !statusNextActionsContain(result, tt.fallbackCommand) {
+				t.Fatalf("expected manual fallback command for %s handoff, got %#v", tt.wantStatus, result.NextAction)
 			}
 		})
 	}

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -1687,6 +1687,32 @@ func TestStatusArchivedPlanNeedsPublishEvidence(t *testing.T) {
 	}
 }
 
+func TestStatusArchivedPlanWithRecordedPRSuggestsEvidenceRefresh(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		return completeAllSteps(content, true)
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+		t.Fatalf("publish evidence: %#v", result)
+	}
+
+	result := status.Service{Workdir: root}.Snapshot()
+	if result.State.CurrentNode != "execution/finalize/publish" {
+		t.Fatalf("unexpected node: %#v", result.State)
+	}
+	if !statusNextActionsContain(result, "harness evidence refresh") {
+		t.Fatalf("expected evidence refresh guidance after recorded PR, got %#v", result.NextAction)
+	}
+	if !statusNextActionsContain(result, "harness evidence submit --kind ci --input <json>") {
+		t.Fatalf("expected manual CI fallback guidance to remain, got %#v", result.NextAction)
+	}
+	if !statusNextActionsContain(result, "harness evidence submit --kind sync --input <json>") {
+		t.Fatalf("expected manual sync fallback guidance to remain, got %#v", result.NextAction)
+	}
+}
+
 func TestStatusWarnsInArchivedPublishWhenCompletedStepStillLacksCloseout(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
@@ -2980,6 +3006,15 @@ func assertStateJSONLacksKeys(t *testing.T, root, planStem string, keys ...strin
 			t.Fatalf("expected state.json to omit %q, got %#v", key, payload)
 		}
 	}
+}
+
+func statusNextActionsContain(result status.Result, command string) bool {
+	for _, action := range result.NextAction {
+		if action.Command != nil && *action.Command == command {
+			return true
+		}
+	}
+	return false
 }
 
 func mustJSONBytes(t *testing.T, value any) []byte {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -1713,6 +1713,57 @@ func TestStatusArchivedPlanWithRecordedPRSuggestsEvidenceRefresh(t *testing.T) {
 	}
 }
 
+func TestStatusArchivedPlanKeepsEvidenceRefreshForNonReadyRecordedPR(t *testing.T) {
+	tests := []struct {
+		name       string
+		ciInput    string
+		syncInput  string
+		wantStatus string
+	}{
+		{
+			name:       "pending CI",
+			ciInput:    `{"status":"pending","provider":"github-actions","url":"https://ci.example/run"}`,
+			syncInput:  `{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`,
+			wantStatus: "pending",
+		},
+		{
+			name:       "stale sync",
+			ciInput:    `{"status":"success","provider":"github-actions","url":"https://ci.example/run"}`,
+			syncInput:  `{"status":"stale","base_ref":"main","head_ref":"codex/test"}`,
+			wantStatus: "stale",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+				return completeAllSteps(content, true)
+			})
+			writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+
+			svc := evidence.Service{Workdir: root}
+			if result := svc.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+				t.Fatalf("publish evidence: %#v", result)
+			}
+			if result := svc.Submit("ci", []byte(tt.ciInput)); !result.OK {
+				t.Fatalf("ci evidence: %#v", result)
+			}
+			if result := svc.Submit("sync", []byte(tt.syncInput)); !result.OK {
+				t.Fatalf("sync evidence: %#v", result)
+			}
+
+			result := status.Service{Workdir: root}.Snapshot()
+			if result.State.CurrentNode != "execution/finalize/publish" {
+				t.Fatalf("unexpected node: %#v", result.State)
+			}
+			if !statusNextActionsContain(result, "harness evidence refresh") {
+				t.Fatalf("expected evidence refresh guidance for %s handoff, got %#v", tt.wantStatus, result.NextAction)
+			}
+		})
+	}
+}
+
 func TestStatusWarnsInArchivedPublishWhenCompletedStepStillLacksCloseout(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {

--- a/schema/commands/evidence.refresh.result.schema.json
+++ b/schema/commands/evidence.refresh.result.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/catu-ai/easyharness/tree/main/schema/commands/evidence.refresh.result.schema.json",
+  "$ref": "#/$defs/EvidenceRefreshResult",
+  "$defs": {
+    "ErrorDetail": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path identifies the field, section, or artifact path associated with the error."
+        },
+        "message": {
+          "type": "string",
+          "description": "Message is the human-readable explanation of the problem."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path",
+        "message"
+      ],
+      "description": "ErrorDetail describes one machine-readable validation or execution problem in a command result."
+    },
+    "EvidenceRefreshArtifacts": {
+      "properties": {
+        "plan_path": {
+          "type": "string",
+          "description": "PlanPath is the archived plan path associated with the evidence records."
+        },
+        "pr_url": {
+          "type": "string",
+          "description": "PRURL is the recorded pull request URL used for remote observation."
+        },
+        "ci_record_id": {
+          "type": "string",
+          "description": "CIRecordID is the created CI evidence record identifier when CI was refreshed."
+        },
+        "sync_record_id": {
+          "type": "string",
+          "description": "SyncRecordID is the created sync evidence record identifier when sync was refreshed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "plan_path"
+      ],
+      "description": "EvidenceRefreshArtifacts lists evidence records touched by `harness evidence refresh`."
+    },
+    "EvidenceRefreshResult": {
+      "properties": {
+        "ok": {
+          "type": "boolean",
+          "description": "OK reports whether at least one evidence domain was refreshed."
+        },
+        "command": {
+          "type": "string",
+          "description": "Command is the stable command identifier for the result payload."
+        },
+        "summary": {
+          "type": "string",
+          "description": "Summary is the concise human-readable outcome description."
+        },
+        "artifacts": {
+          "$ref": "#/$defs/EvidenceRefreshArtifacts",
+          "description": "Artifacts points to the evidence records created by the command."
+        },
+        "next_actions": {
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/NextAction"
+              },
+              "type": "array",
+              "description": "NextAction lists the most relevant follow-up steps in priority order."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "NextAction lists the most relevant follow-up steps in priority order."
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Warnings lists degraded domains that did not prevent other evidence from being refreshed."
+        },
+        "errors": {
+          "items": {
+            "$ref": "#/$defs/ErrorDetail"
+          },
+          "type": "array",
+          "description": "Errors lists hard failures that prevented any evidence refresh."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ok",
+        "command",
+        "summary",
+        "next_actions"
+      ],
+      "description": "EvidenceRefreshResult is the JSON result returned by `harness evidence refresh`."
+    },
+    "NextAction": {
+      "properties": {
+        "command": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Command is the suggested command line to run next when the next step is best expressed as a harness command."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Command is the suggested command line to run next when the next step is best expressed as a harness command."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description explains the suggested next step in plain language."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command",
+        "description"
+      ],
+      "description": "NextAction describes one concrete follow-up action that the caller should consider after reading a command result."
+    }
+  },
+  "title": "Evidence refresh command result",
+  "description": "JSON output for `harness evidence refresh`."
+}

--- a/schema/index.json
+++ b/schema/index.json
@@ -133,6 +133,16 @@
       "go_type": "github.com/catu-ai/easyharness/internal/contracts.BootstrapResult"
     },
     {
+      "key": "commands.evidence.refresh.result",
+      "group": "command_results",
+      "surface": "public",
+      "title": "Evidence refresh command result",
+      "description": "JSON output for `harness evidence refresh`.",
+      "path": "schema/commands/evidence.refresh.result.schema.json",
+      "id": "https://github.com/catu-ai/easyharness/tree/main/schema/commands/evidence.refresh.result.schema.json",
+      "go_type": "github.com/catu-ai/easyharness/internal/contracts.EvidenceRefreshResult"
+    },
+    {
       "key": "commands.evidence.submit.result",
       "group": "command_results",
       "surface": "public",


### PR DESCRIPTION
## Summary

- Add recorded-PR-only GitHub remote handoff observation for PR checks and merge state.
- Add `harness evidence refresh` to append CI and sync evidence from the recorded publish PR URL without guessing from branch state.
- Preserve manual `harness evidence submit --kind publish|ci|sync` fallbacks and update status guidance for missing, pending, stale, and degraded handoff evidence.

Closes #199.

## Validation

- `go test -count=1 ./internal/remote ./internal/evidence ./internal/cli ./internal/status ./internal/contractsync`
- `go test ./...`
- `scripts/sync-contract-artifacts --check`
- `git diff --check`
- `harness plan lint docs/plans/active/2026-05-21-refresh-remote-handoff-evidence.md`
- Final harness review: `review-011-full` passed with zero findings.
