### PR TITLE
Tighten harness subagent and discovery prompts

### DIFF
--- a/.agents/skills/harness-discovery/SKILL.md
+++ b/.agents/skills/harness-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-discovery
-description: Use before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, already-approved execution, or implementation-ready work with clear scope.
+description: Run interactive, collaborative discovery before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, or already-approved execution.
 metadata:
     easyharness-managed: "true"
     easyharness-version: dev
@@ -46,10 +46,12 @@ Use explorer subagents on demand, not by default.
 
 ## Questioning Style
 
-Repository facts are agent-owned. Product intent, priorities, boundaries, and
-approval are human-owned. Before asking the human, read the relevant context
-and answer factual repository questions yourself, using bounded explorers when
-that will sharpen the next human question.
+Repository facts and documented project intent are agent-owned to investigate.
+Humans have final say over goals, priorities, boundaries, and approvals when
+they are ambiguous, contested, or not already settled in the repository. Before
+asking the human, read the relevant context and answer factual repository
+questions yourself, using bounded explorers when that will sharpen the next
+human question.
 
 Keep the harness posture collaborative, not adversarial. Borrow the useful
 parts of brainstorming and grill-style questioning: read context first, ask one
@@ -57,30 +59,40 @@ focused question at a time, frame real choices plainly, and recommend a
 direction when the evidence is strong enough. Do not turn discovery into a long
 interrogation.
 
-Prefer this question shape:
+Prefer option-shaped questions:
 
 1. State the current read in one or two sentences.
-2. Recommend a direction when there is enough signal.
-3. Ask one plain question about the human-owned boundary, priority, or
-   approval.
+2. Present 2-4 realistic options, even when the decision is small.
+3. Put the recommendation under the option the agent prefers, with a short
+   reason.
+4. Ask the human to choose, edit, or reject the options.
 
 Avoid jargon-heavy labels, hedging, and loaded binary implementation choices.
-Do not ask a question like:
+Do not ask a loaded binary question like:
 
-> Do you want direct breaking schema convergence, or the minimal change of
-> reordering fields and folding `remote_handoff`?
+> Do you want the broad breaking rewrite, or the minimal low-risk patch?
 
-Prefer:
+Instead, use the option framing pattern below. Keep labels neutral, name the
+real tradeoff, and put the recommendation under the option the agent prefers:
 
-> I recommend making default `harness status` a short control-panel view and
-> keeping full remote details for diagnostics. Are you comfortable changing the
-> default output shape to get that clarity?
+1. `Option A`
+   - upside: the main goal is addressed directly
+   - downside: the change may be broader
+   - best when: the clean target shape matters most
+   - recommendation: I recommend this when repo context supports the broader
+     change.
+2. `Option B`
+   - upside: the change is smaller
+   - downside: the original confusion may only be reduced, not removed
+   - best when: limiting scope matters most
+
+Which direction should I plan around?
 
 ## Execution Contract
 
 1. If the request is simple repo orientation, factual explanation, code lookup,
-   status checking, already-approved execution, or clear implementation-ready
-   work, answer or route it directly instead of entering discovery.
+   status checking, or already-approved execution, answer directly and do not
+   expand the turn into discovery.
 2. Read the most relevant repository context needed to ask sharper questions.
 3. If the task is still fuzzy after repo-factual context is handled, ask one
    concise clarification question before doing broader discovery.

--- a/.agents/skills/harness-discovery/SKILL.md
+++ b/.agents/skills/harness-discovery/SKILL.md
@@ -69,6 +69,12 @@ Prefer option-shaped questions:
    reason.
 4. Ask the human to choose, edit, or reject the options.
 
+Do not force a new question into every discovery turn. If the human asks for
+details about an option, answers a side question, or needs a factual
+explanation before deciding, answer directly. When a new human decision is
+needed, ask only one question, and make it the highest-leverage question for
+the current moment.
+
 Avoid jargon-heavy labels, hedging, and loaded binary implementation choices.
 Do not ask a loaded binary question like:
 
@@ -103,7 +109,9 @@ Which direction should I plan around?
 5. Discovery may alternate between human answers and further bounded
    exploration. Re-evaluate whether more exploration is needed after each
    clarification turn.
-6. Ask exactly one high-leverage question per turn.
+6. When the next step needs a human decision, ask exactly one question: the
+   highest-leverage question for the current moment. Do not ask a new question
+   merely to satisfy the discovery rhythm.
 7. Use Socratic, focused questioning to clarify:
    - purpose
    - constraints

--- a/.agents/skills/harness-discovery/SKILL.md
+++ b/.agents/skills/harness-discovery/SKILL.md
@@ -70,7 +70,7 @@ Prefer option-shaped questions:
 4. Ask the human to choose, edit, or reject the options.
 
 Do not force a new question into every discovery turn. If the human asks for
-details about an option, answers a side question, or needs a factual
+details about an option, asks a side question, or needs a factual
 explanation before deciding, answer directly. When a new human decision is
 needed, ask only one question, and make it the highest-leverage question for
 the current moment.

--- a/.agents/skills/harness-discovery/SKILL.md
+++ b/.agents/skills/harness-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-discovery
-description: Run interactive, Socratic pre-implementation discovery for medium/large or ambiguous work in a harness-driven repository by clarifying goals, constraints, tradeoffs, and workflow direction before planning or execution. Use this whenever the next move is unclear, the user needs help choosing an approach, or archived work may need to reopen.
+description: Use before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, already-approved execution, or implementation-ready work with clear scope.
 metadata:
     easyharness-managed: "true"
     easyharness-version: dev
@@ -13,6 +13,11 @@ metadata:
 Run discovery before implementation when the task needs real clarification.
 Discovery is conversation-only. It should reduce ambiguity, surface tradeoffs,
 and end with a clear next workflow step.
+
+Discovery is size-independent. Use it to learn whether work is tiny, large, or
+not work at all. Do not use discovery for ordinary repository facts, code
+lookup, status checks, or simple explanations unless the human is deciding what
+work to do next.
 
 ## Inputs
 
@@ -39,33 +44,69 @@ Use explorer subagents on demand, not by default.
   only. They do not choose the next user question, recommend the workflow
   direction, or replace controller judgment.
 
+## Questioning Style
+
+Repository facts are agent-owned. Product intent, priorities, boundaries, and
+approval are human-owned. Before asking the human, read the relevant context
+and answer factual repository questions yourself, using bounded explorers when
+that will sharpen the next human question.
+
+Keep the harness posture collaborative, not adversarial. Borrow the useful
+parts of brainstorming and grill-style questioning: read context first, ask one
+focused question at a time, frame real choices plainly, and recommend a
+direction when the evidence is strong enough. Do not turn discovery into a long
+interrogation.
+
+Prefer this question shape:
+
+1. State the current read in one or two sentences.
+2. Recommend a direction when there is enough signal.
+3. Ask one plain question about the human-owned boundary, priority, or
+   approval.
+
+Avoid jargon-heavy labels, hedging, and loaded binary implementation choices.
+Do not ask a question like:
+
+> Do you want direct breaking schema convergence, or the minimal change of
+> reordering fields and folding `remote_handoff`?
+
+Prefer:
+
+> I recommend making default `harness status` a short control-panel view and
+> keeping full remote details for diagnostics. Are you comfortable changing the
+> default output shape to get that clarity?
+
 ## Execution Contract
 
-1. If the task is still fuzzy, ask one concise clarification question before
-   doing broader discovery.
+1. If the request is simple repo orientation, factual explanation, code lookup,
+   status checking, already-approved execution, or clear implementation-ready
+   work, answer or route it directly instead of entering discovery.
 2. Read the most relevant repository context needed to ask sharper questions.
