### PR TITLE
Update remote handoff controller guidance

### DIFF
--- a/.agents/skills/harness-execute/SKILL.md
+++ b/.agents/skills/harness-execute/SKILL.md
@@ -86,7 +86,8 @@ when it is genuinely impractical, and record the reason in the step's
    - which tracked plan is current
    - which `current_node` the worktree is currently in
    - which step or finalize phase is active or next
-   - whether local state already shows review, evidence, or land work in flight
+   - whether local state already shows review, evidence, or land work in flight,
+     and whether live remote handoff observations are guiding the next action
 5. If `harness` is unavailable or resolves to the wrong binary, first follow
    the repository's documented setup path. If no setup path is documented, ask
    the human to install or expose the correct `harness` command.
@@ -115,9 +116,15 @@ when it is genuinely impractical, and record the reason in the step's
   - the plan is archived, but publish, CI, or sync evidence still needs work
   - for lightweight work, keep the repo-visible breadcrumb requirement in view
     while driving the candidate toward `await_merge`
+  - use `harness status` remote handoff facts as the first orientation surface;
+    status may observe the recorded PR, but only evidence commands move the
+    archived candidate toward `await_merge`
 - `execution/finalize/await_merge`
   - the archived candidate is merge-ready; stay in execute until explicit
     human merge approval switches the controller into `harness-land`
+  - if status warns that live remote facts drifted after local evidence was
+    recorded, repair or refresh the candidate before treating it as still
+    merge-ready
 
 ## Reference Guide
 

--- a/.agents/skills/harness-execute/references/closeout-and-archive.md
+++ b/.agents/skills/harness-execute/references/closeout-and-archive.md
@@ -52,12 +52,16 @@ Archive still needs an explicit handoff flow:
 7. If publish evidence records a supported PR URL, run
    `harness evidence refresh` to record CI and sync facts from that PR.
 8. Run `harness status` after refresh so the archived candidate summary and
-   next actions reflect the evidence that was just written.
+   next actions reflect the evidence that was just written and any live
+   `facts.remote_handoff` observations that still need controller action.
 9. If refresh degrades, is unavailable, or publish evidence lacks a recorded
    PR URL, manually record the affected domains with
    `harness evidence submit --kind publish|ci|sync`.
 10. Run `harness status` again after that handoff work and confirm the candidate
-   is now genuinely ready to report `execution/finalize/await_merge`.
+   is now genuinely ready to report `execution/finalize/await_merge`. If status
+   still reports pending checks, failing checks, stale or conflicted sync,
+   degraded remote reads, or live remote drift, follow
+   [publish-ci-sync.md](publish-ci-sync.md) before claiming merge readiness.
 11. Wait for human merge approval or switch to `harness-land` only when asked
    once status reaches `execution/finalize/await_merge`.
 

--- a/.agents/skills/harness-execute/references/controller-truth-surfaces.md
+++ b/.agents/skills/harness-execute/references/controller-truth-surfaces.md
@@ -51,14 +51,16 @@ self-check for the controller, not a second reviewer protocol.
 ## Pre-Land
 
 - PR truth
-  - refresh the actual PR state instead of trusting a stale local impression of
-    readiness
+  - run `harness status` first and inspect the recorded PR handoff facts instead
+    of trusting a stale local impression of readiness
 - CI truth
-  - verify the latest relevant runs and distinguish `success` from cancelled,
-    stale, superseded, or still-running checks
+  - verify the latest relevant runs through status or refresh output and
+    distinguish `success` from cancelled, stale, superseded, failed, or
+    still-running checks
 - sync truth
-  - refresh branch freshness against the remote base before merge-sensitive
-    handoff or merge work
+  - confirm status shows fresh local sync evidence and no live remote stale or
+    conflicted handoff warning before merge-sensitive handoff or merge work
 - merge and bookkeeping truth
