### PR TITLE
Surface remote handoff facts in status

### DIFF
--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -99,7 +99,7 @@ local evidence.
 
 ### Step 1: Define the status contract for remote observation
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -144,7 +144,12 @@ status schema artifacts. Validation: `scripts/sync-contract-artifacts`,
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` found one important contract bug and one minor docs
+inventory gap: value-typed sub-observation `degraded` fields would serialize
+empty objects, and the top-level status facts inventory omitted
+`remote_handoff`. Fixed both by switching sub-observation degraded fields to
+`*StatusRemoteDegradation` and adding `remote_handoff` to the facts inventory.
+Follow-up `review-002-delta` passed with zero findings.
 
 ### Step 2: Wire read-only remote observation into status
 

--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -68,22 +68,22 @@ local evidence.
 
 ## Acceptance Criteria
 
-- [ ] `harness status` includes remote handoff observation for archived
+- [x] `harness status` includes remote handoff observation for archived
       candidates with recorded GitHub PR URLs when live observation succeeds.
-- [ ] Remote observation failures appear as degraded remote facts, warnings, or
+- [x] Remote observation failures appear as degraded remote facts, warnings, or
       manual fallback next actions without making local status fail.
-- [ ] `state.current_node` remains evidence-driven: live remote passing checks
+- [x] `state.current_node` remains evidence-driven: live remote passing checks
       and clean merge state do not move status to `execution/finalize/await_merge`
       until local CI and sync evidence are recorded.
-- [ ] When live remote facts are passing or fresh but local evidence is missing
+- [x] When live remote facts are passing or fresh but local evidence is missing
       or stale, `next_actions` steer the controller to `harness evidence
       refresh`.
-- [ ] When live remote checks fail, are pending, or remote sync is stale or
+- [x] When live remote checks fail, are pending, or remote sync is stale or
       conflicted, `next_actions` explain the repair or wait path without
       writing evidence.
-- [ ] Missing recorded PR evidence still steers the controller to publish and
+- [x] Missing recorded PR evidence still steers the controller to publish and
       record publish evidence instead of attempting branch-based PR discovery.
-- [ ] Tests cover successful live observation, degraded remote observation,
+- [x] Tests cover successful live observation, degraded remote observation,
       non-authoritative remote facts, no-guess missing PR behavior, and
       preservation of existing evidence-driven publish and await-merge
       behavior.
@@ -321,11 +321,18 @@ Follow-up rounds `review-002-delta`, `review-004-delta`, and
 closeout-recording gap in Step 3, which was fixed before `review-006-delta`.
 Finalize `review-007-full` found one correctness gap around clean live remote
 facts replacing failed or conflicted local evidence; the repair was validated
-by `review-008-delta`, which passed with zero findings.
+by `review-008-delta`, which passed with zero findings. Finalize
+`review-009-full` then passed with zero findings.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: NONE
+- Ready: The candidate has completed tracked implementation, validation,
+  step reviews, and a clean full finalize review. It is ready to archive.
+- Merge Handoff: After archive, commit the tracked archive move, push the
+  branch, open or update the PR for issue #200, record publish evidence with
+  the PR URL, then use `harness evidence refresh` or manual CI/sync evidence
+  until `harness status` reaches `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
@@ -349,4 +356,5 @@ NONE.
 
 ### Follow-Up Issues
 
-NONE
+- #202: update broader controller docs and harness-execute skill guidance after
+  this status surface lands.