-3. Use bounded repository exploration according to `Explorer Subagent
+3. If the task is still fuzzy after repo-factual context is handled, ask one
+   concise clarification question before doing broader discovery.
+4. Use bounded repository exploration according to `Explorer Subagent
    Decision` above whenever local reading alone is not enough.
-4. Discovery may alternate between human answers and further bounded
+5. Discovery may alternate between human answers and further bounded
    exploration. Re-evaluate whether more exploration is needed after each
    clarification turn.
-5. Ask exactly one high-leverage question per turn.
-6. Use Socratic questioning to clarify:
+6. Ask exactly one high-leverage question per turn.
+7. Use focused questioning to clarify:
    - purpose
    - constraints
    - non-goals
    - success criteria
    - workflow direction
-7. When a decision benefits from framing, present 2-4 realistic options.
-8. For each option, give:
+8. When a decision benefits from framing, present 2-4 realistic options.
+9. For each option, give:
    - a short label
    - one clear upside
    - one clear downside
    - when it fits
-9. Recommend a direction when the tradeoffs are asymmetric.
-10. Converge on a concrete approach, draft acceptance criteria, and state the
+10. Recommend a direction when the tradeoffs are asymmetric.
+11. Converge on a concrete approach, draft acceptance criteria, and state the
    next workflow step explicitly.
-11. Hand off to `harness-plan` only after the human confirms the direction.
+12. Give a concise discovery summary before handoff.
+13. Hand off to `harness-plan` only after the human confirms the direction.
 
 ## Option Framing Pattern
 
@@ -92,10 +133,12 @@ Then add a short recommendation and why.
 Discovery should end with a concise conversation summary containing:
 
 - the problem statement
+- discovered repository facts that shaped the decision
 - key constraints and non-goals
 - the accepted direction
 - rejected alternatives with short rationale
 - draft acceptance criteria
+- the rough plan shape
 - the next workflow step
 
 ## Guardrails

--- a/.agents/skills/harness-discovery/SKILL.md
+++ b/.agents/skills/harness-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-discovery
-description: Run interactive, collaborative discovery before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, or already-approved execution.
+description: Run interactive, Socratic discovery before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, or already-approved execution.
 metadata:
     easyharness-managed: "true"
     easyharness-version: dev
@@ -53,11 +53,13 @@ asking the human, read the relevant context and answer factual repository
 questions yourself, using bounded explorers when that will sharpen the next
 human question.
 
-Keep the harness posture collaborative, not adversarial. Borrow the useful
-parts of brainstorming and grill-style questioning: read context first, ask one
-focused question at a time, frame real choices plainly, and recommend a
-direction when the evidence is strong enough. Do not turn discovery into a long
-interrogation.
+Use a Socratic posture to clarify the work: test assumptions, name tensions,
+and ask focused questions when they expose a real decision. Challenge the
+human's framing when repository evidence points another way, but keep the
+challenge tied to a concrete choice instead of debate. Read context first, ask
+one focused question at a time, frame real choices plainly, recommend a
+direction when the evidence is strong enough, and stop when there is enough
+clarity to summarize and hand off.
 
 Prefer option-shaped questions:
 
@@ -102,7 +104,7 @@ Which direction should I plan around?
    exploration. Re-evaluate whether more exploration is needed after each
    clarification turn.
 6. Ask exactly one high-leverage question per turn.
-7. Use focused questioning to clarify:
+7. Use Socratic, focused questioning to clarify:
    - purpose
    - constraints
    - non-goals

--- a/.agents/skills/harness-discovery/SKILL.md
+++ b/.agents/skills/harness-discovery/SKILL.md
@@ -129,6 +129,7 @@ is:
    - upside
    - downside
    - best when ...
+   - recommendation: I recommend this when ...
 2. `Option B`
    - upside
    - downside
@@ -138,7 +139,9 @@ is:
    - downside
    - best when ...
 
-Then add a short recommendation and why.
+Include the recommendation under the option the agent prefers. If no option is
+clearly better, say that briefly after the list instead of forcing a weak
+recommendation.
 
 ## Output
 

--- a/.agents/skills/harness-execute/SKILL.md
+++ b/.agents/skills/harness-execute/SKILL.md
@@ -56,13 +56,11 @@ For `delta` review, use a real git commit anchor. The detailed controller
 dispatch fields, anchor guidance, and reviewer-resume rules live in
 [review-orchestration.md](references/review-orchestration.md).
 
-If the approved plan is likely to require reviewer subagents and explicit
-authorization has not been obtained yet, ask for that authorization as soon as
-the need becomes foreseeable. Do not wait until reviewer spawning is the only
-remaining next action before surfacing the request.
-If execution still reaches a reviewer-subagent boundary without that explicit
-approval, pause only long enough to request it, then continue the review flow
-once the human answers.
+If subagent authorization for this harness run has not been explicit yet, ask
+once before spawning any explorer, worker, or reviewer subagent. Once the human
+authorizes bounded subagents for the run, actively use them for suitable
+independent work instead of waiting until review orchestration is blocked. If
+authorization is denied, continue locally until the human changes that boundary.
 
 Keep exactly one active review round at a time. The detailed review rules live
 in [review-orchestration.md](references/review-orchestration.md).
@@ -157,10 +155,9 @@ Execute is done when:
 - Do not ask the human whether routine step-closeout or finalize review should
   start once `harness status` and the tracked plan make the next review action
   clear.
-- Do not silently stall at review orchestration because reviewer subagent
-  authorization is missing; request it explicitly as soon as you know it will
-  be required, and if you still reach the reviewer boundary without approval,
-  pause only long enough to ask and then resume once the answer arrives.
+- Do not silently stall at review orchestration because subagent authorization
+  is missing; the harness-run authorization should be requested at the first
+  harness workflow boundary, or as soon as the missing authorization is noticed.
 - Do not submit reviewer results from the controller thread or impersonate a
   reviewer slot yourself. Reviewer submissions belong to bounded reviewer
   subagents using `harness review submit --by <reviewer-name>`.

--- a/.agents/skills/harness-execute/SKILL.md
+++ b/.agents/skills/harness-execute/SKILL.md
@@ -56,12 +56,6 @@ For `delta` review, use a real git commit anchor. The detailed controller
 dispatch fields, anchor guidance, and reviewer-resume rules live in
 [review-orchestration.md](references/review-orchestration.md).
 
-If subagent authorization for this harness run has not been explicit yet, ask
-once before spawning any explorer, worker, or reviewer subagent. Once the human
-authorizes bounded subagents for the run, actively use them for suitable
-independent work instead of waiting until review orchestration is blocked. If
-authorization is denied, continue locally until the human changes that boundary.
-
 Keep exactly one active review round at a time. The detailed review rules live
 in [review-orchestration.md](references/review-orchestration.md).
 
@@ -155,9 +149,6 @@ Execute is done when:
 - Do not ask the human whether routine step-closeout or finalize review should
   start once `harness status` and the tracked plan make the next review action
   clear.
-- Do not silently stall at review orchestration because subagent authorization
-  is missing; the harness-run authorization should be requested at the first
-  harness workflow boundary, or as soon as the missing authorization is noticed.
 - Do not submit reviewer results from the controller thread or impersonate a
   reviewer slot yourself. Reviewer submissions belong to bounded reviewer
   subagents using `harness review submit --by <reviewer-name>`.

--- a/.agents/skills/harness-plan/SKILL.md
+++ b/.agents/skills/harness-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-plan
-description: Create or update a tracked harness plan for medium/large work once the direction is clear enough to execute. Use this when work needs a self-contained plan that a future agent can complete from the repository alone, without relying on discovery chat or hidden session memory.
+description: Create or update a tracked harness plan once the direction is clear enough to execute. Use this when work needs a self-contained plan that a future agent can complete from the repository alone, without relying on discovery chat or hidden session memory.
 metadata:
     easyharness-managed: "true"
     easyharness-version: dev
@@ -79,9 +79,10 @@ Use this skill to create or update the tracked plan that will drive execution.
      written plan
    - once the human approves the plan, record that boundary explicitly with
      `harness plan approve --by human`
-   - if the approved execution loop is likely to require reviewer subagents,
-     ask for explicit subagent authorization in the same approval exchange so
-     execution does not stall later at review time
+   - if this is the first harness workflow boundary in the thread and subagent
+     authorization has not already been explicit, ask whether bounded
+     explorer, worker, and reviewer subagents are authorized for this harness
+     run
 
 ## Commands
 
@@ -108,8 +109,8 @@ The plan is ready when:
   tracked locations before archive so the archived supplements are only backup
   context rather than a hidden dependency
 - the human can approve or challenge it without hidden context
-- when reviewer subagents are likely later, the approval handoff makes that
-  expected authorization explicit instead of deferring it implicitly
+- when this is the first harness workflow boundary in the thread, the approval
+  handoff records whether bounded subagents are authorized for the harness run
 - a future agent could continue the work from the plan alone
 
 ## Do Not

--- a/.agents/skills/harness-plan/SKILL.md
+++ b/.agents/skills/harness-plan/SKILL.md
@@ -79,10 +79,6 @@ Use this skill to create or update the tracked plan that will drive execution.
      written plan
    - once the human approves the plan, record that boundary explicitly with
      `harness plan approve --by human`
-   - if this is the first harness workflow boundary in the thread and subagent
-     authorization has not already been explicit, ask whether bounded
-     explorer, worker, and reviewer subagents are authorized for this harness
-     run
 
 ## Commands
 
@@ -109,8 +105,6 @@ The plan is ready when:
   tracked locations before archive so the archived supplements are only backup
   context rather than a hidden dependency
 - the human can approve or challenge it without hidden context
-- when this is the first harness workflow boundary in the thread, the approval
-  handoff records whether bounded subagents are authorized for the harness run
 - a future agent could continue the work from the plan alone
 
 ## Do Not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,9 +173,9 @@ invalidation.
 The controller owns shared repository context and the final workflow judgment.
 Subagents are a normal part of harness work, not an exceptional fallback. When
 a harness workflow skill is first used in a thread, ask once whether the human
-authorizes bounded subagents for this harness run unless that authorization has
-already been explicit in the conversation. This authorization covers explorer,
-worker, and reviewer subagents.
+authorizes specific, well-scoped subagents for this harness run unless that
+authorization has already been explicit in the conversation. This authorization
+covers explorer, worker, and reviewer subagents.
 
 After authorization, actively look for bounded, independent work that
 subagents can handle in parallel or with useful separation. Spawn subagents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
 
 ## Harness Workflow
 
-For medium or large work:
+For harness-managed work that is not already clear enough to execute directly:
 
 1. Discovery
 2. Plan
@@ -171,11 +171,19 @@ invalidation.
 ## Harness Subagent Use
 
 The controller owns shared repository context and the final workflow judgment.
-Spawn subagents only for bounded subproblems; do not split one shared context
-bundle across multiple subagents just to get summaries back.
+Subagents are a normal part of harness work, not an exceptional fallback. When
+a harness workflow skill is first used in a thread, ask once whether the human
+authorizes bounded subagents for this harness run unless that authorization has
+already been explicit in the conversation. This authorization covers explorer,
+worker, and reviewer subagents.
 
-Discovery and execution may stay local, use one subagent, or use multiple
-subagents in parallel according to the current question shape:
+After authorization, actively look for bounded, independent work that
+subagents can handle in parallel or with useful separation. Spawn subagents
+only for concrete subproblems; do not split one shared context bundle across
+multiple subagents just to get summaries back.
+
+Discovery and execution may still stay local, use one subagent, or use
+multiple subagents in parallel according to the current question shape:
 
 - stay local when the controller can answer the next question from the shared
   context it already needs to hold
@@ -183,6 +191,10 @@ subagents in parallel according to the current question shape:
   checking
 - use multiple subagents in parallel only when multiple hypotheses or
   questions are genuinely independent
+
+If subagent authorization is missing when it becomes useful, ask for that
+authorization before spawning. If authorization is denied, continue locally
+until the human changes that boundary.
 
 In Codex, spawned subagents are not fire-and-forget memory. Once a bounded
 subagent task is complete and the controller has received the result, close
@@ -219,10 +231,6 @@ Use `harness status` at routine checkpoints:
 
 Human confirmation is still required for real blockers, scope changes, and
 merge approval, but not for ordinary review closeout.
-
-If an approved plan is likely to require reviewer subagents later, ask for
-explicit human authorization when seeking plan approval instead of waiting
-until review orchestration is already blocked on that permission.
 
 ## Harness Start Points
 

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -81,9 +81,9 @@ invalidation.
 The controller owns shared repository context and the final workflow judgment.
 Subagents are a normal part of harness work, not an exceptional fallback. When
 a harness workflow skill is first used in a thread, ask once whether the human
-authorizes bounded subagents for this harness run unless that authorization has
-already been explicit in the conversation. This authorization covers explorer,
-worker, and reviewer subagents.
+authorizes specific, well-scoped subagents for this harness run unless that
+authorization has already been explicit in the conversation. This authorization
+covers explorer, worker, and reviewer subagents.
 
 After authorization, actively look for bounded, independent work that
 subagents can handle in parallel or with useful separation. Spawn subagents

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -25,7 +25,7 @@ If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
 
 ## Harness Workflow
 
-For medium or large work:
+For harness-managed work that is not already clear enough to execute directly:
 
 1. Discovery
 2. Plan
@@ -79,11 +79,19 @@ invalidation.
 ## Harness Subagent Use
 
 The controller owns shared repository context and the final workflow judgment.
-Spawn subagents only for bounded subproblems; do not split one shared context
-bundle across multiple subagents just to get summaries back.
+Subagents are a normal part of harness work, not an exceptional fallback. When
+a harness workflow skill is first used in a thread, ask once whether the human
+authorizes bounded subagents for this harness run unless that authorization has
+already been explicit in the conversation. This authorization covers explorer,
+worker, and reviewer subagents.
 
-Discovery and execution may stay local, use one subagent, or use multiple
-subagents in parallel according to the current question shape:
+After authorization, actively look for bounded, independent work that
+subagents can handle in parallel or with useful separation. Spawn subagents
+only for concrete subproblems; do not split one shared context bundle across
+multiple subagents just to get summaries back.
+
+Discovery and execution may still stay local, use one subagent, or use
+multiple subagents in parallel according to the current question shape:
 
 - stay local when the controller can answer the next question from the shared
   context it already needs to hold
@@ -91,6 +99,10 @@ subagents in parallel according to the current question shape:
   checking
 - use multiple subagents in parallel only when multiple hypotheses or
   questions are genuinely independent
+
+If subagent authorization is missing when it becomes useful, ask for that
+authorization before spawning. If authorization is denied, continue locally
+until the human changes that boundary.
 
 In Codex, spawned subagents are not fire-and-forget memory. Once a bounded
 subagent task is complete and the controller has received the result, close
@@ -127,10 +139,6 @@ Use `harness status` at routine checkpoints:
 
 Human confirmation is still required for real blockers, scope changes, and
 merge approval, but not for ordinary review closeout.
-
-If an approved plan is likely to require reviewer subagents later, ask for
-explicit human authorization when seeking plan approval instead of waiting
-until review orchestration is already blocked on that permission.
 
 ## Harness Start Points
 

--- a/assets/bootstrap/skills/harness-discovery/SKILL.md
+++ b/assets/bootstrap/skills/harness-discovery/SKILL.md
@@ -66,6 +66,12 @@ Prefer option-shaped questions:
    reason.
 4. Ask the human to choose, edit, or reject the options.
 
+Do not force a new question into every discovery turn. If the human asks for
+details about an option, answers a side question, or needs a factual
+explanation before deciding, answer directly. When a new human decision is
+needed, ask only one question, and make it the highest-leverage question for
+the current moment.
+
 Avoid jargon-heavy labels, hedging, and loaded binary implementation choices.
 Do not ask a loaded binary question like:
 
@@ -100,7 +106,9 @@ Which direction should I plan around?
 5. Discovery may alternate between human answers and further bounded
    exploration. Re-evaluate whether more exploration is needed after each
    clarification turn.
-6. Ask exactly one high-leverage question per turn.
+6. When the next step needs a human decision, ask exactly one question: the
+   highest-leverage question for the current moment. Do not ask a new question
+   merely to satisfy the discovery rhythm.
 7. Use Socratic, focused questioning to clarify:
    - purpose
    - constraints

--- a/assets/bootstrap/skills/harness-discovery/SKILL.md
+++ b/assets/bootstrap/skills/harness-discovery/SKILL.md
@@ -67,7 +67,7 @@ Prefer option-shaped questions:
 4. Ask the human to choose, edit, or reject the options.
 
 Do not force a new question into every discovery turn. If the human asks for
-details about an option, answers a side question, or needs a factual
+details about an option, asks a side question, or needs a factual
 explanation before deciding, answer directly. When a new human decision is
 needed, ask only one question, and make it the highest-leverage question for
 the current moment.

--- a/assets/bootstrap/skills/harness-discovery/SKILL.md
+++ b/assets/bootstrap/skills/harness-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-discovery
-description: Use before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, already-approved execution, or implementation-ready work with clear scope.
+description: Run interactive, collaborative discovery before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, or already-approved execution.
 ---
 
 # Harness Discovery
@@ -43,10 +43,12 @@ Use explorer subagents on demand, not by default.
 
 ## Questioning Style
 
-Repository facts are agent-owned. Product intent, priorities, boundaries, and
-approval are human-owned. Before asking the human, read the relevant context
-and answer factual repository questions yourself, using bounded explorers when
-that will sharpen the next human question.
+Repository facts and documented project intent are agent-owned to investigate.
+Humans have final say over goals, priorities, boundaries, and approvals when
+they are ambiguous, contested, or not already settled in the repository. Before
+asking the human, read the relevant context and answer factual repository
+questions yourself, using bounded explorers when that will sharpen the next
+human question.
 
 Keep the harness posture collaborative, not adversarial. Borrow the useful
 parts of brainstorming and grill-style questioning: read context first, ask one
@@ -54,30 +56,40 @@ focused question at a time, frame real choices plainly, and recommend a
 direction when the evidence is strong enough. Do not turn discovery into a long
 interrogation.
 
-Prefer this question shape:
+Prefer option-shaped questions:
 
 1. State the current read in one or two sentences.
-2. Recommend a direction when there is enough signal.
-3. Ask one plain question about the human-owned boundary, priority, or
-   approval.
+2. Present 2-4 realistic options, even when the decision is small.
+3. Put the recommendation under the option the agent prefers, with a short
+   reason.
+4. Ask the human to choose, edit, or reject the options.
 
 Avoid jargon-heavy labels, hedging, and loaded binary implementation choices.
-Do not ask a question like:
+Do not ask a loaded binary question like:
 
-> Do you want direct breaking schema convergence, or the minimal change of
-> reordering fields and folding `remote_handoff`?
+> Do you want the broad breaking rewrite, or the minimal low-risk patch?
 
-Prefer:
+Instead, use the option framing pattern below. Keep labels neutral, name the
+real tradeoff, and put the recommendation under the option the agent prefers:
 
-> I recommend making default `harness status` a short control-panel view and
-> keeping full remote details for diagnostics. Are you comfortable changing the
-> default output shape to get that clarity?
+1. `Option A`
+   - upside: the main goal is addressed directly
+   - downside: the change may be broader
+   - best when: the clean target shape matters most
+   - recommendation: I recommend this when repo context supports the broader
+     change.
+2. `Option B`
+   - upside: the change is smaller
+   - downside: the original confusion may only be reduced, not removed
+   - best when: limiting scope matters most
+
+Which direction should I plan around?
 
 ## Execution Contract
 
 1. If the request is simple repo orientation, factual explanation, code lookup,
-   status checking, already-approved execution, or clear implementation-ready
-   work, answer or route it directly instead of entering discovery.
+   status checking, or already-approved execution, answer directly and do not
+   expand the turn into discovery.
 2. Read the most relevant repository context needed to ask sharper questions.
 3. If the task is still fuzzy after repo-factual context is handled, ask one
    concise clarification question before doing broader discovery.

--- a/assets/bootstrap/skills/harness-discovery/SKILL.md
+++ b/assets/bootstrap/skills/harness-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-discovery
-description: Run interactive, Socratic pre-implementation discovery for medium/large or ambiguous work in a harness-driven repository by clarifying goals, constraints, tradeoffs, and workflow direction before planning or execution. Use this whenever the next move is unclear, the user needs help choosing an approach, or archived work may need to reopen.
+description: Use before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, already-approved execution, or implementation-ready work with clear scope.
 ---
 
 # Harness Discovery
@@ -10,6 +10,11 @@ description: Run interactive, Socratic pre-implementation discovery for medium/l
 Run discovery before implementation when the task needs real clarification.
 Discovery is conversation-only. It should reduce ambiguity, surface tradeoffs,
 and end with a clear next workflow step.
+
+Discovery is size-independent. Use it to learn whether work is tiny, large, or
+not work at all. Do not use discovery for ordinary repository facts, code
+lookup, status checks, or simple explanations unless the human is deciding what
+work to do next.
 
 ## Inputs
 
@@ -36,33 +41,69 @@ Use explorer subagents on demand, not by default.
   only. They do not choose the next user question, recommend the workflow
   direction, or replace controller judgment.
 
+## Questioning Style
+
+Repository facts are agent-owned. Product intent, priorities, boundaries, and
+approval are human-owned. Before asking the human, read the relevant context
+and answer factual repository questions yourself, using bounded explorers when
+that will sharpen the next human question.
+
+Keep the harness posture collaborative, not adversarial. Borrow the useful
+parts of brainstorming and grill-style questioning: read context first, ask one
+focused question at a time, frame real choices plainly, and recommend a
+direction when the evidence is strong enough. Do not turn discovery into a long
+interrogation.
+
+Prefer this question shape:
+
+1. State the current read in one or two sentences.
+2. Recommend a direction when there is enough signal.
+3. Ask one plain question about the human-owned boundary, priority, or
+   approval.
+
+Avoid jargon-heavy labels, hedging, and loaded binary implementation choices.
+Do not ask a question like:
+
+> Do you want direct breaking schema convergence, or the minimal change of
+> reordering fields and folding `remote_handoff`?
+
+Prefer:
+
+> I recommend making default `harness status` a short control-panel view and
+> keeping full remote details for diagnostics. Are you comfortable changing the
+> default output shape to get that clarity?
+
 ## Execution Contract
 
-1. If the task is still fuzzy, ask one concise clarification question before
-   doing broader discovery.
+1. If the request is simple repo orientation, factual explanation, code lookup,
+   status checking, already-approved execution, or clear implementation-ready
+   work, answer or route it directly instead of entering discovery.
 2. Read the most relevant repository context needed to ask sharper questions.
-3. Use bounded repository exploration according to `Explorer Subagent
+3. If the task is still fuzzy after repo-factual context is handled, ask one
+   concise clarification question before doing broader discovery.
+4. Use bounded repository exploration according to `Explorer Subagent
    Decision` above whenever local reading alone is not enough.
