### PR TITLE
Tighten release triage minor milestone rule

### DIFF
--- a/.agents/skills/release-triage/SKILL.md
+++ b/.agents/skills/release-triage/SKILL.md
@@ -37,8 +37,9 @@ milestones, and release-readiness judgment.
    consideration, minor release consideration, or release repair.
 2. Read `docs/releasing.md` before making a recommendation.
 3. Inspect the relevant GitHub issue or milestone:
-   - for minor candidates, check whether the milestone represents one coherent
-     user promise and whether its release-critical issues are closed
+   - for minor candidates, start from an existing concrete version milestone;
+     check whether it represents the selected coherent user promise and
+     whether its release-critical issues are closed
    - for patch candidates, check whether the work is a small repair,
      same-theme fast-follow, documentation/CI correction, or another low-risk
      improvement worth shipping without waiting for a later minor
@@ -64,14 +65,22 @@ low-risk fast-follow, or same-theme improvement that users should get before
 the next minor. Do not require a patch milestone unless the patch needs an
 explicit coordinated bucket.
 
-Recommend `Consider a minor release PR` when the target milestone's
-release-critical issues are complete and together deliver a coherent
-user-facing promise. Minor releases should feel like a complete first version
-of the promise, not only a specification or a half-finished feature family.
+Recommend `Consider a minor release PR` only when an existing concrete version
+milestone is the selected release promise, its release-critical issues are
+complete, and those issues together deliver a coherent user-facing promise.
+Minor releases should feel like a complete first version of the promise, not
+only a specification or a half-finished feature family.
+
+Do not recommend a minor release merely because one landed change touches a
+public, user-facing, or agent-facing contract. If that change is not already
+part of a completed minor milestone, recommend `No release recommended yet`,
+`Consider a patch release PR`, or `Shape or adjust the milestone first`
+according to the policy source and the current release context.
 
 Recommend `Shape or adjust the milestone first` when the issue list does not
-yet match the release promise: the milestone includes broad backlog ideas,
-misses release-critical work, carries open blockers, or needs clearer
+yet match the release promise: there is no concrete minor milestone, the
+milestone includes broad backlog ideas, misses release-critical work, carries
+open blockers, is not clearly connected to the candidate work, or needs clearer
 must-deliver versus follow-up boundaries in issue bodies.
 
 ## Guardrails

