### PR TITLE
Harden evidence refresh workflow integration

### DIFF
--- a/.agents/skills/harness-execute/references/closeout-and-archive.md
+++ b/.agents/skills/harness-execute/references/closeout-and-archive.md
@@ -47,10 +47,18 @@ Archive still needs an explicit handoff flow:
    merge approval.
 5. Run `harness status` again to confirm the archived candidate entered
    `execution/finalize/publish` for this worktree.
-6. Record publish, CI, and sync facts through `harness evidence submit`.
-7. Run `harness status` again after that handoff work and confirm the candidate
+6. Record publish evidence with the PR URL or handoff target through
+   `harness evidence submit --kind publish`.
+7. If publish evidence records a supported PR URL, run
+   `harness evidence refresh` to record CI and sync facts from that PR.
+8. Run `harness status` after refresh so the archived candidate summary and
+   next actions reflect the evidence that was just written.
+9. If refresh degrades, is unavailable, or publish evidence lacks a recorded
+   PR URL, manually record the affected domains with
+   `harness evidence submit --kind publish|ci|sync`.
+10. Run `harness status` again after that handoff work and confirm the candidate
    is now genuinely ready to report `execution/finalize/await_merge`.
-8. Wait for human merge approval or switch to `harness-land` only when asked
+11. Wait for human merge approval or switch to `harness-land` only when asked
    once status reaches `execution/finalize/await_merge`.
 
 If new feedback or remote changes invalidate the archived candidate, use:

--- a/.agents/skills/harness-execute/references/publish-ci-sync.md
+++ b/.agents/skills/harness-execute/references/publish-ci-sync.md
@@ -13,26 +13,35 @@ current step and eventually into archived-candidate handoff.
 6. decide whether the repair needs delta review or full review
 
 For archived candidates, use the same sequence as post-archive handoff work,
-but record the observed external facts through `harness evidence submit`:
+but record the observed external facts through harness-owned evidence:
 
 1. commit the archive move
 2. push the branch
 3. open or update the PR
 4. run `harness evidence submit --kind publish` once the PR or handoff target
    exists
-5. wait for post-archive CI and record updates with
-   `harness evidence submit --kind ci`
-6. refresh remote readiness and record it with
-   `harness evidence submit --kind sync`
-7. once those remote facts exist, run the `Pre-Land` scan from
+5. when publish evidence records a supported PR URL, run
+   `harness evidence refresh` to read CI and sync facts from that recorded PR
+6. run `harness status` after refresh so the local summary and next actions
+   reflect the evidence that was just written
+7. if refresh degrades, is unavailable, or publish evidence lacks a recorded
+   PR URL, use manual
+   `harness evidence submit --kind publish|ci|sync --input <json>` for the
+   affected evidence domains
+8. once those remote facts exist, run the `Pre-Land` scan from
    [controller-truth-surfaces.md](controller-truth-surfaces.md) before treating
    the archived candidate as genuinely merge-ready
-8. only then treat the candidate as ready to enter
+9. only then treat the candidate as ready to enter
    `execution/finalize/await_merge`
 
 ## Remote Freshness
 
 Refresh remote state before merge-sensitive handoff work.
+
+Use `harness evidence refresh` as the ordinary refresh path when publish
+evidence has a recorded PR URL. Direct `gh` inspection is a diagnostic fallback
+for confusing or degraded refresh results, not the controller's first path for
+routine CI/sync evidence refresh.
 
 If remote changes introduce real conflict work:
 

--- a/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
+++ b/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
@@ -47,10 +47,18 @@ Archive still needs an explicit handoff flow:
    merge approval.
 5. Run `harness status` again to confirm the archived candidate entered
    `execution/finalize/publish` for this worktree.
-6. Record publish, CI, and sync facts through `harness evidence submit`.
-7. Run `harness status` again after that handoff work and confirm the candidate
+6. Record publish evidence with the PR URL or handoff target through
+   `harness evidence submit --kind publish`.
+7. If publish evidence records a supported PR URL, run
+   `harness evidence refresh` to record CI and sync facts from that PR.
+8. Run `harness status` after refresh so the archived candidate summary and
+   next actions reflect the evidence that was just written.
+9. If refresh degrades, is unavailable, or publish evidence lacks a recorded
+   PR URL, manually record the affected domains with
+   `harness evidence submit --kind publish|ci|sync`.
+10. Run `harness status` again after that handoff work and confirm the candidate
    is now genuinely ready to report `execution/finalize/await_merge`.
-8. Wait for human merge approval or switch to `harness-land` only when asked
+11. Wait for human merge approval or switch to `harness-land` only when asked
    once status reaches `execution/finalize/await_merge`.
 
 If new feedback or remote changes invalidate the archived candidate, use:

--- a/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
+++ b/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
@@ -13,26 +13,35 @@ current step and eventually into archived-candidate handoff.
 6. decide whether the repair needs delta review or full review
 
 For archived candidates, use the same sequence as post-archive handoff work,
-but record the observed external facts through `harness evidence submit`:
+but record the observed external facts through harness-owned evidence:
 
 1. commit the archive move
 2. push the branch
 3. open or update the PR
 4. run `harness evidence submit --kind publish` once the PR or handoff target
    exists
-5. wait for post-archive CI and record updates with
-   `harness evidence submit --kind ci`
-6. refresh remote readiness and record it with
-   `harness evidence submit --kind sync`
-7. once those remote facts exist, run the `Pre-Land` scan from
+5. when publish evidence records a supported PR URL, run
+   `harness evidence refresh` to read CI and sync facts from that recorded PR
+6. run `harness status` after refresh so the local summary and next actions
+   reflect the evidence that was just written
+7. if refresh degrades, is unavailable, or publish evidence lacks a recorded
+   PR URL, use manual
+   `harness evidence submit --kind publish|ci|sync --input <json>` for the
+   affected evidence domains
+8. once those remote facts exist, run the `Pre-Land` scan from
    [controller-truth-surfaces.md](controller-truth-surfaces.md) before treating
    the archived candidate as genuinely merge-ready
-8. only then treat the candidate as ready to enter
+9. only then treat the candidate as ready to enter
    `execution/finalize/await_merge`
 
 ## Remote Freshness
 
 Refresh remote state before merge-sensitive handoff work.