-4. Discovery may alternate between human answers and further bounded
+5. Discovery may alternate between human answers and further bounded
    exploration. Re-evaluate whether more exploration is needed after each
    clarification turn.
-5. Ask exactly one high-leverage question per turn.
-6. Use Socratic questioning to clarify:
+6. Ask exactly one high-leverage question per turn.
+7. Use focused questioning to clarify:
    - purpose
    - constraints
    - non-goals
    - success criteria
    - workflow direction
-7. When a decision benefits from framing, present 2-4 realistic options.
-8. For each option, give:
+8. When a decision benefits from framing, present 2-4 realistic options.
+9. For each option, give:
    - a short label
    - one clear upside
    - one clear downside
    - when it fits
-9. Recommend a direction when the tradeoffs are asymmetric.
-10. Converge on a concrete approach, draft acceptance criteria, and state the
+10. Recommend a direction when the tradeoffs are asymmetric.
+11. Converge on a concrete approach, draft acceptance criteria, and state the
    next workflow step explicitly.
-11. Hand off to `harness-plan` only after the human confirms the direction.
+12. Give a concise discovery summary before handoff.
+13. Hand off to `harness-plan` only after the human confirms the direction.
 
 ## Option Framing Pattern
 
@@ -89,10 +130,12 @@ Then add a short recommendation and why.
 Discovery should end with a concise conversation summary containing:
 
 - the problem statement
+- discovered repository facts that shaped the decision
 - key constraints and non-goals
 - the accepted direction
 - rejected alternatives with short rationale
 - draft acceptance criteria
+- the rough plan shape
 - the next workflow step
 
 ## Guardrails

--- a/assets/bootstrap/skills/harness-discovery/SKILL.md
+++ b/assets/bootstrap/skills/harness-discovery/SKILL.md
@@ -126,6 +126,7 @@ is:
    - upside
    - downside
    - best when ...
+   - recommendation: I recommend this when ...
 2. `Option B`
    - upside
    - downside
@@ -135,7 +136,9 @@ is:
    - downside
    - best when ...
 
-Then add a short recommendation and why.
+Include the recommendation under the option the agent prefers. If no option is
+clearly better, say that briefly after the list instead of forcing a weak
+recommendation.
 
 ## Output
 

--- a/assets/bootstrap/skills/harness-discovery/SKILL.md
+++ b/assets/bootstrap/skills/harness-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-discovery
-description: Run interactive, collaborative discovery before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, or already-approved execution.
+description: Run interactive, Socratic discovery before planning or execution when the objective, boundaries, tradeoffs, success criteria, size, or workflow direction are unclear, or when archived work may need to reopen. Do not use for casual Q&A, simple repo orientation, status checks, or already-approved execution.
 ---
 
 # Harness Discovery
@@ -50,11 +50,13 @@ asking the human, read the relevant context and answer factual repository
 questions yourself, using bounded explorers when that will sharpen the next
 human question.
 