--- a/docs/plans/active/2026-05-31-tighten-release-triage-minor-milestone-rule.md
+++ b/docs/plans/active/2026-05-31-tighten-release-triage-minor-milestone-rule.md
@@ -1,0 +1,199 @@
+---
+template_version: 0.2.0
+created_at: "2026-05-31T13:32:04+08:00"
+approved_at: "2026-05-31T13:33:08+08:00"
+source_type: direct_request
+source_refs: []
+size: XS
+---
+
+# Tighten Release Triage Minor Milestone Rule
+
+## Goal
+
+Clarify the release-triage contract so agents do not recommend a minor release
+only because a landed change touches a public or agent-facing workflow surface.
+Minor release recommendations should require a preselected concrete milestone
+whose release-critical issues are complete and whose coherent user promise is
+ready to ship.
+
+Keep the rule general. The durable guidance should describe the decision order
+for future release triage, not encode a one-off example from the conversation.
+
+## Scope
+
+### In Scope
+
+- Strengthen the repo-local `release-triage` skill so minor recommendations
+  must be tied to an existing concrete milestone and completed release promise.
+- Clarify `docs/releasing.md` so minor releases are not treated as the default
+  response to any public contract change.
+- Preserve patch-release flexibility for low-risk fixes, repairs,
+  documentation or CI corrections, and same-theme follow-ups worth shipping
+  before the next minor.
+- Validate that the updated guidance is internally consistent and does not
+  mention a specific PR as policy.
+
+### Out of Scope
+
+- Creating, retitling, closing, or reshaping GitHub milestones.
+- Creating a release PR or changing `VERSION`.
+- Changing issue triage rules beyond any release-policy wording needed for
+  this slice.
+- Adding automation, hard gates, labels, project fields, or release machinery.
+
+## Acceptance Criteria
+
+- [ ] `release-triage` requires `Consider a minor release PR` to be grounded in
+      an existing concrete milestone whose release-critical issues are complete.
+- [ ] `release-triage` directs single-landed-PR follow-up toward
+      `No release recommended yet`, `Consider a patch release PR`, or
+      `Shape or adjust the milestone first` unless that PR is already part of
+      the completed minor milestone.
+- [ ] `docs/releasing.md` says minor releases are selected release promises,
+      not automatic version bumps for any public or agent-facing contract
+      change.
+- [ ] The final wording is general and does not depend on any one PR number,
+      title, or recent incident.
+- [ ] No release publication, `VERSION` change, or milestone mutation is made.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Tighten the release-triage skill
+
+- Done: [x]
+
+#### Objective
+
+Update `.agents/skills/release-triage/SKILL.md` so the skill's decision order
+prevents agents from jumping from "public surface changed" directly to a minor
+release recommendation.
+
+#### Details
+
+The skill should make the strict milestone rule explicit:
+
+- minor candidates require an existing concrete version milestone
+- the milestone must represent the selected coherent release promise
+- release-critical issues in that milestone must be complete
+- if the milestone is missing, incomplete, or not clearly connected to the
+  landed work, the recommendation should not be `Consider a minor release PR`
+- ordinary post-PR triage should decide among no release, patch, or milestone
+  shaping unless the landed work completes the selected minor promise
+
+Keep examples and wording generic.
+
+#### Expected Files
+
+- `.agents/skills/release-triage/SKILL.md`
+
+#### Validation
+
+- Read the updated skill for contradiction with `docs/releasing.md`.
+- Confirm the skill does not mention a specific PR, incident, or release as the
+  reason for the new rule.
+
+#### Execution Notes
+
+Updated the repo-local `release-triage` skill so minor release triage starts
+from an existing concrete version milestone and only recommends a minor release
+when that selected milestone's release-critical issues are complete. TDD was
+not practical because this step changes policy guidance text rather than
+runtime behavior; validation was direct wording inspection against the approved
+scope.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: this step is a narrow wording update to a repo-local
+skill, and the broader consistency check belongs with the final combined review
+after the release policy wording is updated.
+
+### Step 2: Clarify the release policy
+
+- Done: [x]
+
+#### Objective
+
+Update `docs/releasing.md` with concise general language that matches the
+strict minor-milestone rule while preserving patch-release flexibility.
+
+#### Details
+
+The policy should explain that a public or agent-facing contract change can be
+release-worthy without automatically defining the next minor release. Minor
+releases should follow the maintainer-selected release promise represented by a
+concrete milestone; changes outside that promise can wait or ship as a patch
+when they fit the patch criteria.
+
+#### Expected Files
+
+- `docs/releasing.md`
+
+#### Validation
+
+- Read the release policy and skill together to ensure the normative policy and
+  agent workflow guidance agree.
+- Confirm no release checklist or publication mechanics are changed.
+
+#### Execution Notes
+
+Clarified `docs/releasing.md` so minor releases are selected release promises,
+not automatic version bumps for every public, user-facing, or agent-facing
+contract change. Preserved patch flexibility by saying such changes can wait
+for a later selected promise or ship as a patch when they fit the patch
+criteria. TDD was not practical because this step changes policy guidance text
+rather than runtime behavior.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: this is a narrow release-policy wording update and will
+be covered by the final consistency review for the combined policy and skill
+change.
+
+## Validation Strategy
+
+- Run `harness plan lint` before approval.
+- After implementation, inspect the changed text directly and run any existing
+  lightweight documentation or formatting checks that apply.
+- Confirm `git diff` contains only release-policy and repo-local skill wording,
+  with no `VERSION`, milestone, release workflow, or unrelated churn.
+
+## Risks
+
+- Risk: The new wording could make patch releases sound too restrictive.
+  - Mitigation: Explicitly preserve patch releases for small repairs,
+    same-theme fast-follows, and low-risk improvements worth shipping before a
+    later minor.
+- Risk: The skill and release policy could drift in authority.
+  - Mitigation: Keep `docs/releasing.md` as the policy source and make the
+    skill point agents at the same strict milestone interpretation.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-05-31-tighten-release-triage-minor-milestone-rule.md
+++ b/docs/plans/active/2026-05-31-tighten-release-triage-minor-milestone-rule.md
@@ -44,18 +44,18 @@ for future release triage, not encode a one-off example from the conversation.
 
 ## Acceptance Criteria
 