+
+Use `harness evidence refresh` as the ordinary refresh path when publish
+evidence has a recorded PR URL. Direct `gh` inspection is a diagnostic fallback
+for confusing or degraded refresh results, not the controller's first path for
+routine CI/sync evidence refresh.
 
 If remote changes introduce real conflict work:
 

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -245,9 +245,17 @@ fallback rather than the routine refresh path. Refreshed materialized
 `.agents/skills/` output from `assets/bootstrap/`. Validation:
 `scripts/sync-bootstrap-assets --check`.
 
+After `review-005-delta`, also updated the managed closeout/archive handoff
+checklist so it no longer presents manual CI/sync submit as the ordinary path.
+The checklist now records publish evidence, runs `harness evidence refresh`,
+runs `harness status`, and keeps manual submit as fallback for degraded or
+unavailable refresh paths. Validation: `scripts/sync-bootstrap-assets --check`.
+
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-005-delta` found the managed closeout/archive checklist still taught
+manual evidence submit as the ordinary handoff path. The repair aligned that
+checklist with refresh-first guidance; follow-up delta review is pending.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -146,7 +146,7 @@ non-empty stdout path. The repair addressed all three findings, and
 
 ### Step 2: Return refreshed statuses from the command result
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -203,7 +203,7 @@ omits the unwritten status key. Validation:
 
 `review-003-delta` found a missing CLI assertion for partial refresh JSON
 omitting unwritten status keys. The repair added that coverage; follow-up
-delta review is pending.
+`review-004-delta` passed clean.
 
 ### Step 3: Refresh controller guidance
 

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -1,0 +1,271 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-22T23:58:56+08:00"
+approved_at: "2026-05-23T00:00:36+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/213
+size: S
+---
+
+# Harden Evidence Refresh Workflow Integration
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Resolve issue #213 by hardening `harness evidence refresh` so controllers can
+prefer it for ordinary archived-candidate publish/CI/sync handoff after
+publish evidence records a PR URL.
+
+The command should bound its read-only GitHub CLI calls, degrade without
+writing misleading evidence when remote reads hang or fail, and return enough
+machine-readable refresh detail for an agent to understand what was just
+recorded before it runs `harness status`.
+
+## Scope
+
+### In Scope
+
+- Add bounded timeout behavior around the `gh pr view` and `gh pr checks`
+  reads used by `harness evidence refresh`.
+- Classify timeout results as degraded remote reads and avoid writing evidence
+  for domains whose facts were not confidently refreshed.
+- Extend the `harness evidence refresh` result contract with a
+  machine-readable refreshed/observed status surface, including CI and sync
+  statuses when those domains are written.
+- Update generated command schemas and contract references for the changed
+  refresh result payload.
+- Update repo-local `harness-execute` publish/CI/sync guidance so future
+  controllers prefer:
+  1. `harness evidence refresh` when publish evidence has a recorded PR URL.
+  2. `harness status` after refresh.
+  3. manual `harness evidence submit --kind publish|ci|sync` fallback when
+     refresh degrades, is unavailable, or lacks a recorded PR URL.
+- Refresh materialized bootstrap assets after editing
+  `assets/bootstrap/skills/harness-execute/...`.
+
+### Out of Scope
+
+- Richer live remote handoff facts in `harness status`; that remains issue
+  #200.
+- Broad controller workflow redesign beyond the publish/CI/sync refresh
+  guidance needed for this issue.
+- Configurable timeout settings or repository-specific timeout policy.
+- Opening, updating, commenting on, labeling, reviewing, rerunning checks for,
+  or merging PRs.
+- Guessing a PR from the current branch when publish evidence lacks a recorded
+  PR URL.
+- Replacing manual `harness evidence submit` fallback paths.
+
+## Acceptance Criteria
+
+- [ ] `gh pr view` and `gh pr checks` calls used by refresh have bounded
+      runtime in the default command runner.
+- [ ] Timeout and other remote read failures degrade cleanly and do not write
+      misleading CI or sync evidence.
+- [ ] Successful and partial refresh results expose machine-readable status
+      details for the domains actually written, without requiring agents to
+      parse summary text.
+- [ ] The public refresh result schema and contract artifacts match the new
+      output shape.
+- [ ] `harness-execute` publish/CI/sync guidance names refresh as the ordinary
+      first path after publish evidence records a PR URL, with `harness status`
+      next and manual submit as fallback.
+- [ ] Focused tests cover success, partial refresh, timeout degradation, and
+      no-evidence timeout/failure behavior.
+
+## Deferred Items
+
+- Issue #200 remains responsible for richer remote handoff facts and status
+  surfaces.
+- Issue #202 remains responsible for broader controller documentation and
+  skill updates after the handoff workflow settles.
+
+## Work Breakdown
+
+### Step 1: Bound remote refresh reads
+
+- Done: [ ]
+
+#### Objective
+
+Ensure refresh cannot hang indefinitely while reading the recorded PR or PR
+checks through `gh`.
+
+#### Details
+
+Use a conservative fixed timeout in the default remote command runner rather
+than adding a user-facing setting. The timeout should apply to read-only `gh`
+operations used by `harness evidence refresh`, while keeping the existing
+injectable command runner simple enough for tests to simulate success,
+failure, and timeout outcomes.
+
+Timeouts should classify as degraded remote reads. If PR observation times out,
+refresh should write no CI or sync evidence. If checks observation times out
+after PR observation succeeds, refresh may still write sync evidence when the
+merge state is clear, but it must not write CI evidence.
+
+#### Expected Files
+
+- `internal/remote/identity.go`
+- `internal/remote/gh_test.go`
+- `internal/evidence/service_test.go`
+
+#### Validation
+
+- Unit tests prove the default runner returns a timeout failure instead of
+  waiting forever.
+- Remote and evidence tests prove timeout degradation preserves the existing
+  no-misleading-evidence behavior.
+
+#### Execution Notes
+
+Added a fixed 30-second timeout to the default remote command runner used for
+read-only `gh` calls, plus `gh_timeout` degradation classification. Added
+focused tests proving the default runner returns `context.DeadlineExceeded`
+for slow commands, PR observation timeout writes no evidence, and checks
+timeout can still write sync evidence when merge state is clear. Validation:
+`go test ./internal/remote ./internal/evidence`.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Return refreshed statuses from the command result
+
+- Done: [ ]
+
+#### Objective
+
+Make `harness evidence refresh` output directly useful to controllers by
+returning the machine-readable CI and sync statuses it just recorded.
+
+#### Details
+
+Add a semantic refreshed or observed result object rather than making agents
+infer status from prose or record IDs. The result should expose status fields
+only for domains whose evidence was actually written, and warnings/next
+actions should continue to guide manual fallback for degraded domains.
+
+The exact field names should be chosen to read clearly in the JSON contract,
+for example a `refreshed` object with `ci_status` and `sync_status` fields.
+Keep the payload compact; this slice does not need to embed full check rows or
+PR metadata.
+
+#### Expected Files
+
+- `internal/contracts/evidence.go`
+- `internal/evidence/service.go`
+- `internal/evidence/service_test.go`
+- `schema/commands/evidence.refresh.result.schema.json`
+- `schema/index.json`
+- any generated contract reference artifacts touched by the repository's
+  contract sync workflow
+
+#### Validation
+
+- Service and CLI tests assert that full refresh returns both statuses, partial
+  refresh returns only the written domain's status, and all-failed refresh
+  omits misleading success detail.
+- Contract/schema sync checks pass after regenerating artifacts.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Refresh controller guidance
+
+- Done: [ ]
+
+#### Objective
+
+Teach future controller agents to use refresh as the ordinary publish/CI/sync
+handoff path once publish evidence contains a recorded PR URL.
+
+#### Details
+
+Update the managed bootstrap `harness-execute` reference material in
+`assets/bootstrap/` first, then run the bootstrap sync script so
+`.agents/skills/` and the managed instructions block stay materialized from
+the source assets. The guidance should make direct `gh` inspection diagnostic,
+not the first path for routine evidence refresh.
+
+#### Expected Files
+
+- `assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md`
+- `.agents/skills/harness-execute/references/publish-ci-sync.md`
+- `AGENTS.md`, only if the bootstrap sync script refreshes the managed block
+
+#### Validation
+
+- `scripts/sync-bootstrap-assets --check` passes after the asset refresh.
+- The updated guidance clearly lists refresh, status, and manual submit
+  fallback in that order.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run focused Go tests for remote observation, evidence refresh, and CLI
+  output behavior.
+- Run the contract artifact sync check after updating the refresh result
+  schema.
+- Run the bootstrap asset sync check after updating managed skill guidance.
+- Run `harness plan lint` before approval and again after any plan edits.
+
+## Risks
+
+- Risk: A timeout could be classified too broadly and hide an actionable auth
+  or provider error.
+  - Mitigation: Preserve existing `gh` failure classifications where possible
+    and add timeout-specific coverage for only elapsed reads.
+- Risk: The result contract could grow into the broader status surface tracked
+  by issue #200.
+  - Mitigation: Return only the statuses written by this refresh command and
+    keep full remote handoff surfacing out of scope.
+- Risk: Updating managed bootstrap guidance by hand could drift from
+  materialized `.agents/skills/`.
+  - Mitigation: Edit `assets/bootstrap/` first and use
+    `scripts/sync-bootstrap-assets` to refresh generated outputs.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+- #200 remains the follow-up for richer remote handoff facts in status.
+- #202 remains the follow-up for broader controller documentation and skills.

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -90,7 +90,7 @@ recorded before it runs `harness status`.
 
 ### Step 1: Bound remote refresh reads
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -141,8 +141,8 @@ held-pipe cases, and added focused regression coverage. Validation:
 
 `review-001-delta` found timeout reads with non-empty stdout could still write
 CI evidence, the default runner lacked `WaitDelay`, and tests missed the
-non-empty stdout path. The repair addresses all three findings; follow-up
-delta review is pending.
+non-empty stdout path. The repair addressed all three findings, and
+`review-002-delta` passed clean.
 
 ### Step 2: Return refreshed statuses from the command result
 

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -64,19 +64,19 @@ recorded before it runs `harness status`.
 
 ## Acceptance Criteria
 
-- [ ] `gh pr view` and `gh pr checks` calls used by refresh have bounded
+- [x] `gh pr view` and `gh pr checks` calls used by refresh have bounded
       runtime in the default command runner.
-- [ ] Timeout and other remote read failures degrade cleanly and do not write
+- [x] Timeout and other remote read failures degrade cleanly and do not write
       misleading CI or sync evidence.
-- [ ] Successful and partial refresh results expose machine-readable status
+- [x] Successful and partial refresh results expose machine-readable status
       details for the domains actually written, without requiring agents to
       parse summary text.
-- [ ] The public refresh result schema and contract artifacts match the new
+- [x] The public refresh result schema and contract artifacts match the new
       output shape.
-- [ ] `harness-execute` publish/CI/sync guidance names refresh as the ordinary
+- [x] `harness-execute` publish/CI/sync guidance names refresh as the ordinary
       first path after publish evidence records a PR URL, with `harness status`
       next and manual submit as fallback.
-- [ ] Focused tests cover success, partial refresh, timeout degradation, and
+- [x] Focused tests cover success, partial refresh, timeout degradation, and
       no-evidence timeout/failure behavior.
 
 ## Deferred Items
@@ -283,25 +283,60 @@ checklist with refresh-first guidance, and `review-006-delta` passed clean.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `go test ./internal/remote ./internal/evidence ./internal/cli ./internal/contractsync -count=1`
+  passed before finalize review.
+- `scripts/sync-contract-artifacts --check` passed.
+- `scripts/sync-bootstrap-assets --check` passed.
+- `harness plan lint docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md`
+  passed.
+- `review-007-full` passed clean across correctness, contract/tests, and
+  docs-consistency reviewer slots.
+- Controller note: `go test ./... -count=1` was attempted after finalize
+  review and manually stopped after a long quiet smoke tail; it is not counted
+  as archive evidence.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step 1 review: `review-001-delta` requested timeout repairs for non-empty
+  stdout, `WaitDelay`, and coverage; `review-002-delta` passed after repair.
+- Step 2 review: `review-003-delta` requested CLI partial-output coverage;
+  `review-004-delta` passed after repair.
+- Step 3 review: `review-005-delta` requested closeout/archive guidance
+  alignment; `review-006-delta` passed after repair.
+- Finalize review: `review-007-full` passed with no blocking or non-blocking
+  findings.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: NONE. Create or update the PR after committing and pushing this archived
+  candidate.
+- Ready: The tracked steps are complete, acceptance criteria are checked,
+  focused validation and sync checks passed, and finalize review passed clean.
+- Merge Handoff: After archive, commit the archive move and summary updates,
+  push the branch, open or update the PR, record publish evidence with the PR
+  URL, run `harness evidence refresh`, run `harness status`, and use manual
+  evidence submit fallback only for degraded or unavailable refresh domains.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Bounded default `gh` reads used by evidence refresh with timeout and
+  `WaitDelay` handling.
+- Added `gh_timeout` degradation classification and prevented timeout results
+  from writing misleading evidence, including timed-out checks with stdout.
+- Added compact `refreshed.ci_status` and `refreshed.sync_status` output for
+  evidence domains written by `harness evidence refresh`.
+- Regenerated the public evidence refresh result schema.
+- Updated managed controller guidance so publish/CI/sync and archive handoff
+  flows prefer `harness evidence refresh`, then `harness status`, with manual
+  submit as fallback.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Richer remote handoff facts in `harness status`; that remains #200.
+- Broader controller documentation and skill updates beyond this handoff
+  guidance; that remains #202.
 
 ### Follow-Up Issues
 

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -184,7 +184,14 @@ PR metadata.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added `refreshed` to the `harness evidence refresh` result contract with
+compact `ci_status` and `sync_status` fields for evidence domains written by
+the refresh. Wired service and CLI outputs to populate the statuses for full
+and partial refreshes while omitting the object on failed refreshes. Refreshed
+the generated schema artifacts. Validation:
+`go test ./internal/evidence ./internal/cli -run 'TestRefresh|TestEvidenceRefresh'`;
+`scripts/sync-contract-artifacts --check`;
+`go test ./internal/evidence ./internal/cli ./internal/contractsync -count=1`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -193,9 +193,17 @@ the generated schema artifacts. Validation:
 `scripts/sync-contract-artifacts --check`;
 `go test ./internal/evidence ./internal/cli ./internal/contractsync -count=1`.
 
+After `review-003-delta`, added CLI coverage proving partial refresh JSON
+omits the unwritten status key. Validation:
+`go test ./internal/cli -run 'TestEvidenceRefreshCommand(PartialOutputOmitsUnwrittenStatus|WritesEvidenceAndUpdatesStatus|MapsNonSuccessRemoteStates)' -count=1`;
+`scripts/sync-contract-artifacts --check`;
+`go test ./internal/evidence ./internal/cli ./internal/contractsync -count=1`.
+
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-003-delta` found a missing CLI assertion for partial refresh JSON
+omitting unwritten status keys. The repair added that coverage; follow-up
+delta review is pending.
 
 ### Step 3: Refresh controller guidance
 

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -132,9 +132,17 @@ for slow commands, PR observation timeout writes no evidence, and checks
 timeout can still write sync evidence when merge state is clear. Validation:
 `go test ./internal/remote ./internal/evidence`.
 