--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -153,7 +153,7 @@ Follow-up `review-002-delta` passed with zero findings.
 
 ### Step 2: Wire read-only remote observation into status
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -205,7 +205,13 @@ pending or failed checks and stale or conflicted sync. Validation:
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-003-delta` found two important gaps: await-merge status observed live
+remote facts but did not include remote-specific wait/repair guidance, and the
+tests did not cover remote observation when durable local evidence already
+placed status in `execution/finalize/await_merge`. Fixed both by prepending
+remote handoff guidance in the await-merge action list and adding
+`TestStatusAwaitMergeIncludesRemoteHandoffWarningsWithoutRegressingNode`.
+Follow-up `review-004-delta` passed with zero findings.
 
 ### Step 3: Align handoff guidance and full validation
 

--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -1,0 +1,297 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-24T23:35:00+08:00"
+approved_at: "2026-05-24T23:34:00+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/200
+    - https://github.com/catu-ai/easyharness/issues/12
+size: M
+---
+
+# Surface Remote Handoff Status
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Resolve issue #200 by making `harness status` surface read-only remote
+handoff facts for an archived candidate with recorded PR evidence.
+
+The end state should let a controller treat `harness status` as the primary
+orientation command during publish and merge handoff: local durable evidence
+continues to decide `current_node`, while optional live remote observation
+explains what the recorded PR currently says about PR state, checks, and merge
+freshness. `harness status` must remain non-mutating; `harness evidence
+refresh` remains the explicit command that records remote CI and sync facts as
+local evidence.
+
+## Scope
+
+### In Scope
+
+- Extend the `harness status` contract with a compact remote observation
+  surface anchored only on the PR URL recorded in latest publish evidence.
+- Default to read-only observation of the recorded PR when status is in the
+  archived publish or await-merge handoff path and a supported PR URL exists.
+- Keep live remote facts non-authoritative: they may inform summaries,
+  warnings, and `next_actions`, but must not advance `state.current_node` or
+  replace local durable evidence.
+- Degrade cleanly when `gh`, auth, network/API access, provider output, or the
+  PR itself is unavailable; local status should still return `ok: true` when
+  local harness state is readable.
+- Preserve the no-guess identity rule: status must not discover a PR from the
+  current branch when publish evidence lacks a PR URL.
+- Add next actions for common handoff cases such as missing PR evidence,
+  pending checks, failed checks, stale or conflicted sync, unreadable remote
+  state, passing remote facts that still need `harness evidence refresh`, and
+  already-recorded merge-ready local evidence.
+- Update CLI contract text, generated status schema artifacts, and tests for
+  the new status surface.
+
+### Out of Scope
+
+- Writing CI or sync evidence from `harness status`.
+- Removing or weakening `harness evidence refresh`; it remains the explicit
+  command for recording remote facts as durable local evidence.
+- Opening, updating, commenting on, labeling, reviewing, rerunning checks for,
+  or merging PRs.
+- Inferring a PR from branch name, upstream remote, local git config, or GitHub
+  PR lists.
+- Provider support beyond the existing recorded GitHub PR URL model.
+- Broader controller skill guidance for remote handoff beyond status-specific
+  references; issue #202 remains the larger skill/docs integration bucket.
+
+## Acceptance Criteria
+
+- [ ] `harness status` includes remote handoff observation for archived
+      candidates with recorded GitHub PR URLs when live observation succeeds.
+- [ ] Remote observation failures appear as degraded remote facts, warnings, or
+      manual fallback next actions without making local status fail.
+- [ ] `state.current_node` remains evidence-driven: live remote passing checks
+      and clean merge state do not move status to `execution/finalize/await_merge`
+      until local CI and sync evidence are recorded.
+- [ ] When live remote facts are passing or fresh but local evidence is missing
+      or stale, `next_actions` steer the controller to `harness evidence
+      refresh`.
+- [ ] When live remote checks fail, are pending, or remote sync is stale or
+      conflicted, `next_actions` explain the repair or wait path without
+      writing evidence.
+- [ ] Missing recorded PR evidence still steers the controller to publish and
+      record publish evidence instead of attempting branch-based PR discovery.
+- [ ] Tests cover successful live observation, degraded remote observation,
+      non-authoritative remote facts, no-guess missing PR behavior, and
+      preservation of existing evidence-driven publish and await-merge
+      behavior.
+
+## Deferred Items
+
+- Issue #202: update broader controller docs and harness-execute skill
+  guidance after the status surface lands.
+- A future issue may add explicit flags or output filters if default live
+  observation proves too noisy in dogfooding.
+
+## Work Breakdown
+
+### Step 1: Define the status contract for remote observation
+
+- Done: [ ]
+
+#### Objective
+
+Make the non-authoritative remote observation boundary explicit in normative
+docs and generated contract types before changing status behavior.
+
+#### Details
+
+The contract should distinguish durable local evidence from live remote
+observation. The remote surface should be compact enough for agents to use in
+handoff decisions without dumping raw provider output. It should include a
+clear status or degraded result, PR identity/state when available, CI/check
+summary, sync or merge-state summary, and enough degradation information to
+explain why live observation is unavailable.
+
+This step should also state the key invariant: `harness status` may observe
+the recorded PR URL, but it must not write evidence or advance
+`state.current_node` based on live facts alone.
+
+#### Expected Files
+
+- `docs/specs/cli-contract.md`
+- `internal/contracts/status.go`
+- `internal/contracts/registry.go`
+- `schema/commands/status.result.schema.json`
+- `schema/index.json`
+
+#### Validation
+
+- Run contract generation or sync commands required by the repository.
+- Run focused contract or schema tests if the changed files have package-local
+  coverage.
+
+#### Execution Notes
+
+Defined `facts.remote_handoff` as the non-authoritative live remote
+observation surface in `internal/contracts/status.go`, updated the CLI
+contract to keep status read-only and evidence-driven, and regenerated the
+status schema artifacts. Validation: `scripts/sync-contract-artifacts`,
+`scripts/sync-contract-artifacts --check`, and
+`go test ./internal/contracts ./internal/contractsync -count=1`.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Wire read-only remote observation into status
+
+- Done: [ ]
+
+#### Objective
+
+Teach `internal/status` to observe the recorded PR URL during archived handoff
+status resolution while keeping local evidence as the only progression source.
+
+#### Details
+
+Reuse the existing `internal/remote` service and command runner boundary
+instead of creating another GitHub read path. Observation should run only when
+status has latest publish evidence with a supported recorded PR URL and the
+current status node is in the archived publish or await-merge handoff path.
+
+When observation succeeds, status should expose the remote facts and refine
+summary or next-action text. When observation degrades, status should retain
+the local publish or await-merge node, include the degraded remote state, and
+preserve manual evidence submit fallback guidance. If no recorded PR URL
+exists, status should keep the existing publish guidance and must not call
+`gh`.
+
+#### Expected Files
+
+- `internal/status/service.go`
+- `internal/status/service_test.go`
+- `internal/cli/app.go`
+- `internal/cli/app_test.go`
+
+#### Validation
+
+- Add or update unit tests proving status observes recorded PRs through an
+  injectable command runner.
+- Add or update tests for missing PR URL, `gh` failure, auth failure, pending
+  checks, failed checks, clean remote facts without local evidence, and
+  existing local merge-ready evidence.
+- Run focused Go tests for status, remote, evidence, and CLI packages.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Align handoff guidance and full validation
+
+- Done: [ ]
+
+#### Objective
+
+Make the delivered behavior coherent across docs, schemas, and end-to-end
+workflow expectations, then validate the complete slice.
+
+#### Details
+
+Review the status next actions in realistic handoff states. A passing live
+remote observation with missing local evidence should point to `harness
+evidence refresh`; pending or failed checks should point to waiting or repair;
+degraded remote observation should point to retrying refresh or manual
+evidence submit fallbacks. The final wording should make it obvious that
+`status` explains and `evidence refresh` records.
+
+If the implementation changes the status JSON schema or generated contract
+reference files, regenerate them and keep drift checks passing.
+
+#### Expected Files
+
+- `docs/specs/cli-contract.md`
+- `internal/status/service_test.go`
+- `internal/cli/app_test.go`
+- `tests/e2e/...`
+- `schema/...`
+
+#### Validation
+
+- Run focused Go tests for changed packages.
+- Run relevant e2e coverage for archived publish and await-merge handoff.
+- Run schema or contract drift checks.
+- Run `git diff --check`.
+- Run `harness plan lint` on this plan before execution starts and again if
+  the plan changes materially.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Start with focused unit coverage in `internal/status` using fake remote
+  command runners to avoid real `gh`, auth, or network dependencies.
+- Keep existing `internal/remote` and `internal/evidence` tests green so status
+  reuses the same classification rules as `harness evidence refresh`.
+- Add CLI-level coverage for JSON output and degraded remote observation where
+  the command runner injection matters.
+- Use relevant e2e coverage to confirm the archived publish and await-merge
+  workflow still advances only after durable local evidence is present.
+- Run contract/schema sync checks whenever status contract types change.
+
+## Risks
+
+- Risk: Live remote observation could make `harness status` feel flaky or slow.
+  - Mitigation: Treat remote failures as degraded observations, preserve
+    local `ok: true` status when local state is readable, and reuse the bounded
+    remote read behavior from the existing refresh path.
+- Risk: Agents could confuse live remote observations with durable evidence.
+  - Mitigation: Name and document the remote surface as observation, keep
+    `current_node` evidence-driven, and make next actions tell agents to run
+    `harness evidence refresh` when remote facts need to be recorded.
+- Risk: The status contract could grow too provider-shaped.
+  - Mitigation: Expose normalized PR, CI, sync, and degraded summaries instead
+    of raw `gh` payloads, and keep GitHub-specific details behind
+    `internal/remote`.
+- Risk: Default live observation could accidentally infer PR identity from
+  local branch state.
+  - Mitigation: Test the no-guess missing-PR case and call remote observation
+    only from recorded publish evidence.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -303,11 +303,21 @@ findings.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `harness plan lint docs/plans/active/2026-05-24-surface-remote-handoff-status.md`
+- `scripts/sync-contract-artifacts --check`
+- `go test ./internal/contracts ./internal/contractsync -count=1`
+- `go test ./internal/status -run 'TestStatusArchivedPlanSurfacesRemoteHandoffObservation|TestStatusRemoteHandoffObservationDegradesWithoutFailingLocalStatus|TestStatusRemoteHandoffNextActionsExplainNonReadyRemoteFacts|TestStatusAwaitMergeIncludesRemoteHandoffWarningsWithoutRegressingNode|TestStatusRemoteHandoffDoesNotGuessPRWhenPublishEvidenceMissing' -count=1`
+- `go test ./internal/status ./internal/cli ./internal/remote ./internal/evidence ./internal/contractsync -count=1`
+- `go test ./tests/e2e -run 'TestPublishHandoff|TestAwaitMerge|TestLandWorkflow|TestLightweightWorkflow' -count=1`
+- `git diff --check`
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Step closeout reviews ran for each work step. `review-001-delta` and
+`review-003-delta` requested changes that were fixed and re-reviewed.
+Follow-up rounds `review-002-delta`, `review-004-delta`, and
+`review-006-delta` passed with zero findings. `review-005-delta` found one
+closeout-recording gap in Step 3, which was fixed before `review-006-delta`.
 
 ## Archive Summary
 
@@ -317,11 +327,19 @@ PENDING_UNTIL_ARCHIVE
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added the `facts.remote_handoff` status contract and generated schemas for
+  non-authoritative live remote observation of the recorded PR.
+- Updated the CLI contract to state that status observes, evidence refresh
+  records, and `current_node` remains driven by local durable evidence.
+- Wired `harness status` to observe recorded PR handoff facts through the
+  existing `internal/remote` read model without guessing PRs from branch state.
+- Added status and CLI tests covering successful observation, degraded remote
+  observation, no-guess behavior, non-ready remote next actions, and
+  await-merge behavior with live remote drift.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+NONE.
 
 ### Follow-Up Issues
 

--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -253,7 +253,14 @@ reference files, regenerate them and keep drift checks passing.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Ran the final guidance and workflow validation pass after the contract and
+status implementation steps. Confirmed the generated contract artifacts are in
+sync, the status/CLI/remote/evidence packages pass together, and the
+publish/await-merge/land e2e paths still progress through local durable
+evidence. Validation: `scripts/sync-contract-artifacts --check`;
+`go test ./internal/status ./internal/cli ./internal/remote ./internal/evidence ./internal/contractsync -count=1`;
+`go test ./tests/e2e -run 'TestPublishHandoff|TestAwaitMerge|TestLandWorkflow|TestLightweightWorkflow' -count=1`;
+`git diff --check`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -257,7 +257,8 @@ Ran the final guidance and workflow validation pass after the contract and
 status implementation steps. Confirmed the generated contract artifacts are in
 sync, the status/CLI/remote/evidence packages pass together, and the
 publish/await-merge/land e2e paths still progress through local durable
-evidence. Validation: `scripts/sync-contract-artifacts --check`;
+evidence. Validation: `harness plan lint docs/plans/active/2026-05-24-surface-remote-handoff-status.md`;
+`scripts/sync-contract-artifacts --check`;
 `go test ./internal/status ./internal/cli ./internal/remote ./internal/evidence ./internal/contractsync -count=1`;
 `go test ./tests/e2e -run 'TestPublishHandoff|TestAwaitMerge|TestLandWorkflow|TestLightweightWorkflow' -count=1`;
 `git diff --check`.

--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -307,6 +307,7 @@ findings.
 - `scripts/sync-contract-artifacts --check`
 - `go test ./internal/contracts ./internal/contractsync -count=1`
 - `go test ./internal/status -run 'TestStatusArchivedPlanSurfacesRemoteHandoffObservation|TestStatusRemoteHandoffObservationDegradesWithoutFailingLocalStatus|TestStatusRemoteHandoffNextActionsExplainNonReadyRemoteFacts|TestStatusAwaitMergeIncludesRemoteHandoffWarningsWithoutRegressingNode|TestStatusRemoteHandoffDoesNotGuessPRWhenPublishEvidenceMissing' -count=1`
+- `go test ./internal/status -run 'TestStatusSuggestsRefreshWhenCleanRemoteCanReplaceNonReadyEvidence|TestStatusArchivedPlanSurfacesRemoteHandoffObservation|TestStatusAwaitMergeIncludesRemoteHandoffWarningsWithoutRegressingNode' -count=1`
 - `go test ./internal/status ./internal/cli ./internal/remote ./internal/evidence ./internal/contractsync -count=1`
 - `go test ./tests/e2e -run 'TestPublishHandoff|TestAwaitMerge|TestLandWorkflow|TestLightweightWorkflow' -count=1`
 - `git diff --check`
@@ -318,6 +319,9 @@ Step closeout reviews ran for each work step. `review-001-delta` and
 Follow-up rounds `review-002-delta`, `review-004-delta`, and
 `review-006-delta` passed with zero findings. `review-005-delta` found one
 closeout-recording gap in Step 3, which was fixed before `review-006-delta`.
+Finalize `review-007-full` found one correctness gap around clean live remote
+facts replacing failed or conflicted local evidence; the repair was validated
+by `review-008-delta`, which passed with zero findings.
 
 ## Archive Summary
 
@@ -336,6 +340,8 @@ PENDING_UNTIL_ARCHIVE
 - Added status and CLI tests covering successful observation, degraded remote
   observation, no-guess behavior, non-ready remote next actions, and
   await-merge behavior with live remote drift.
+- Added refresh guidance when clean live remote facts can replace failed CI or
+  conflicted sync evidence while keeping `current_node` evidence-driven.
 
 ### Not Delivered
 

--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -192,7 +192,16 @@ exists, status should keep the existing publish guidance and must not call
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Wired read-only remote observation into status behind an explicit
+`status.Service.ObserveRemote` switch, with `harness status` enabling it and
+passing the CLI's injectable `RunCommand`. Status now maps the existing
+`internal/remote` handoff observation into `facts.remote_handoff`, keeps
+`current_node` driven by local evidence, avoids branch-based PR guessing when
+publish evidence is missing, and adds remote-specific next-action guidance for
+pending or failed checks and stale or conflicted sync. Validation:
+`go test ./internal/status ./internal/cli -run 'TestStatusArchivedPlanSurfacesRemoteHandoffObservation|TestStatusRemoteHandoffObservationDegradesWithoutFailingLocalStatus|TestStatusRemoteHandoffNextActionsExplainNonReadyRemoteFacts|TestStatusRemoteHandoffDoesNotGuessPRWhenPublishEvidenceMissing|TestStatusCommandSurfacesRemoteHandoffObservation' -count=1`;
+`go test ./internal/status ./internal/cli ./internal/remote ./internal/evidence -count=1`;
+`git diff --check`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/active/2026-05-24-surface-remote-handoff-status.md
@@ -215,7 +215,7 @@ Follow-up `review-004-delta` passed with zero findings.
 
 ### Step 3: Align handoff guidance and full validation
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -265,7 +265,10 @@ evidence. Validation: `harness plan lint docs/plans/active/2026-05-24-surface-re
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-005-delta` found that Step 3 closeout omitted the required
+`harness plan lint` validation from its execution notes. Fixed the validation
+record, reran plan lint, and follow-up `review-006-delta` passed with zero
+findings.
 
 ## Validation Strategy
 

--- a/docs/plans/archived/2026-05-24-surface-remote-handoff-status.md
+++ b/docs/plans/archived/2026-05-24-surface-remote-handoff-status.md
@@ -326,6 +326,8 @@ by `review-008-delta`, which passed with zero findings. Finalize
 
 ## Archive Summary
 
+- Archived At: 2026-05-25T00:08:24+08:00
+- Revision: 1
 - PR: NONE
 - Ready: The candidate has completed tracked implementation, validation,
   step reviews, and a clean full finalize review. It is ready to archive.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -501,11 +501,20 @@ Contract:
   observation should anchor on that PR URL; when it does not, status should
   steer the controller to open or update the PR and record publish evidence
   rather than guessing a PR from the current branch
-- keep live remote observation optional and read-only: `gh` may be used to
-  observe a recorded PR URL when available, but missing `gh`, missing auth,
-  network/API failure, an unreadable PR, or mismatched local git context should
-  degrade to warnings or manual evidence guidance instead of failing local
-  workflow state
+- for archived publish and await-merge handoff states, default to live
+  read-only observation of the recorded PR URL when that URL is available and
+  supported
+- surface live remote observation under `facts.remote_handoff` as a
+  non-authoritative hint containing normalized PR, CI/check, sync/merge, and
+  degraded observation facts
+- keep live remote observation read-only and non-authoritative: `gh` may be
+  used to observe a recorded PR URL when available, but missing `gh`, missing
+  auth, network/API failure, an unreadable PR, or mismatched local git context
+  should degrade to warnings or manual evidence guidance instead of failing
+  local workflow state
+- never advance `state.current_node` based on live remote observation alone;
+  publish and await-merge progression remains driven by durable local publish,
+  CI, and sync evidence
 - never append evidence from `harness status`; automatic remote-to-evidence
   updates belong to the explicit `harness evidence refresh` command
 - when recorded publish evidence has a PR URL but CI or sync evidence is
@@ -822,12 +831,16 @@ trigger branch-based PR discovery. If no PR URL has been recorded, the
 controller should continue the existing manual publish path and record evidence
 once the PR or handoff target exists.
 
-When a future status implementation observes a recorded PR through `gh`, it
-must treat `gh` as an optional read-through provider rather than a hard
-workflow dependency. Missing `gh`, missing auth, network or API errors, invalid
-provider output, and unreadable PRs should produce degraded remote facts or
+When `harness status` observes a recorded PR through `gh`, it must treat `gh`
+as an optional read-through provider rather than a hard workflow dependency.
+Missing `gh`, missing auth, network or API errors, invalid provider output, and
+unreadable PRs should produce degraded `facts.remote_handoff` output or
 next-action guidance while preserving the local status result and the manual
-`harness evidence submit --kind publish|ci|sync` fallback.
+`harness evidence submit --kind publish|ci|sync` fallback. Live remote
+observation is useful for explaining what to do next, but it is not durable
+evidence: status must not enter `execution/finalize/await_merge` from passing
+remote checks or clean merge state until those facts have been recorded through
+local CI and sync evidence, normally by `harness evidence refresh`.
 
 ### `harness execute start`
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -254,6 +254,10 @@ help explain the node:
 - `pr_url`
 - `ci_status`
 - `sync_status`
+- `remote_handoff`
+  - optional non-authoritative live observation of the recorded PR handoff
+    target; local evidence remains the source of truth for workflow
+    progression
 - `land_pr_url`
 - `land_commit`
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -804,7 +804,11 @@ func (a *App) runStatus(args []string) int {
 	if result, settled := a.settleStatusSnapshot(workdir); !settled {
 		return a.writeJSONResultForWorkdir(workdir, result)
 	}
-	result := status.Service{Workdir: workdir}.Snapshot()
+	result := status.Service{
+		Workdir:       workdir,
+		ObserveRemote: true,
+		RunCommand:    a.RunCommand,
+	}.Snapshot()
 	return a.writeJSONResultForWorkdir(workdir, result)
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -709,6 +709,57 @@ func TestStatusCommandDoesNotCreateStateMutationLock(t *testing.T) {
 	}
 }
 
+func TestStatusCommandSurfacesRemoteHandoffObservation(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	app.RunCommand = fakeCLIRefreshCommands(`"CLEAN"`, `[{"name":"Go Test","bucket":"pass","state":"SUCCESS","link":"https://ci.example/run"}]`)
+
+	writeArchivedPlanForCLI(t, root, "docs/plans/archived/2026-03-18-landed-plan.md")
+	if _, err := runstate.SaveCurrentPlan(root, "docs/plans/archived/2026-03-18-landed-plan.md"); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/99"}`)); !result.OK {
+		t.Fatalf("seed publish evidence: %#v", result)
+	}
+
+	if exitCode := app.Run([]string{"status"}); exitCode != 0 {
+		t.Fatalf("status command failed with %d: %s", exitCode, stderr.String())
+	}
+
+	var payload struct {
+		Facts struct {
+			RemoteHandoff *struct {
+				Status string `json:"status"`
+				PR     struct {
+					Number int    `json:"number"`
+					State  string `json:"state"`
+				} `json:"pr"`
+				CI struct {
+					EvidenceStatus string `json:"evidence_status"`
+				} `json:"ci"`
+				Sync struct {
+					EvidenceStatus string `json:"evidence_status"`
+				} `json:"sync"`
+			} `json:"remote_handoff"`
+		} `json:"facts"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON status output: %v\n%s", err, stdout.String())
+	}
+	if payload.Facts.RemoteHandoff == nil || payload.Facts.RemoteHandoff.Status != "available" {
+		t.Fatalf("expected available remote handoff facts, got %s", stdout.String())
+	}
+	if payload.Facts.RemoteHandoff.PR.Number != 99 || payload.Facts.RemoteHandoff.PR.State != "OPEN" {
+		t.Fatalf("unexpected remote PR facts: %#v", payload.Facts.RemoteHandoff.PR)
+	}
+	if payload.Facts.RemoteHandoff.CI.EvidenceStatus != "success" || payload.Facts.RemoteHandoff.Sync.EvidenceStatus != "fresh" {
+		t.Fatalf("unexpected remote evidence statuses: %#v", payload.Facts.RemoteHandoff)
+	}
+}
+
 func TestStatusCommandWaitsForStateMutationLockRelease(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/contracts/status.go
+++ b/internal/contracts/status.go
@@ -83,12 +83,142 @@ type StatusFacts struct {
 	// SyncStatus summarizes the latest remote-sync evidence state.
 	SyncStatus string `json:"sync_status,omitempty"`
 
+	// RemoteHandoff is a non-authoritative live observation of the recorded PR
+	// handoff target. It may explain remote PR, CI, and sync state, but local
+	// durable evidence remains the source of truth for workflow progression.
+	RemoteHandoff *StatusRemoteHandoffObservation `json:"remote_handoff,omitempty"`
+
 	// LandPRURL is the pull request URL recorded for the land phase.
 	LandPRURL string `json:"land_pr_url,omitempty"`
 
 	// LandCommit is the merge commit or landed commit recorded for the land
 	// phase.
 	LandCommit string `json:"land_commit,omitempty"`
+}
+
+// StatusRemoteHandoffObservation is the live, read-only remote state surfaced
+// by `harness status` for an archived candidate with recorded publish PR
+// evidence.
+type StatusRemoteHandoffObservation struct {
+	// Status is the overall remote observation status such as available,
+	// degraded, or unavailable.
+	Status string `json:"status"`
+
+	// PR summarizes the recorded pull request when it can be observed.
+	PR StatusRemotePRObservation `json:"pr"`
+
+	// CI summarizes the live PR check state when it can be observed.
+	CI StatusRemoteCIObservation `json:"ci"`
+
+	// Sync summarizes the live PR merge or freshness state when it can be
+	// observed.
+	Sync StatusRemoteSyncObservation `json:"sync"`
+
+	// Degraded lists non-fatal remote observation failures.
+	Degraded []StatusRemoteDegradation `json:"degraded,omitempty"`
+}
+
+// StatusRemotePRObservation summarizes the recorded pull request observed by
+// `harness status`.
+type StatusRemotePRObservation struct {
+	// Status is the PR observation status such as available or unavailable.
+	Status string `json:"status"`
+
+	// URL is the recorded pull request URL.
+	URL string `json:"url,omitempty"`
+
+	// Number is the pull request number when available.
+	Number int `json:"number,omitempty"`
+
+	// State is the provider PR state such as OPEN, CLOSED, or MERGED.
+	State string `json:"state,omitempty"`
+
+	// IsDraft reports whether the observed pull request is a draft.
+	IsDraft bool `json:"is_draft,omitempty"`
+
+	// MergeStateStatus is the provider merge-state status when available.
+	MergeStateStatus string `json:"merge_state_status,omitempty"`
+
+	// Mergeable is the provider mergeability value when available.
+	Mergeable string `json:"mergeable,omitempty"`
+
+	// ReviewDecision is the provider review decision when available.
+	ReviewDecision string `json:"review_decision,omitempty"`
+
+	// HeadRefName is the pull request head branch name when available.
+	HeadRefName string `json:"head_ref_name,omitempty"`
+
+	// HeadRefOID is the pull request head commit OID when available.
+	HeadRefOID string `json:"head_ref_oid,omitempty"`
+
+	// BaseRefName is the pull request base branch name when available.
+	BaseRefName string `json:"base_ref_name,omitempty"`
+
+	// Degraded explains why the PR could not be observed.
+	Degraded StatusRemoteDegradation `json:"degraded,omitempty"`
+}
+
+// StatusRemoteCIObservation summarizes live remote CI/check state for a
+// recorded pull request.
+type StatusRemoteCIObservation struct {
+	// Status is the CI observation status such as available or unavailable.
+	Status string `json:"status"`
+
+	// EvidenceStatus is the local evidence status that `harness evidence
+	// refresh` would record if this remote observation were refreshed now.
+	EvidenceStatus string `json:"evidence_status,omitempty"`
+
+	// Checks lists compact remote check rows.
+	Checks []StatusRemoteCheckRun `json:"checks,omitempty"`
+
+	// Degraded explains why CI checks could not be observed.
+	Degraded StatusRemoteDegradation `json:"degraded,omitempty"`
+}
+
+// StatusRemoteSyncObservation summarizes live remote merge/sync state for a
+// recorded pull request.
+type StatusRemoteSyncObservation struct {
+	// Status is the sync observation status such as available or unavailable.
+	Status string `json:"status"`
+
+	// EvidenceStatus is the local evidence status that `harness evidence
+	// refresh` would record if this remote observation were refreshed now.
+	EvidenceStatus string `json:"evidence_status,omitempty"`
+
+	// MergeState is the provider merge-state value used for sync classification.
+	MergeState string `json:"merge_state,omitempty"`
+
+	// Degraded explains why sync state could not be observed.
+	Degraded StatusRemoteDegradation `json:"degraded,omitempty"`
+}
+
+// StatusRemoteCheckRun is a compact provider check row surfaced through
+// `harness status`.
+type StatusRemoteCheckRun struct {
+	// Name is the check run name when available.
+	Name string `json:"name,omitempty"`
+
+	// Workflow is the workflow name when available.
+	Workflow string `json:"workflow,omitempty"`
+
+	// Bucket is the provider's coarse check bucket when available.
+	Bucket string `json:"bucket,omitempty"`
+
+	// State is the provider's check state when available.
+	State string `json:"state,omitempty"`
+
+	// Link is the provider URL for the check run when available.
+	Link string `json:"link,omitempty"`
+}
+
+// StatusRemoteDegradation explains a non-fatal live remote observation
+// failure.
+type StatusRemoteDegradation struct {
+	// Code is a stable degradation code such as gh_missing or pr_unreadable.
+	Code string `json:"code"`
+
+	// Message is a concise human-readable explanation.
+	Message string `json:"message,omitempty"`
 }
 
 // StatusArtifacts lists stable paths or identifiers related to the current

