### PR TITLE
Standardize PR body handoff guidance

### DIFF
--- a/.agents/skills/harness-execute/references/closeout-and-archive.md
+++ b/.agents/skills/harness-execute/references/closeout-and-archive.md
@@ -43,8 +43,9 @@ Archive still needs an explicit handoff flow:
 2. Push the branch.
 3. Open or update the PR.
 4. If the profile is `lightweight`, update the agreed repo-visible breadcrumb
-   such as the PR body note before treating the candidate as ready to wait for
-   merge approval.
+   such as the PR body memo before treating the candidate as ready to wait for
+   merge approval. Follow the readable `What Changed`, `Confidence`, and
+   optional `Handoff` shape in [publish-ci-sync.md](publish-ci-sync.md).
 5. Run `harness status` again to confirm the archived candidate entered
    `execution/finalize/publish` for this worktree.
 6. Record publish evidence with the PR URL or handoff target through

--- a/.agents/skills/harness-execute/references/publish-ci-sync.md
+++ b/.agents/skills/harness-execute/references/publish-ci-sync.md
@@ -28,11 +28,45 @@ but record the observed external facts through harness-owned evidence:
    PR URL, use manual
    `harness evidence submit --kind publish|ci|sync --input <json>` for the
    affected evidence domains
-8. once those remote facts exist, run the `Pre-Land` scan from
+8. write or update the PR body as a readable merge memo; see
+   [PR Body Handoff](#pr-body-handoff)
+9. once those remote facts exist, run the `Pre-Land` scan from
    [controller-truth-surfaces.md](controller-truth-surfaces.md) before treating
    the archived candidate as genuinely merge-ready
-9. only then treat the candidate as ready to enter
+10. only then treat the candidate as ready to enter
    `execution/finalize/await_merge`
+
+## PR Body Handoff
+
+Treat the PR body as a human merge memo, not as a copied execution log. The
+tracked plan and harness evidence already hold the full audit trail: scope,
+acceptance criteria, validation commands, review rounds, repair history, and
+publish/CI/sync facts. The PR body should summarize why the branch is
+mergeable without asking the human to rereview the diff.
+
+Use this shape unless the repository has a stricter local convention:
+
+- `What Changed`
+  - Lead with what is now true after the PR.
+  - Write a readable explanation, not a file list, command list, commit-log
+    rewrite, or pasted plan summary.
+  - Use short paragraphs or bullets according to the change shape. Length is
+    secondary to clarity.
+- `Confidence`
+  - Combine self-review and validation into three to five high-signal bullets.
+  - Each bullet should name a checked risk surface and the result, such as
+    contract sync, generated bootstrap output, remote experiment completeness,
+    focused tests, review-found repairs, or diff hygiene.
+  - Do not dump raw validation commands unless the command result itself is the
+    user-facing fact, such as release version parsing.
+- `Handoff`
+  - Include only merge-time, release-time, follow-up, non-goal, known-gap, or
+    deferred-work notes that still matter after reading the PR.
+  - Omit the section when it has no useful content.
+
+For lightweight work, the required repo-visible breadcrumb can be this PR body
+memo. It should still explain why the lightweight path was appropriate, but it
+should follow the same readable merge-memo standard.
 
 ## Status-First Remote Handoff
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,8 @@ lightweight`, keep the same workflow shape but store the active plan under
 `docs/plans/active/` like any other plan. Only the archived lightweight
 snapshot moves to `.local/harness/plans/archived/<plan-stem>.md`. That
 shortcut does not remove human steering, low-risk eligibility checks, or the
-requirement to leave a repo-visible breadcrumb such as a PR body note.
+requirement to leave a repo-visible breadcrumb such as a readable PR body
+merge memo.
 
 Use `lightweight` only when all of these are true:
 

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -44,7 +44,8 @@ lightweight`, keep the same workflow shape but store the active plan under
 `docs/plans/active/` like any other plan. Only the archived lightweight
 snapshot moves to `.local/harness/plans/archived/<plan-stem>.md`. That
 shortcut does not remove human steering, low-risk eligibility checks, or the
-requirement to leave a repo-visible breadcrumb such as a PR body note.
+requirement to leave a repo-visible breadcrumb such as a readable PR body
+merge memo.
 
 Use `lightweight` only when all of these are true:
 

--- a/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
+++ b/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
@@ -43,8 +43,9 @@ Archive still needs an explicit handoff flow:
 2. Push the branch.
 3. Open or update the PR.
 4. If the profile is `lightweight`, update the agreed repo-visible breadcrumb
-   such as the PR body note before treating the candidate as ready to wait for
-   merge approval.
+   such as the PR body memo before treating the candidate as ready to wait for
+   merge approval. Follow the readable `What Changed`, `Confidence`, and
+   optional `Handoff` shape in [publish-ci-sync.md](publish-ci-sync.md).
 5. Run `harness status` again to confirm the archived candidate entered
    `execution/finalize/publish` for this worktree.
 6. Record publish evidence with the PR URL or handoff target through

--- a/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
+++ b/assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md
@@ -28,11 +28,45 @@ but record the observed external facts through harness-owned evidence:
    PR URL, use manual
    `harness evidence submit --kind publish|ci|sync --input <json>` for the
    affected evidence domains
-8. once those remote facts exist, run the `Pre-Land` scan from
+8. write or update the PR body as a readable merge memo; see
+   [PR Body Handoff](#pr-body-handoff)
+9. once those remote facts exist, run the `Pre-Land` scan from
    [controller-truth-surfaces.md](controller-truth-surfaces.md) before treating
    the archived candidate as genuinely merge-ready
-9. only then treat the candidate as ready to enter
+10. only then treat the candidate as ready to enter
    `execution/finalize/await_merge`
+
+## PR Body Handoff
+
+Treat the PR body as a human merge memo, not as a copied execution log. The
+tracked plan and harness evidence already hold the full audit trail: scope,
+acceptance criteria, validation commands, review rounds, repair history, and
+publish/CI/sync facts. The PR body should summarize why the branch is
+mergeable without asking the human to rereview the diff.
+
+Use this shape unless the repository has a stricter local convention:
+
+- `What Changed`
+  - Lead with what is now true after the PR.
+  - Write a readable explanation, not a file list, command list, commit-log
+    rewrite, or pasted plan summary.
+  - Use short paragraphs or bullets according to the change shape. Length is
+    secondary to clarity.
+- `Confidence`
+  - Combine self-review and validation into three to five high-signal bullets.
+  - Each bullet should name a checked risk surface and the result, such as
+    contract sync, generated bootstrap output, remote experiment completeness,
+    focused tests, review-found repairs, or diff hygiene.
+  - Do not dump raw validation commands unless the command result itself is the
+    user-facing fact, such as release version parsing.
+- `Handoff`
+  - Include only merge-time, release-time, follow-up, non-goal, known-gap, or
+    deferred-work notes that still matter after reading the PR.
+  - Omit the section when it has no useful content.
+
+For lightweight work, the required repo-visible breadcrumb can be this PR body
+memo. It should still explain why the lightweight path was appropriate, but it
+should follow the same readable merge-memo standard.
 
 ## Status-First Remote Handoff
 

--- a/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
+++ b/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
@@ -151,7 +151,7 @@ or command dumps.
 
 ### Step 2: Sync outputs and validate the guidance
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -187,11 +187,19 @@ record that explicitly in execution notes rather than forcing a spec edit.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Ran `scripts/sync-bootstrap-assets`, which refreshed the materialized root
+`AGENTS.md` managed block and `.agents/skills/harness-execute` reference files
+from `assets/bootstrap/`. Validation confirmed bootstrap outputs are in sync,
+the tracked plan lints, targeted wording checks find the new merge-memo
+guidance in both source and materialized outputs, and diff hygiene is clean.
+No normative spec edit was skipped; the lightweight breadcrumb references in
+`cli-contract`, `state-model`, and `plan-schema` were updated in Step 1.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 2 only synchronized generated bootstrap outputs
+from the reviewed source guidance and reran the planned consistency checks.
+The guidance contract itself passed `review-001-delta` in Step 1.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
+++ b/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
@@ -60,21 +60,21 @@ the tracked plan and harness evidence artifacts.
 
 ## Acceptance Criteria
 
-- [ ] Managed controller guidance tells agents to use a `What Changed`,
+- [x] Managed controller guidance tells agents to use a `What Changed`,
       `Confidence`, and optional `Handoff` PR body shape during publish
       handoff.
-- [ ] `What Changed` guidance explains that the section should lead with the
+- [x] `What Changed` guidance explains that the section should lead with the
       outcome, use readable short sentences, and avoid file-shaped or
       command-shaped summaries.
-- [ ] `Confidence` guidance explains that self-review and validation are
+- [x] `Confidence` guidance explains that self-review and validation are
       combined and condensed into risk-surface-plus-result bullets, with raw
       command lists left to the tracked plan or evidence artifacts.
-- [ ] Guidance clearly distinguishes what belongs in the PR body from what
+- [x] Guidance clearly distinguishes what belongs in the PR body from what
       belongs in the plan and what belongs in harness evidence.
-- [ ] Lightweight repo-visible breadcrumb guidance remains intact but points at
+- [x] Lightweight repo-visible breadcrumb guidance remains intact but points at
       the same readable merge-memo principles.
-- [ ] Bootstrap assets and materialized skill outputs are synchronized.
-- [ ] Validation confirms plan lint, bootstrap sync check, and targeted wording
+- [x] Bootstrap assets and materialized skill outputs are synchronized.
+- [x] Validation confirms plan lint, bootstrap sync check, and targeted wording
       checks pass.
 
 ## Deferred Items

--- a/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
+++ b/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
@@ -225,25 +225,59 @@ code or generated contracts.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `scripts/sync-bootstrap-assets --check`
+- `harness plan lint docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md`
+- Targeted wording checks for `What Changed`, `Confidence`, `Handoff`,
+  `PR body`, `repo-visible breadcrumb`, `merge memo`, and `validation command`
+  across managed source, materialized outputs, root guidance, and specs.
+- `git diff --check`
+- Repair validation after finalize review: plan lint, bootstrap sync check,
+  diff hygiene, and deferred/follow-up scan all passed.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step-closeout delta review `review-001-delta` passed with no findings across
+  `docs_consistency` and `agent_ux`.
+- Finalize review `review-002-full` found one archive-readiness blocker: real
+  deferred items still had `Follow-Up Issues: NONE`.
+- The blocker was repaired by adding explicit follow-up handoff bullets for
+  possible future PR body generation/linting and downstream repository
+  templates.
+- Finalize repair review `review-003-full` passed with no findings across
+  `archive_readiness` and `docs_consistency`.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-05-25T22:35:49+08:00
+- Revision: 1
+- PR: pending publish after archive; no PR URL exists yet.
+- Ready: Managed source guidance, materialized bootstrap output, root managed
+  block, and normative specs agree on the readable PR body merge-memo
+  standard, and the final repair review passed cleanly.
+- Merge Handoff: Commit the archive move, push branch
+  `codex/pr-body-handoff-guidance`, open or update the PR with a `What
+  Changed` / `Confidence` / optional `Handoff` body, then record publish, CI,
+  and sync evidence before waiting for merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added PR body handoff guidance to the managed `harness-execute`
+  publish/CI/sync reference.
+- Defined the preferred PR body shape as `What Changed`, `Confidence`, and
+  optional `Handoff`.
+- Clarified that PR bodies are readable merge memos for human merge approval,
+  while tracked plans and harness evidence hold the full audit trail.
+- Updated lightweight breadcrumb wording in managed guidance and normative
+  specs to point at readable PR body merge memos.
+- Synchronized materialized `.agents/skills` output and the root managed
+  `AGENTS.md` block from `assets/bootstrap`.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No automated PR body generation or linting was added.
+- No downstream repository-specific PR template was created.
 
 ### Follow-Up Issues
 

--- a/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
+++ b/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
@@ -247,4 +247,7 @@ PENDING_UNTIL_ARCHIVE
 
 ### Follow-Up Issues
 
-NONE
+- Future work may add automated PR body generation or linting if repeated
+  manual application of the merge-memo guidance proves inconsistent.
+- Downstream repositories may add local PR templates when their domain needs
+  more specific handoff fields than the generic easyharness guidance provides.

--- a/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
+++ b/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
@@ -1,0 +1,236 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-25T22:23:40+08:00"
+approved_at: "2026-05-25T22:25:15+08:00"
+source_type: direct_request
+source_refs:
+    - https://github.com/catu-ai/easyharness/pull/217
+    - https://github.com/catu-ai/easyharness/pull/215
+    - https://github.com/yzhang1918/HEJI/pull/107
+    - https://github.com/yzhang1918/HEJI/pull/106
+size: S
+---
+
+# Standardize PR Body Handoff Guidance
+
+## Goal
+
+Update the distributed easyharness controller guidance so PR bodies become
+readable merge memos instead of duplicated execution logs.
+
+The end state should make the PR body answer three human-facing questions:
+what changed, why the branch is mergeable without a human rereviewing the diff,
+and what handoff notes still matter. Detailed commands, review trajectory,
+acceptance criteria, repair history, and full validation records should stay in
+the tracked plan and harness evidence artifacts.
+
+## Scope
+
+### In Scope
+
+- Define the preferred PR body structure as:
+  - `What Changed`
+  - `Confidence`
+  - `Handoff`
+- Describe `What Changed` as outcome-first and story-shaped rather than a file
+  list, command log, commit-log rewrite, or copied plan summary.
+- Describe `Confidence` as a compact merge of self-review and validation:
+  three to five high-signal bullets that pair each checked risk surface with
+  its result.
+- Clarify that raw validation command lists, full review-round logs, and
+  step-by-step execution history belong in the tracked plan or evidence
+  artifacts, not in the PR body.
+- Clarify the boundary between PR body, tracked plan, and harness evidence for
+  standard and lightweight workflows.
+- Update the managed bootstrap skill guidance under `assets/bootstrap/` and
+  refresh the materialized `.agents/skills/` output.
+- Update any normative spec wording that currently mentions PR-body
+  breadcrumbs if it needs to point at the new merge-memo shape.
+
+### Out of Scope
+
+- Adding a `harness publish` command or automating PR body creation.
+- Changing publish, CI, sync, review, archive, land, or state-transition
+  semantics.
+- Rewriting historical PR bodies.
+- Rewriting archived plans except for this plan's normal execution closeout.
+- Creating repository-specific PR templates for HEJI, missless, or any
+  downstream repository.
+- Requiring humans to review code diffs after harness finalize review.
+
+## Acceptance Criteria
+
+- [ ] Managed controller guidance tells agents to use a `What Changed`,
+      `Confidence`, and optional `Handoff` PR body shape during publish
+      handoff.
+- [ ] `What Changed` guidance explains that the section should lead with the
+      outcome, use readable short sentences, and avoid file-shaped or
+      command-shaped summaries.
+- [ ] `Confidence` guidance explains that self-review and validation are
+      combined and condensed into risk-surface-plus-result bullets, with raw
+      command lists left to the tracked plan or evidence artifacts.
+- [ ] Guidance clearly distinguishes what belongs in the PR body from what
+      belongs in the plan and what belongs in harness evidence.
+- [ ] Lightweight repo-visible breadcrumb guidance remains intact but points at
+      the same readable merge-memo principles.
+- [ ] Bootstrap assets and materialized skill outputs are synchronized.
+- [ ] Validation confirms plan lint, bootstrap sync check, and targeted wording
+      checks pass.
+
+## Deferred Items
+
+- Automated PR body generation or linting.
+- Downstream repository-specific templates.
+
+## Work Breakdown
+
+### Step 1: Define the PR body guidance contract
+
+- Done: [ ]
+
+#### Objective
+
+Write the reusable guidance for what easyharness expects a PR body to contain
+and what it should leave to the tracked plan or evidence artifacts.
+
+#### Details
+
+The guidance should encode the discovered direction:
+
+- PR body is a human merge memo, not a review request or execution log.
+- `What Changed` explains what is now true after the PR. It should be
+  outcome-first, story-shaped, and readable; length is secondary to clarity.
+- `Confidence` combines self-review and validation into concise bullets. Each
+  bullet should name a risk surface and the evidence/result that supports
+  merge confidence.
+- `Handoff` is optional and only carries merge-time, release-time, follow-up,
+  non-goal, known-gap, or deferred-work notes that matter after reading the PR.
+- The tracked plan remains the full audit trail for scope, acceptance criteria,
+  commands, review rounds, repairs, validation details, and outcome history.
+- Harness evidence remains the durable record for publish, CI, and sync facts.
+
+The guidance may include a small illustrative example if that makes the
+standard easier for future agents to apply, but it should avoid a long template
+that agents copy mechanically.
+
+#### Expected Files
+
+- `assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md`
+- `assets/bootstrap/skills/harness-execute/references/publish-ci-sync.md`
+- `assets/bootstrap/agents-managed-block.md`
+- `docs/specs/cli-contract.md`
+- `docs/specs/state-model.md`
+
+#### Validation
+
+- The edited source guidance consistently uses the `What Changed`,
+  `Confidence`, and `Handoff` terms.
+- Targeted search confirms the older generic "PR body note" or
+  "repo-visible breadcrumb" wording is either still correct or explicitly tied
+  to the new merge-memo standard.
+
+#### Execution Notes
+
+Added the reusable PR body handoff guidance to the managed
+`harness-execute` publish/CI/sync reference. The new guidance defines the PR
+body as a readable merge memo with `What Changed`, `Confidence`, and optional
+`Handoff`, and it draws the boundary between PR body, tracked plan, and
+harness evidence. Updated lightweight breadcrumb wording in the managed block
+and normative specs so PR body breadcrumbs point at the same merge-memo shape.
+Validation used targeted wording search, `git diff --check`, and plan lint.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Sync outputs and validate the guidance
+
+- Done: [ ]
+
+#### Objective
+
+Refresh generated bootstrap outputs, verify the managed guidance is coherent in
+both source and materialized locations, and leave the plan ready for normal
+harness review and archive.
+
+#### Details
+
+Run the repository's bootstrap sync after editing `assets/bootstrap/`. Then
+verify that `.agents/skills/` and the managed block are synchronized and that
+the new PR-body guidance does not conflict with publish/CI/sync evidence
+semantics or lightweight breadcrumb requirements.
+
+If execution discovers that the normative spec wording does not need changes,
+record that explicitly in execution notes rather than forcing a spec edit.
+
+#### Expected Files
+
+- `.agents/skills/harness-execute/references/closeout-and-archive.md`
+- `.agents/skills/harness-execute/references/publish-ci-sync.md`
+- `AGENTS.md`
+- `docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md`
+
+#### Validation
+
+- `scripts/sync-bootstrap-assets --check`
+- `harness plan lint docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md`
+- targeted `rg` checks for `What Changed`, `Confidence`, `Handoff`,
+  `PR body`, and `repo-visible breadcrumb` across managed source and
+  materialized outputs
+- `git diff --check`
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+This is a guidance-only change, so validation should focus on plan integrity,
+bootstrap synchronization, wording consistency, and diff hygiene. No Go,
+frontend, or end-to-end runtime tests are expected unless execution changes
+code or generated contracts.
+
+## Risks
+
+- Risk: The PR body standard could become a rigid template that produces
+  formulaic text instead of clearer handoff notes.
+  - Mitigation: Phrase `What Changed` as a readability principle and permit
+    paragraphs or bullets according to the shape of the change.
+- Risk: Condensing validation could hide important merge risks.
+  - Mitigation: Require `Confidence` bullets to pair each checked risk surface
+    with a result, and keep full validation details in the tracked plan and
+    evidence artifacts.
+- Risk: Updating only the skill source could leave materialized bootstrap
+  output stale.
+  - Mitigation: Run bootstrap sync and verify with
+    `scripts/sync-bootstrap-assets --check`.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
+++ b/docs/plans/active/2026-05-25-standardize-pr-body-handoff-guidance.md
@@ -86,7 +86,7 @@ the tracked plan and harness evidence artifacts.
 
 ### Step 1: Define the PR body guidance contract
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -141,7 +141,13 @@ Validation used targeted wording search, `git diff --check`, and plan lint.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+Step-closeout delta review `review-001-delta` passed with no findings. The
+`docs_consistency` slot confirmed that managed bootstrap source and normative
+specs consistently frame PR bodies as readable merge memos while preserving
+lightweight breadcrumb and publish/CI/sync evidence semantics. The `agent_ux`
+slot confirmed that future controllers can distinguish `What Changed`,
+`Confidence`, and optional `Handoff` without being steered into rigid templates
+or command dumps.
 
 ### Step 2: Sync outputs and validate the guidance
 

--- a/docs/plans/archived/2026-05-25-standardize-pr-body-handoff-guidance.md
+++ b/docs/plans/archived/2026-05-25-standardize-pr-body-handoff-guidance.md
@@ -248,7 +248,7 @@ code or generated contracts.
 
 ## Archive Summary
 
-- Archived At: 2026-05-25T22:35:49+08:00
+- Archived At: 2026-05-25T22:36:14+08:00
 - Revision: 1
 - PR: pending publish after archive; no PR URL exists yet.
 - Ready: Managed source guidance, materialized bootstrap output, root managed

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -529,8 +529,9 @@ Contract:
   landed candidate, return `state.current_node: idle` with landed context in
   `artifacts`
 - when the current plan uses the lightweight profile, remind the controller to
-  leave the agreed repo-visible breadcrumb, such as a PR body note explaining
-  why the lightweight path was used
+  leave the agreed repo-visible breadcrumb, such as a readable PR body merge
+  memo explaining what changed, why the branch is mergeable, and why the
+  lightweight path was used
 - return recommended next actions for both "continue work" and "wait/observe"
   situations
 - if an already completed earlier step is missing review-complete closeout,
@@ -951,7 +952,8 @@ Important note:
   treating the candidate as truly waiting for merge approval
 - the controller agent should also update the agreed repo-visible breadcrumb
   for `lightweight` before treating the candidate as truly waiting for merge
-  approval
+  approval; a PR body breadcrumb should read as a merge memo rather than a raw
+  validation command log
 - after archive, record publish, CI, and sync observations through
   `harness evidence submit` instead of treating missing evidence as success
 - after archive, correctness should not depend on archived supplements still

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -445,7 +445,7 @@ The lightweight profile is eligible only when all of these are true:
     schema meaning, state transitions, review/archive/evidence semantics,
     release safety, or security-sensitive behavior
 - the controller can explain the lightweight choice in one small repo-visible
-  breadcrumb such as a PR body note
+  breadcrumb such as a readable PR body merge memo
 - the plan can stay clear and reviewable without depending on supplements as a
   default authoring pattern
 

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -295,8 +295,9 @@ appropriate archive move or snapshot update.
 The plan is already archived, but merge readiness still depends on external
 handoff facts recorded through `publish`, `ci`, and `sync` evidence. For
 lightweight work, this phase is also where status should remind the controller
-to leave the agreed repo-visible breadcrumb, such as a PR body note explaining
-why the lightweight path was used.
+to leave the agreed repo-visible breadcrumb. A PR body can satisfy that
+breadcrumb when it is a readable merge memo that explains what changed, why the
+branch is mergeable, and why the lightweight path was appropriate.
 
 ### `execution/finalize/await_merge`
 


### PR DESCRIPTION
## What Changed

This PR teaches easyharness controllers to write PR bodies as readable merge memos instead of execution logs.

The managed publish handoff guidance now uses a `What Changed`, `Confidence`, and optional `Handoff` shape. `What Changed` leads with the outcome in plain language. `Confidence` combines self-review and validation into a few risk-surface-plus-result bullets. `Handoff` is reserved for merge-time, release-time, follow-up, non-goal, known-gap, or deferred-work notes that still matter after reading the PR.

The lightweight breadcrumb wording now points at the same merge-memo standard across the managed block, status/archive specs, plan schema, and materialized bootstrap outputs.

## Confidence

- Managed source and materialized outputs are synchronized; `scripts/sync-bootstrap-assets --check` passed after the asset sync.
- Plan integrity and archive readiness were checked with `harness plan lint` before and after archive.
- Targeted wording checks confirmed the new PR body vocabulary and breadcrumb wording appear in the managed source, materialized outputs, root guidance, and specs.
- Step review `review-001-delta` passed with no findings; finalize review found one archive handoff blocker, it was fixed, and repair review `review-003-full` passed with no findings.
- Diff hygiene passed with `git diff --check`.

## Handoff

Archived plan: `docs/plans/archived/2026-05-25-standardize-pr-body-handoff-guidance.md`.

Deferred follow-up remains non-blocking: automated PR body generation/linting and downstream repo-specific templates can be considered later if manual application of this guidance proves inconsistent.