+After `review-001-delta`, tightened timeout handling so `gh pr checks`
+timeouts degrade even when stdout is non-empty, added a finite `WaitDelay` for
+held-pipe cases, and added focused regression coverage. Validation:
+`go test ./internal/remote ./internal/evidence -count=1`.
+
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` found timeout reads with non-empty stdout could still write
+CI evidence, the default runner lacked `WaitDelay`, and tests missed the
+non-empty stdout path. The repair addresses all three findings; follow-up
+delta review is pending.
 
 ### Step 2: Return refreshed statuses from the command result
 

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -207,7 +207,7 @@ omitting unwritten status keys. The repair added that coverage; follow-up
 
 ### Step 3: Refresh controller guidance
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -255,7 +255,7 @@ unavailable refresh paths. Validation: `scripts/sync-bootstrap-assets --check`.
 
 `review-005-delta` found the managed closeout/archive checklist still taught
 manual evidence submit as the ordinary handoff path. The repair aligned that
-checklist with refresh-first guidance; follow-up delta review is pending.
+checklist with refresh-first guidance, and `review-006-delta` passed clean.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -236,7 +236,14 @@ not the first path for routine evidence refresh.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Updated the managed `harness-execute` publish/CI/sync guidance so archived
+candidate handoff records publish evidence first, then prefers
+`harness evidence refresh`, then runs `harness status`, with manual
+`harness evidence submit --kind publish|ci|sync` as fallback for degraded or
+unavailable refresh paths. Clarified direct `gh` inspection as a diagnostic
+fallback rather than the routine refresh path. Refreshed materialized
+`.agents/skills/` output from `assets/bootstrap/`. Validation:
+`scripts/sync-bootstrap-assets --check`.
 
 #### Review Notes
 

--- a/docs/plans/archived/2026-05-22-harden-evidence-refresh-workflow-integration.md
+++ b/docs/plans/archived/2026-05-22-harden-evidence-refresh-workflow-integration.md
@@ -308,6 +308,8 @@ checklist with refresh-first guidance, and `review-006-delta` passed clean.
 
 ## Archive Summary
 
+- Archived At: 2026-05-23T00:46:59+08:00
+- Revision: 1
 - PR: NONE. Create or update the PR after committing and pushing this archived
   candidate.
 - Ready: The tracked steps are complete, acceptance criteria are checked,

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1151,6 +1151,10 @@ func TestEvidenceRefreshCommandWritesEvidenceAndUpdatesStatus(t *testing.T) {
 	if payload["command"] != "evidence refresh" {
 		t.Fatalf("unexpected payload: %#v", payload)
 	}
+	refreshed, ok := payload["refreshed"].(map[string]any)
+	if !ok || refreshed["ci_status"] != "success" || refreshed["sync_status"] != "fresh" {
+		t.Fatalf("expected refreshed statuses in payload, got %#v", payload["refreshed"])
+	}
 	statusResult := status.Service{Workdir: root}.Snapshot()
 	if !statusResult.OK || statusResult.State.CurrentNode != "execution/finalize/await_merge" {
 		t.Fatalf("expected refresh to satisfy merge-ready evidence, got %#v", statusResult)
@@ -1320,6 +1324,18 @@ func TestEvidenceRefreshCommandMapsNonSuccessRemoteStates(t *testing.T) {
 
 			if exitCode := app.Run([]string{"evidence", "refresh"}); exitCode != 0 {
 				t.Fatalf("expected refresh success, got %d: %s", exitCode, stderr.String())
+			}
+			var payload struct {
+				Refreshed *struct {
+					CIStatus   string `json:"ci_status,omitempty"`
+					SyncStatus string `json:"sync_status,omitempty"`
+				} `json:"refreshed,omitempty"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+				t.Fatalf("expected JSON evidence refresh output: %v\n%s", err, stdout.String())
+			}
+			if payload.Refreshed == nil || payload.Refreshed.CIStatus != tt.wantCI || payload.Refreshed.SyncStatus != tt.wantSync {
+				t.Fatalf("expected refreshed statuses %q/%q, got %#v", tt.wantCI, tt.wantSync, payload.Refreshed)
 			}
 			ci, err := evidence.LoadLatestCI(root, "2026-03-18-landed-plan", 1)
 			if err != nil || ci == nil || ci.Status != tt.wantCI {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1163,6 +1163,60 @@ func TestEvidenceRefreshCommandWritesEvidenceAndUpdatesStatus(t *testing.T) {
 	assertWatchlistContainsWorkspace(t, home, root)
 }
 
+func TestEvidenceRefreshCommandPartialOutputOmitsUnwrittenStatus(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.RunCommand = func(name string, args ...string) remote.CommandResult {
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "view" {
+			return remote.CommandResult{Stdout: `{
+				"url":"https://github.com/catu-ai/easyharness/pull/99",
+				"number":99,
+				"state":"OPEN",
+				"isDraft":false,
+				"mergeStateStatus":"CLEAN",
+				"mergeable":"MERGEABLE",
+				"reviewDecision":"APPROVED",
+				"headRefName":"codex/test",
+				"headRefOid":"abc123",
+				"baseRefName":"main"
+			}`}
+		}
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "checks" {
+			return remote.CommandResult{Err: context.DeadlineExceeded}
+		}
+		return remote.CommandResult{}
+	}
+
+	writeArchivedPlanForCLI(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
+		t.Fatalf("seed publish evidence: %#v", result)
+	}
+
+	if exitCode := app.Run([]string{"evidence", "refresh"}); exitCode != 0 {
+		t.Fatalf("expected partial refresh success, got %d: %s", exitCode, stderr.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON evidence refresh output: %v\n%s", err, stdout.String())
+	}
+	refreshed, ok := payload["refreshed"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected refreshed object, got %#v", payload["refreshed"])
+	}
+	if _, exists := refreshed["ci_status"]; exists {
+		t.Fatalf("partial refresh should omit unwritten ci_status, got %#v", refreshed)
+	}
+	if refreshed["sync_status"] != "fresh" {
+		t.Fatalf("expected fresh sync status, got %#v", refreshed)
+	}
+}
+
 func TestEvidenceRefreshCommandDegradesWithoutRecordedPR(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/contracts/evidence.go
+++ b/internal/contracts/evidence.go
@@ -37,6 +37,10 @@ type EvidenceRefreshResult struct {
 	// Artifacts points to the evidence records created by the command.
 	Artifacts *EvidenceRefreshArtifacts `json:"artifacts,omitempty"`
 
+	// Refreshed reports the machine-readable evidence statuses written by this
+	// refresh.
+	Refreshed *EvidenceRefreshStatuses `json:"refreshed,omitempty"`
+
 	// NextAction lists the most relevant follow-up steps in priority order.
 	NextAction []NextAction `json:"next_actions"`
 
@@ -77,6 +81,16 @@ type EvidenceRefreshArtifacts struct {
 	// SyncRecordID is the created sync evidence record identifier when sync was
 	// refreshed.
 	SyncRecordID string `json:"sync_record_id,omitempty"`
+}
+
+// EvidenceRefreshStatuses lists the compact evidence statuses written by
+// `harness evidence refresh`.
+type EvidenceRefreshStatuses struct {
+	// CIStatus is the CI evidence status written by this refresh.
+	CIStatus string `json:"ci_status,omitempty"`
+
+	// SyncStatus is the sync evidence status written by this refresh.
+	SyncStatus string `json:"sync_status,omitempty"`
 }
 
 // EvidenceCIInput is the JSON input consumed by `harness evidence submit --kind

--- a/internal/evidence/service.go
+++ b/internal/evidence/service.go
@@ -33,6 +33,7 @@ type Result = contracts.EvidenceSubmitResult
 type RefreshResult = contracts.EvidenceRefreshResult
 type Artifacts = contracts.EvidenceArtifacts
 type RefreshArtifacts = contracts.EvidenceRefreshArtifacts
+type RefreshStatuses = contracts.EvidenceRefreshStatuses
 type NextAction = contracts.NextAction
 type CommandError = contracts.ErrorDetail
 type CIInput = contracts.EvidenceCIInput
@@ -186,6 +187,7 @@ func (s Service) Refresh() RefreshResult {
 		PlanPath: relPlanPath,
 		PRURL:    identity.URL,
 	}
+	refreshed := &RefreshStatuses{}
 	warnings := make([]string, 0, 2)
 	rollbackPaths := make([]string, 0, 2)
 	var ciRecord *CIRecord
@@ -242,6 +244,7 @@ func (s Service) Refresh() RefreshResult {
 			return refreshErrorResult("Unable to persist CI evidence refresh.", []CommandError{{Path: "ci.record", Message: err.Error()}})
 		}
 		artifacts.CIRecordID = ciRecord.RecordID
+		refreshed.CIStatus = ciRecord.Status
 		rollbackPaths = append(rollbackPaths, ciRecordPath)
 	}
 	if syncRecord != nil {
@@ -253,6 +256,7 @@ func (s Service) Refresh() RefreshResult {
 			return refreshErrorResult("Unable to persist sync evidence refresh.", issues)
 		}
 		artifacts.SyncRecordID = syncRecord.RecordID
+		refreshed.SyncStatus = syncRecord.Status
 		rollbackPaths = append(rollbackPaths, syncRecordPath)
 	}
 
@@ -285,6 +289,7 @@ func (s Service) Refresh() RefreshResult {
 		Command:    "evidence refresh",
 		Summary:    refreshSummary(artifacts),
 		Artifacts:  artifacts,
+		Refreshed:  refreshed,
 		Warnings:   warnings,
 		NextAction: nextActions,
 	}

--- a/internal/evidence/service_test.go
+++ b/internal/evidence/service_test.go
@@ -80,6 +80,9 @@ func TestRefreshWritesCIAndSyncEvidenceFromRecordedPR(t *testing.T) {
 	if refresh.Artifacts == nil || refresh.Artifacts.CIRecordID != "ci-001" || refresh.Artifacts.SyncRecordID != "sync-001" {
 		t.Fatalf("unexpected refresh artifacts: %#v", refresh.Artifacts)
 	}
+	if refresh.Refreshed == nil || refresh.Refreshed.CIStatus != "success" || refresh.Refreshed.SyncStatus != "fresh" {
+		t.Fatalf("unexpected refreshed statuses: %#v", refresh.Refreshed)
+	}
 	ci, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 1)
 	if err != nil {
 		t.Fatalf("load CI: %v", err)
@@ -182,6 +185,9 @@ func TestRefreshWritesOnlyClearDomainEvidence(t *testing.T) {
 	if result.Artifacts == nil || result.Artifacts.CIRecordID != "ci-001" || result.Artifacts.SyncRecordID != "" {
 		t.Fatalf("unexpected partial refresh artifacts: %#v", result.Artifacts)
 	}
+	if result.Refreshed == nil || result.Refreshed.CIStatus != "success" || result.Refreshed.SyncStatus != "" {
+		t.Fatalf("unexpected partial refreshed statuses: %#v", result.Refreshed)
+	}
 	if len(result.Warnings) == 0 {
 		t.Fatalf("expected degraded sync warning, got %#v", result)
 	}
@@ -215,6 +221,9 @@ func TestRefreshWritesNoEvidenceWhenPRViewTimesOut(t *testing.T) {
 
 	if result.OK {
 		t.Fatalf("expected timeout refresh failure, got %#v", result)
+	}
+	if result.Refreshed != nil {
+		t.Fatalf("failed refresh should not report refreshed statuses, got %#v", result.Refreshed)
 	}
 	if len(result.Warnings) == 0 || !strings.Contains(result.Warnings[0], "timed out") {
 		t.Fatalf("expected timeout warning, got %#v", result.Warnings)
@@ -269,6 +278,9 @@ func TestRefreshWritesSyncOnlyWhenChecksTimeOut(t *testing.T) {
 	}
 	if result.Artifacts == nil || result.Artifacts.CIRecordID != "" || result.Artifacts.SyncRecordID != "sync-001" {
 		t.Fatalf("unexpected partial refresh artifacts: %#v", result.Artifacts)
+	}
+	if result.Refreshed == nil || result.Refreshed.CIStatus != "" || result.Refreshed.SyncStatus != "fresh" {
+		t.Fatalf("unexpected partial refreshed statuses: %#v", result.Refreshed)
 	}
 	if len(result.Warnings) == 0 || !strings.Contains(result.Warnings[0], "timed out") {
 		t.Fatalf("expected timeout warning, got %#v", result.Warnings)

--- a/internal/evidence/service_test.go
+++ b/internal/evidence/service_test.go
@@ -255,7 +255,10 @@ func TestRefreshWritesSyncOnlyWhenChecksTimeOut(t *testing.T) {
 				}`}
 			}
 			if len(args) >= 3 && args[0] == "pr" && args[1] == "checks" {
-				return remote.CommandResult{Err: context.DeadlineExceeded}
+				return remote.CommandResult{
+					Stdout: `[{"name":"Go Test","bucket":"pass","state":"SUCCESS"}]`,
+					Err:    context.DeadlineExceeded,
+				}
 			}
 			return remote.CommandResult{}
 		},

--- a/internal/evidence/service_test.go
+++ b/internal/evidence/service_test.go
@@ -1,6 +1,7 @@
 package evidence_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -189,6 +190,91 @@ func TestRefreshWritesOnlyClearDomainEvidence(t *testing.T) {
 	}
 	if sync, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1); err != nil || sync != nil {
 		t.Fatalf("expected no sync evidence, got %#v err=%v", sync, err)
+	}
+}
+
+func TestRefreshWritesNoEvidenceWhenPRViewTimesOut(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
+		t.Fatalf("seed publish evidence: %#v", result)
+	}
+
+	result := evidence.Service{
+		Workdir: root,
+		RunCommand: func(name string, args ...string) remote.CommandResult {
+			if len(args) >= 3 && args[0] == "pr" && args[1] == "view" {
+				return remote.CommandResult{Err: context.DeadlineExceeded}
+			}
+			return remote.CommandResult{Stdout: `[]`}
+		},
+	}.Refresh()
+
+	if result.OK {
+		t.Fatalf("expected timeout refresh failure, got %#v", result)
+	}
+	if len(result.Warnings) == 0 || !strings.Contains(result.Warnings[0], "timed out") {
+		t.Fatalf("expected timeout warning, got %#v", result.Warnings)
+	}
+	if ci, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 1); err != nil || ci != nil {
+		t.Fatalf("expected no CI evidence, got %#v err=%v", ci, err)
+	}
+	if sync, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1); err != nil || sync != nil {
+		t.Fatalf("expected no sync evidence, got %#v err=%v", sync, err)
+	}
+}
+
+func TestRefreshWritesSyncOnlyWhenChecksTimeOut(t *testing.T) {
+	root := t.TempDir()
+	relPlanPath := writeArchivedPlan(t, root, "docs/plans/archived/2026-03-21-evidence-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, relPlanPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
+		t.Fatalf("seed publish evidence: %#v", result)
+	}
+
+	result := evidence.Service{
+		Workdir: root,
+		RunCommand: func(name string, args ...string) remote.CommandResult {
+			if len(args) >= 3 && args[0] == "pr" && args[1] == "view" {
+				return remote.CommandResult{Stdout: `{
+					"url":"https://github.com/catu-ai/easyharness/pull/99",
+					"number":99,
+					"state":"OPEN",
+					"isDraft":false,
+					"mergeStateStatus":"CLEAN",
+					"mergeable":"MERGEABLE",
+					"reviewDecision":"APPROVED",
+					"headRefName":"codex/test",
+					"headRefOid":"abc123",
+					"baseRefName":"main"
+				}`}
+			}
+			if len(args) >= 3 && args[0] == "pr" && args[1] == "checks" {
+				return remote.CommandResult{Err: context.DeadlineExceeded}
+			}
+			return remote.CommandResult{}
+		},
+	}.Refresh()
+
+	if !result.OK {
+		t.Fatalf("expected partial refresh success, got %#v", result)
+	}
+	if result.Artifacts == nil || result.Artifacts.CIRecordID != "" || result.Artifacts.SyncRecordID != "sync-001" {
+		t.Fatalf("unexpected partial refresh artifacts: %#v", result.Artifacts)
+	}
+	if len(result.Warnings) == 0 || !strings.Contains(result.Warnings[0], "timed out") {
+		t.Fatalf("expected timeout warning, got %#v", result.Warnings)
+	}
+	if ci, err := evidence.LoadLatestCI(root, "2026-03-21-evidence-plan", 1); err != nil || ci != nil {
+		t.Fatalf("expected no CI evidence, got %#v err=%v", ci, err)
+	}
+	if sync, err := evidence.LoadLatestSync(root, "2026-03-21-evidence-plan", 1); err != nil || sync == nil || sync.Status != "fresh" {
+		t.Fatalf("expected fresh sync evidence, got %#v err=%v", sync, err)
 	}
 }
 

--- a/internal/remote/gh_test.go
+++ b/internal/remote/gh_test.go
@@ -281,9 +281,12 @@ func TestObserveRecordedPRDegradesWhenGhMissing(t *testing.T) {
 
 func TestDefaultRunnerTimesOutGhReads(t *testing.T) {
 	oldTimeout := defaultCommandTimeout
+	oldWaitDelay := defaultCommandWaitDelay
 	defaultCommandTimeout = 20 * time.Millisecond
+	defaultCommandWaitDelay = 20 * time.Millisecond
 	defer func() {
 		defaultCommandTimeout = oldTimeout
+		defaultCommandWaitDelay = oldWaitDelay
 	}()
 
 	scriptPath := filepath.Join(t.TempDir(), "slow-command")
@@ -303,6 +306,33 @@ func TestDefaultRunnerTimesOutGhReads(t *testing.T) {
 	}
 }
 
+func TestDefaultRunnerBoundsHeldPipesAfterCommandExit(t *testing.T) {
+	oldTimeout := defaultCommandTimeout
+	oldWaitDelay := defaultCommandWaitDelay
+	defaultCommandTimeout = 20 * time.Millisecond
+	defaultCommandWaitDelay = 20 * time.Millisecond
+	defer func() {
+		defaultCommandTimeout = oldTimeout
+		defaultCommandWaitDelay = oldWaitDelay
+	}()
+
+	scriptPath := filepath.Join(t.TempDir(), "held-pipe-command")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\n(sleep 1) &\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write held-pipe command: %v", err)
+	}
+
+	start := time.Now()
+	result := (Service{}).run(scriptPath)
+	elapsed := time.Since(start)
+
+	if !errors.Is(result.Err, context.DeadlineExceeded) && !errors.Is(result.Err, exec.ErrWaitDelay) {
+		t.Fatalf("expected bounded timeout or wait delay error, got %#v", result)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("expected held pipes to be bounded, ran for %s", elapsed)
+	}
+}
+
 func TestObserveRecordedPRDegradesForGhTimeout(t *testing.T) {
 	svc := Service{
 		RunCommand: func(name string, args ...string) CommandResult {
@@ -314,6 +344,27 @@ func TestObserveRecordedPRDegradesForGhTimeout(t *testing.T) {
 
 	if observation.Status != PRObservationUnavailable || observation.Degraded.Code != DegradedGhTimeout {
 		t.Fatalf("expected gh timeout degradation, got %#v", observation)
+	}
+}
+
+func TestObserveHandoffDegradesTimedOutChecksEvenWithStdout(t *testing.T) {
+	svc := Service{RunCommand: func(name string, args ...string) CommandResult {
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "view" {
+			return CommandResult{Stdout: `{"mergeStateStatus":"CLEAN"}`}
+		}
+		return CommandResult{
+			Stdout: `[{"name":"Go Test","bucket":"pass","state":"SUCCESS"}]`,
+			Err:    context.DeadlineExceeded,
+		}
+	}}
+
+	observation := svc.ObserveHandoff(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/199"))
+
+	if observation.CI.Status != RemoteCIUnavailable || observation.CI.Degraded.Code != DegradedGhTimeout {
+		t.Fatalf("expected timeout checks degradation, got %#v", observation.CI)
+	}
+	if observation.Sync.Status != RemoteSyncAvailable || observation.Sync.EvidenceStatus != "fresh" {
+		t.Fatalf("expected sync to remain refreshable, got %#v", observation.Sync)
 	}
 }
 

--- a/internal/remote/gh_test.go
+++ b/internal/remote/gh_test.go
@@ -1,11 +1,15 @@
 package remote
 
 import (
+	"context"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestObserveRecordedPRUsesGhView(t *testing.T) {
@@ -272,6 +276,44 @@ func TestObserveRecordedPRDegradesWhenGhMissing(t *testing.T) {
 
 	if observation.Status != PRObservationUnavailable || observation.Degraded.Code != DegradedGhMissing {
 		t.Fatalf("expected missing gh degradation, got %#v", observation)
+	}
+}
+
+func TestDefaultRunnerTimesOutGhReads(t *testing.T) {
+	oldTimeout := defaultCommandTimeout
+	defaultCommandTimeout = 20 * time.Millisecond
+	defer func() {
+		defaultCommandTimeout = oldTimeout
+	}()
+
+	scriptPath := filepath.Join(t.TempDir(), "slow-command")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 1\n"), 0o755); err != nil {
+		t.Fatalf("write slow command: %v", err)
+	}
+
+	start := time.Now()
+	result := (Service{}).run(scriptPath)
+	elapsed := time.Since(start)
+
+	if !errors.Is(result.Err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %#v", result)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("expected command to be bounded, ran for %s", elapsed)
+	}
+}
+
+func TestObserveRecordedPRDegradesForGhTimeout(t *testing.T) {
+	svc := Service{
+		RunCommand: func(name string, args ...string) CommandResult {
+			return CommandResult{Err: context.DeadlineExceeded}
+		},
+	}
+
+	observation := svc.ObserveRecordedPR(ParseRecordedPRURL("https://github.com/catu-ai/easyharness/pull/203"))
+
+	if observation.Status != PRObservationUnavailable || observation.Degraded.Code != DegradedGhTimeout {
+		t.Fatalf("expected gh timeout degradation, got %#v", observation)
 	}
 }
 

--- a/internal/remote/identity.go
+++ b/internal/remote/identity.go
@@ -51,6 +51,7 @@ const (
 
 var scpLikeGitHubRemote = regexp.MustCompile(`^git@github\.com:([^/]+)/(.+?)(?:\.git)?$`)
 var defaultCommandTimeout = 30 * time.Second
+var defaultCommandWaitDelay = 2 * time.Second
 
 type Service struct {
 	Workdir    string
@@ -246,6 +247,9 @@ func (s Service) ObserveHandoff(identity PRIdentity) HandoffObservation {
 
 func (s Service) observeChecks(prURL string) RemoteCIObservation {
 	result := s.run("gh", "pr", "checks", prURL, "--json", "name,workflow,bucket,state,link")
+	if errors.Is(result.Err, context.DeadlineExceeded) || errors.Is(result.Err, exec.ErrWaitDelay) {
+		return unavailableCI(classifyGhFailure(result))
+	}
 	if result.Err != nil && strings.TrimSpace(result.Stdout) == "" {
 		return unavailableCI(classifyGhFailure(result))
 	}
@@ -543,6 +547,7 @@ func (s Service) run(name string, args ...string) CommandResult {
 		defer cancel()
 	}
 	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = defaultCommandWaitDelay
 	output, err := cmd.Output()
 	stderr := ""
 	if exitErr := new(exec.ExitError); errors.As(err, &exitErr) {
@@ -559,7 +564,7 @@ func (s Service) run(name string, args ...string) CommandResult {
 }
 
 func classifyGhFailure(result CommandResult) Degradation {
-	if errors.Is(result.Err, context.DeadlineExceeded) {
+	if errors.Is(result.Err, context.DeadlineExceeded) || errors.Is(result.Err, exec.ErrWaitDelay) {
 		return Degradation{
 			Code:    DegradedGhTimeout,
 			Message: "gh timed out while observing the recorded PR",

--- a/internal/remote/identity.go
+++ b/internal/remote/identity.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -39,6 +41,7 @@ const (
 	DegradedAmbiguousRemote   = "ambiguous_remote"
 	DegradedGhMissing         = "gh_missing"
 	DegradedGhAuthUnavailable = "gh_auth_unavailable"
+	DegradedGhTimeout         = "gh_timeout"
 	DegradedPRUnreadable      = "pr_unreadable"
 	DegradedChecksUnreadable  = "checks_unreadable"
 	DegradedMergeUnreadable   = "merge_unreadable"
@@ -47,6 +50,7 @@ const (
 )
 
 var scpLikeGitHubRemote = regexp.MustCompile(`^git@github\.com:([^/]+)/(.+?)(?:\.git)?$`)
+var defaultCommandTimeout = 30 * time.Second
 
 type Service struct {
 	Workdir    string
@@ -532,11 +536,20 @@ func (s Service) run(name string, args ...string) CommandResult {
 	if s.RunCommand != nil {
 		return s.RunCommand(name, args...)
 	}
-	cmd := exec.Command(name, args...)
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if defaultCommandTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, defaultCommandTimeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
 	output, err := cmd.Output()
 	stderr := ""
 	if exitErr := new(exec.ExitError); errors.As(err, &exitErr) {
 		stderr = string(exitErr.Stderr)
+	}
+	if ctx.Err() != nil {
+		err = ctx.Err()
 	}
 	return CommandResult{
 		Stdout: string(output),
@@ -546,6 +559,12 @@ func (s Service) run(name string, args ...string) CommandResult {
 }
 
 func classifyGhFailure(result CommandResult) Degradation {
+	if errors.Is(result.Err, context.DeadlineExceeded) {
+		return Degradation{
+			Code:    DegradedGhTimeout,
+			Message: "gh timed out while observing the recorded PR",
+		}
+	}
 	text := strings.ToLower(result.Stderr + "\n" + result.Err.Error())
 	switch {
 	case errors.Is(result.Err, exec.ErrNotFound):

--- a/schema/commands/evidence.refresh.result.schema.json
+++ b/schema/commands/evidence.refresh.result.schema.json
@@ -66,6 +66,10 @@
           "$ref": "#/$defs/EvidenceRefreshArtifacts",
           "description": "Artifacts points to the evidence records created by the command."
         },
+        "refreshed": {
+          "$ref": "#/$defs/EvidenceRefreshStatuses",
+          "description": "Refreshed reports the machine-readable evidence statuses written by this refresh."
+        },
         "next_actions": {
           "oneOf": [
             {
@@ -105,6 +109,21 @@
         "next_actions"
       ],
       "description": "EvidenceRefreshResult is the JSON result returned by `harness evidence refresh`."
+    },
+    "EvidenceRefreshStatuses": {
+      "properties": {
+        "ci_status": {
+          "type": "string",
+          "description": "CIStatus is the CI evidence status written by this refresh."
+        },
+        "sync_status": {
+          "type": "string",
+          "description": "SyncStatus is the sync evidence status written by this refresh."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "EvidenceRefreshStatuses lists the compact evidence statuses written by `harness evidence refresh`."
     },
     "NextAction": {
       "properties": {


### PR DESCRIPTION
## Summary

- Bound `gh` reads used by `harness evidence refresh` with timeout and `WaitDelay` handling.
- Added compact `refreshed.ci_status` / `refreshed.sync_status` output for statuses written by refresh.
- Updated managed controller guidance so publish/CI/sync handoff prefers `harness evidence refresh`, then `harness status`, with manual submit fallback.

## Validation

- `go test ./internal/remote ./internal/evidence ./internal/cli ./internal/contractsync -count=1`
- `scripts/sync-contract-artifacts --check`
- `scripts/sync-bootstrap-assets --check`
- `harness plan lint docs/plans/active/2026-05-22-harden-evidence-refresh-workflow-integration.md`
- `review-007-full` passed clean

Note: controller attempted `go test ./... -count=1`, but stopped it after a long quiet smoke tail; it is not used as merge-readiness evidence.

Resolves #213.
