### PR TITLE
Tighten reviewer prompt boundaries

### DIFF
--- a/.agents/skills/harness-reviewer/SKILL.md
+++ b/.agents/skills/harness-reviewer/SKILL.md
@@ -96,6 +96,19 @@ Use severities like this:
 Prefer no finding over a vague finding. If the issue is real, say exactly what
 is wrong and why it matters to your assigned slot.
 
+Report only actionable defects that the reviewed change introduced, exposed, or
+made relevant to the current plan. Do not report pre-existing unrelated cleanup
+or style preferences as findings.
+
+For security findings, describe the concrete exploitable risk, removed safety
+check, or missing validation at a trust boundary. Do not flag shell, filesystem,
+network, authentication, or other sensitive surfaces just because the change
+touches them.
+
+Use the smallest useful location that demonstrates the issue. When a finding
+points at code outside the directly changed files, explain why the reviewed
+change makes that unchanged code part of the defect.
+
 If the current plan explicitly defers a risk and the implementation still
 matches that deferral, you do not need to raise it again as a finding. Raise it
 only if the change contradicts the deferral, expands the risk, or makes the
@@ -118,7 +131,9 @@ deferral stale.
    checked areas, open questions, candidate findings, or similar review
    progress in top-level worklog-style fields instead of a separate scratchpad.
 6. For `delta` review, start from the anchored change since `Anchor SHA`.
-   Treat that diff as the default starting lens, not a hard boundary.
+   Treat that diff as the default starting lens, not a hard boundary. Begin
+   with directly changed paths, then follow related logic, contracts, and
+   runtime behavior when needed to decide whether the change is sound.
 7. Continue inspection when related logic, plan intent, or contract meaning
    warrants it. If that deeper read uncovers additional real issues, report
    them in the same round with normal severities.

--- a/.agents/skills/harness-reviewer/SKILL.md
+++ b/.agents/skills/harness-reviewer/SKILL.md
@@ -97,8 +97,8 @@ Prefer no finding over a vague finding. If the issue is real, say exactly what
 is wrong and why it matters to your assigned slot.
 
 Report only actionable defects that the reviewed change introduced, exposed, or
-made relevant to the current plan. Do not report pre-existing unrelated cleanup
-or style preferences as findings.
+made relevant. Do not report pre-existing unrelated cleanup or style
+preferences as findings.
 
 For security findings, describe the concrete exploitable risk, removed safety
 check, or missing validation at a trust boundary. Do not flag shell, filesystem,

--- a/assets/bootstrap/skills/harness-reviewer/SKILL.md
+++ b/assets/bootstrap/skills/harness-reviewer/SKILL.md
@@ -93,6 +93,19 @@ Use severities like this:
 Prefer no finding over a vague finding. If the issue is real, say exactly what
 is wrong and why it matters to your assigned slot.
 
+Report only actionable defects that the reviewed change introduced, exposed, or
+made relevant to the current plan. Do not report pre-existing unrelated cleanup
+or style preferences as findings.
+
+For security findings, describe the concrete exploitable risk, removed safety
+check, or missing validation at a trust boundary. Do not flag shell, filesystem,
+network, authentication, or other sensitive surfaces just because the change
+touches them.
+
+Use the smallest useful location that demonstrates the issue. When a finding
+points at code outside the directly changed files, explain why the reviewed
+change makes that unchanged code part of the defect.
+
 If the current plan explicitly defers a risk and the implementation still
 matches that deferral, you do not need to raise it again as a finding. Raise it
 only if the change contradicts the deferral, expands the risk, or makes the
@@ -115,7 +128,9 @@ deferral stale.
    checked areas, open questions, candidate findings, or similar review
    progress in top-level worklog-style fields instead of a separate scratchpad.
 6. For `delta` review, start from the anchored change since `Anchor SHA`.
-   Treat that diff as the default starting lens, not a hard boundary.
+   Treat that diff as the default starting lens, not a hard boundary. Begin
+   with directly changed paths, then follow related logic, contracts, and
+   runtime behavior when needed to decide whether the change is sound.
 7. Continue inspection when related logic, plan intent, or contract meaning
    warrants it. If that deeper read uncovers additional real issues, report
    them in the same round with normal severities.