--- a/internal/contracts/status.go
+++ b/internal/contracts/status.go
@@ -155,7 +155,7 @@ type StatusRemotePRObservation struct {
 	BaseRefName string `json:"base_ref_name,omitempty"`
 
 	// Degraded explains why the PR could not be observed.
-	Degraded StatusRemoteDegradation `json:"degraded,omitempty"`
+	Degraded *StatusRemoteDegradation `json:"degraded,omitempty"`
 }
 
 // StatusRemoteCIObservation summarizes live remote CI/check state for a
@@ -172,7 +172,7 @@ type StatusRemoteCIObservation struct {
 	Checks []StatusRemoteCheckRun `json:"checks,omitempty"`
 
 	// Degraded explains why CI checks could not be observed.
-	Degraded StatusRemoteDegradation `json:"degraded,omitempty"`
+	Degraded *StatusRemoteDegradation `json:"degraded,omitempty"`
 }
 
 // StatusRemoteSyncObservation summarizes live remote merge/sync state for a
@@ -189,7 +189,7 @@ type StatusRemoteSyncObservation struct {
 	MergeState string `json:"merge_state,omitempty"`
 
 	// Degraded explains why sync state could not be observed.
-	Degraded StatusRemoteDegradation `json:"degraded,omitempty"`
+	Degraded *StatusRemoteDegradation `json:"degraded,omitempty"`
 }
 
 // StatusRemoteCheckRun is a compact provider check row surfaced through

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -1140,7 +1140,16 @@ func shouldSuggestEvidenceRefresh(facts *Facts) bool {
 	return facts.CIStatus == "" ||
 		facts.CIStatus == "pending" ||
 		facts.SyncStatus == "" ||
-		facts.SyncStatus == "stale"
+		facts.SyncStatus == "stale" ||
+		cleanRemoteCanRefreshNonReadyEvidence(facts)
+}
+
+func cleanRemoteCanRefreshNonReadyEvidence(facts *Facts) bool {
+	if facts == nil || facts.RemoteHandoff == nil {
+		return false
+	}
+	return (facts.CIStatus == "failed" && facts.RemoteHandoff.CI.Status == remote.RemoteCIAvailable && facts.RemoteHandoff.CI.EvidenceStatus == "success") ||
+		(facts.SyncStatus == "conflicted" && facts.RemoteHandoff.Sync.Status == remote.RemoteSyncAvailable && facts.RemoteHandoff.Sync.EvidenceStatus == "fresh")
 }
 
 func idleResult(workdir string, currentPlan *runstate.CurrentPlan) Result {

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -14,12 +14,15 @@ import (
 	"github.com/catu-ai/easyharness/internal/install"
 	"github.com/catu-ai/easyharness/internal/lifecycle"
 	"github.com/catu-ai/easyharness/internal/plan"
+	"github.com/catu-ai/easyharness/internal/remote"
 	"github.com/catu-ai/easyharness/internal/runstate"
 	"github.com/catu-ai/easyharness/internal/stepcloseout"
 )
 
 type Service struct {
-	Workdir string
+	Workdir       string
+	ObserveRemote bool
+	RunCommand    remote.CommandRunner
 }
 
 type Result = contracts.StatusResult
@@ -190,6 +193,7 @@ func (s Service) Snapshot() Result {
 		} else {
 			result.State.CurrentNode = "execution/finalize/publish"
 		}
+		applyRemoteHandoffFacts(s, facts, evidenceCtx)
 	default:
 		return Result{
 			OK:      false,
@@ -510,6 +514,123 @@ func applyEvidenceFacts(facts *Facts, artifacts *Artifacts, evidenceCtx *evidenc
 		if artifacts != nil {
 			artifacts.SyncRecordID = evidenceCtx.Sync.RecordID
 		}
+	}
+}
+
+func applyRemoteHandoffFacts(s Service, facts *Facts, evidenceCtx *evidenceContext) {
+	if !s.ObserveRemote || facts == nil || evidenceCtx == nil || evidenceCtx.Publish == nil {
+		return
+	}
+	if evidenceCtx.Publish.Status != "recorded" || strings.TrimSpace(evidenceCtx.Publish.PRURL) == "" {
+		return
+	}
+	identity := remote.ParseRecordedPRURL(evidenceCtx.Publish.PRURL)
+	if identity.Status != remote.PRStatusRecorded {
+		facts.RemoteHandoff = remoteHandoffUnavailable(identity.Degraded)
+		return
+	}
+	observation := remote.Service{Workdir: s.Workdir, RunCommand: s.RunCommand}.ObserveHandoff(identity)
+	facts.RemoteHandoff = mapRemoteHandoffObservation(observation)
+}
+
+func mapRemoteHandoffObservation(observation remote.HandoffObservation) *contracts.StatusRemoteHandoffObservation {
+	return &contracts.StatusRemoteHandoffObservation{
+		Status:   observation.Status,
+		PR:       mapRemotePRObservation(observation.PR),
+		CI:       mapRemoteCIObservation(observation.CI),
+		Sync:     mapRemoteSyncObservation(observation.Sync),
+		Degraded: mapRemoteDegradations(observation.Degraded),
+	}
+}
+
+func remoteHandoffUnavailable(degradation remote.Degradation) *contracts.StatusRemoteHandoffObservation {
+	return &contracts.StatusRemoteHandoffObservation{
+		Status: remote.HandoffObservationUnavailable,
+		PR: contracts.StatusRemotePRObservation{
+			Status:   remote.PRObservationUnavailable,
+			Degraded: mapRemoteDegradationPtr(degradation),
+		},
+		CI: contracts.StatusRemoteCIObservation{
+			Status:   remote.RemoteCIUnavailable,
+			Degraded: mapRemoteDegradationPtr(degradation),
+		},
+		Sync: contracts.StatusRemoteSyncObservation{
+			Status:   remote.RemoteSyncUnavailable,
+			Degraded: mapRemoteDegradationPtr(degradation),
+		},
+		Degraded: mapRemoteDegradations([]remote.Degradation{degradation}),
+	}
+}
+
+func mapRemotePRObservation(observation remote.PRObservation) contracts.StatusRemotePRObservation {
+	return contracts.StatusRemotePRObservation{
+		Status:           observation.Status,
+		URL:              observation.URL,
+		Number:           observation.Number,
+		State:            observation.State,
+		IsDraft:          observation.IsDraft,
+		MergeStateStatus: observation.MergeStateStatus,
+		Mergeable:        observation.Mergeable,
+		ReviewDecision:   observation.ReviewDecision,
+		HeadRefName:      observation.HeadRefName,
+		HeadRefOID:       observation.HeadRefOID,
+		BaseRefName:      observation.BaseRefName,
+		Degraded:         mapRemoteDegradationPtr(observation.Degraded),
+	}
+}
+
+func mapRemoteCIObservation(observation remote.RemoteCIObservation) contracts.StatusRemoteCIObservation {
+	checks := make([]contracts.StatusRemoteCheckRun, 0, len(observation.Checks))
+	for _, check := range observation.Checks {
+		checks = append(checks, contracts.StatusRemoteCheckRun{
+			Name:     check.Name,
+			Workflow: check.Workflow,
+			Bucket:   check.Bucket,
+			State:    check.State,
+			Link:     check.Link,
+		})
+	}
+	return contracts.StatusRemoteCIObservation{
+		Status:         observation.Status,
+		EvidenceStatus: observation.EvidenceStatus,
+		Checks:         checks,
+		Degraded:       mapRemoteDegradationPtr(observation.Degraded),
+	}
+}
+
+func mapRemoteSyncObservation(observation remote.RemoteSyncObservation) contracts.StatusRemoteSyncObservation {
+	return contracts.StatusRemoteSyncObservation{
+		Status:         observation.Status,
+		EvidenceStatus: observation.EvidenceStatus,
+		MergeState:     observation.MergeState,
+		Degraded:       mapRemoteDegradationPtr(observation.Degraded),
+	}
+}
+
+func mapRemoteDegradations(degradations []remote.Degradation) []contracts.StatusRemoteDegradation {
+	out := make([]contracts.StatusRemoteDegradation, 0, len(degradations))
+	for _, degradation := range degradations {
+		if strings.TrimSpace(degradation.Code) == "" {
+			continue
+		}
+		out = append(out, contracts.StatusRemoteDegradation{
+			Code:    degradation.Code,
+			Message: degradation.Message,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func mapRemoteDegradationPtr(degradation remote.Degradation) *contracts.StatusRemoteDegradation {
+	if strings.TrimSpace(degradation.Code) == "" {
+		return nil
+	}
+	return &contracts.StatusRemoteDegradation{
+		Code:    degradation.Code,
+		Message: degradation.Message,
 	}
 }
 
@@ -912,6 +1033,7 @@ func buildPublishNextActions(facts *Facts) []NextAction {
 			Description: "Commit and push the tracked plan change created by archiving before treating the candidate as merge-ready.",
 		},
 	}
+	actions = append(actions, remoteHandoffNextActions(facts)...)
 
 	switch {
 	case facts == nil || facts.PublishStatus == "":
@@ -972,6 +1094,43 @@ func buildPublishNextActions(facts *Facts) []NextAction {
 		Description: "If the archived candidate is invalidated, reopen with `harness reopen --mode finalize-fix` for narrow repair or `harness reopen --mode new-step` when the change deserves a new unfinished step.",
 	})
 
+	return actions
+}
+
+func remoteHandoffNextActions(facts *Facts) []NextAction {
+	if facts == nil || facts.RemoteHandoff == nil {
+		return nil
+	}
+	remoteFacts := facts.RemoteHandoff
+	actions := make([]NextAction, 0, 2)
+	if remoteFacts.CI.Status == remote.RemoteCIAvailable {
+		switch remoteFacts.CI.EvidenceStatus {
+		case "pending":
+			actions = append(actions, NextAction{
+				Command:     nil,
+				Description: "Remote PR checks are still pending; wait for them to finish, then run `harness evidence refresh` to record the final CI and sync evidence.",
+			})
+		case "failed":
+			actions = append(actions, NextAction{
+				Command:     nil,
+				Description: "Remote PR checks are failing; fix CI before recording merge-ready evidence.",
+			})
+		}
+	}
+	if remoteFacts.Sync.Status == remote.RemoteSyncAvailable {
+		switch remoteFacts.Sync.EvidenceStatus {
+		case "stale":
+			actions = append(actions, NextAction{
+				Command:     nil,
+				Description: "Remote PR merge state is stale; refresh the branch against the base, then run `harness evidence refresh` once the PR is current.",
+			})
+		case "conflicted":
+			actions = append(actions, NextAction{
+				Command:     nil,
+				Description: "Remote PR merge state is conflicted; resolve the conflict before recording fresh sync evidence.",
+			})
+		}
+	}
 	return actions
 }
 
@@ -1179,6 +1338,7 @@ func factsEmpty(f *Facts) bool {
 		strings.TrimSpace(f.PRURL) == "" &&
 		strings.TrimSpace(f.CIStatus) == "" &&
 		strings.TrimSpace(f.SyncStatus) == "" &&
+		f.RemoteHandoff == nil &&
 		strings.TrimSpace(f.LandPRURL) == "" &&
 		strings.TrimSpace(f.LandCommit) == ""
 }

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -832,9 +832,8 @@ func buildNextActions(node string, facts *Facts, reviewCtx *reviewContext, block
 	case "execution/finalize/publish":
 		return buildPublishNextActions(facts)
 	case "execution/finalize/await_merge":
-		actions := []NextAction{
-			{Command: nil, Description: "Wait for explicit human approval before merging the PR."},
-		}
+		actions := remoteHandoffNextActions(facts)
+		actions = append(actions, NextAction{Command: nil, Description: "Wait for explicit human approval before merging the PR."})
 		if facts != nil && strings.TrimSpace(facts.PRURL) != "" {
 			actions = append(actions, NextAction{
 				Command:     strPtr(fmt.Sprintf("harness land --pr %s [--commit <sha>]", facts.PRURL)),

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -3,6 +3,7 @@ package status_test
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/evidence"
 	"github.com/catu-ai/easyharness/internal/install"
 	"github.com/catu-ai/easyharness/internal/plan"
+	"github.com/catu-ai/easyharness/internal/remote"
 	"github.com/catu-ai/easyharness/internal/review"
 	"github.com/catu-ai/easyharness/internal/runstate"
 	"github.com/catu-ai/easyharness/internal/status"
@@ -1713,6 +1715,168 @@ func TestStatusArchivedPlanWithRecordedPRSuggestsEvidenceRefresh(t *testing.T) {
 	}
 }
 
+func TestStatusArchivedPlanSurfacesRemoteHandoffObservation(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		return completeAllSteps(content, true)
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+		t.Fatalf("publish evidence: %#v", result)
+	}
+
+	result := status.Service{
+		Workdir:       root,
+		ObserveRemote: true,
+		RunCommand:    fakeStatusRemoteCommands(`"CLEAN"`, `[{"name":"Go Test","workflow":"CI","bucket":"pass","state":"SUCCESS","link":"https://ci.example/run"}]`),
+	}.Snapshot()
+	if result.State.CurrentNode != "execution/finalize/publish" {
+		t.Fatalf("live remote facts must not advance without local evidence, got %#v", result.State)
+	}
+	if result.Facts == nil || result.Facts.RemoteHandoff == nil {
+		t.Fatalf("expected remote handoff facts, got %#v", result.Facts)
+	}
+	remoteHandoff := result.Facts.RemoteHandoff
+	if remoteHandoff.Status != "available" || remoteHandoff.PR.State != "OPEN" || remoteHandoff.PR.Number != 13 {
+		t.Fatalf("unexpected remote PR observation: %#v", remoteHandoff)
+	}
+	if remoteHandoff.CI.EvidenceStatus != "success" || len(remoteHandoff.CI.Checks) != 1 {
+		t.Fatalf("unexpected remote CI observation: %#v", remoteHandoff.CI)
+	}
+	if remoteHandoff.Sync.EvidenceStatus != "fresh" || remoteHandoff.Sync.MergeState != "CLEAN" {
+		t.Fatalf("unexpected remote sync observation: %#v", remoteHandoff.Sync)
+	}
+	if !statusNextActionsContain(result, "harness evidence refresh") {
+		t.Fatalf("expected evidence refresh guidance for recorded remote facts, got %#v", result.NextAction)
+	}
+}
+
+func TestStatusRemoteHandoffObservationDegradesWithoutFailingLocalStatus(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		return completeAllSteps(content, true)
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+
+	if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+		t.Fatalf("publish evidence: %#v", result)
+	}
+
+	result := status.Service{
+		Workdir:       root,
+		ObserveRemote: true,
+		RunCommand: func(name string, args ...string) remote.CommandResult {
+			return remote.CommandResult{Err: exec.ErrNotFound}
+		},
+	}.Snapshot()
+	if !result.OK || result.State.CurrentNode != "execution/finalize/publish" {
+		t.Fatalf("remote degradation should not fail local status, got %#v", result)
+	}
+	if result.Facts == nil || result.Facts.RemoteHandoff == nil {
+		t.Fatalf("expected degraded remote handoff facts, got %#v", result.Facts)
+	}
+	if result.Facts.RemoteHandoff.Status != "unavailable" {
+		t.Fatalf("expected unavailable remote handoff, got %#v", result.Facts.RemoteHandoff)
+	}
+	if len(result.Facts.RemoteHandoff.Degraded) != 1 || result.Facts.RemoteHandoff.Degraded[0].Code != "gh_missing" {
+		t.Fatalf("expected gh_missing degradation, got %#v", result.Facts.RemoteHandoff.Degraded)
+	}
+	if result.Facts.RemoteHandoff.PR.Degraded == nil || result.Facts.RemoteHandoff.PR.Degraded.Code != "gh_missing" {
+		t.Fatalf("expected PR degradation pointer, got %#v", result.Facts.RemoteHandoff.PR)
+	}
+	if !statusNextActionsContain(result, "harness evidence submit --kind ci --input <json>") {
+		t.Fatalf("expected manual CI fallback guidance, got %#v", result.NextAction)
+	}
+}
+
+func TestStatusRemoteHandoffNextActionsExplainNonReadyRemoteFacts(t *testing.T) {
+	tests := []struct {
+		name       string
+		mergeState string
+		checks     string
+		wantCue    string
+	}{
+		{
+			name:       "pending checks",
+			mergeState: `"CLEAN"`,
+			checks:     `[{"name":"Go Test","bucket":"pending","state":"IN_PROGRESS"}]`,
+			wantCue:    "Remote PR checks are still pending",
+		},
+		{
+			name:       "failed checks",
+			mergeState: `"CLEAN"`,
+			checks:     `[{"name":"Go Test","bucket":"fail","state":"FAILURE"}]`,
+			wantCue:    "Remote PR checks are failing",
+		},
+		{
+			name:       "stale sync",
+			mergeState: `"BEHIND"`,
+			checks:     `[{"name":"Go Test","bucket":"pass","state":"SUCCESS"}]`,
+			wantCue:    "Remote PR merge state is stale",
+		},
+		{
+			name:       "conflicted sync",
+			mergeState: `"DIRTY"`,
+			checks:     `[{"name":"Go Test","bucket":"pass","state":"SUCCESS"}]`,
+			wantCue:    "Remote PR merge state is conflicted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+				return completeAllSteps(content, true)
+			})
+			writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+			if result := (evidence.Service{Workdir: root}).Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+				t.Fatalf("publish evidence: %#v", result)
+			}
+
+			result := status.Service{
+				Workdir:       root,
+				ObserveRemote: true,
+				RunCommand:    fakeStatusRemoteCommands(tt.mergeState, tt.checks),
+			}.Snapshot()
+			found := false
+			for _, action := range result.NextAction {
+				if strings.Contains(action.Description, tt.wantCue) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected next action containing %q, got %#v", tt.wantCue, result.NextAction)
+			}
+		})
+	}
+}
+
+func TestStatusRemoteHandoffDoesNotGuessPRWhenPublishEvidenceMissing(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		return completeAllSteps(content, true)
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+
+	called := false
+	result := status.Service{
+		Workdir:       root,
+		ObserveRemote: true,
+		RunCommand: func(name string, args ...string) remote.CommandResult {
+			called = true
+			return remote.CommandResult{}
+		},
+	}.Snapshot()
+	if called {
+		t.Fatal("status should not call gh without recorded publish PR evidence")
+	}
+	if result.Facts != nil && result.Facts.RemoteHandoff != nil {
+		t.Fatalf("did not expect remote handoff facts without recorded PR evidence, got %#v", result.Facts.RemoteHandoff)
+	}
+}
+
 func TestStatusArchivedPlanKeepsEvidenceRefreshForNonReadyRecordedPR(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -3072,6 +3236,32 @@ func statusNextActionsContain(result status.Result, command string) bool {
 		}
 	}
 	return false