-Keep the harness posture collaborative, not adversarial. Borrow the useful
-parts of brainstorming and grill-style questioning: read context first, ask one
-focused question at a time, frame real choices plainly, and recommend a
-direction when the evidence is strong enough. Do not turn discovery into a long
-interrogation.
+Use a Socratic posture to clarify the work: test assumptions, name tensions,
+and ask focused questions when they expose a real decision. Challenge the
+human's framing when repository evidence points another way, but keep the
+challenge tied to a concrete choice instead of debate. Read context first, ask
+one focused question at a time, frame real choices plainly, recommend a
+direction when the evidence is strong enough, and stop when there is enough
+clarity to summarize and hand off.
 
 Prefer option-shaped questions:
 
@@ -99,7 +101,7 @@ Which direction should I plan around?
    exploration. Re-evaluate whether more exploration is needed after each
    clarification turn.
 6. Ask exactly one high-leverage question per turn.
-7. Use focused questioning to clarify:
+7. Use Socratic, focused questioning to clarify:
    - purpose
    - constraints
    - non-goals

--- a/assets/bootstrap/skills/harness-execute/SKILL.md
+++ b/assets/bootstrap/skills/harness-execute/SKILL.md
@@ -53,12 +53,6 @@ For `delta` review, use a real git commit anchor. The detailed controller
 dispatch fields, anchor guidance, and reviewer-resume rules live in
 [review-orchestration.md](references/review-orchestration.md).
 
-If subagent authorization for this harness run has not been explicit yet, ask
-once before spawning any explorer, worker, or reviewer subagent. Once the human
-authorizes bounded subagents for the run, actively use them for suitable
-independent work instead of waiting until review orchestration is blocked. If
-authorization is denied, continue locally until the human changes that boundary.
-
 Keep exactly one active review round at a time. The detailed review rules live
 in [review-orchestration.md](references/review-orchestration.md).
 
@@ -152,9 +146,6 @@ Execute is done when:
 - Do not ask the human whether routine step-closeout or finalize review should
   start once `harness status` and the tracked plan make the next review action
   clear.
-- Do not silently stall at review orchestration because subagent authorization
-  is missing; the harness-run authorization should be requested at the first
-  harness workflow boundary, or as soon as the missing authorization is noticed.
 - Do not submit reviewer results from the controller thread or impersonate a
   reviewer slot yourself. Reviewer submissions belong to bounded reviewer
   subagents using `harness review submit --by <reviewer-name>`.

--- a/assets/bootstrap/skills/harness-execute/SKILL.md
+++ b/assets/bootstrap/skills/harness-execute/SKILL.md
@@ -53,13 +53,11 @@ For `delta` review, use a real git commit anchor. The detailed controller
 dispatch fields, anchor guidance, and reviewer-resume rules live in
 [review-orchestration.md](references/review-orchestration.md).
 
-If the approved plan is likely to require reviewer subagents and explicit
-authorization has not been obtained yet, ask for that authorization as soon as
-the need becomes foreseeable. Do not wait until reviewer spawning is the only
-remaining next action before surfacing the request.
-If execution still reaches a reviewer-subagent boundary without that explicit
-approval, pause only long enough to request it, then continue the review flow
-once the human answers.
+If subagent authorization for this harness run has not been explicit yet, ask
+once before spawning any explorer, worker, or reviewer subagent. Once the human
+authorizes bounded subagents for the run, actively use them for suitable
+independent work instead of waiting until review orchestration is blocked. If
+authorization is denied, continue locally until the human changes that boundary.
 
 Keep exactly one active review round at a time. The detailed review rules live
 in [review-orchestration.md](references/review-orchestration.md).
@@ -154,10 +152,9 @@ Execute is done when:
 - Do not ask the human whether routine step-closeout or finalize review should
   start once `harness status` and the tracked plan make the next review action
   clear.
-- Do not silently stall at review orchestration because reviewer subagent
-  authorization is missing; request it explicitly as soon as you know it will
-  be required, and if you still reach the reviewer boundary without approval,
-  pause only long enough to ask and then resume once the answer arrives.
+- Do not silently stall at review orchestration because subagent authorization
+  is missing; the harness-run authorization should be requested at the first
+  harness workflow boundary, or as soon as the missing authorization is noticed.
 - Do not submit reviewer results from the controller thread or impersonate a
   reviewer slot yourself. Reviewer submissions belong to bounded reviewer
   subagents using `harness review submit --by <reviewer-name>`.

--- a/assets/bootstrap/skills/harness-plan/SKILL.md
+++ b/assets/bootstrap/skills/harness-plan/SKILL.md
@@ -76,10 +76,6 @@ Use this skill to create or update the tracked plan that will drive execution.
      written plan
    - once the human approves the plan, record that boundary explicitly with
      `harness plan approve --by human`
-   - if this is the first harness workflow boundary in the thread and subagent
-     authorization has not already been explicit, ask whether bounded
-     explorer, worker, and reviewer subagents are authorized for this harness
-     run
 
 ## Commands
 
@@ -106,8 +102,6 @@ The plan is ready when:
   tracked locations before archive so the archived supplements are only backup
   context rather than a hidden dependency
 - the human can approve or challenge it without hidden context
-- when this is the first harness workflow boundary in the thread, the approval
-  handoff records whether bounded subagents are authorized for the harness run
 - a future agent could continue the work from the plan alone
 
 ## Do Not

--- a/assets/bootstrap/skills/harness-plan/SKILL.md
+++ b/assets/bootstrap/skills/harness-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: harness-plan
-description: Create or update a tracked harness plan for medium/large work once the direction is clear enough to execute. Use this when work needs a self-contained plan that a future agent can complete from the repository alone, without relying on discovery chat or hidden session memory.
+description: Create or update a tracked harness plan once the direction is clear enough to execute. Use this when work needs a self-contained plan that a future agent can complete from the repository alone, without relying on discovery chat or hidden session memory.
 ---
 
 # Harness Plan
@@ -76,9 +76,10 @@ Use this skill to create or update the tracked plan that will drive execution.
      written plan
    - once the human approves the plan, record that boundary explicitly with
      `harness plan approve --by human`
-   - if the approved execution loop is likely to require reviewer subagents,
-     ask for explicit subagent authorization in the same approval exchange so
-     execution does not stall later at review time
+   - if this is the first harness workflow boundary in the thread and subagent
+     authorization has not already been explicit, ask whether bounded
+     explorer, worker, and reviewer subagents are authorized for this harness
+     run
 
 ## Commands
 
@@ -105,8 +106,8 @@ The plan is ready when:
   tracked locations before archive so the archived supplements are only backup
   context rather than a hidden dependency
 - the human can approve or challenge it without hidden context
-- when reviewer subagents are likely later, the approval handoff makes that
-  expected authorization explicit instead of deferring it implicitly
+- when this is the first harness workflow boundary in the thread, the approval
+  handoff records whether bounded subagents are authorized for the harness run
 - a future agent could continue the work from the plan alone
 
 ## Do Not

--- a/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -412,6 +412,9 @@ Revision 4 validation covers the discovery-turn rhythm repair:
 - replaced the absolute "ask exactly one high-leverage question per turn" rule
   with "when the next step needs a human decision, ask exactly one question:
   the highest-leverage question for the current moment"
+- after `review-005-delta` found a minor wording slip, changed "answers a side
+  question" to "asks a side question" in bootstrap source and materialized
+  output
 - synced bootstrap output into `.agents/skills/harness-discovery/SKILL.md`
 - `scripts/sync-bootstrap-assets --check`
 - `git diff --check`
@@ -434,7 +437,10 @@ Socratic wording repair satisfies the PR comments, is self-contained for cold
 agents, allows concrete challenge when it clarifies the work, removes the old
 "borrow useful parts" and "not adversarial" wording, and keeps bootstrap
 source/materialized output synchronized.
-Revision 4 review is pending after the latest discovery-turn rhythm repair.
+Revision 4 `review-005-delta` passed with 1 non-blocking `agent_ux` finding:
+the new side-question carveout used "answers a side question" where the prompt
+should say "asks a side question." The wording was repaired in bootstrap
+source and materialized output. A narrow follow-up review is pending.
 Revision 1 reviewer slots:
 
 - `docs_consistency`: confirmed the active plan, managed `AGENTS.md` source and

--- a/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -359,8 +359,6 @@ the final full review will cover the prompt wording as one coherent change.
 
 ## Validation Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 Revision 2 validation covers the original prompt-only candidate plus the PR
 feedback repair:
 
@@ -418,10 +416,13 @@ Revision 4 validation covers the discovery-turn rhythm repair:
 - synced bootstrap output into `.agents/skills/harness-discovery/SKILL.md`
 - `scripts/sync-bootstrap-assets --check`
 - `git diff --check`
+- `harness plan lint docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md`
+- `review-005-delta` verified the discovery-turn rhythm repair in substance
+  and found 1 minor wording slip
+- `review-006-delta` verified the side-question wording follow-up and passed
+  with 0 findings
 
 ## Review Summary
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 Revision 1 `review-001-full` passed cleanly with 0 findings before PR feedback.
 Revision 2 `review-002-full` found 1 blocking `agent_ux` issue: the reusable
@@ -440,7 +441,11 @@ source/materialized output synchronized.
 Revision 4 `review-005-delta` passed with 1 non-blocking `agent_ux` finding:
 the new side-question carveout used "answers a side question" where the prompt
 should say "asks a side question." The wording was repaired in bootstrap
-source and materialized output. A narrow follow-up review is pending.
+source and materialized output.
+Revision 4 `review-006-delta` passed with 0 findings and confirmed the prompt
+now says the human may ask a side question, still tells agents to answer option
+details, side questions, and factual explanations directly, and keeps
+bootstrap source/materialized output synchronized.
 Revision 1 reviewer slots:
 
 - `docs_consistency`: confirmed the active plan, managed `AGENTS.md` source and
@@ -454,17 +459,17 @@ Revision 1 reviewer slots:
 
 ## Archive Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
-- Archived At: UPDATE_REQUIRED_AFTER_REOPEN
+- Archived At: 2026-05-30T23:26:22+08:00
 - Revision: 4
 - PR: https://github.com/catu-ai/easyharness/pull/224
 - Ready: The managed bootstrap source, root managed block, materialized
   harness skills, and active plan now satisfy the approved prompt-only scope
   plus the PR feedback repairs. Validation passed, `review-002-full` feedback
   was repaired, `review-003-delta` passed cleanly, the revision 3 Socratic
-  wording repair passed `review-004-delta` cleanly, and the revision 4
-  discovery-turn rhythm repair is pending review.
+  wording repair passed `review-004-delta` cleanly, the revision 4
+  discovery-turn rhythm repair passed `review-005-delta` with one minor
+  wording finding, and `review-006-delta` verified that follow-up repair
+  cleanly.
 - Merge Handoff: Archive the repaired plan, commit and push revision 4 to PR
   `#224`, refresh publish/CI/sync evidence, and wait for explicit human merge
   approval.
@@ -472,8 +477,6 @@ UPDATE_REQUIRED_AFTER_REOPEN
 ## Outcome Summary
 
 ### Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Added first-boundary harness-run subagent authorization guidance to the
   managed `AGENTS.md` contract, covering explorer, worker, and reviewer
@@ -500,13 +503,9 @@ UPDATE_REQUIRED_AFTER_REOPEN
 
 ### Not Delivered
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 No CLI behavior, command schema, state transition, or subagent runtime changes
 were made.
 
 ### Follow-Up Issues
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 NONE

