### PR TITLE
Document 0.x release policy

### DIFF
--- a/.agents/skills/issue-triage/SKILL.md
+++ b/.agents/skills/issue-triage/SKILL.md
@@ -51,9 +51,9 @@ Use milestones for real version intent, not vague release buckets.
 
 A milestone means "this issue belongs to the intended scope of that version"
 and should be more specific than `state/accepted`. It does not by itself mean
-the release is ready to cut, nor does it define the release cadence or quality
-bar. Those release-policy questions remain separate work, currently tracked by
-issue `#87`.
+the release is ready to cut. The release policy in `docs/releasing.md` defines
+minor versus patch release shape, release-readiness judgment, and when patch
+releases can skip milestones.
 
 ## Workflow
 

--- a/.agents/skills/release-triage/SKILL.md
+++ b/.agents/skills/release-triage/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: release-triage
-description: Decide whether easyharness maintainers should consider a release PR after merged work, milestone closeout, or release-scope review. Use only for advisory release-readiness checks in this repository; do not bump versions or publish releases.
+description: Proactively use after every easyharness PR lands, and when checking milestone closeout or release scope, to decide whether to recommend that the human open a patch or minor release PR. This repo-local skill is advisory only: do not bump VERSION, create release PRs, publish releases, or create release-process machinery.
 ---
 
 # Release Triage
 
 ## Overview
 
-Use this repo-local skill when reviewing whether recent `easyharness` work is
-ready to ship as a patch or minor release. The skill is advisory: it helps the
-agent recommend a next release action, but it does not authorize publishing,
-version bumps, issue closure, or milestone creation by itself.
+Use this repo-local skill proactively after every `easyharness` PR lands, and
+when reviewing whether recent work, milestone closeout, or release-scope
+changes are ready to ship as a patch or minor release. The skill is advisory:
+it helps the agent recommend a next release action to the human, but it does
+not authorize publishing, version bumps, issue closure, or milestone creation
+by itself.
 
 Read `docs/releasing.md` first. That file is the policy source for the public
 0.x release line, including minor versus patch shape, optional patch

--- a/.agents/skills/release-triage/SKILL.md
+++ b/.agents/skills/release-triage/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: release-triage
+description: Decide whether easyharness maintainers should consider a release PR after merged work, milestone closeout, or release-scope review. Use only for advisory release-readiness checks in this repository; do not bump versions or publish releases.
+---
+
+# Release Triage
+
+## Overview
+
+Use this repo-local skill when reviewing whether recent `easyharness` work is
+ready to ship as a patch or minor release. The skill is advisory: it helps the
+agent recommend a next release action, but it does not authorize publishing,
+version bumps, issue closure, or milestone creation by itself.
+
+Read `docs/releasing.md` first. That file is the policy source for the public
+0.x release line, including minor versus patch shape, optional patch
+milestones, and release-readiness judgment.
+
+## Inputs
+
+- the relevant merged PRs, closed issues, or active milestone
+- current `VERSION`
+- the latest GitHub Release, when release recency matters
+- `docs/releasing.md`
+- any known release blockers, failed CI, or post-publication repair context
+
+## Workflow
+
+1. Identify the question: recent land follow-up, milestone closeout, patch
+   consideration, minor release consideration, or release repair.
+2. Read `docs/releasing.md` before making a recommendation.
+3. Inspect the relevant GitHub issue or milestone:
+   - for minor candidates, check whether the milestone represents one coherent
+     user promise and whether its release-critical issues are closed
+   - for patch candidates, check whether the work is a small repair,
+     same-theme fast-follow, documentation/CI correction, or another low-risk
+     improvement worth shipping without waiting for a later minor
+4. Check whether required CI or known blocker information is already available.
+   If it is not available, say what needs checking rather than pretending the
+   release is ready.
+5. Recommend exactly one next action:
+   - `No release recommended yet`
+   - `Consider a patch release PR`
+   - `Consider a minor release PR`
+   - `Shape or adjust the milestone first`
+6. Explain the recommendation in a short paragraph with concrete references to
+   the issue, milestone, PR, or release policy that drove the judgment.
+
+## Recommendation Guidance
+
+Recommend `No release recommended yet` when the merged work is internal,
+incomplete, blocked, too small to matter on its own, or better batched with
+nearby work.
+
+Recommend `Consider a patch release PR` when `main` contains a small repair,
+low-risk fast-follow, or same-theme improvement that users should get before
+the next minor. Do not require a patch milestone unless the patch needs an
+explicit coordinated bucket.
+
+Recommend `Consider a minor release PR` when the target milestone's
+release-critical issues are complete and together deliver a coherent
+user-facing promise. Minor releases should feel like a complete first version
+of the promise, not only a specification or a half-finished feature family.
+
+Recommend `Shape or adjust the milestone first` when the issue list does not
+yet match the release promise: the milestone includes broad backlog ideas,
+misses release-critical work, carries open blockers, or needs clearer
+must-deliver versus follow-up boundaries in issue bodies.
+
+## Guardrails
+
+- Do not edit `VERSION`.
+- Do not create a release PR.
+- Do not create, close, or retitle milestones unless the human explicitly asks
+  for that action.
+- Do not publish, rerun, or repair a release.
+- Do not add priority labels, project fields, or tracker issues.
+- Do not require patch releases to have milestones.
+- Do not treat this skill as part of the distributed easyharness-managed skill
+  pack. It belongs under `.agents/skills/` only unless the repository later
+  makes a deliberate promotion decision.