--- a/assets/bootstrap/skills/harness-reviewer/SKILL.md
+++ b/assets/bootstrap/skills/harness-reviewer/SKILL.md
@@ -94,8 +94,8 @@ Prefer no finding over a vague finding. If the issue is real, say exactly what
 is wrong and why it matters to your assigned slot.
 
 Report only actionable defects that the reviewed change introduced, exposed, or
-made relevant to the current plan. Do not report pre-existing unrelated cleanup
-or style preferences as findings.
+made relevant. Do not report pre-existing unrelated cleanup or style
+preferences as findings.
 
 For security findings, describe the concrete exploitable risk, removed safety
 check, or missing validation at a trust boundary. Do not flag shell, filesystem,

--- a/docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md
+++ b/docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md
@@ -55,11 +55,11 @@ helper. Codex subagents remain the review runtime.
 
 ## Deferred Items
 
-- Open or update a follow-up issue to research first-class review
-  evidence/context packets for reviewer handoff.
-- Open or update a follow-up issue to research optional finding metadata such
-  as category and confidence, likely starting as reviewer `worklog` data before
-  any contract decision.
+- [#221](https://github.com/catu-ai/easyharness/issues/221): Research
+  first-class review evidence/context packets for reviewer handoff.
+- [#222](https://github.com/catu-ai/easyharness/issues/222): Research optional
+  finding metadata such as category and confidence, likely starting as reviewer
+  `worklog` data before any contract decision.
 
 ## Work Breakdown
 
@@ -165,4 +165,7 @@ PENDING_UNTIL_ARCHIVE
 
 ### Follow-Up Issues
 
-PENDING_UNTIL_ARCHIVE
+- [#221](https://github.com/catu-ai/easyharness/issues/221): Research
+  first-class review evidence/context packets for reviewer handoff.
+- [#222](https://github.com/catu-ai/easyharness/issues/222): Research optional
+  review finding metadata.

--- a/docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md
+++ b/docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md
@@ -1,0 +1,159 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-29T00:05:04+08:00"
+approved_at: "2026-05-29T00:05:56+08:00"
+source_type: direct_request
+source_refs: []
+size: XS
+---
+
+# Tighten Reviewer Prompt Boundaries
+
+## Goal
+
+Refine the managed `harness-reviewer` skill so reviewer subagents give sharper
+findings without adding new review machinery. The change should borrow the
+useful prompt-level lessons from `autoreview`: report actionable defects tied
+to the reviewed change, use the anchor diff as the starting lens, avoid vague
+security alarms, and point findings at the smallest useful location.
+
+This plan intentionally does not integrate external review CLIs or add a review
+helper. Codex subagents remain the review runtime.
+
+## Scope
+
+### In Scope
+
+- Update the managed reviewer skill source under `assets/bootstrap/`.
+- Sync the materialized `.agents/skills/` output from the bootstrap asset.
+- Clarify changed-path awareness for `delta` review as a starting point, not a
+  hard boundary.
+- Clarify that findings outside directly changed files must explain why the
+  reviewed change introduced, exposed, or made the issue relevant.
+- Clarify high-signal security finding expectations.
+
+### Out of Scope
+
+- No Codex CLI, Claude CLI, or other external review-engine integration.
+- No new `harness review` command behavior.
+- No schema or aggregate contract changes for category, confidence, or scope
+  metadata.
+- No automatic out-of-scope finding filtering.
+- No first-class review evidence packet design in this slice.
+
+## Acceptance Criteria
+
+- [ ] `assets/bootstrap/skills/harness-reviewer/SKILL.md` includes concise
+  reviewer guidance for actionable findings, security findings, smallest useful
+  locations, and changed-path awareness.
+- [ ] The synced `.agents/skills/harness-reviewer/SKILL.md` matches the
+  bootstrap source after running `scripts/sync-bootstrap-assets`.
+- [ ] The wording preserves the current reviewer workflow shape: reviewer
+  subagents inspect the repo directly and submit through `harness review
+  submit`.
+- [ ] No CLI behavior, schema, or generated contract artifact changes are made.
+
+## Deferred Items
+
+- Open or update a follow-up issue to research first-class review
+  evidence/context packets for reviewer handoff.
+- Open or update a follow-up issue to research optional finding metadata such
+  as category and confidence, likely starting as reviewer `worklog` data before
+  any contract decision.
+
+## Work Breakdown
+
+### Step 1: Tighten Managed Reviewer Prompt Guidance
+
+- Done: [ ]
+
+#### Objective
+
+Update the managed reviewer skill text with focused prompt rules for
+high-signal review findings.
+
+#### Details
+
+Keep the change small and prompt-only. The added guidance should make reviewer
+expectations clearer without turning the skill into a long checklist.
+
+The intended behavior is:
+
+- findings should be actionable defects introduced, exposed, or made relevant
+  by the reviewed change
+- security findings should describe a concrete exploitable risk, removed safety
+  check, or missing trust-boundary validation
+- locations should point at the smallest useful repo-relative anchor
+- `delta` review should begin from the anchor diff and then inspect related
+  code when plan intent, contract meaning, or runtime behavior warrants it
+- findings in unchanged files should explain their relationship to the reviewed
+  change instead of being automatically discarded
+
+#### Expected Files
+
+- `assets/bootstrap/skills/harness-reviewer/SKILL.md`
+- `.agents/skills/harness-reviewer/SKILL.md`
+
+#### Validation
+
+- Run `scripts/sync-bootstrap-assets`.
+- Run `harness plan lint docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md`.
+- Inspect the synced diff to confirm only intended prompt text changed.
+
+#### Execution Notes
+
+Updated the managed reviewer skill prompt guidance in
+`assets/bootstrap/skills/harness-reviewer/SKILL.md` and synced the materialized
+`.agents/skills/harness-reviewer/SKILL.md` output with
+`scripts/sync-bootstrap-assets`. The change is prompt-only and does not alter
+CLI behavior, schemas, or review artifacts. TDD is not applicable because this
+slice changes reviewer instructions rather than executable behavior; validation
+used bootstrap sync, plan lint, and diff inspection.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Use plan lint for the tracked plan.
+- Use bootstrap sync to verify the materialized skill output matches the
+  managed source.
+- Use git diff review to confirm this remains a skill-only prompt adjustment.
+
+## Risks
+
+- Risk: The reviewer skill becomes too verbose and increases reviewer cognitive
+  load.
+  - Mitigation: Keep the new text short and place it near existing severity and
+    workflow guidance.
+- Risk: Changed-path awareness is misread as a hard scope filter.
+  - Mitigation: State explicitly that the anchor diff is a starting lens, not a
+    boundary, and that related unchanged-code findings are allowed when
+    explained.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+PENDING_UNTIL_ARCHIVE

--- a/docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md
+++ b/docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md
@@ -43,15 +43,15 @@ helper. Codex subagents remain the review runtime.
 
 ## Acceptance Criteria
 
-- [ ] `assets/bootstrap/skills/harness-reviewer/SKILL.md` includes concise
+- [x] `assets/bootstrap/skills/harness-reviewer/SKILL.md` includes concise
   reviewer guidance for actionable findings, security findings, smallest useful
   locations, and changed-path awareness.
-- [ ] The synced `.agents/skills/harness-reviewer/SKILL.md` matches the
+- [x] The synced `.agents/skills/harness-reviewer/SKILL.md` matches the
   bootstrap source after running `scripts/sync-bootstrap-assets`.
-- [ ] The wording preserves the current reviewer workflow shape: reviewer
+- [x] The wording preserves the current reviewer workflow shape: reviewer
   subagents inspect the repo directly and submit through `harness review
   submit`.
-- [ ] No CLI behavior, schema, or generated contract artifact changes are made.
+- [x] No CLI behavior, schema, or generated contract artifact changes are made.
 
 ## Deferred Items
 
@@ -65,7 +65,7 @@ helper. Codex subagents remain the review runtime.
 
 ### Step 1: Tighten Managed Reviewer Prompt Guidance
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -117,7 +117,11 @@ resynced the materialized skill output.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+Delta review `review-001-delta` found one important agent UX issue: "made
+relevant to the current plan" could broaden scope beyond defects made relevant
+by the reviewed change. The wording was repaired and resynced.
+
+Follow-up delta review `review-002-delta` passed with no findings.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md
+++ b/docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md
@@ -110,6 +110,11 @@ CLI behavior, schemas, or review artifacts. TDD is not applicable because this
 slice changes reviewer instructions rather than executable behavior; validation
 used bootstrap sync, plan lint, and diff inspection.
 
+Round `review-001-delta` found one agent UX issue: the phrase "made relevant to
+the current plan" could broaden review scope beyond change-tied defects. The
+repair changed that sentence to keep relevance tied to the reviewed change and
+resynced the materialized skill output.
+
 #### Review Notes
 
 PENDING_STEP_REVIEW

--- a/docs/plans/archived/2026-05-29-tighten-reviewer-prompt-boundaries.md
+++ b/docs/plans/archived/2026-05-29-tighten-reviewer-prompt-boundaries.md
@@ -143,25 +143,68 @@ Follow-up delta review `review-002-delta` passed with no findings.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `scripts/sync-bootstrap-assets` updated the materialized
+  `.agents/skills/harness-reviewer/SKILL.md` output from the managed bootstrap
+  source.
+- `harness plan lint
+  docs/plans/active/2026-05-29-tighten-reviewer-prompt-boundaries.md` passed
+  after plan creation, implementation, review repairs, and archive-summary
+  updates.
+- `git diff --check` passed for the prompt-only change.
+- Follow-up issues [#221](https://github.com/catu-ai/easyharness/issues/221)
+  and [#222](https://github.com/catu-ai/easyharness/issues/222) were created
+  and linked in the plan handoff.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step-closeout delta review `review-001-delta` found one important agent UX
+  issue: the phrase "made relevant to the current plan" could broaden scope
+  beyond defects tied to the reviewed change.
+- The wording was repaired and resynced; follow-up delta review
+  `review-002-delta` passed with no findings.
+- Finalize full review `review-003-full` found one archive-readiness issue:
+  deferred follow-up items needed concrete issue links.
+- Issues [#221](https://github.com/catu-ai/easyharness/issues/221) and
+  [#222](https://github.com/catu-ai/easyharness/issues/222) were created and
+  linked; finalize delta repair review `review-004-delta` passed with no
+  findings.
+- Finalize full review `review-005-full` passed with no findings across
+  `correctness` and `docs_consistency`.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-05-29T00:22:22+08:00
+- Revision: 1
+- PR: pending publish after archive; no PR URL exists yet.
+- Ready: The managed reviewer skill source and materialized skill output now
+  give sharper prompt-only review guidance for actionable findings, concrete
+  security findings, smallest useful locations, and changed-path awareness as a
+  starting lens rather than a hard boundary.
+- Merge Handoff: Commit the archive move, push branch
+  `codex/tighten-reviewer-prompt-boundaries`, open the PR with a concise merge
+  memo, record publish/CI/sync evidence, and stop at
+  `execution/finalize/await_merge` for explicit human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added high-signal finding guidance to the managed `harness-reviewer` skill.
+- Clarified that security findings need concrete risk or missing
+  trust-boundary validation rather than generic sensitive-surface alarms.
+- Clarified that reviewers should use the smallest useful location and explain
+  unchanged-code findings when the reviewed change makes them relevant.
+- Clarified that delta review begins from directly changed paths and may follow
+  related logic, contracts, and runtime behavior when needed.
+- Synced the materialized `.agents/skills/harness-reviewer/SKILL.md` output
+  from the bootstrap source.
+- Created and linked follow-up issues for review context packets and optional
+  review finding metadata research.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+No CLI review-engine integration, schema change, automatic finding filtering,
+or first-class review evidence packet was delivered in this slice.
 
 ### Follow-Up Issues
 


### PR DESCRIPTION
## What Changed

This PR tightens the managed `harness-reviewer` skill so review findings stay tied to actionable defects introduced, exposed, or made relevant by the reviewed change.

It adds prompt guidance for concrete security findings, smallest useful source locations, and changed-path awareness as a starting lens rather than a hard review boundary. The materialized `.agents/skills/harness-reviewer/SKILL.md` output is synced from the bootstrap source, and the tracked plan has been archived with follow-up research issues linked.

## Confidence

- Bootstrap source and materialized skill output were synced with `scripts/sync-bootstrap-assets`.
- `harness plan lint` passed for the active plan and archived plan.
- `git diff --check` passed.
- Step review found and repaired one scope wording issue, then passed.
- Finalize review passed cleanly after follow-up issues #221 and #222 were created and linked.

## Handoff

No CLI behavior, schema, aggregate contract, automatic finding filtering, or external review-engine integration is included. Follow-up research is tracked in #221 and #222.