+}
+
+func fakeStatusRemoteCommands(mergeStateJSON, checksJSON string) remote.CommandRunner {
+	return func(name string, args ...string) remote.CommandResult {
+		if name != "gh" {
+			return remote.CommandResult{}
+		}
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "view" {
+			return remote.CommandResult{Stdout: `{
+				"url":"https://github.com/catu-ai/easyharness/pull/13",
+				"number":13,
+				"state":"OPEN",
+				"isDraft":false,
+				"mergeStateStatus":` + mergeStateJSON + `,
+				"mergeable":"MERGEABLE",
+				"reviewDecision":"APPROVED",
+				"headRefName":"codex/test",
+				"headRefOid":"abc123",
+				"baseRefName":"main"
+			}`}
+		}
+		if len(args) >= 3 && args[0] == "pr" && args[1] == "checks" {
+			return remote.CommandResult{Stdout: checksJSON}
+		}
+		return remote.CommandResult{}
+	}
 }
 
 func mustJSONBytes(t *testing.T, value any) []byte {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -1853,6 +1853,58 @@ func TestStatusRemoteHandoffNextActionsExplainNonReadyRemoteFacts(t *testing.T) 
 	}
 }
 
+func TestStatusAwaitMergeIncludesRemoteHandoffWarningsWithoutRegressingNode(t *testing.T) {
+	root := t.TempDir()
+	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+		return completeAllSteps(content, true)
+	})
+	writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+
+	svc := evidence.Service{
+		Workdir: root,
+		Now: func() time.Time {
+			return time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC)
+		},
+	}
+	if result := svc.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+		t.Fatalf("publish evidence: %#v", result)
+	}
+	if result := svc.Submit("ci", []byte(`{"status":"success","provider":"github-actions"}`)); !result.OK {
+		t.Fatalf("ci evidence: %#v", result)
+	}
+	if result := svc.Submit("sync", []byte(`{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`)); !result.OK {
+		t.Fatalf("sync evidence: %#v", result)
+	}
+
+	result := status.Service{
+		Workdir:       root,
+		ObserveRemote: true,
+		RunCommand:    fakeStatusRemoteCommands(`"CLEAN"`, `[{"name":"Go Test","bucket":"fail","state":"FAILURE"}]`),
+	}.Snapshot()
+	if result.State.CurrentNode != "execution/finalize/await_merge" {
+		t.Fatalf("live remote facts must not regress evidence-driven await_merge node, got %#v", result.State)
+	}
+	if result.Facts == nil || result.Facts.RemoteHandoff == nil || result.Facts.RemoteHandoff.CI.EvidenceStatus != "failed" {
+		t.Fatalf("expected failed live remote CI facts, got %#v", result.Facts)
+	}
+	foundRemoteGuidance := false
+	foundLandGuidance := false
+	for _, action := range result.NextAction {
+		if strings.Contains(action.Description, "Remote PR checks are failing") {
+			foundRemoteGuidance = true
+		}
+		if action.Command != nil && strings.Contains(*action.Command, "harness land --pr https://github.com/catu-ai/easyharness/pull/13") {
+			foundLandGuidance = true
+		}
+	}
+	if !foundRemoteGuidance {
+		t.Fatalf("expected await_merge next actions to include remote failure guidance, got %#v", result.NextAction)
+	}
+	if !foundLandGuidance {
+		t.Fatalf("expected ordinary land guidance to remain after remote guidance, got %#v", result.NextAction)
+	}
+}
+
 func TestStatusRemoteHandoffDoesNotGuessPRWhenPublishEvidenceMissing(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -1853,6 +1853,63 @@ func TestStatusRemoteHandoffNextActionsExplainNonReadyRemoteFacts(t *testing.T) 
 	}
 }
 