--- a/.agents/skills/release-triage/SKILL.md
+++ b/.agents/skills/release-triage/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: release-triage
-description: Proactively use after every easyharness PR lands, and when checking milestone closeout or release scope, to decide whether to recommend that the human open a patch or minor release PR. This repo-local skill is advisory only: do not bump VERSION, create release PRs, publish releases, or create release-process machinery.
+description: >-
+  Proactively use after every easyharness PR lands, and when checking milestone
+  closeout or release scope, to decide whether to recommend that the human open
+  a patch or minor release PR. This repo-local skill is advisory only: do not
+  bump VERSION, create release PRs, publish releases, or create release-process
+  machinery.
 ---
 
 # Release Triage

--- a/docs/plans/active/2026-05-29-document-0-x-release-policy.md
+++ b/docs/plans/active/2026-05-29-document-0-x-release-policy.md
@@ -1,0 +1,321 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-29T00:04:04+08:00"
+approved_at: "2026-05-29T00:05:40+08:00"
+source_type: issue
+source_refs:
+    - '#87'
+size: S
+---
+
+# Document 0.x release policy and release-readiness triage
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Resolve issue #87 by documenting the repository's current 0.x release policy:
+minor releases represent coherent user-facing promises, patch releases can be
+lightweight fast-follows or repairs, and version bumps happen only in dedicated
+release PRs after the intended scope is ready.
+
+Add one repo-local `release-triage` skill that helps future agents decide,
+after merged work or milestone closeout, whether to recommend no release, a
+patch release PR, a minor release PR, or more milestone shaping. The skill is a
+repository helper only; it should not become part of the distributed
+easyharness-managed skill pack.
+
+## Scope
+
+### In Scope
+
+- Update `docs/releasing.md` with a concise release policy for the public 0.x
+  line.
+- Clarify that ordinary implementation PRs do not bump `VERSION`; only a
+  dedicated release PR bumps the tracked release source of truth.
+- Define minor releases as coherent user promises, usually represented by a
+  concrete GitHub milestone whose release-critical issues are complete.
+- Define patch releases as small repairs, fast-follows, or same-theme
+  incremental improvements that do not require a patch milestone by default.
+- State that milestones are release promises, not feature-family backlogs, and
+  that issue bodies may carry lightweight context for must-deliver,
+  fast-follow, and later/not-now distinctions when useful.
+- Clarify the release bar as required CI plus maintainer judgment about scope,
+  blockers, and publication readiness, rather than duplicating CI command lists
+  as manual ceremony.
+- Update repo-local issue triage guidance so future triage points to the new
+  release policy instead of treating #87 as unresolved.
+- Update issue #87's live GitHub title/body or closing handoff so the issue no
+  longer frames the work as alpha-only.
+- Add a repo-local `.agents/skills/release-triage/SKILL.md` for release
+  readiness recommendation after meaningful land, milestone closeout, or
+  release-scope review.
+
+### Out of Scope
+
+- Changing release automation, `VERSION` semantics, tag creation, GitHub
+  Actions workflows, release asset packaging, or Homebrew publishing behavior.
+- Adding priority labels, GitHub Projects, custom fields, a long-running
+  release tracker issue, or a new roadmap document for customization
+  follow-ups.
+- Requiring patch releases to use GitHub milestones.
+- Closing #87 before the tracked policy change has landed.
+- Adding `release-triage` to `assets/bootstrap/` or the distributed
+  easyharness-managed skill pack.
+- Reworking current `v0.5.0` scope or splitting customization issues as part
+  of this slice.
+
+## Acceptance Criteria
+
+- [x] `docs/releasing.md` explains how `easyharness` chooses minor versus
+      patch releases during the public 0.x line.
+- [x] The policy states that release PRs, not ordinary feature/fix PRs, bump
+      `VERSION`.
+- [x] The policy states that minor milestones hold the current release promise
+      and should contain only release-critical issues, while related
+      follow-ups can remain ordinary triaged issues until selected for a later
+      release.
+- [x] The policy allows routine patch releases without patch milestones while
+      preserving the option to create a patch milestone when a patch needs an
+      explicit bucket.
+- [x] The policy describes release readiness as required CI plus maintainer
+      judgment about scope completeness, known blockers, and post-publication
+      verification.
+- [x] Repo-local issue triage guidance no longer says release-cadence policy is
+      still tracked by #87 after this work lands.
+- [x] A repo-local `release-triage` skill exists, is not easyharness-managed,
+      and tells future agents how to recommend release readiness without
+      automatically bumping versions, creating milestones, or performing
+      release work.
+- [x] Issue #87 is updated or the archive/publish handoff clearly instructs
+      the PR to close it after merge.
+
+## Deferred Items
+
+- Any future release automation that detects closed milestones or opens
+  release PRs automatically.
+- Any future priority label system if the GitHub backlog later becomes hard to
+  steer with milestones, issue bodies, and maintainer judgment alone.
+- Any customization-specific issue splitting or `v0.5.0` milestone refinement
+  beyond using the new policy as context.
+
+## Work Breakdown
+
+### Step 1: Document the 0.x release policy
+
+- Done: [x]
+
+#### Objective
+
+Make the current release-selection rules durable in `docs/releasing.md` and
+align repo-local triage wording with the new policy.
+
+#### Details
+
+The policy should reflect the discovery decisions:
+
+- `easyharness` no longer ships alpha-only releases; the policy is for the
+  public 0.x line.
+- Minor releases should deliver a coherent user-facing promise, not a complete
+  feature universe. A minor can be built from several implementation PRs and
+  should usually be represented by a GitHub milestone.
+- Patch releases can include bugfixes, release repairs, documentation or CI
+  corrections, and small same-theme follow-ups. They do not need patch
+  milestones by default.
+- GitHub milestones should contain the issues that are critical for that
+  release promise. They should not become backlogs for every related idea.
+- Issue bodies may carry lightweight context such as "must deliver",
+  "likely fast-follow", and "later/not now" when that helps maintainers choose
+  future issues, but the repository should not add priority labels or a
+  separate tracker workflow in this slice.
+- Required CI is the mechanical release bar. Maintainer judgment still decides
+  whether the release scope is complete, whether blockers remain, and whether
+  publication verification needs repair.
+
+Update `.agents/skills/issue-triage/SKILL.md` so it points to the documented
+release policy once this work lands. Because this skill is repo-owned local
+material, edit `.agents/skills/` directly and do not sync bootstrap assets.
+
+#### Expected Files
+
+- `docs/releasing.md`
+- `.agents/skills/issue-triage/SKILL.md`
+
+#### Validation
+
+- Reread `docs/releasing.md` against issue #87's requested topics:
+  release timing shape, validation/release bar, urgent fixes, stable/public
+  line language, and milestone/patch interaction.
+- Confirm the issue-triage skill no longer describes #87 as the active source
+  of release-policy truth after the policy has been documented.
+
+#### Execution Notes
+
+Updated `docs/releasing.md` with a new `Release Policy` section for the public
+0.x line. It now distinguishes change-driven releases from calendar-driven
+cadence, keeps `VERSION` bumps in dedicated release PRs, defines minor releases
+as coherent user promises, allows routine patch releases without patch
+milestones, treats milestones as release promises rather than feature-family
+backlogs, and frames release readiness as required CI plus maintainer judgment.
+
+Updated `.agents/skills/issue-triage/SKILL.md` so milestone triage points to
+`docs/releasing.md` for release policy instead of describing #87 as unresolved.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 is text-only policy documentation and repo-local
+skill wording; finalize review will cover the combined docs/skill change.
+
+### Step 2: Add repo-local release readiness triage skill
+
+- Done: [x]
+
+#### Objective
+
+Create a small repo-local skill that future agents can use to recommend
+whether maintainers should consider a release PR after land, milestone
+closeout, or release-scope review.
+
+#### Details
+
+The skill should be advisory and lightweight. It should tell agents to inspect
+the relevant GitHub milestone, recently merged work, closed issues, release
+policy, and known blockers, then report one of a small set of recommendations:
+
+- no release recommended yet
+- consider a patch release PR
+- consider a minor release PR
+- shape or adjust a milestone before deciding
+
+It must not instruct agents to automatically bump `VERSION`, open release PRs,
+create milestones, close issues, or perform release publication. It should also
+avoid adding priority labels or tracker issues. The skill belongs only in this
+repository's local skill set and must not include easyharness-managed metadata.
+
+#### Expected Files
+
+- `.agents/skills/release-triage/SKILL.md`
+
+#### Validation
+
+- Confirm the skill references `docs/releasing.md` as the policy source.
+- Confirm the skill is repo-local only and does not appear under
+  `assets/bootstrap/`.
+- Reread the skill as a cold agent and verify it can produce an advisory
+  release-readiness recommendation without hidden chat context.
+
+#### Execution Notes
+
+Added `.agents/skills/release-triage/SKILL.md` as a repo-local advisory skill.
+It tells future agents to read `docs/releasing.md`, inspect relevant merged
+work, milestones, issues, CI/blocker context, and then recommend one of four
+outcomes: no release yet, consider a patch release PR, consider a minor release
+PR, or shape/adjust the milestone first. The guardrails explicitly forbid
+editing `VERSION`, opening release PRs, publishing releases, creating required
+patch milestones, adding priority labels, or treating the skill as distributed
+easyharness-managed material.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 adds one repo-local text skill with no runtime
+behavior; finalize review will cover whether the advisory boundaries are clear.
+
+### Step 3: Update #87 handoff and validate the plan package
+
+- Done: [x]
+
+#### Objective
+
+Make the live issue and tracked plan package consistent enough for execution,
+review, and eventual PR closeout.
+
+#### Details
+
+During execution, update issue #87's live title/body or add a clear rationale
+comment so the issue no longer frames the missing policy as "beyond alpha" and
+so maintainers can see that the intended resolution is the tracked
+`docs/releasing.md` policy plus the repo-local release-triage skill.
+
+If the implementation reaches archive before merge, the archive/publish
+handoff should make the closeout explicit: the PR should close #87 after the
+tracked policy lands. Do not close #87 while the policy is still only a local
+candidate.
+
+#### Expected Files
+
+- `docs/plans/active/2026-05-29-document-0-x-release-policy.md`
+- GitHub issue #87
+
+#### Validation
+
+- Run `harness plan lint` on the active plan after edits.
+- Run documentation or formatting checks that are locally relevant to changed
+  Markdown/skill files.
+- Confirm `git status --short` shows only intentional plan/docs/skill changes.
+
+#### Execution Notes
+
+Updated live GitHub issue #87 to `Define release policy for the public 0.x
+line` and replaced the alpha-only body with the current 0.x release-policy
+scope. Validation so far:
+
+- `harness plan lint docs/plans/active/2026-05-29-document-0-x-release-policy.md`
+- `git diff --check`
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 3 is issue text and plan validation bookkeeping;
+finalize review will cover the complete candidate before archive.
+
+## Validation Strategy
+
+- Lint the tracked plan with `harness plan lint`.
+- Reread the changed release policy and skills against #87 and this plan's
+  acceptance criteria.
+- Run any existing lightweight Markdown/docs checks if the repository exposes
+  one; otherwise record that the validation is review-based because the slice
+  is documentation and repo-local skill text only.
+
+## Risks
+
+- Risk: The policy becomes too bureaucratic and slows normal patch releases.
+  - Mitigation: State that patch milestones are optional and that release PRs
+    remain the only version-bump mechanism.
+- Risk: The policy under-specifies release readiness and future agents
+  recommend releases too eagerly.
+  - Mitigation: Require advisory recommendations to check CI, scope
+    completeness, known blockers, and maintainer judgment without
+    auto-publishing.
+- Risk: The new skill is mistaken for distributed easyharness behavior.
+  - Mitigation: Keep it under `.agents/skills/`, omit managed metadata, and
+    explicitly say it is repo-local.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/archived/2026-05-29-document-0-x-release-policy.md
+++ b/docs/plans/archived/2026-05-29-document-0-x-release-policy.md
@@ -225,6 +225,10 @@ every `easyharness` PR lands, and when checking milestone closeout or release
 scope, to decide whether to recommend that the human open a patch or minor
 release PR. The body overview was aligned with the same proactive trigger.
 
+Revision 3 finalize-fix converted the frontmatter `description` to folded YAML
+style after CI showed the unquoted colon in the proactive advisory sentence
+broke skill YAML parsing during bootstrap dogfood checks.
+
 #### Review Notes
 
 NO_STEP_REVIEW_NEEDED: Step 2 adds one repo-local text skill with no runtime
@@ -309,10 +313,12 @@ Validated the documentation and repo-local skill candidate with:
 - live #87 verification with `gh issue view 87 --json number,title,state,labels,body,url`
 - revision 1 remote PR CI through GitHub Actions `Go Test`
 - revision 1 local `go test ./...`
+- revision 3 `scripts/sync-bootstrap-assets --check`
 
 The slice is text-only. No Go, UI, release workflow, or packaging behavior
-changed in revision 2, so the finalize-fix validation was limited to plan lint,
-whitespace validation, and delta review of the skill trigger metadata.
+changed in revisions 2 or 3, so finalize-fix validation focused on plan lint,
+whitespace validation, bootstrap skill parsing, and delta review of the skill
+trigger metadata.
 
 ## Review Summary
 
@@ -333,14 +339,25 @@ the proactive discoverability trigger after every `easyharness` PR lands, while
 preserving advisory-only guardrails and accurately recording the repair in the
 active plan.
 
+Revision 3 fixed YAML formatting for that same frontmatter description after
+remote CI caught the parse failure. The follow-up review should confirm the
+proactive trigger remains discoverable and the YAML shape is valid.
+
+Finalize repair delta review `review-003-delta` passed with 0 findings at
+revision 3. The reviewer confirmed the folded YAML frontmatter parses, the
+proactive trigger remains discoverable in skill metadata, advisory-only
+guardrails are preserved, and the active plan accurately records the CI parse
+failure plus fix.
+
 ## Archive Summary
 
-- Archived At: 2026-05-29T22:43:37+08:00
-- Revision: 2
+- Archived At: 2026-05-29T22:52:01+08:00
+- Revision: 3
 - PR: Open from branch `codex/document-0-x-release-policy` after archive.
 - Ready: Documentation, repo-local skills, live issue #87 handoff, plan lint,
-  whitespace validation, finalize full review, and revision 2 delta repair
-  review are complete.
+  whitespace validation, bootstrap dogfood check, finalize full review,
+  revision 2 delta repair review, and revision 3 YAML-format delta review are
+  complete.
 - Merge Handoff: After PR publication, record publish evidence, refresh CI/sync
   evidence, and wait for human merge approval once `harness status` reaches
   `execution/finalize/await_merge`.
@@ -360,6 +377,8 @@ active plan.
 - Updated the `release-triage` frontmatter description so skill discovery can
   proactively trigger it after every `easyharness` PR lands and when checking
   milestone closeout or release scope.
+- Formatted the proactive frontmatter description as folded YAML so
+  repo-local skill parsing stays valid during bootstrap dogfood checks.
 - Updated live issue #87 to remove alpha-only framing and point at the tracked
   policy plus repo-local release-triage skill as the intended resolution.
 

--- a/docs/plans/archived/2026-05-29-document-0-x-release-policy.md
+++ b/docs/plans/archived/2026-05-29-document-0-x-release-policy.md
@@ -296,26 +296,66 @@ finalize review will cover the complete candidate before archive.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+Validated the documentation and repo-local skill candidate with:
+
+- `harness plan lint docs/plans/active/2026-05-29-document-0-x-release-policy.md`
+- `git diff --check`
+- live #87 verification with `gh issue view 87 --json number,title,state,labels,body,url`
+
+The slice is text-only. No Go, UI, release workflow, or packaging behavior
+changed, so runtime test suites were not run.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Finalize full review `review-001-full` passed with 0 findings at revision 1.
+Reviewer slots:
+
+- `policy_consistency`: no findings; confirmed the release policy,
+  issue-triage handoff, release-triage skill, active plan, and live issue #87
+  framing agree without stale alpha assumptions or rejected process machinery.
+- `agent_ux`: no findings; confirmed the repo-local release-triage skill is
+  advisory, points to `docs/releasing.md`, and includes guardrails against
+  version bumps, release PR creation, publication, milestone churn, priority
+  labels, tracker issues, and distributed-skill confusion.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-05-29T00:11:17+08:00
+- Revision: 1
+- PR: Open from branch `codex/document-0-x-release-policy` after archive.
+- Ready: Documentation, repo-local skills, live issue #87 handoff, plan lint,
+  whitespace validation, and finalize full review are complete.
+- Merge Handoff: After PR publication, record publish evidence, refresh CI/sync
+  evidence, and wait for human merge approval once `harness status` reaches
+  `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added the public 0.x release policy to `docs/releasing.md`, including
+  change-driven release timing, dedicated release PR version bumps, minor
+  release promises, optional patch milestones, milestone scope boundaries, and
+  release-readiness judgment.
+- Updated the repo-local `issue-triage` skill so milestone triage points to
+  `docs/releasing.md` for release policy instead of treating #87 as unresolved.
+- Added the repo-local `release-triage` skill for advisory release-readiness
+  recommendations after land, milestone closeout, or release-scope review.
+- Updated live issue #87 to remove alpha-only framing and point at the tracked
+  policy plus repo-local release-triage skill as the intended resolution.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No release automation, `VERSION` behavior, GitHub Actions workflows,
+  packaging, or Homebrew publishing behavior changed.
+- No priority labels, GitHub Projects, tracker issues, or roadmap documents
+  were added.
+- No patch milestone requirement was introduced.
+- No `v0.5.0` customization scope or issue splitting was performed.
 
 ### Follow-Up Issues
 