--- a/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -1,0 +1,351 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-29T23:58:05+08:00"
+approved_at: "2026-05-30T00:07:14+08:00"
+source_type: direct_request
+source_refs:
+    - https://github.com/obra/superpowers/blob/main/skills/brainstorming/SKILL.md
+    - https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md
+size: S
+---
+
+# Tighten Harness Subagent and Discovery Prompts
+
+## Goal
+
+Update the harness-managed prompts so agents treat bounded subagents as a
+normal, actively used part of harness work once the human authorizes them for a
+harness run.
+
+At the same time, tighten `harness-discovery` so it is used for unclear
+workflow direction, boundaries, size, tradeoffs, or success criteria, not for
+ordinary repo facts, code lookup, status checks, or simple explanations. The
+discovery guidance should stay direct and low-jargon: agents should own repo
+fact-finding, make clear recommendations, and avoid pushing low-level
+implementation choices back to the human as false binary decisions.
+When discovery asks the human a question, the preferred shape is: state the
+agent's current read, give a direct recommendation when there is enough signal,
+then ask one plain boundary or approval question. Avoid jargon-heavy labels,
+hedging, and loaded binary choices such as "big breaking rewrite or minimal
+tweak?"
+
+The discovery update should deliberately learn from the current
+`superpowers/brainstorming` and `grill-me` skills without copying either one
+wholesale. Keep the harness skill closer to boundary-setting than grilling:
+use the brainstorming-style context read, one-question rhythm, option framing,
+and recommendation discipline; borrow the grill-me habit of making the agent
+answer repo-factual questions itself before asking the human; do not turn
+harness discovery into adversarial interrogation.
+
+## Scope
+
+### In Scope
+
+- Update the harness-managed `AGENTS.md` block source to request one harness-run
+  subagent authorization at the first harness workflow boundary.
+- Clarify that authorization covers explorer, worker, and reviewer subagents.
+- Strengthen the managed block so subagents are used proactively for bounded,
+  independent work after authorization instead of treated as an unusual
+  fallback.
+- Align adjacent harness skill wording that currently talks about reviewer
+  subagent authorization later in the workflow, so the new first harness
+  workflow boundary authorization rule is not contradicted by plan or execute
+  guidance.
+- Update `harness-discovery` frontmatter so discovery is size-independent and
+  keyed to unclear direction, boundaries, tradeoffs, success criteria, or
+  workflow path.
+- Clarify in `harness-discovery` that simple repo orientation, factual
+  explanation, status checks, and implementation-ready clear-scope work should
+  not enter discovery.
+- Tighten discovery questioning guidance so agents answer repository-factual
+  parts themselves, use explorer subagents for bounded repo questions when
+  useful, keep synthesis in the controller, recommend a direction when
+  appropriate, and ask direct human-facing boundary questions.
+- Define the preferred question format for discovery: current read,
+  recommendation when available, then one plain boundary or approval question.
+  Explicitly discourage loaded either/or implementation choices and
+  jargon-heavy wording.
+- Preserve and strengthen the end-of-discovery summary handoff before planning:
+  summarize what was discovered, what direction the human accepted, rejected
+  alternatives, draft acceptance criteria, and the rough plan shape before
+  switching to `harness-plan`.
+- Fold in the relevant lessons from `superpowers/brainstorming` and
+  `grill-me`: read context first, ask one useful question at a time, frame
+  choices plainly, recommend a path when the agent has enough signal, and ask
+  the human for goals, priorities, boundaries, and approval rather than repo
+  facts.
+- Sync bootstrap assets so the materialized `.agents/skills/` and root
+  `AGENTS.md` managed block match the bootstrap source.
+
+### Out of Scope
+
+- Changing CLI behavior, command schemas, or state transitions.
+- Changing the subagent tool itself or runtime permission rules.
+- Reworking reviewer orchestration beyond aligning it with the shared
+  subagent authorization rule.
+- Adding compatibility shims for old prompt wording.
+
+## Acceptance Criteria
+
+- [x] The managed `AGENTS.md` block says that, once a harness workflow skill is
+  triggered, the controller should ask once for this harness run whether bounded
+  subagents may be used.
+- [x] The managed block says the authorization covers explorer, worker, and
+  reviewer subagents, and that subagents should be actively used for bounded,
+  independent work after authorization.
+- [x] The managed block still preserves human steering, controller ownership of
+  shared context, bounded subagent tasks, and prompt/tool rules that require
+  explicit authorization before spawning.
+- [x] Adjacent `harness-plan` and `harness-execute` authorization wording is
+  aligned with the shared first-boundary harness-run authorization model rather
+  than preserving a reviewer-only or late-workflow permission model.
+- [x] `harness-discovery` frontmatter no longer limits discovery to
+  medium/large work and clearly excludes casual Q&A, simple repo orientation,
+  simple status checks, already-approved execution, and implementation-ready
+  clear-scope changes.
+- [x] `harness-discovery` guidance distinguishes agent-owned repo facts from
+  human-owned goals, priorities, boundaries, approvals, and workflow direction.
+- [x] `harness-discovery` discourages low-level binary implementation-choice
+  questions and prefers direct recommendations plus one human-facing boundary
+  question.
+- [x] `harness-discovery` gives agents a concrete question format: current
+  read, recommendation when there is enough signal, then one plain boundary or
+  approval question, without jargon-heavy labels or loaded either/or wording.
+- [x] `harness-discovery` requires a concise discovery summary before handoff
+  to `harness-plan`, including discovered facts, confirmed direction, rejected
+  alternatives, draft acceptance criteria, rough plan content, and the next
+  workflow step.
+- [x] `harness-discovery` explicitly captures the useful parts of
+  `superpowers/brainstorming` and `grill-me` while preserving harness discovery
+  as collaborative boundary-setting, not a user-grilling mode.
+- [x] `scripts/sync-bootstrap-assets --check` passes after syncing managed
+  assets.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Update the managed subagent contract
+
+- Done: [x]
+
+#### Objective
+
+Revise the managed `AGENTS.md` source so harness runs ask once for broad
+bounded-subagent authorization and then actively use authorized subagents.
+
+#### Details
+
+The wording should keep the human in control without making subagents feel
+exceptional. It should trigger only when a harness workflow skill is actually
+being used, not for casual chat or simple repo questions. The authorization
+should cover explorer, worker, and reviewer subagents for the current harness
+run.
+
+Also update any nearby managed harness skill wording that still treats subagent
+authorization as reviewer-only or something to request late in plan approval or
+execution. Those sections should point back to the shared first-boundary
+authorization model while still respecting explicit human approval before
+subagent spawning.
+
+#### Expected Files
+
+- `assets/bootstrap/agents-managed-block.md`
+- `assets/bootstrap/skills/harness-plan/SKILL.md`
+- `assets/bootstrap/skills/harness-execute/SKILL.md`
+
+#### Validation
+
+- Reread the managed block for consistency with the existing "Humans steer.
+  Agents execute." rule.
+- Confirm the text does not imply the controller may spawn subagents without
+  explicit user authorization.
+
+#### Execution Notes
+
+Updated the managed `AGENTS.md` source so subagents are described as a normal
+harness workflow tool after explicit run-level authorization. The new wording
+asks once at the first harness workflow boundary, covers explorer, worker, and
+reviewer subagents, and keeps the controller responsible for shared context and
+final workflow judgment. Also aligned `harness-plan` and `harness-execute` so
+they no longer preserve reviewer-only or late-workflow authorization language.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This tightly-coupled prompt-only slice will receive one
+final full review after bootstrap sync and validation.
+
+### Step 2: Tighten the discovery prompt contract
+
+- Done: [x]
+
+#### Objective
+
+Revise `harness-discovery` so its use-when, repo fact-finding, explorer use,
+and question style match the agreed discovery boundary.
+
+#### Details
+
+Discovery should not be tied to work size because discovery may be needed to
+learn the size. It should be tied to unclear direction, scope, boundary, size,
+tradeoff, success criteria, or workflow path. Simple factual repo explanation
+should stay outside discovery unless the user is deciding what work to do next.
+
+Questioning guidance should stay plain and direct. Agents should not ask the
+human to answer repository facts or choose between low-level implementation
+mechanics when the controller can recommend the better path from repo context.
+The skill should give agents a compact question pattern instead of abstract
+style advice:
+
+1. Say the current read in one or two sentences.
+2. Recommend a direction when the evidence is strong enough.
+3. Ask one plain question about the human-owned boundary, priority, or
+   approval.
+
+Bad discovery question shape:
+
+> Do you want direct breaking schema convergence, or the minimal change of
+> reordering fields and folding `remote_handoff`?
+
+Better shape:
+
+> I recommend making default `harness status` a short control-panel view and
+> keeping full remote details for diagnostics. Are you comfortable changing the
+> default output shape to get that clarity?
+
+The existing end-of-discovery `Output` section should be kept and made harder
+to skip. Before handing off to `harness-plan`, the controller should give a
+concise discovery summary with:
+
+- what was discovered
+- the accepted direction
+- rejected alternatives and why
+- draft acceptance criteria
+- the rough plan shape
+- the next workflow step
+
+Use the two reference skills as design input:
+
+- From `superpowers/brainstorming`, keep the flow of reading context first,
+  asking one focused question per turn, using concise option framing when it
+  helps, and giving a recommendation rather than staying neutral when tradeoffs
+  are asymmetric.
+- From `grill-me`, keep the discipline that the agent should investigate
+  factual repo questions itself before asking the human.
+- Do not import the whole grill-me posture. Harness discovery should help the
+  human clarify boundaries and workflow direction, not pressure-test them with
+  a long interrogation.
+
+#### Expected Files
+
+- `assets/bootstrap/skills/harness-discovery/SKILL.md`
+
+#### Validation
+
+- Reread the skill as if a future agent has no chat context.
+- Confirm it gives enough guidance to avoid the observed "breaking schema or
+  minimal tweak?" style of implementation-level binary question.
+
+#### Execution Notes
+
+Updated `harness-discovery` source frontmatter and body so discovery is
+size-independent, excludes simple repo orientation/status/code lookup and clear
+implementation-ready work, assigns repo facts to the agent and goals/boundaries
+to the human, defines the current-read/recommendation/plain-question format,
+discourages loaded implementation binaries, and strengthens the required
+end-of-discovery summary before handoff to `harness-plan`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This tightly-coupled prompt-only slice will receive one
+final full review after bootstrap sync and validation.
+
+### Step 3: Sync and validate bootstrap output
+
+- Done: [x]
+
+#### Objective
+
+Materialize the bootstrap source changes into repo-local generated prompt
+assets and run the relevant drift checks.
+
+#### Details
+
+Use the repository's bootstrap sync script rather than hand-editing generated
+`.agents/skills/` files or the managed root `AGENTS.md` block.
+
+#### Expected Files
+
+- `AGENTS.md`
+- `.agents/skills/harness-discovery/SKILL.md`
+- `.agents/skills/harness-plan/SKILL.md`
+- `.agents/skills/harness-execute/SKILL.md`
+
+#### Validation
+
+- Run `scripts/sync-bootstrap-assets`.
+- Run `scripts/sync-bootstrap-assets --check`.
+- Run `harness plan lint docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md`.
+
+#### Execution Notes
+
+Ran `scripts/sync-bootstrap-assets` to update the materialized root
+`AGENTS.md` block and `.agents/skills/` copies from `assets/bootstrap/`.
+Validation passed with `scripts/sync-bootstrap-assets --check`, `harness plan
+lint docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md`,
+and a stale-wording search for the old medium/large, Socratic, and
+reviewer-only authorization phrases across the edited managed prompt files.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step validation is mechanical bootstrap sync and lint;
+the final full review will cover the prompt wording as one coherent change.
+
+## Validation Strategy
+
+- Lint the tracked plan before approval.
+- During execution, use bootstrap sync and its `--check` mode as the primary
+  prompt drift validation.
+- Review the updated managed instructions and discovery skill manually against
+  the discovery decisions captured in this plan.
+
+## Risks
+
+- Risk: The managed block could make subagent use sound automatic even though
+  Codex requires explicit user authorization.
+  - Mitigation: Require one harness-run authorization at the first harness
+    workflow boundary, then allow proactive bounded use only after that.
+- Risk: Discovery guidance could become too long or jargon-heavy and increase
+  agent/user cognitive load.
+  - Mitigation: Prefer direct rules and short examples over abstract labels.
+- Risk: Discovery exclusions could prevent useful discovery for small work.
+  - Mitigation: Make discovery size-independent and exclude only clear factual
+    or implementation-ready cases.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -13,21 +13,22 @@ size: S
 
 ## Goal
 