-  - confirm the remaining PR comment, issue follow-up, evidence, and land
-    bookkeeping work rather than assuming merge-ready means done
+  - remember that status is read-only: PR creation, reruns, comments, issue
+    follow-up, merge, and land bookkeeping remain human/agent actions outside
+    harness core commands

--- a/.agents/skills/harness-execute/references/publish-ci-sync.md
+++ b/.agents/skills/harness-execute/references/publish-ci-sync.md
@@ -34,6 +34,74 @@ but record the observed external facts through harness-owned evidence:
 9. only then treat the candidate as ready to enter
    `execution/finalize/await_merge`
 
+## Status-First Remote Handoff
+
+During archived-candidate handoff, treat `harness status` as the first
+orientation surface. Read these parts together:
+
+- `state.current_node`: the durable local workflow node
+- local publish, CI, and sync evidence facts
+- `facts.remote_handoff`: optional live read-only observation of the recorded PR
+- `warnings` and `next_actions`: the controller-facing interpretation
+
+The remote handoff surface is deliberately read-only and non-authoritative.
+Passing checks or clean merge state in `facts.remote_handoff` explain what the
+controller should do next; they do not move `state.current_node` to
+`execution/finalize/await_merge` until local evidence records the facts.
+
+Use these cases as the controller decision guide:
+
+- No recorded PR evidence
+  - Open or update the PR outside harness, then record publish evidence with
+    `harness evidence submit --kind publish`.
+  - Do not ask harness to infer a PR from the current branch, upstream, or local
+    remote.
+- Unsupported or non-PR handoff target
+  - Keep using manual `harness evidence submit --kind ci|sync` for the affected
+    evidence domains.
+  - Use direct provider inspection only to decide what manual evidence to
+    record.
+- Degraded remote observation
+  - Treat missing `gh`, missing auth, network or API failure, unreadable PRs, and
+    malformed provider output as degraded remote reads, not as local workflow
+    failures.
+  - Retry `harness evidence refresh` when the provider problem is temporary, or
+    manually submit the evidence when the facts are clear through another
+    trusted surface.
+- Pending remote checks
+  - Wait for checks to finish, then rerun `harness evidence refresh`.
+  - Do not mark CI successful from a still-running live observation.
+- Failed or cancelled remote checks
+  - Inspect the failing checks, fix the branch, rerun focused validation, and
+    decide whether the repair needs delta or full review.
+  - After the PR checks recover, use `harness evidence refresh` or manual CI
+    evidence to update the local handoff facts.
+- Passing remote checks or fresh merge state with missing or stale local
+  evidence
+  - Run `harness evidence refresh` so the observed facts become durable local
+    CI and sync evidence.
+  - Rerun `harness status` after refresh before reporting the candidate as
+    merge-ready.
+- Stale remote sync
+  - Refresh the branch against the base outside harness, push the repaired
+    branch, validate the change, and rerun `harness evidence refresh`.
+- Conflicted remote sync
+  - Resolve the conflict outside harness and treat the repair like any other
+    merge-sensitive code or docs change: validate it and review it at the
+    appropriate delta or full scope before refreshing evidence.
+- Locally merge-ready but live remote facts have drifted
+  - Keep `execution/finalize/await_merge` as the historical local evidence
+    state, but do not tell the human the candidate is still ready to merge until
+    the drift is repaired, refreshed, or intentionally recorded.
+- PR already merged
+  - Switch to `harness-land` only after explicit human merge approval. The land
+    flow records merge confirmation and required post-merge bookkeeping; status
+    observation alone is not a substitute for that boundary.
+
+Direct `gh` inspection is a diagnostic fallback for confusing or degraded
+status/refresh results. It is not the ordinary first path when `harness status`
+and `harness evidence refresh` can carry the handoff.
+
 ## Remote Freshness
 
 Refresh remote state before merge-sensitive handoff work.

--- a/assets/bootstrap/skills/harness-execute/SKILL.md
+++ b/assets/bootstrap/skills/harness-execute/SKILL.md
@@ -83,7 +83,8 @@ when it is genuinely impractical, and record the reason in the step's
    - which tracked plan is current
    - which `current_node` the worktree is currently in
    - which step or finalize phase is active or next