-NONE
+- No new GitHub follow-up issue was created. Deferred items are optional future
+  expansions already named in this plan: release automation, possible future
+  priority labels if the backlog outgrows the current system, and separate
+  customization milestone refinement if maintainers choose to pursue it later.

--- a/docs/plans/archived/2026-05-29-document-0-x-release-policy.md
+++ b/docs/plans/archived/2026-05-29-document-0-x-release-policy.md
@@ -219,6 +219,12 @@ editing `VERSION`, opening release PRs, publishing releases, creating required
 patch milestones, adding priority labels, or treating the skill as distributed
 easyharness-managed material.
 
+Revision 2 finalize-fix updated the skill frontmatter `description` to carry
+the proactive trigger condition directly in discoverable metadata: use after
+every `easyharness` PR lands, and when checking milestone closeout or release
+scope, to decide whether to recommend that the human open a patch or minor
+release PR. The body overview was aligned with the same proactive trigger.
+
 #### Review Notes
 
 NO_STEP_REVIEW_NEEDED: Step 2 adds one repo-local text skill with no runtime
@@ -301,9 +307,12 @@ Validated the documentation and repo-local skill candidate with:
 - `harness plan lint docs/plans/active/2026-05-29-document-0-x-release-policy.md`
 - `git diff --check`
 - live #87 verification with `gh issue view 87 --json number,title,state,labels,body,url`