-Update the harness-managed prompts so agents treat bounded subagents as a
-normal, actively used part of harness work once the human authorizes them for a
-harness run.
+Update the harness-managed prompts so agents treat specific, well-scoped
+subagents as a normal, actively used part of harness work once the human
+authorizes them for a harness run.
 
 At the same time, tighten `harness-discovery` so it is used for unclear
 workflow direction, boundaries, size, tradeoffs, or success criteria, not for
 ordinary repo facts, code lookup, status checks, or simple explanations. The
 discovery guidance should stay direct and low-jargon: agents should own repo
-fact-finding, make clear recommendations, and avoid pushing low-level
-implementation choices back to the human as false binary decisions.
+fact-finding, frame choices as options, make clear recommendations under the
+preferred option, and avoid pushing low-level implementation choices back to the
+human as false binary decisions.
 When discovery asks the human a question, the preferred shape is: state the
-agent's current read, give a direct recommendation when there is enough signal,
-then ask one plain boundary or approval question. Avoid jargon-heavy labels,
-hedging, and loaded binary choices such as "big breaking rewrite or minimal
-tweak?"
+agent's current read, present 2-4 realistic options, put the recommendation
+under the preferred option, and ask the human to choose, edit, or reject the
+options. Avoid jargon-heavy labels, hedging, and loaded binaries such as "big
+breaking rewrite or minimal tweak?"
 
 The discovery update should deliberately learn from the current
 `superpowers/brainstorming` and `grill-me` skills without copying either one
@@ -55,14 +56,16 @@ harness discovery into adversarial interrogation.
   keyed to unclear direction, boundaries, tradeoffs, success criteria, or
   workflow path.
 - Clarify in `harness-discovery` that simple repo orientation, factual
-  explanation, status checks, and implementation-ready clear-scope work should
-  not enter discovery.
+  explanation, status checks, and already-approved execution should not expand
+  into discovery.
 - Tighten discovery questioning guidance so agents answer repository-factual
   parts themselves, use explorer subagents for bounded repo questions when
-  useful, keep synthesis in the controller, recommend a direction when
-  appropriate, and ask direct human-facing boundary questions.
-- Define the preferred question format for discovery: current read,
-  recommendation when available, then one plain boundary or approval question.
+  useful, keep synthesis in the controller, frame choices as options, put the
+  recommendation under the preferred option, and ask direct human-facing
+  boundary questions.
+- Define the preferred question format for discovery: current read, 2-4
+  realistic options, recommendation under the preferred option, then a request
+  for the human to choose, edit, or reject the options.
   Explicitly discourage loaded either/or implementation choices and
   jargon-heavy wording.
 - Preserve and strengthen the end-of-discovery summary handoff before planning:
@@ -71,9 +74,9 @@ harness discovery into adversarial interrogation.
   switching to `harness-plan`.
 - Fold in the relevant lessons from `superpowers/brainstorming` and
   `grill-me`: read context first, ask one useful question at a time, frame
-  choices plainly, recommend a path when the agent has enough signal, and ask
-  the human for goals, priorities, boundaries, and approval rather than repo
-  facts.
+  choices plainly as options, recommend a path when the agent has enough
+  signal, and treat the human as having final say over goals, priorities,
+  boundaries, and approval when repo context does not already settle them.
 - Sync bootstrap assets so the materialized `.agents/skills/` and root
   `AGENTS.md` managed block match the bootstrap source.
 
@@ -88,8 +91,8 @@ harness discovery into adversarial interrogation.
 ## Acceptance Criteria
 
 - [x] The managed `AGENTS.md` block says that, once a harness workflow skill is
-  triggered, the controller should ask once for this harness run whether bounded
-  subagents may be used.
+  triggered, the controller should ask once for this harness run whether
+  specific, well-scoped subagents may be used.
 - [x] The managed block says the authorization covers explorer, worker, and
   reviewer subagents, and that subagents should be actively used for bounded,
   independent work after authorization.
@@ -101,16 +104,18 @@ harness discovery into adversarial interrogation.
   than preserving a reviewer-only or late-workflow permission model.
 - [x] `harness-discovery` frontmatter no longer limits discovery to
   medium/large work and clearly excludes casual Q&A, simple repo orientation,
-  simple status checks, already-approved execution, and implementation-ready
-  clear-scope changes.
-- [x] `harness-discovery` guidance distinguishes agent-owned repo facts from
-  human-owned goals, priorities, boundaries, approvals, and workflow direction.
+  simple status checks, and already-approved execution.
+- [x] `harness-discovery` guidance distinguishes agent-investigated repo facts
+  and documented intent from human final say over goals, priorities,
+  boundaries, approvals, and workflow direction when those are ambiguous,
+  contested, or not already settled in the repository.
 - [x] `harness-discovery` discourages low-level binary implementation-choice
-  questions and prefers direct recommendations plus one human-facing boundary
-  question.
+  questions and prefers neutral option framing with a recommendation under the
+  preferred option.
 - [x] `harness-discovery` gives agents a concrete question format: current
-  read, recommendation when there is enough signal, then one plain boundary or
-  approval question, without jargon-heavy labels or loaded either/or wording.
+  read, 2-4 realistic options, recommendation under the preferred option, then
+  a request for the human to choose, edit, or reject the options, without
+  jargon-heavy labels or loaded either/or wording.
 - [x] `harness-discovery` requires a concise discovery summary before handoff
   to `harness-plan`, including discovered facts, confirmed direction, rejected
   alternatives, draft acceptance criteria, rough plan content, and the next
@@ -134,7 +139,8 @@ harness discovery into adversarial interrogation.
 #### Objective
 
 Revise the managed `AGENTS.md` source so harness runs ask once for broad
-bounded-subagent authorization and then actively use authorized subagents.
+subagent authorization and then actively use authorized, specific, well-scoped
+subagents.
 
 #### Details
 
@@ -142,13 +148,13 @@ The wording should keep the human in control without making subagents feel
 exceptional. It should trigger only when a harness workflow skill is actually
 being used, not for casual chat or simple repo questions. The authorization
 should cover explorer, worker, and reviewer subagents for the current harness
-run.
+run, using plain wording such as "specific, well-scoped subagents" where that
+is clearer than "bounded subagents."
 
-Also update any nearby managed harness skill wording that still treats subagent
-authorization as reviewer-only or something to request late in plan approval or
-execution. Those sections should point back to the shared first-boundary
-authorization model while still respecting explicit human approval before
-subagent spawning.
+Do not duplicate the authorization prompt in every harness skill. The shared
+managed `AGENTS.md` block owns that run-level rule. Nearby managed harness
+skills should avoid reviewer-only or late-workflow authorization wording that
+would contradict the shared model.
 
 #### Expected Files
 
@@ -166,11 +172,13 @@ subagent spawning.
 #### Execution Notes
 
 Updated the managed `AGENTS.md` source so subagents are described as a normal
-harness workflow tool after explicit run-level authorization. The new wording
-asks once at the first harness workflow boundary, covers explorer, worker, and
-reviewer subagents, and keeps the controller responsible for shared context and
-final workflow judgment. Also aligned `harness-plan` and `harness-execute` so
-they no longer preserve reviewer-only or late-workflow authorization language.
+harness workflow tool after explicit run-level authorization. The revised
+wording asks once at the first harness workflow boundary, uses "specific,
+well-scoped subagents" for the authorization prompt, covers explorer, worker,
+and reviewer subagents, and keeps the controller responsible for shared context
+and final workflow judgment. Removed duplicate authorization prompting from
+`harness-plan` and `harness-execute` while preserving the shared managed-block
+rule.
 
 #### Review Notes
 
@@ -196,24 +204,33 @@ should stay outside discovery unless the user is deciding what work to do next.
 Questioning guidance should stay plain and direct. Agents should not ask the
 human to answer repository facts or choose between low-level implementation
 mechanics when the controller can recommend the better path from repo context.
-The skill should give agents a compact question pattern instead of abstract
-style advice:
+The skill should give agents a compact option-shaped question pattern instead
+of abstract style advice:
 
 1. Say the current read in one or two sentences.
-2. Recommend a direction when the evidence is strong enough.
-3. Ask one plain question about the human-owned boundary, priority, or
-   approval.
+2. Present 2-4 realistic options, even for small decisions.
+3. Put the recommendation under the option the agent prefers, with a short
+   reason.
+4. Ask the human to choose, edit, or reject the options.
 
 Bad discovery question shape:
 
-> Do you want direct breaking schema convergence, or the minimal change of
-> reordering fields and folding `remote_handoff`?
+> Do you want the broad breaking rewrite, or the minimal low-risk patch?
 
 Better shape:
 
-> I recommend making default `harness status` a short control-panel view and
-> keeping full remote details for diagnostics. Are you comfortable changing the
-> default output shape to get that clarity?
+1. `Option A`
+   - upside: the main goal is addressed directly
+   - downside: the change may be broader
+   - best when: the clean target shape matters most
+   - recommendation: I recommend this when repo context supports the broader
+     change.
+2. `Option B`
+   - upside: the change is smaller
+   - downside: the original confusion may only be reduced, not removed
+   - best when: limiting scope matters most
+
+Which direction should I plan around?
 
 The existing end-of-discovery `Output` section should be kept and made harder
 to skip. Before handing off to `harness-plan`, the controller should give a
@@ -230,8 +247,8 @@ Use the two reference skills as design input:
 
 - From `superpowers/brainstorming`, keep the flow of reading context first,
   asking one focused question per turn, using concise option framing when it
-  helps, and giving a recommendation rather than staying neutral when tradeoffs
-  are asymmetric.
+  helps, and putting a recommendation under the preferred option rather than
+  staying neutral when tradeoffs are asymmetric.
 - From `grill-me`, keep the discipline that the agent should investigate
   factual repo questions itself before asking the human.
 - Do not import the whole grill-me posture. Harness discovery should help the
@@ -251,11 +268,13 @@ Use the two reference skills as design input:
 #### Execution Notes
 
 Updated `harness-discovery` source frontmatter and body so discovery is