-   - whether local state already shows review, evidence, or land work in flight
+   - whether local state already shows review, evidence, or land work in flight,
+     and whether live remote handoff observations are guiding the next action
 5. If `harness` is unavailable or resolves to the wrong binary, first follow
    the repository's documented setup path. If no setup path is documented, ask
    the human to install or expose the correct `harness` command.
@@ -112,9 +113,15 @@ when it is genuinely impractical, and record the reason in the step's
   - the plan is archived, but publish, CI, or sync evidence still needs work
   - for lightweight work, keep the repo-visible breadcrumb requirement in view
     while driving the candidate toward `await_merge`
+  - use `harness status` remote handoff facts as the first orientation surface;
+    status may observe the recorded PR, but only evidence commands move the
+    archived candidate toward `await_merge`
 - `execution/finalize/await_merge`
   - the archived candidate is merge-ready; stay in execute until explicit
     human merge approval switches the controller into `harness-land`
+  - if status warns that live remote facts drifted after local evidence was
+    recorded, repair or refresh the candidate before treating it as still
+    merge-ready
 
 ## Reference Guide
 

--- a/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
+++ b/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
@@ -52,12 +52,16 @@ Archive still needs an explicit handoff flow:
 7. If publish evidence records a supported PR URL, run
    `harness evidence refresh` to record CI and sync facts from that PR.
 8. Run `harness status` after refresh so the archived candidate summary and
-   next actions reflect the evidence that was just written.
+   next actions reflect the evidence that was just written and any live
+   `facts.remote_handoff` observations that still need controller action.
 9. If refresh degrades, is unavailable, or publish evidence lacks a recorded
    PR URL, manually record the affected domains with
    `harness evidence submit --kind publish|ci|sync`.
 10. Run `harness status` again after that handoff work and confirm the candidate
-   is now genuinely ready to report `execution/finalize/await_merge`.
+   is now genuinely ready to report `execution/finalize/await_merge`. If status
+   still reports pending checks, failing checks, stale or conflicted sync,
+   degraded remote reads, or live remote drift, follow
+   [publish-ci-sync.md](publish-ci-sync.md) before claiming merge readiness.
 11. Wait for human merge approval or switch to `harness-land` only when asked
    once status reaches `execution/finalize/await_merge`.
 

--- a/assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md
+++ b/assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md
@@ -51,14 +51,16 @@ self-check for the controller, not a second reviewer protocol.
 ## Pre-Land
 
 - PR truth
-  - refresh the actual PR state instead of trusting a stale local impression of
-    readiness
+  - run `harness status` first and inspect the recorded PR handoff facts instead
+    of trusting a stale local impression of readiness
 - CI truth
-  - verify the latest relevant runs and distinguish `success` from cancelled,
-    stale, superseded, or still-running checks
+  - verify the latest relevant runs through status or refresh output and
+    distinguish `success` from cancelled, stale, superseded, failed, or
+    still-running checks
 - sync truth
-  - refresh branch freshness against the remote base before merge-sensitive
-    handoff or merge work
+  - confirm status shows fresh local sync evidence and no live remote stale or
+    conflicted handoff warning before merge-sensitive handoff or merge work
 - merge and bookkeeping truth
-  - confirm the remaining PR comment, issue follow-up, evidence, and land
-    bookkeeping work rather than assuming merge-ready means done
+  - remember that status is read-only: PR creation, reruns, comments, issue
+    follow-up, merge, and land bookkeeping remain human/agent actions outside
+    harness core commands

--- a/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
+++ b/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
@@ -34,6 +34,74 @@ but record the observed external facts through harness-owned evidence:
 9. only then treat the candidate as ready to enter
    `execution/finalize/await_merge`
 