+- revision 1 remote PR CI through GitHub Actions `Go Test`
+- revision 1 local `go test ./...`
 
 The slice is text-only. No Go, UI, release workflow, or packaging behavior
-changed, so runtime test suites were not run.
+changed in revision 2, so the finalize-fix validation was limited to plan lint,
+whitespace validation, and delta review of the skill trigger metadata.
 
 ## Review Summary
 
@@ -318,13 +327,20 @@ Reviewer slots:
   version bumps, release PR creation, publication, milestone churn, priority
   labels, tracker issues, and distributed-skill confusion.
 
+Finalize repair delta review `review-002-delta` passed with 0 findings at
+revision 2. The reviewer confirmed the `release-triage` frontmatter now carries
+the proactive discoverability trigger after every `easyharness` PR lands, while
+preserving advisory-only guardrails and accurately recording the repair in the
+active plan.
+
 ## Archive Summary
 
-- Archived At: 2026-05-29T00:11:17+08:00
-- Revision: 1
+- Archived At: 2026-05-29T22:43:37+08:00
+- Revision: 2
 - PR: Open from branch `codex/document-0-x-release-policy` after archive.
 - Ready: Documentation, repo-local skills, live issue #87 handoff, plan lint,
-  whitespace validation, and finalize full review are complete.
+  whitespace validation, finalize full review, and revision 2 delta repair
+  review are complete.
 - Merge Handoff: After PR publication, record publish evidence, refresh CI/sync
   evidence, and wait for human merge approval once `harness status` reaches
   `execution/finalize/await_merge`.