-- [ ] `release-triage` requires `Consider a minor release PR` to be grounded in
+- [x] `release-triage` requires `Consider a minor release PR` to be grounded in
       an existing concrete milestone whose release-critical issues are complete.
-- [ ] `release-triage` directs single-landed-PR follow-up toward
+- [x] `release-triage` directs single-landed-PR follow-up toward
       `No release recommended yet`, `Consider a patch release PR`, or
       `Shape or adjust the milestone first` unless that PR is already part of
       the completed minor milestone.
-- [ ] `docs/releasing.md` says minor releases are selected release promises,
+- [x] `docs/releasing.md` says minor releases are selected release promises,
       not automatic version bumps for any public or agent-facing contract
       change.
-- [ ] The final wording is general and does not depend on any one PR number,
+- [x] The final wording is general and does not depend on any one PR number,
       title, or recent incident.
-- [ ] No release publication, `VERSION` change, or milestone mutation is made.
+- [x] No release publication, `VERSION` change, or milestone mutation is made.
 
 ## Deferred Items
 
@@ -145,14 +145,24 @@ Clarified `docs/releasing.md` so minor releases are selected release promises,
 not automatic version bumps for every public, user-facing, or agent-facing
 contract change. Preserved patch flexibility by saying such changes can wait
 for a later selected promise or ship as a patch when they fit the patch
-criteria. TDD was not practical because this step changes policy guidance text
-rather than runtime behavior.
+criteria. Final review found that `docs/releasing.md` still made minor
+milestones sound optional, so the repair changed the policy to say a minor
+release must be selected through a concrete GitHub milestone. TDD was not
+practical because this step changes policy guidance text rather than runtime
+behavior.
 
 #### Review Notes
 
-NO_STEP_REVIEW_NEEDED: this is a narrow release-policy wording update and will
-be covered by the final consistency review for the combined policy and skill
-change.
+NO_STEP_REVIEW_NEEDED: this release-policy wording step was reviewed as part of
+the combined finalize review because the risk was consistency between the
+policy and the repo-local skill, not the policy file in isolation.
+
+Initial full finalize review `review-001-full` found one blocking
+policy-consistency issue: `docs/releasing.md` still said minor releases were
+usually represented by milestones while the skill required an existing concrete
+milestone. The focused repair was checked by `review-002-delta` with no
+findings, and the repaired full candidate passed `review-003-full` with no
+findings.
 
 ## Validation Strategy
 
@@ -174,25 +184,48 @@ change.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `harness plan lint docs/plans/active/2026-05-31-tighten-release-triage-minor-milestone-rule.md`
+  passed before execution and before archive.
+- `git diff --check` passed after implementation and after the review repair.
+- Direct wording inspection confirmed the changed policy and skill are general:
+  no PR number, recent incident, `VERSION` bump, release workflow change, or
+  milestone mutation was introduced.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- `review-001-full` found one blocking policy-consistency issue: the release
+  policy still used optional milestone wording while the skill used a strict
+  milestone requirement.
+- The repair aligned `docs/releasing.md` with the strict concrete milestone
+  rule.
+- `review-002-delta` passed with no findings on the focused repair.
+- `review-003-full` passed with no findings on the repaired full candidate.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: PENDING_UNTIL_PUBLISH
+- Ready: The candidate passed validation and final full review, and is ready
+  for archive/publish handoff.
+- Merge Handoff: Open a PR with a readable merge memo, record publish evidence,
+  refresh CI/sync evidence, and wait for explicit human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Tightened the repo-local `release-triage` skill so `Consider a minor release
+  PR` requires an existing concrete version milestone whose selected release
+  promise is complete.
+- Clarified `docs/releasing.md` so minor releases must be selected through a
+  concrete GitHub milestone and are not automatic responses to public,
+  user-facing, or agent-facing contract changes.
+- Preserved patch-release flexibility for qualifying repairs, low-risk
+  follow-ups, documentation or CI corrections, and same-theme improvements.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No `VERSION` change, release PR, release publication, milestone mutation, or
+  release mechanics change was made.
 
 ### Follow-Up Issues
 