+## Status-First Remote Handoff
+
+During archived-candidate handoff, treat `harness status` as the first
+orientation surface. Read these parts together:
+
+- `state.current_node`: the durable local workflow node
+- local publish, CI, and sync evidence facts
+- `facts.remote_handoff`: optional live read-only observation of the recorded PR
+- `warnings` and `next_actions`: the controller-facing interpretation
+
+The remote handoff surface is deliberately read-only and non-authoritative.
+Passing checks or clean merge state in `facts.remote_handoff` explain what the
+controller should do next; they do not move `state.current_node` to
+`execution/finalize/await_merge` until local evidence records the facts.
+
+Use these cases as the controller decision guide:
+
+- No recorded PR evidence
+  - Open or update the PR outside harness, then record publish evidence with
+    `harness evidence submit --kind publish`.
+  - Do not ask harness to infer a PR from the current branch, upstream, or local
+    remote.
+- Unsupported or non-PR handoff target
+  - Keep using manual `harness evidence submit --kind ci|sync` for the affected
+    evidence domains.
+  - Use direct provider inspection only to decide what manual evidence to
+    record.
+- Degraded remote observation
+  - Treat missing `gh`, missing auth, network or API failure, unreadable PRs, and
+    malformed provider output as degraded remote reads, not as local workflow
+    failures.
+  - Retry `harness evidence refresh` when the provider problem is temporary, or
+    manually submit the evidence when the facts are clear through another
+    trusted surface.
+- Pending remote checks
+  - Wait for checks to finish, then rerun `harness evidence refresh`.
+  - Do not mark CI successful from a still-running live observation.
+- Failed or cancelled remote checks
+  - Inspect the failing checks, fix the branch, rerun focused validation, and
+    decide whether the repair needs delta or full review.
+  - After the PR checks recover, use `harness evidence refresh` or manual CI
+    evidence to update the local handoff facts.
+- Passing remote checks or fresh merge state with missing or stale local
+  evidence
+  - Run `harness evidence refresh` so the observed facts become durable local
+    CI and sync evidence.
+  - Rerun `harness status` after refresh before reporting the candidate as
+    merge-ready.
+- Stale remote sync
+  - Refresh the branch against the base outside harness, push the repaired
+    branch, validate the change, and rerun `harness evidence refresh`.
+- Conflicted remote sync
+  - Resolve the conflict outside harness and treat the repair like any other
+    merge-sensitive code or docs change: validate it and review it at the
+    appropriate delta or full scope before refreshing evidence.
+- Locally merge-ready but live remote facts have drifted
+  - Keep `execution/finalize/await_merge` as the historical local evidence
+    state, but do not tell the human the candidate is still ready to merge until
+    the drift is repaired, refreshed, or intentionally recorded.
+- PR already merged
+  - Switch to `harness-land` only after explicit human merge approval. The land
+    flow records merge confirmation and required post-merge bookkeeping; status
+    observation alone is not a substitute for that boundary.
+
+Direct `gh` inspection is a diagnostic fallback for confusing or degraded
+status/refresh results. It is not the ordinary first path when `harness status`
+and `harness evidence refresh` can carry the handoff.
+
 ## Remote Freshness
 
 Refresh remote state before merge-sensitive handoff work.