+func TestStatusSuggestsRefreshWhenCleanRemoteCanReplaceNonReadyEvidence(t *testing.T) {
+	tests := []struct {
+		name      string
+		ciInput   string
+		syncInput string
+	}{
+		{
+			name:      "failed CI evidence",
+			ciInput:   `{"status":"failed","provider":"github-actions","url":"https://ci.example/run"}`,
+			syncInput: `{"status":"fresh","base_ref":"main","head_ref":"codex/test"}`,
+		},
+		{
+			name:      "conflicted sync evidence",
+			ciInput:   `{"status":"success","provider":"github-actions","url":"https://ci.example/run"}`,
+			syncInput: `{"status":"conflicted","base_ref":"main","head_ref":"codex/test"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {
+				return completeAllSteps(content, true)
+			})
+			writeCurrentPlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md")
+
+			svc := evidence.Service{
+				Workdir: root,
+				Now: func() time.Time {
+					return time.Date(2026, 3, 18, 11, 0, 0, 0, time.UTC)
+				},
+			}
+			if result := svc.Submit("publish", []byte(`{"status":"recorded","pr_url":"https://github.com/catu-ai/easyharness/pull/13"}`)); !result.OK {
+				t.Fatalf("publish evidence: %#v", result)
+			}
+			if result := svc.Submit("ci", []byte(tt.ciInput)); !result.OK {
+				t.Fatalf("ci evidence: %#v", result)
+			}
+			if result := svc.Submit("sync", []byte(tt.syncInput)); !result.OK {
+				t.Fatalf("sync evidence: %#v", result)
+			}
+
+			result := status.Service{
+				Workdir:       root,
+				ObserveRemote: true,
+				RunCommand:    fakeStatusRemoteCommands(`"CLEAN"`, `[{"name":"Go Test","bucket":"pass","state":"SUCCESS"}]`),
+			}.Snapshot()
+			if result.State.CurrentNode != "execution/finalize/publish" {
+				t.Fatalf("clean live facts must not advance stale local evidence, got %#v", result.State)
+			}
+			if !statusNextActionsContain(result, "harness evidence refresh") {
+				t.Fatalf("expected evidence refresh guidance when clean remote facts can replace non-ready evidence, got %#v", result.NextAction)
+			}
+		})
+	}
+}
+
 func TestStatusAwaitMergeIncludesRemoteHandoffWarningsWithoutRegressingNode(t *testing.T) {
 	root := t.TempDir()
 	writePlan(t, root, "docs/plans/archived/2026-03-18-status-plan.md", func(content string) string {

--- a/schema/commands/status.result.schema.json
+++ b/schema/commands/status.result.schema.json
@@ -180,6 +180,10 @@
           "type": "string",
           "description": "SyncStatus summarizes the latest remote-sync evidence state."
         },
+        "remote_handoff": {
+          "$ref": "#/$defs/StatusRemoteHandoffObservation",
+          "description": "RemoteHandoff is a non-authoritative live observation of the recorded PR handoff target. It may explain remote PR, CI, and sync state, but local durable evidence remains the source of truth for workflow progression."
+        },
         "land_pr_url": {
           "type": "string",
           "description": "LandPRURL is the pull request URL recorded for the land phase."
@@ -192,6 +196,200 @@
       "additionalProperties": false,
       "type": "object",
       "description": "StatusFacts carries selected derived details that help interpret a status node without dumping the full local state model."
+    },
+    "StatusRemoteCIObservation": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status is the CI observation status such as available or unavailable."
+        },
+        "evidence_status": {
+          "type": "string",
+          "description": "EvidenceStatus is the local evidence status that `harness evidence refresh` would record if this remote observation were refreshed now."
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/StatusRemoteCheckRun"
+          },
+          "type": "array",
+          "description": "Checks lists compact remote check rows."
+        },
+        "degraded": {
+          "$ref": "#/$defs/StatusRemoteDegradation",
+          "description": "Degraded explains why CI checks could not be observed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "description": "StatusRemoteCIObservation summarizes live remote CI/check state for a recorded pull request."
+    },
+    "StatusRemoteCheckRun": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the check run name when available."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Workflow is the workflow name when available."
+        },
+        "bucket": {
+          "type": "string",
+          "description": "Bucket is the provider's coarse check bucket when available."
+        },
+        "state": {
+          "type": "string",
+          "description": "State is the provider's check state when available."
+        },
+        "link": {
+          "type": "string",
+          "description": "Link is the provider URL for the check run when available."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "StatusRemoteCheckRun is a compact provider check row surfaced through `harness status`."
+    },
+    "StatusRemoteDegradation": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Code is a stable degradation code such as gh_missing or pr_unreadable."
+        },
+        "message": {
+          "type": "string",
+          "description": "Message is a concise human-readable explanation."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "code"
+      ],
+      "description": "StatusRemoteDegradation explains a non-fatal live remote observation failure."
+    },
+    "StatusRemoteHandoffObservation": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status is the overall remote observation status such as available, degraded, or unavailable."
+        },
+        "pr": {
+          "$ref": "#/$defs/StatusRemotePRObservation",
+          "description": "PR summarizes the recorded pull request when it can be observed."
+        },
+        "ci": {
+          "$ref": "#/$defs/StatusRemoteCIObservation",
+          "description": "CI summarizes the live PR check state when it can be observed."
+        },
+        "sync": {
+          "$ref": "#/$defs/StatusRemoteSyncObservation",
+          "description": "Sync summarizes the live PR merge or freshness state when it can be observed."
+        },
+        "degraded": {
+          "items": {
+            "$ref": "#/$defs/StatusRemoteDegradation"
+          },
+          "type": "array",
+          "description": "Degraded lists non-fatal remote observation failures."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status",
+        "pr",
+        "ci",
+        "sync"
+      ],
+      "description": "StatusRemoteHandoffObservation is the live, read-only remote state surfaced by `harness status` for an archived candidate with recorded publish PR evidence."
+    },
+    "StatusRemotePRObservation": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status is the PR observation status such as available or unavailable."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL is the recorded pull request URL."
+        },
+        "number": {
+          "type": "integer",
+          "description": "Number is the pull request number when available."
+        },
+        "state": {
+          "type": "string",
+          "description": "State is the provider PR state such as OPEN, CLOSED, or MERGED."
+        },
+        "is_draft": {
+          "type": "boolean",
+          "description": "IsDraft reports whether the observed pull request is a draft."
+        },
+        "merge_state_status": {
+          "type": "string",
+          "description": "MergeStateStatus is the provider merge-state status when available."
+        },
+        "mergeable": {
+          "type": "string",
+          "description": "Mergeable is the provider mergeability value when available."
+        },
+        "review_decision": {
+          "type": "string",
+          "description": "ReviewDecision is the provider review decision when available."
+        },
+        "head_ref_name": {
+          "type": "string",
+          "description": "HeadRefName is the pull request head branch name when available."
+        },
+        "head_ref_oid": {
+          "type": "string",
+          "description": "HeadRefOID is the pull request head commit OID when available."
+        },
+        "base_ref_name": {
+          "type": "string",
+          "description": "BaseRefName is the pull request base branch name when available."
+        },
+        "degraded": {
+          "$ref": "#/$defs/StatusRemoteDegradation",
+          "description": "Degraded explains why the PR could not be observed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "description": "StatusRemotePRObservation summarizes the recorded pull request observed by `harness status`."
+    },
+    "StatusRemoteSyncObservation": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status is the sync observation status such as available or unavailable."
+        },
+        "evidence_status": {
+          "type": "string",
+          "description": "EvidenceStatus is the local evidence status that `harness evidence refresh` would record if this remote observation were refreshed now."
+        },
+        "merge_state": {
+          "type": "string",
+          "description": "MergeState is the provider merge-state value used for sync classification."
+        },
+        "degraded": {
+          "$ref": "#/$defs/StatusRemoteDegradation",
+          "description": "Degraded explains why sync state could not be observed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "description": "StatusRemoteSyncObservation summarizes live remote merge/sync state for a recorded pull request."
     },
     "StatusResult": {
       "properties": {

--- a/schema/ui-resources/dashboard.schema.json
+++ b/schema/ui-resources/dashboard.schema.json
@@ -384,6 +384,10 @@
           "type": "string",
           "description": "SyncStatus summarizes the latest remote-sync evidence state."
         },
+        "remote_handoff": {
+          "$ref": "#/$defs/StatusRemoteHandoffObservation",
+          "description": "RemoteHandoff is a non-authoritative live observation of the recorded PR handoff target. It may explain remote PR, CI, and sync state, but local durable evidence remains the source of truth for workflow progression."
+        },
         "land_pr_url": {
           "type": "string",
           "description": "LandPRURL is the pull request URL recorded for the land phase."
@@ -396,6 +400,200 @@
       "additionalProperties": false,
       "type": "object",
       "description": "StatusFacts carries selected derived details that help interpret a status node without dumping the full local state model."
+    },
+    "StatusRemoteCIObservation": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status is the CI observation status such as available or unavailable."
+        },
+        "evidence_status": {
+          "type": "string",
+          "description": "EvidenceStatus is the local evidence status that `harness evidence refresh` would record if this remote observation were refreshed now."
+        },
+        "checks": {
+          "items": {
+            "$ref": "#/$defs/StatusRemoteCheckRun"
+          },
+          "type": "array",
+          "description": "Checks lists compact remote check rows."
+        },
+        "degraded": {
+          "$ref": "#/$defs/StatusRemoteDegradation",
+          "description": "Degraded explains why CI checks could not be observed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "description": "StatusRemoteCIObservation summarizes live remote CI/check state for a recorded pull request."
+    },
+    "StatusRemoteCheckRun": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the check run name when available."
+        },
+        "workflow": {
+          "type": "string",
+          "description": "Workflow is the workflow name when available."
+        },
+        "bucket": {
+          "type": "string",
+          "description": "Bucket is the provider's coarse check bucket when available."
+        },
+        "state": {
+          "type": "string",
+          "description": "State is the provider's check state when available."
+        },
+        "link": {
+          "type": "string",
+          "description": "Link is the provider URL for the check run when available."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "StatusRemoteCheckRun is a compact provider check row surfaced through `harness status`."
+    },
+    "StatusRemoteDegradation": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Code is a stable degradation code such as gh_missing or pr_unreadable."
+        },
+        "message": {
+          "type": "string",
+          "description": "Message is a concise human-readable explanation."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "code"
+      ],
+      "description": "StatusRemoteDegradation explains a non-fatal live remote observation failure."
+    },
+    "StatusRemoteHandoffObservation": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status is the overall remote observation status such as available, degraded, or unavailable."
+        },
+        "pr": {
+          "$ref": "#/$defs/StatusRemotePRObservation",
+          "description": "PR summarizes the recorded pull request when it can be observed."
+        },
+        "ci": {
+          "$ref": "#/$defs/StatusRemoteCIObservation",
+          "description": "CI summarizes the live PR check state when it can be observed."
+        },
+        "sync": {
+          "$ref": "#/$defs/StatusRemoteSyncObservation",
+          "description": "Sync summarizes the live PR merge or freshness state when it can be observed."
+        },
+        "degraded": {
+          "items": {
+            "$ref": "#/$defs/StatusRemoteDegradation"
+          },
+          "type": "array",
+          "description": "Degraded lists non-fatal remote observation failures."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status",
+        "pr",
+        "ci",
+        "sync"
+      ],
+      "description": "StatusRemoteHandoffObservation is the live, read-only remote state surfaced by `harness status` for an archived candidate with recorded publish PR evidence."
+    },
+    "StatusRemotePRObservation": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status is the PR observation status such as available or unavailable."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL is the recorded pull request URL."
+        },
+        "number": {
+          "type": "integer",
+          "description": "Number is the pull request number when available."
+        },
+        "state": {
+          "type": "string",
+          "description": "State is the provider PR state such as OPEN, CLOSED, or MERGED."
+        },
+        "is_draft": {
+          "type": "boolean",
+          "description": "IsDraft reports whether the observed pull request is a draft."
+        },
+        "merge_state_status": {
+          "type": "string",
+          "description": "MergeStateStatus is the provider merge-state status when available."
+        },
+        "mergeable": {
+          "type": "string",
+          "description": "Mergeable is the provider mergeability value when available."
+        },
+        "review_decision": {
+          "type": "string",
+          "description": "ReviewDecision is the provider review decision when available."
+        },
+        "head_ref_name": {
+          "type": "string",
+          "description": "HeadRefName is the pull request head branch name when available."
+        },
+        "head_ref_oid": {
+          "type": "string",
+          "description": "HeadRefOID is the pull request head commit OID when available."
+        },
+        "base_ref_name": {
+          "type": "string",
+          "description": "BaseRefName is the pull request base branch name when available."
+        },
+        "degraded": {
+          "$ref": "#/$defs/StatusRemoteDegradation",
+          "description": "Degraded explains why the PR could not be observed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "description": "StatusRemotePRObservation summarizes the recorded pull request observed by `harness status`."
+    },
+    "StatusRemoteSyncObservation": {
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status is the sync observation status such as available or unavailable."
+        },
+        "evidence_status": {
+          "type": "string",
+          "description": "EvidenceStatus is the local evidence status that `harness evidence refresh` would record if this remote observation were refreshed now."
+        },
+        "merge_state": {
+          "type": "string",
+          "description": "MergeState is the provider merge-state value used for sync classification."
+        },
+        "degraded": {
+          "$ref": "#/$defs/StatusRemoteDegradation",
+          "description": "Degraded explains why sync state could not be observed."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "description": "StatusRemoteSyncObservation summarizes live remote merge/sync state for a recorded pull request."
     }
   },
   "title": "Dashboard UI resource",


### PR DESCRIPTION
## Summary

- Add `facts.remote_handoff` to `harness status` as non-authoritative live observation of the recorded publish PR.
- Wire CLI `harness status` to observe the recorded PR through the existing read-only `internal/remote` path without guessing PR identity from branch state.
- Keep workflow progression evidence-driven while refining next actions for pending/failed checks, stale/conflicted sync, and clean live remote facts that should be recorded through `harness evidence refresh`.

Closes #200.

## Validation

- `harness plan lint docs/plans/active/2026-05-24-surface-remote-handoff-status.md`
- `scripts/sync-contract-artifacts --check`
- `go test ./internal/contracts ./internal/contractsync -count=1`
- `go test ./internal/status -run 'TestStatusArchivedPlanSurfacesRemoteHandoffObservation|TestStatusRemoteHandoffObservationDegradesWithoutFailingLocalStatus|TestStatusRemoteHandoffNextActionsExplainNonReadyRemoteFacts|TestStatusAwaitMergeIncludesRemoteHandoffWarningsWithoutRegressingNode|TestStatusRemoteHandoffDoesNotGuessPRWhenPublishEvidenceMissing' -count=1`
- `go test ./internal/status -run 'TestStatusSuggestsRefreshWhenCleanRemoteCanReplaceNonReadyEvidence|TestStatusArchivedPlanSurfacesRemoteHandoffObservation|TestStatusAwaitMergeIncludesRemoteHandoffWarningsWithoutRegressingNode' -count=1`
- `go test ./internal/status ./internal/cli ./internal/remote ./internal/evidence ./internal/contractsync -count=1`
- `go test ./tests/e2e -run 'TestPublishHandoff|TestAwaitMerge|TestLandWorkflow|TestLightweightWorkflow' -count=1`
- `git diff --check`

## Harness handoff

- Archived plan: `docs/plans/archived/2026-05-24-surface-remote-handoff-status.md`
- Finalize review: `review-009-full` passed with zero findings.
- Follow-up: #202 remains the broader controller docs/skill integration bucket.