@@ -341,6 +357,9 @@ Reviewer slots:
   `docs/releasing.md` for release policy instead of treating #87 as unresolved.
 - Added the repo-local `release-triage` skill for advisory release-readiness
   recommendations after land, milestone closeout, or release-scope review.
+- Updated the `release-triage` frontmatter description so skill discovery can
+  proactively trigger it after every `easyharness` PR lands and when checking
+  milestone closeout or release scope.
 - Updated live issue #87 to remove alpha-only framing and point at the tracked
   policy plus repo-local release-triage skill as the intended resolution.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,6 +9,46 @@ executable remains `harness`. Tagged releases can also update the dedicated
 Homebrew tap formula `easyharness` in `catu-ai/homebrew-tap`, which users
 install as `catu-ai/tap/easyharness`.
 
+## Release Policy
+
+`easyharness` currently ships a public 0.x release line. Releases are
+change-driven rather than calendar-driven: maintainers cut a release when the
+current `main` branch contains a coherent user-facing improvement, a useful
+same-theme fast-follow, or a repair worth shipping to users.
+
+Ordinary feature, documentation, and fix PRs do not bump `VERSION`. Version
+changes happen in a dedicated release PR after the intended scope is already
+merged or ready to publish. That release PR should stay narrow: update the
+root `VERSION` file, include any directly related release documentation, and
+let the VERSION-driven automation create the tag and publish assets after the
+PR merges.
+
+Minor releases such as `v0.5.0` represent a coherent user promise. They do not
+need to finish every possible idea in a feature family, but they should deliver
+enough of the promise that users can understand and start relying on it. A
+minor release is usually represented by a concrete GitHub milestone whose
+issues are release-critical for that promise.
+
+Patch releases such as `v0.5.1` are smaller. They may ship bug fixes, release
+repairs, documentation or CI corrections, and low-risk follow-ups that extend
+the same already-shipped promise. Routine patch releases do not need a GitHub
+milestone. Create a patch milestone only when the patch needs an explicit
+bucket, such as a small coordinated set of related fixes.
+
+Milestones are release promises, not feature-family backlogs. Put only the
+issues that must be done before that version should ship into the milestone.
+Related follow-up issues can remain normal triaged issues until maintainers
+select them for a later release. When useful, an umbrella or delivery issue can
+use its body to distinguish must-deliver work from likely fast-follows and
+later/not-now ideas; do not add priority labels or tracker issues just to carry
+that context.
+
+Release readiness depends on both automation and maintainer judgment. Required
+CI must be green for the release PR, and the release workflow must publish the
+expected GitHub Release and Homebrew artifacts after merge. Maintainers also
+decide whether the release promise is complete enough, whether known blockers
+remain, and whether a post-publication repair is needed.
+
 ## Release Checklist
 
 1. Decide the next release version, such as `0.0.0`, and update the


### PR DESCRIPTION
## What Changed

- Documented the public 0.x release policy in `docs/releasing.md`, including minor versus patch release shape, optional patch milestones, release PR version bumps, and release-readiness judgment.
- Updated the repo-local `issue-triage` skill so release-policy questions now point to `docs/releasing.md` instead of unresolved issue #87.
- Added a repo-local `release-triage` skill for advisory release-readiness recommendations after meaningful land, milestone closeout, or release-scope review.
- Clarified the `release-triage` skill frontmatter so skill discovery can proactively trigger it after every `easyharness` PR lands, while keeping it advisory-only.
- Formatted that frontmatter as valid folded YAML so bootstrap skill parsing stays green.
- Archived the tracked harness plan after finalize review.

## Validation

- `harness plan lint docs/plans/active/2026-05-29-document-0-x-release-policy.md`
- `git diff --check`
- `scripts/sync-bootstrap-assets --check`
- `go test ./...`
- finalize full review `review-001-full`: pass, 0 findings
- finalize repair delta review `review-002-delta`: pass, 0 findings
- finalize repair delta review `review-003-delta`: pass, 0 findings

Closes #87