-size-independent, excludes simple repo orientation/status/code lookup and clear
-implementation-ready work, assigns repo facts to the agent and goals/boundaries
-to the human, defines the current-read/recommendation/plain-question format,
-discourages loaded implementation binaries, and strengthens the required
-end-of-discovery summary before handoff to `harness-plan`.
+interactive and collaborative, size-independent, excludes simple repo
+orientation/status/code lookup and already-approved execution, treats repo
+facts and documented intent as agent-investigated context while preserving
+human final say over ambiguous goals/boundaries/approvals, defines the
+current-read/options/recommendation-under-preferred-option format, discourages
+loaded implementation binaries, and strengthens the required end-of-discovery
+summary before handoff to `harness-plan`.
 
 #### Review Notes
 
@@ -316,37 +335,47 @@ the final full review will cover the prompt wording as one coherent change.
 - Risk: The managed block could make subagent use sound automatic even though
   Codex requires explicit user authorization.
   - Mitigation: Require one harness-run authorization at the first harness
-    workflow boundary, then allow proactive bounded use only after that.
+    workflow boundary, then allow proactive use of specific, well-scoped
+    subagents only after that.
 - Risk: Discovery guidance could become too long or jargon-heavy and increase
   agent/user cognitive load.
   - Mitigation: Prefer direct rules and short examples over abstract labels.
 - Risk: Discovery exclusions could prevent useful discovery for small work.
-  - Mitigation: Make discovery size-independent and exclude only clear factual
-    or implementation-ready cases.
+  - Mitigation: Make discovery size-independent and exclude only simple factual
+    orientation, status/code lookup, and already-approved execution cases.
 
 ## Validation Summary
 
-Validated the prompt-only candidate with:
+Revision 2 validation covers the original prompt-only candidate plus the PR
+feedback repair:
 
 - `git diff --check`
 - `scripts/sync-bootstrap-assets --check`
 - `harness plan lint docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md`
 - stale-wording search across the edited managed prompt surfaces for old
-  medium/large discovery, Socratic discovery, reviewer-only authorization, and
-  late reviewer-subagent authorization language
+  medium/large discovery, Socratic discovery, reviewer-only authorization,
+  late reviewer-subagent authorization, implementation-ready exclusion,
+  obsolete direct-question format, and status-specific example wording
+- no-context simulation subagents against the materialized prompts:
+  - unclear `harness status` noise request correctly entered discovery and
+    asked for run-level subagent authorization before repo exploration
+  - dashboard watchlist code-lookup request correctly bypassed discovery and
+    did not ask for subagent authorization
 
 ## Review Summary
 
-`review-001-full` passed cleanly with 0 findings. Reviewer slots:
+Revision 1 `review-001-full` passed cleanly with 0 findings before PR feedback.
+Revision 2 requires a fresh finalize review after the comment repairs.
+Revision 1 reviewer slots:
 
 - `docs_consistency`: confirmed the active plan, managed `AGENTS.md` source and
   output, bootstrap skill sources, and materialized skill copies consistently
-  describe run-level bounded-subagent authorization, active post-authorization
-  subagent use, and the tightened discovery boundary.
+  described the revision-1 run-level subagent authorization, active
+  post-authorization subagent use, and the tightened discovery boundary.
 - `agent_ux`: confirmed the updated prompts are direct and usable for future
   agents, including size-independent discovery, agent-owned repo facts, the
-  current-read/recommendation/plain-boundary question format, no loaded
-  implementation binaries, and explicit discovery-summary handoff.
+  earlier direct question format, no loaded implementation binaries, and
+  explicit discovery-summary handoff.
 
 ## Archive Summary
 
@@ -368,15 +397,17 @@ Validated the prompt-only candidate with:
 - Added first-boundary harness-run subagent authorization guidance to the
   managed `AGENTS.md` contract, covering explorer, worker, and reviewer
   subagents.
-- Reframed subagents as a normal authorized harness workflow tool for bounded,
-  independent work while preserving controller ownership and human steering.
-- Aligned `harness-plan` and `harness-execute` with the shared run-level
-  authorization model instead of reviewer-only late authorization wording.
+- Reframed subagents as a normal authorized harness workflow tool for specific,
+  well-scoped work while preserving controller ownership and human steering.
+- Removed duplicated subagent authorization prompts from `harness-plan` and
+  `harness-execute`; the managed `AGENTS.md` block owns the shared run-level
+  authorization model.
 - Updated `harness-discovery` so discovery is size-independent, excludes simple
-  repo Q&A/status/code lookup and clear implementation-ready work, assigns repo
-  facts to the agent, gives a direct question format, discourages loaded
-  implementation binaries, and requires a concise discovery summary before
-  handoff to `harness-plan`.
+  repo Q&A/status/code lookup and already-approved execution, treats repo facts
+  and documented intent as agent-investigated context, gives an option-shaped
+  question format with the recommendation under the preferred option,
+  discourages loaded implementation binaries, and requires a concise discovery
+  summary before handoff to `harness-plan`.
 - Synced bootstrap outputs into root `AGENTS.md` and `.agents/skills/`.
 
 ### Not Delivered

--- a/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -282,6 +282,13 @@ direct cold-agent instructions, and made explicit that discovery may challenge
 the human's framing when repository evidence points another way, as long as
 the challenge serves a concrete decision.
 
+Revision 4 PR feedback repair clarified that discovery should not force a new
+question or option set into every turn. When the human asks for details about
+existing options, asks a side question, or needs a factual explanation before
+deciding, the agent should answer directly. The "one high-leverage question"
+rule now applies only when the next step needs a human decision, and the
+question should be the highest-leverage question for that moment.
+
 #### Review Notes
 
 NO_STEP_REVIEW_NEEDED: This tightly-coupled prompt-only slice will receive one
@@ -352,6 +359,8 @@ the final full review will cover the prompt wording as one coherent change.
 
 ## Validation Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 Revision 2 validation covers the original prompt-only candidate plus the PR
 feedback repair:
 
@@ -394,7 +403,22 @@ Revision 3 validation covers the latest PR feedback repair:
 - `review-004-delta` verified the Socratic wording repair and passed with 0
   findings
 
+Revision 4 validation covers the discovery-turn rhythm repair:
+
+- clarified in `harness-discovery` that agents should not force a new question
+  into every discovery turn
+- clarified that details about an existing option, side questions, and factual
+  explanations should be answered directly
+- replaced the absolute "ask exactly one high-leverage question per turn" rule
+  with "when the next step needs a human decision, ask exactly one question:
+  the highest-leverage question for the current moment"
+- synced bootstrap output into `.agents/skills/harness-discovery/SKILL.md`
+- `scripts/sync-bootstrap-assets --check`
+- `git diff --check`
+
 ## Review Summary
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 Revision 1 `review-001-full` passed cleanly with 0 findings before PR feedback.
 Revision 2 `review-002-full` found 1 blocking `agent_ux` issue: the reusable
@@ -410,6 +434,7 @@ Socratic wording repair satisfies the PR comments, is self-contained for cold
 agents, allows concrete challenge when it clarifies the work, removes the old
 "borrow useful parts" and "not adversarial" wording, and keeps bootstrap
 source/materialized output synchronized.
+Revision 4 review is pending after the latest discovery-turn rhythm repair.
 Revision 1 reviewer slots:
 
 - `docs_consistency`: confirmed the active plan, managed `AGENTS.md` source and
@@ -423,21 +448,26 @@ Revision 1 reviewer slots:
 
 ## Archive Summary
 
-- Archived At: 2026-05-30T23:02:09+08:00
-- Revision: 3
+UPDATE_REQUIRED_AFTER_REOPEN
+
+- Archived At: UPDATE_REQUIRED_AFTER_REOPEN
+- Revision: 4
 - PR: https://github.com/catu-ai/easyharness/pull/224
 - Ready: The managed bootstrap source, root managed block, materialized
   harness skills, and active plan now satisfy the approved prompt-only scope
   plus the PR feedback repairs. Validation passed, `review-002-full` feedback
-  was repaired, `review-003-delta` passed cleanly, and the revision 3
-  Socratic wording repair passed `review-004-delta` cleanly.
-- Merge Handoff: Archive the repaired plan, commit and push revision 3 to PR
+  was repaired, `review-003-delta` passed cleanly, the revision 3 Socratic
+  wording repair passed `review-004-delta` cleanly, and the revision 4
+  discovery-turn rhythm repair is pending review.
+- Merge Handoff: Archive the repaired plan, commit and push revision 4 to PR
   `#224`, refresh publish/CI/sync evidence, and wait for explicit human merge
   approval.
 
 ## Outcome Summary
 
 ### Delivered
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Added first-boundary harness-run subagent authorization guidance to the
   managed `AGENTS.md` contract, covering explorer, worker, and reviewer
@@ -457,13 +487,20 @@ Revision 1 reviewer slots:
   self-contained for cold agents, and clarified that agents may challenge the
   human's framing when repository evidence points another way and the
   challenge serves a concrete decision.
+- Clarified that discovery should answer option-detail, side-question, and
+  factual-explanation turns directly instead of forcing a fresh question, and
+  that the one-question rule applies only when a human decision is needed.
 - Synced bootstrap outputs into root `AGENTS.md` and `.agents/skills/`.
 
 ### Not Delivered
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 No CLI behavior, command schema, state transition, or subagent runtime changes
 were made.
 
 ### Follow-Up Issues
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 NONE

--- a/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -361,11 +361,18 @@ feedback repair:
     asked for run-level subagent authorization before repo exploration
   - dashboard watchlist code-lookup request correctly bypassed discovery and
     did not ask for subagent authorization
+- after `review-002-full` found the reusable option pattern still placed the
+  recommendation after the list, updated both bootstrap source and materialized
+  output so the recommendation lives under the preferred option, then reran
+  `scripts/sync-bootstrap-assets --check` and `git diff --check`
 
 ## Review Summary
 
 Revision 1 `review-001-full` passed cleanly with 0 findings before PR feedback.
-Revision 2 requires a fresh finalize review after the comment repairs.
+Revision 2 `review-002-full` found 1 blocking `agent_ux` issue: the reusable
+`Option Framing Pattern` still told agents to add the recommendation after the
+options. The source and materialized skill were repaired so the reusable
+pattern now puts the recommendation under the preferred option.
 Revision 1 reviewer slots:
 
 - `docs_consistency`: confirmed the active plan, managed `AGENTS.md` source and

--- a/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -276,6 +276,12 @@ current-read/options/recommendation-under-preferred-option format, discourages
 loaded implementation binaries, and strengthens the required end-of-discovery
 summary before handoff to `harness-plan`.
 
+Revision 3 PR feedback repair restored `Socratic` to the discovery frontmatter
+and body, replaced the non-self-contained "borrow useful parts" wording with
+direct cold-agent instructions, and made explicit that discovery may challenge
+the human's framing when repository evidence points another way, as long as
+the challenge serves a concrete decision.
+
 #### Review Notes
 
 NO_STEP_REVIEW_NEEDED: This tightly-coupled prompt-only slice will receive one
@@ -346,6 +352,8 @@ the final full review will cover the prompt wording as one coherent change.
 
 ## Validation Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 Revision 2 validation covers the original prompt-only candidate plus the PR
 feedback repair:
 
@@ -370,6 +378,8 @@ feedback repair:
 
 ## Review Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 Revision 1 `review-001-full` passed cleanly with 0 findings before PR feedback.
 Revision 2 `review-002-full` found 1 blocking `agent_ux` issue: the reusable
 `Option Framing Pattern` still told agents to add the recommendation after the