--- a/docs/plans/archived/2026-05-31-tighten-release-triage-minor-milestone-rule.md
+++ b/docs/plans/archived/2026-05-31-tighten-release-triage-minor-milestone-rule.md
@@ -203,6 +203,8 @@ findings.
 
 ## Archive Summary
 
+- Archived At: 2026-05-31T13:40:35+08:00
+- Revision: 1
 - PR: PENDING_UNTIL_PUBLISH
 - Ready: The candidate passed validation and final full review, and is ready
   for archive/publish handoff.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -26,12 +26,12 @@ PR merges.
 Minor releases such as `v0.5.0` represent a coherent user promise. They do not
 need to finish every possible idea in a feature family, but they should deliver
 enough of the promise that users can understand and start relying on it. A
-minor release is usually represented by a concrete GitHub milestone whose
-issues are release-critical for that promise.
+minor release must be selected through a concrete GitHub milestone whose issues
+are release-critical for that promise.
 
 Minor releases are selected release promises, not automatic version bumps for
 every public, user-facing, or agent-facing contract change. A contract change
-outside the current minor milestone can still be release-worthy, but it should
+outside the selected minor milestone can still be release-worthy, but it should
 wait for a later selected promise or ship as a patch when it fits the patch
 criteria below.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,6 +29,12 @@ enough of the promise that users can understand and start relying on it. A
 minor release is usually represented by a concrete GitHub milestone whose
 issues are release-critical for that promise.
 
+Minor releases are selected release promises, not automatic version bumps for
+every public, user-facing, or agent-facing contract change. A contract change
+outside the current minor milestone can still be release-worthy, but it should
+wait for a later selected promise or ship as a patch when it fits the patch
+criteria below.
+
 Patch releases such as `v0.5.1` are smaller. They may ship bug fixes, release
 repairs, documentation or CI corrections, and low-risk follow-ups that extend
 the same already-shipped promise. Routine patch releases do not need a GitHub


### PR DESCRIPTION
## What Changed

This PR tightens easyharness release triage so minor release recommendations must start from a selected concrete milestone whose release-critical issues are complete. Public, user-facing, or agent-facing contract changes no longer automatically imply a minor release recommendation.

The repo-local `release-triage` skill now sends ordinary landed-work follow-up toward no release, patch release, or milestone shaping unless the work is already part of a completed minor milestone. `docs/releasing.md` now carries the same rule as the policy source while preserving patch-release flexibility for qualifying repairs, low-risk follow-ups, documentation or CI corrections, and same-theme improvements.

## Confidence

- The archived plan records the approved strict milestone direction, the final wording, and the non-goals around `VERSION`, release publication, milestone mutation, and release mechanics.
- `harness plan lint docs/plans/active/2026-05-31-tighten-release-triage-minor-milestone-rule.md` passed before archive, and `git diff --check` passed after implementation and repair.
- Finalize review `review-001-full` found one policy-consistency issue, the repair aligned `docs/releasing.md` with the strict milestone rule, `review-002-delta` passed, and repaired full review `review-003-full` passed with no findings.
- Scope guardrails were checked: no release workflow, `VERSION`, milestone-state, automation, or unrelated code changes were made.

## Handoff

Archived plan: `docs/plans/archived/2026-05-31-tighten-release-triage-minor-milestone-rule.md`.