--- a/docs/plans/archived/2026-05-25-controller-remote-handoff-guidance.md
+++ b/docs/plans/archived/2026-05-25-controller-remote-handoff-guidance.md
@@ -1,0 +1,279 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-25T09:45:05+08:00"
+approved_at: "2026-05-25T09:46:40+08:00"
+source_type: direct_request
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/202
+    - https://github.com/catu-ai/easyharness/issues/12
+    - https://github.com/catu-ai/easyharness/issues/200
+    - https://github.com/catu-ai/easyharness/issues/213
+size: XS
+---
+
+# Controller remote handoff guidance
+
+## Goal
+
+Resolve issue #202 by updating the controller-facing docs and managed
+`harness-execute` skill guidance for the read-only remote handoff workflow
+delivered across #199, #200, and #213.
+
+The end state should let a future controller use `harness status` as the first
+orientation surface during publish, CI, sync, and merge handoff. The guidance
+should explain how to interpret durable local evidence together with
+non-authoritative `facts.remote_handoff`, while preserving the boundary that
+`harness status` is read-only, `harness evidence refresh` is the explicit
+remote-to-evidence write path, and git/GitHub write operations stay outside
+harness core commands.
+
+## Scope
+
+### In Scope
+
+- Update the distributed managed skill pack under `assets/bootstrap/` so
+  controller agents get complete remote handoff guidance from the packaged
+  `harness-execute` materials.
+- Cover the common `harness status` remote handoff cases a controller must act
+  on: missing recorded PR evidence, degraded remote reads, pending checks,
+  failing checks, passing or fresh remote facts that still need local evidence,
+  stale or conflicted sync, and merge-ready / merged handoff boundaries.
+- Clarify that `facts.remote_handoff` is an advisory live observation surface;
+  `state.current_node` remains driven by durable local publish, CI, and sync
+  evidence.
+- Preserve the explicit manual fallback path through
+  `harness evidence submit --kind publish|ci|sync`.
+- Run bootstrap sync so `.agents/skills/` and the managed `AGENTS.md` block, if
+  touched by generated output, match `assets/bootstrap/`.
+- Record the milestone closeout implication: v0.4.0 currently has #202 and the
+  parent umbrella #12 open; #202 appears to be the final concrete child item
+  before #12 can be closed or marked complete.
+
+### Out of Scope
+
+- Implementing new remote observation, evidence refresh, status, or schema
+  behavior.
+- Changing merge policy, review policy, state transitions, or evidence
+  semantics.
+- Adding a `harness publish` command or any git/GitHub write command to harness
+  core.
+- Performing PR creation, issue closure, or milestone bookkeeping before the
+  archived candidate reaches publish handoff.
+
+## Acceptance Criteria
+
+- [x] `harness-execute` publish/CI/sync guidance tells controllers to consult
+      `harness status` remote facts before ad hoc remote inspection.
+- [x] The guidance explains the expected controller response for missing PR
+      evidence, degraded observations, pending checks, failing checks,
+      passing/fresh-but-unrecorded facts, stale/conflicted sync, and
+      merge-ready handoff states.
+- [x] The docs clearly distinguish read-only status facts from evidence-writing
+      commands and from human/agent-executed git or GitHub write actions.
+- [x] Managed bootstrap outputs are synchronized after editing
+      `assets/bootstrap/`.
+- [x] Validation confirms the plan lint, bootstrap sync check, and relevant
+      docs checks pass.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Update managed controller guidance
+
+- Done: [x]
+
+#### Objective
+
+Make the packaged `harness-execute` remote handoff guidance complete enough for
+a future controller to follow without reconstructing #200/#213 from issue
+history.
+
+#### Details
+
+Focus on the distributed source materials under `assets/bootstrap/`, especially
+`harness-execute` references that govern publish, CI, sync, closeout, and
+controller truth-surface use. Keep the guidance concise and decision-shaped:
+the controller should know what `harness status` is saying, which command or
+manual action comes next, and when direct `gh` inspection is only diagnostic.
+
+Do not duplicate full JSON schemas or implementation internals. Point to the
+existing command contracts where appropriate, but make the controller workflow
+clear enough that an agent can handle normal handoff cases from the skill text.
+
+#### Expected Files
+
+- `assets/bootstrap/skills/harness-execute/SKILL.md`
+- `assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md`
+- `assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md`
+- `assets/bootstrap/skills/harness-execute/references/controller-truth-surfaces.md`
+
+#### Validation
+
+- Reread the changed guidance against issue #202 acceptance criteria.
+- Confirm the wording preserves the read-only boundary for `harness status` and
+  the explicit write boundary for `harness evidence refresh`.
+
+#### Execution Notes
+
+Updated the managed `harness-execute` source under `assets/bootstrap/` to make
+remote handoff status-first. The main addition is a decision guide in
+`publish-ci-sync.md` covering missing recorded PR evidence, unsupported
+handoff targets, degraded observations, pending checks, failed checks,
+passing/fresh remote facts that still need evidence refresh, stale or
+conflicted sync, live drift after local merge-ready evidence, and already
+merged PRs.
+
+Also tightened the main execute skill's node hints, closeout/archive handoff
+steps, and Pre-Land truth-surface checklist so controllers look at
+`harness status` first, treat `facts.remote_handoff` as read-only and
+non-authoritative, use `harness evidence refresh` to record remote facts, keep
+manual `harness evidence submit` as fallback, and reserve direct `gh`
+inspection for diagnostics.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 is documentation and managed-skill guidance only;
+Step 2 will run bootstrap sync, lint, and final validation before finalize
+review.
+
+### Step 2: Sync bootstrap outputs and verify closeout readiness
+
+- Done: [x]
+
+#### Objective
+
+Refresh materialized bootstrap outputs, validate the plan and docs, and record
+whether #202 completes the v0.4.0 parent issue split.
+
+#### Details
+
+Run the bootstrap sync script after editing `assets/bootstrap/` so repo-local
+materialized skills stay in sync. Recheck the v0.4.0 milestone before archive:
+as of planning, GitHub reports open issues #202 and parent #12 only, and #12's
+split comment identifies #202 as the remaining controller-doc child item. The
+archive or PR handoff should state whether landing this plan is expected to
+close #202 and make #12 closeable.
+
+#### Expected Files
+
+- `.agents/skills/harness-execute/SKILL.md`
+- `.agents/skills/harness-execute/references/publish-ci-sync.md`
+- `.agents/skills/harness-execute/references/closeout-and-archive.md`
+- `.agents/skills/harness-execute/references/controller-truth-surfaces.md`
+- `AGENTS.md`
+- `docs/plans/active/2026-05-25-controller-remote-handoff-guidance.md`
+
+#### Validation
+
+- `scripts/sync-bootstrap-assets --check`
+- `harness plan lint docs/plans/active/2026-05-25-controller-remote-handoff-guidance.md`
+- `git diff --check`
+
+#### Execution Notes
+
+Ran `scripts/sync-bootstrap-assets`, which refreshed the materialized
+`.agents/skills/harness-execute` files from `assets/bootstrap/`. Verified the
+managed bootstrap output is synchronized, the tracked plan still lints, and the
+diff has no whitespace errors.
+
+Rechecked the v0.4.0 milestone through `gh api`: it still has open issues #202
+and parent #12 only. #12's split comment lists #203, #199, #200, and #202 as
+the v0.4.0 child scope, so landing this plan should close #202 and make #12
+ready to close or explicitly retarget.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 only synchronized generated bootstrap output,
+validated the docs/plan state, and recorded milestone status. Finalize review
+will cover the full docs and managed-skill change.
+
+## Validation Strategy
+
+This is docs and managed-skill integration work, so validation centers on
+contract consistency rather than runtime behavior. The executor should lint the
+tracked plan, verify bootstrap dogfood outputs are synchronized, run
+whitespace/diff checks, and reread the changed guidance against the status and
+evidence contracts in `docs/specs/cli-contract.md` and `docs/specs/state-model.md`.
+
+No Go behavior tests are expected unless the implementation unexpectedly changes
+runtime code.
+
+## Risks
+
+- Risk: The guidance could imply that live remote facts advance workflow state.
+  - Mitigation: State repeatedly that `facts.remote_handoff` is
+    non-authoritative and that durable publish, CI, and sync evidence still
+    drive `state.current_node`.
+- Risk: The skill text could drift from the distributed bootstrap source.
+  - Mitigation: Edit `assets/bootstrap/` first and run
+    `scripts/sync-bootstrap-assets` before validation.
+- Risk: Closing #202 could leave parent #12 ambiguous.
+  - Mitigation: Record in archive/PR handoff that #202 is the last concrete
+    child item observed in the v0.4.0 milestone and that #12 should be closed or
+    explicitly retargeted if maintainers want more parent-scope work.
+
+## Validation Summary
+
+- `scripts/sync-bootstrap-assets --check`
+- `harness plan lint docs/plans/active/2026-05-25-controller-remote-handoff-guidance.md`
+- `git diff --check`
+- `gh api repos/catu-ai/easyharness/milestones --jq '.[] | select(.title=="v0.4.0") | {number,title,open_issues,closed_issues,state}'`
+- `gh api 'repos/catu-ai/easyharness/issues?milestone=6&state=open&per_page=100' --jq '.[] | {number,title,state,html_url}'`
+
+## Review Summary
+
+Finalize `review-001-full` passed with no blocking findings. The `agent_ux`
+and `workflow_boundary` reviewer slots found no issues. The
+`docs_consistency` slot reported one minor wording drift where the main
+`harness-execute` startup checklist described live remote handoff observations
+as local state; the wording was repaired to distinguish local review/evidence
+state from live remote handoff observations, and bootstrap output was
+resynchronized.
+
+## Archive Summary
+
+- Archived At: 2026-05-25T09:51:59+08:00
+- Revision: 1
+- PR: NONE. Create or update the PR after committing and pushing this archived
+  candidate.
+- Ready: The tracked steps are complete, acceptance criteria are checked,
+  validation has passed, and full finalize review passed with the single
+  non-blocking docs wording finding repaired.
+- Merge Handoff: After archive, commit the archive move and summary updates,
+  push the branch, open or update the PR for issue #202, record publish
+  evidence with the PR URL, then use `harness evidence refresh` or manual
+  CI/sync evidence until `harness status` reaches
+  `execution/finalize/await_merge`. Landing this candidate should also make
+  parent issue #12 ready to close or explicitly retarget.
+
+## Outcome Summary
+
+### Delivered
+
+- Added status-first remote handoff guidance to the managed
+  `harness-execute` skill.
+- Added a controller decision guide for missing recorded PR evidence,
+  unsupported handoff targets, degraded observations, pending checks, failed
+  checks, passing/fresh live facts that still need evidence refresh, stale or
+  conflicted sync, live drift after local merge-ready evidence, and already
+  merged PRs.
+- Tightened closeout/archive and Pre-Land guidance so controllers use
+  `harness status` first, record remote facts through `harness evidence
+  refresh` or manual evidence submit, and keep git/GitHub write actions outside
+  harness core commands.
+- Synchronized the materialized `.agents/skills/harness-execute` output from
+  `assets/bootstrap/`.
+- Rechecked the v0.4.0 milestone: #202 and umbrella #12 are the only open
+  issues, and #202 appears to be the last concrete child item in #12's v0.4.0
+  split.
+
+### Not Delivered
+
+NONE.
+
+### Follow-Up Issues
+
+NONE


### PR DESCRIPTION
## Summary

- Add status-first remote handoff guidance to the managed `harness-execute` skill.
- Cover controller responses for missing PR evidence, degraded reads, pending/failed checks, passing or fresh facts that still need evidence refresh, stale/conflicted sync, live drift, and already-merged PRs.
- Sync the materialized `.agents/skills/harness-execute` output and archive the tracked plan.

Closes #202.

## Parent scope

#12 is the v0.4.0 umbrella for read-only remote handoff. As of this plan's closeout, #202 and #12 are the only open v0.4.0 issues, and #202 appears to be the last concrete child item in #12's split.

## Validation

- `scripts/sync-bootstrap-assets --check`
- `harness plan lint docs/plans/archived/2026-05-25-controller-remote-handoff-guidance.md`
- `git diff --check`
- Full finalize review: `review-001-full` passed with no blocking findings; one minor docs wording finding was fixed before archive.