@@ -392,6 +402,8 @@ Revision 1 reviewer slots:
 
 ## Archive Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - Archived At: 2026-05-30T10:43:48+08:00
 - Revision: 2
 - PR: https://github.com/catu-ai/easyharness/pull/224
@@ -406,6 +418,8 @@ Revision 1 reviewer slots:
 ## Outcome Summary
 
 ### Delivered
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Added first-boundary harness-run subagent authorization guidance to the
   managed `AGENTS.md` contract, covering explorer, worker, and reviewer
@@ -425,9 +439,13 @@ Revision 1 reviewer slots:
 
 ### Not Delivered
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 No CLI behavior, command schema, state transition, or subagent runtime changes
 were made.
 
 ### Follow-Up Issues
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 NONE

--- a/docs/plans/archived/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/archived/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -365,6 +365,8 @@ feedback repair:
   recommendation after the list, updated both bootstrap source and materialized
   output so the recommendation lives under the preferred option, then reran
   `scripts/sync-bootstrap-assets --check` and `git diff --check`
+- `review-003-delta` verified the option-pattern repair and passed with 0
+  findings
 
 ## Review Summary
 
@@ -373,6 +375,10 @@ Revision 2 `review-002-full` found 1 blocking `agent_ux` issue: the reusable
 `Option Framing Pattern` still told agents to add the recommendation after the
 options. The source and materialized skill were repaired so the reusable
 pattern now puts the recommendation under the preferred option.
+Revision 2 `review-003-delta` passed with 0 findings and confirmed the
+recommendation now lives under the preferred option in both bootstrap source
+and materialized output, with no remaining contradictory recommendation
+placement wording.
 Revision 1 reviewer slots:
 
 - `docs_consistency`: confirmed the active plan, managed `AGENTS.md` source and
@@ -386,15 +392,15 @@ Revision 1 reviewer slots:
 
 ## Archive Summary
 
-- Archived At: 2026-05-30T00:16:03+08:00
-- Revision: 1
-- PR: pending publish after archive; no PR URL exists yet.
+- Archived At: 2026-05-30T10:43:48+08:00
+- Revision: 2
+- PR: https://github.com/catu-ai/easyharness/pull/224
 - Ready: The managed bootstrap source, root managed block, materialized
-  harness skills, and active plan now satisfy the approved prompt-only scope.
-  Validation passed and `review-001-full` found no issues.
-- Merge Handoff: Archive the plan, commit the tracked plan move and closeout
-  summary, push branch `codex/tighten-harness-subagent-discovery-prompts`, open
-  a PR, record publish/CI/sync evidence, and wait for explicit human merge
+  harness skills, and active plan now satisfy the approved prompt-only scope
+  plus the PR feedback repair. Validation passed, `review-002-full` feedback
+  was repaired, and `review-003-delta` passed cleanly.
+- Merge Handoff: Archive the repaired plan, commit and push revision 2 to PR
+  `#224`, refresh publish/CI/sync evidence, and wait for explicit human merge
   approval.
 
 ## Outcome Summary

--- a/docs/plans/archived/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/archived/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -459,7 +459,7 @@ Revision 1 reviewer slots:
 
 ## Archive Summary
 
-- Archived At: 2026-05-30T23:26:22+08:00
+- Archived At: 2026-05-30T23:27:07+08:00
 - Revision: 4
 - PR: https://github.com/catu-ai/easyharness/pull/224
 - Ready: The managed bootstrap source, root managed block, materialized

--- a/docs/plans/archived/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/archived/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -326,25 +326,63 @@ the final full review will cover the prompt wording as one coherent change.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+Validated the prompt-only candidate with:
+
+- `git diff --check`
+- `scripts/sync-bootstrap-assets --check`
+- `harness plan lint docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md`
+- stale-wording search across the edited managed prompt surfaces for old
+  medium/large discovery, Socratic discovery, reviewer-only authorization, and
+  late reviewer-subagent authorization language
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+`review-001-full` passed cleanly with 0 findings. Reviewer slots:
+
+- `docs_consistency`: confirmed the active plan, managed `AGENTS.md` source and
+  output, bootstrap skill sources, and materialized skill copies consistently
+  describe run-level bounded-subagent authorization, active post-authorization
+  subagent use, and the tightened discovery boundary.
+- `agent_ux`: confirmed the updated prompts are direct and usable for future
+  agents, including size-independent discovery, agent-owned repo facts, the
+  current-read/recommendation/plain-boundary question format, no loaded
+  implementation binaries, and explicit discovery-summary handoff.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-05-30T00:16:03+08:00
+- Revision: 1
+- PR: pending publish after archive; no PR URL exists yet.
+- Ready: The managed bootstrap source, root managed block, materialized
+  harness skills, and active plan now satisfy the approved prompt-only scope.
+  Validation passed and `review-001-full` found no issues.
+- Merge Handoff: Archive the plan, commit the tracked plan move and closeout
+  summary, push branch `codex/tighten-harness-subagent-discovery-prompts`, open
+  a PR, record publish/CI/sync evidence, and wait for explicit human merge
+  approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added first-boundary harness-run subagent authorization guidance to the
+  managed `AGENTS.md` contract, covering explorer, worker, and reviewer
+  subagents.
+- Reframed subagents as a normal authorized harness workflow tool for bounded,
+  independent work while preserving controller ownership and human steering.
+- Aligned `harness-plan` and `harness-execute` with the shared run-level
+  authorization model instead of reviewer-only late authorization wording.
+- Updated `harness-discovery` so discovery is size-independent, excludes simple
+  repo Q&A/status/code lookup and clear implementation-ready work, assigns repo
+  facts to the agent, gives a direct question format, discourages loaded
+  implementation binaries, and requires a concise discovery summary before
+  handoff to `harness-plan`.
+- Synced bootstrap outputs into root `AGENTS.md` and `.agents/skills/`.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+No CLI behavior, command schema, state transition, or subagent runtime changes
+were made.
 
 ### Follow-Up Issues
 

--- a/docs/plans/archived/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
+++ b/docs/plans/archived/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md
@@ -352,8 +352,6 @@ the final full review will cover the prompt wording as one coherent change.
 
 ## Validation Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 Revision 2 validation covers the original prompt-only candidate plus the PR
 feedback repair:
 
@@ -376,9 +374,27 @@ feedback repair:
 - `review-003-delta` verified the option-pattern repair and passed with 0
   findings
 
-## Review Summary
+Revision 3 validation covers the latest PR feedback repair:
 
-UPDATE_REQUIRED_AFTER_REOPEN
+- restored `Socratic` to `harness-discovery` frontmatter and execution
+  guidance
+- replaced the non-self-contained "borrow useful parts" wording with direct
+  cold-agent instructions for testing assumptions, naming tensions, and asking
+  focused questions
+- changed the prior "not adversarial" framing into explicit permission to
+  challenge the human's framing when repository evidence points another way,
+  while keeping the challenge tied to a concrete decision
+- synced bootstrap output into `.agents/skills/harness-discovery/SKILL.md`
+- `scripts/sync-bootstrap-assets --check`
+- `harness plan lint docs/plans/active/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md`
+- `git diff --check`
+- stale-wording search for the old "Borrow the useful parts",
+  "collaborative, not adversarial", focused-only questioning, and
+  collaborative-only frontmatter phrases
+- `review-004-delta` verified the Socratic wording repair and passed with 0
+  findings
+
+## Review Summary
 
 Revision 1 `review-001-full` passed cleanly with 0 findings before PR feedback.
 Revision 2 `review-002-full` found 1 blocking `agent_ux` issue: the reusable
@@ -389,6 +405,11 @@ Revision 2 `review-003-delta` passed with 0 findings and confirmed the
 recommendation now lives under the preferred option in both bootstrap source
 and materialized output, with no remaining contradictory recommendation
 placement wording.
+Revision 3 `review-004-delta` passed with 0 findings and confirmed the latest
+Socratic wording repair satisfies the PR comments, is self-contained for cold
+agents, allows concrete challenge when it clarifies the work, removes the old
+"borrow useful parts" and "not adversarial" wording, and keeps bootstrap
+source/materialized output synchronized.
 Revision 1 reviewer slots:
 
 - `docs_consistency`: confirmed the active plan, managed `AGENTS.md` source and
@@ -402,24 +423,21 @@ Revision 1 reviewer slots:
 
 ## Archive Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
-- Archived At: 2026-05-30T10:43:48+08:00
-- Revision: 2
+- Archived At: 2026-05-30T23:02:09+08:00
+- Revision: 3
 - PR: https://github.com/catu-ai/easyharness/pull/224
 - Ready: The managed bootstrap source, root managed block, materialized
   harness skills, and active plan now satisfy the approved prompt-only scope
-  plus the PR feedback repair. Validation passed, `review-002-full` feedback
-  was repaired, and `review-003-delta` passed cleanly.
-- Merge Handoff: Archive the repaired plan, commit and push revision 2 to PR
+  plus the PR feedback repairs. Validation passed, `review-002-full` feedback
+  was repaired, `review-003-delta` passed cleanly, and the revision 3
+  Socratic wording repair passed `review-004-delta` cleanly.
+- Merge Handoff: Archive the repaired plan, commit and push revision 3 to PR
   `#224`, refresh publish/CI/sync evidence, and wait for explicit human merge
   approval.
 
 ## Outcome Summary
 
 ### Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Added first-boundary harness-run subagent authorization guidance to the
   managed `AGENTS.md` contract, covering explorer, worker, and reviewer
@@ -435,17 +453,17 @@ UPDATE_REQUIRED_AFTER_REOPEN
   question format with the recommendation under the preferred option,
   discourages loaded implementation binaries, and requires a concise discovery
   summary before handoff to `harness-plan`.
+- Restored Socratic wording in `harness-discovery`, made the Socratic posture
+  self-contained for cold agents, and clarified that agents may challenge the
+  human's framing when repository evidence points another way and the
+  challenge serves a concrete decision.
 - Synced bootstrap outputs into root `AGENTS.md` and `.agents/skills/`.
 
 ### Not Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 No CLI behavior, command schema, state transition, or subagent runtime changes
 were made.
 
 ### Follow-Up Issues
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 NONE


### PR DESCRIPTION
## What Changed

This updates the harness-managed prompts so bounded subagents are treated as a normal part of harness work after explicit run-level authorization. The managed `AGENTS.md` contract now asks once at the first harness workflow boundary and covers explorer, worker, and reviewer subagents.

It also tightens `harness-discovery`: discovery is size-independent, excludes simple repo orientation/status/code lookup, assigns repo facts to the agent, gives a direct current-read/recommendation/plain-question format, discourages loaded implementation-choice binaries, and requires a concise discovery summary before handoff to `harness-plan`.

## Confidence

- Bootstrap source and generated prompt outputs are in sync via `scripts/sync-bootstrap-assets --check`.
- The archived plan validates with `harness plan lint docs/plans/archived/2026-05-29-tighten-harness-subagent-and-discovery-prompts.md`.
- Finalize review `review-001-full` passed with 0 findings across `docs_consistency` and `agent_ux` reviewer slots.
- Diff hygiene passed with `git diff --check`.

## Handoff

No CLI behavior, command schema, state transition, or subagent runtime behavior changed. This is a prompt/managed-instruction update only.
