### PR TITLE
[codex] Add repo config manifest and repo command group

### DIFF
--- a/.harness/config.yaml
+++ b/.harness/config.yaml
@@ -1,0 +1,1 @@
+version: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,9 @@ If you change Go CLI code, rerun the installer before relying on the direct
 
 ## Bootstrap Asset Editing
 
-This repository dogsfoods the same bootstrap assets that `harness init` and
-the bootstrap resource commands package for other repositories.
+This repository dogfoods the same repo resource assets that
+`harness repo init` and the granular repo resource commands package for other
+repositories.
 
 - Edit `assets/bootstrap/` when changing the harness-managed skill pack or the
   managed `AGENTS.md` block content.
@@ -86,7 +87,7 @@ When triaging this repository's GitHub issues, use the repo-local
 the self-contained triage contract lives in the skill package.
 
 The block below is the same harness-managed repository contract that
-`harness instructions install` would install into another repository.
+`harness repo instructions install` would install into another repository.
 Keep easyharness-specific guidance outside the managed markers.
 
 <!-- easyharness:begin version="dev" -->

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Bootstrap a repository:
 
 ```bash
 cd /path/to/your-repo
-harness init
+harness repo init
 ```
 
-`harness init` installs the managed `AGENTS.md` block and repo-local
-`.agents/skills/` pack that tell your coding agent how to work in that
-repository. After running it, restart your coding agent so it picks up the new
-instructions and skills cleanly. In practice, that is the point where the
-repository starts telling the agent what it needs to know.
+`harness repo init` installs the managed `AGENTS.md` block and repo-local
+`.agents/skills/` pack, and creates the tracked `.harness/config.yaml`
+manifest when it is missing. After running it, restart your coding agent so it
+picks up the new instructions and skills cleanly. In practice, that is the
+point where the repository starts telling the agent what it needs to know.
 
 When you or the agent need the current workflow position, use:
 
@@ -146,11 +146,12 @@ The root CLI currently ships:
 
 - `harness plan template`
 - `harness plan lint`
-- `harness init`
-- `harness skills install`
-- `harness skills uninstall`
-- `harness instructions install`
-- `harness instructions uninstall`
+- `harness repo init`
+- `harness repo skills install`
+- `harness repo skills uninstall`
+- `harness repo instructions install`
+- `harness repo instructions uninstall`
+- `harness repo config init`
 - `harness execute start`
 - `harness evidence submit`
 - `harness status`

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,8 +123,9 @@ HARNESS_UI_API_TARGET=http://127.0.0.1:<actual-port> pnpm --dir web dev
 
 ## Bootstrap Asset Editing
 
-This repository dogsfoods the same bootstrap assets that `harness init` and
-the bootstrap resource commands package for other repositories.
+This repository dogfoods the same repo resource assets that
+`harness repo init` and the granular repo resource commands package for other
+repositories.
 
 Edit `assets/bootstrap/` when changing the harness-managed skill pack or the
 managed `AGENTS.md` block content. Treat `.agents/skills/` in this repository

--- a/docs/plans/active/2026-06-06-repo-resource-config-manifest.md
+++ b/docs/plans/active/2026-06-06-repo-resource-config-manifest.md
@@ -157,7 +157,9 @@ resource surface.
 #### Review Notes
 
 NO_STEP_REVIEW_NEEDED: This step was implemented as part of one integrated
-CLI/docs/schema slice and will receive a full finalize review before archive.
+CLI/docs/schema slice. Finalized by full review `review-001-full`, which
+requested AGENTS guidance and config-path obstruction repairs, followed by
+clean delta repair review `review-002-delta`.
 
 ### Step 2: Add config loader and init behavior
 
@@ -200,8 +202,10 @@ existing config files, and surface invalid config as warnings.
 
 #### Review Notes
 
-NO_STEP_REVIEW_NEEDED: Covered by focused loader/install/CLI tests and the
-planned full finalize review for the integrated branch.
+NO_STEP_REVIEW_NEEDED: This step was implemented as part of one integrated
+CLI/docs/schema slice. Finalized by full review `review-001-full`; repaired
+the obstructed `.harness` path finding and verified it with clean delta repair
+review `review-002-delta`.
 
 ### Step 3: Move repo resource commands under `harness repo`
 
@@ -257,8 +261,9 @@ coverage.
 
 #### Review Notes
 
-NO_STEP_REVIEW_NEEDED: Command regrouping is validated by CLI and smoke tests
-and will receive a full finalize review before archive.
+NO_STEP_REVIEW_NEEDED: This step was implemented as part of one integrated
+CLI/docs/schema slice. Finalized by full review `review-001-full` and clean
+delta repair review `review-002-delta`.
 
 ### Step 4: Refresh generated assets and end-to-end evidence
 
@@ -306,8 +311,9 @@ harness, and validated the integrated change.
 
 #### Review Notes
 
-NO_STEP_REVIEW_NEEDED: Generated artifacts and smoke coverage were validated
-directly; full candidate review remains required before archive.
+NO_STEP_REVIEW_NEEDED: This step was implemented as part of one integrated
+CLI/docs/schema slice. Finalized by full review `review-001-full` and clean
+delta repair review `review-002-delta`.
 
 ## Validation Strategy
 
@@ -336,11 +342,28 @@ directly; full candidate review remains required before archive.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+Validation completed:
+
+- `go test ./internal/repoconfig ./internal/install ./internal/cli ./internal/status`
+- `go test ./internal/repoconfig ./internal/install ./internal/cli ./internal/status ./internal/contractsync ./internal/bootstrapsync`
+- `go test ./internal/contractsync ./internal/bootstrapsync`
+- `scripts/sync-contract-artifacts --check`
+- `scripts/sync-bootstrap-assets --check`
+- `go test ./tests/smoke`
+- `go test ./tests/smoke -run 'TestHelpShowsTopLevelUsage|TestInit|TestRepo|TestSkills|TestInstructions|TestStatusIdle'`
+- `go test ./...`
+- `scripts/install-dev-harness`
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Finalize review `review-001-full` requested two blocking fixes:
+
+- `harness repo config init` could report no-op success when `.harness` was an
+  obstructing non-directory path.
+- Root `AGENTS.md` still referenced removed top-level repo-resource commands.
+
+Both were fixed in commit `4e168b4`. Delta repair review `review-002-delta`
+passed with zero findings.
 
 ## Archive Summary
 

--- a/docs/plans/active/2026-06-06-repo-resource-config-manifest.md
+++ b/docs/plans/active/2026-06-06-repo-resource-config-manifest.md
@@ -1,0 +1,361 @@
+---
+template_version: 0.2.0
+created_at: "2026-06-06T23:34:52+08:00"
+approved_at: "2026-06-06T23:38:49+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/228
+size: M
+---
+
+# Repo Resource Config Manifest
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Define the first repo-level customization manifest contract for easyharness
+and make the repository resource commands read as one coherent command group.
+
+After this slice, `.harness/config.yaml` is a tracked, visible manifest
+entrypoint with a versioned v1 shape, `harness repo init` creates the minimal
+config baseline alongside managed instructions and skills, and the former
+top-level bootstrap resource commands move under `harness repo ...`.
+
+## Scope
+
+### In Scope
+
+- Define `.harness/` as the tracked repo-level harness customization root and
+  `.harness/config.yaml` as the manifest/index entrypoint.
+- Define the v1 config contract with the minimal valid file:
+
+  ```yaml
+  version: 1
+  ```
+
+- Implement repo config loading and validation with this behavior:
+  missing config is valid and uses built-in defaults; valid config is parsed
+  and available to consumers; invalid config produces an agent-facing warning,
+  is ignored as a whole, and falls back to built-in defaults.
+- Introduce the `harness repo ...` command group as the clean target command
+  shape:
+  `harness repo init`, `harness repo skills install`,
+  `harness repo skills uninstall`, `harness repo instructions install`,
+  `harness repo instructions uninstall`, and `harness repo config init`.
+- Update `harness repo init` to install or refresh managed instructions and
+  skills and create `.harness/config.yaml` when it is missing, without
+  overwriting an existing config.
+- Add `harness repo config init` as the focused command for creating the
+  minimal config file without installing other repo resources.
+- Remove the old top-level `harness init`, `harness skills ...`, and
+  `harness instructions ...` command shapes rather than preserving
+  compatibility shims.
+- Update CLI help, specs, docs, schemas or generated references as needed so a
+  future agent can discover the repo resource contract without relying on this
+  plan.
+- Add focused automated coverage for the command routing, config creation,
+  no-overwrite behavior, invalid-config warning/fallback behavior, and updated
+  docs/schema expectations.
+
+### Out of Scope
+
+- Defining real business customization fields such as review defaults, remote
+  provider mappings, plan paths, bootstrap target customization, or
+  instruction-content customization.
+- Wiring all workflow commands to read repo config. Only commands in the repo
+  resource/config surface need to exercise the v1 loader in this slice.
+- `harness repo config lint`.
+- A broader `doctor` command.
+- A repo config guide/skill for agents. Defer this until the first real
+  customization field exists.
+- Migration helpers or compatibility aliases for the old top-level
+  `init`, `skills`, and `instructions` commands.
+
+## Acceptance Criteria
+
+- [x] `harness repo init` installs or refreshes managed skills and
+      instructions, creates `.harness/config.yaml` with `version: 1` when it is
+      missing, and never overwrites an existing config file.
+- [x] `harness repo config init` creates the minimal config file, supports
+      dry-run behavior, and reports clearly when the config already exists.
+- [x] Old top-level repo-resource commands are removed from the public command
+      tree and root usage points users to `harness repo ...`.
+- [x] The v1 config contract is documented in a tracked spec/reference
+      location, including versioning, missing/valid/invalid behavior,
+      whole-config fallback on invalid config, and the rule that long-form
+      customization text belongs in referenced `.harness/**/*.md` files rather
+      than inline YAML.
+- [x] Invalid `.harness/config.yaml` content, unsupported versions, and
+      non-object YAML shapes are surfaced as warnings and ignored by the repo
+      config loader instead of blocking repo-resource commands.
+- [x] Tests cover config init, repo init, no-overwrite behavior, invalid
+      config warnings/fallback, command help/routing, and any generated
+      contract/docs updates.
+
+## Deferred Items
+
+- Add `harness repo config lint` once the config surface has enough behavior
+  to justify an explicit validation command.
+- Add a broader `doctor` command only after the project decides what health
+  surfaces belong in a general diagnostic.
+- Add an agent-facing repo config guide/skill after the first real
+  customization field lands.
+- Define and consume concrete business customization fields in follow-up
+  issues, such as instruction path/content customization, review defaults, or
+  remote mappings.
+
+## Work Breakdown
+
+### Step 1: Specify the repo config contract
+
+- Done: [x]
+
+#### Objective
+
+Write the normative v1 `.harness/config.yaml` contract and update public
+references for the new `harness repo ...` command group.
+
+#### Details
+
+The spec should describe `.harness/` as tracked repo customization space,
+`.harness/config.yaml` as a manifest/index, and `version: 1` as the first
+required version marker. It should explicitly say that missing config is okay,
+invalid config warns and falls back to defaults, and invalid config is ignored
+as a whole rather than partially consumed.
+
+The spec should avoid inventing real customization fields in this slice. It may
+describe the future extension rule that long-form customization text should be
+referenced from `.harness/**/*.md` files instead of stored inline in YAML.
+
+#### Expected Files
+
+- `docs/specs/`
+- `docs/specs/cli-contract.md`
+- `docs/specs/index.md`
+- `README.md`
+- `docs/development.md`
+
+#### Validation
+
+- Documentation names the new command group and no longer presents the old
+  top-level commands as the target shape.
+- A cold reader can explain the v1 config behavior without reading chat
+  history.
+
+#### Execution Notes
+
+Added `docs/specs/repo-config.md` for the v1 `.harness/config.yaml` manifest
+contract and updated the spec index, CLI contract, bootstrap resource spec,
+README, and development docs to present `harness repo ...` as the target repo
+resource surface.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This step was implemented as part of one integrated
+CLI/docs/schema slice and will receive a full finalize review before archive.
+
+### Step 2: Add config loader and init behavior
+
+- Done: [x]
+
+#### Objective
+
+Implement the minimal v1 config loader plus creation behavior for
+`.harness/config.yaml`.
+
+#### Details
+
+Add a small internal package or service for repo config loading and validation.
+The public behavior is intentionally narrow: no file means defaults, a valid
+file returns parsed config, and an invalid file returns warnings plus defaults.
+
+Config init should create the `.harness/` directory and write a minimal
+`config.yaml` containing `version: 1`. Existing config must be preserved.
+Dry-run should show the planned creation without writing files.
+
+#### Expected Files
+
+- `internal/`
+- `internal/cli/`
+- `tests/`
+
+#### Validation
+
+- Unit tests cover missing, valid, malformed YAML, unsupported version,
+  non-object YAML, config creation, dry-run, and existing-file preservation.
+- Loader tests verify invalid config produces warnings and falls back to
+  defaults without returning partially parsed config.
+
+#### Execution Notes
+
+Added `internal/repoconfig` with v1 loading and whole-config fallback on
+invalid config. Updated repo resource installation so `harness repo init` and
+`harness repo config init` create the minimal config when missing, preserve
+existing config files, and surface invalid config as warnings.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Covered by focused loader/install/CLI tests and the
+planned full finalize review for the integrated branch.
+
+### Step 3: Move repo resource commands under `harness repo`
+
+- Done: [x]
+
+#### Objective
+
+Replace top-level repo resource commands with the nested `harness repo ...`
+command group.
+
+#### Details
+
+The target command tree is:
+
+```text
+harness repo init
+harness repo skills install
+harness repo skills uninstall
+harness repo instructions install
+harness repo instructions uninstall
+harness repo config init
+```
+
+Keep command depth at this level. Do not introduce deeper config subcommands
+such as `harness repo config schema validate` in this slice.
+
+Because the repository is still in fast development, remove the old top-level
+`harness init`, `harness skills ...`, and `harness instructions ...` shapes
+instead of adding compatibility aliases. Update tests and docs to the clean
+target shape.
+
+#### Expected Files
+
+- `internal/cli/`
+- `internal/install/`
+- `assets/bootstrap/`
+- `docs/`
+- `tests/`
+
+#### Validation
+
+- CLI routing tests cover the new command tree and the removed old command
+  shapes.
+- Help output shows the `repo` group clearly and keeps the root command list
+  legible.
+
+#### Execution Notes
+
+Moved public repo resource routing under `harness repo ...`, removed top-level
+`init`, `skills`, and `instructions` command routing, updated root/subcommand
+help, status idle guidance, command-result identifiers, and black-box smoke
+coverage.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Command regrouping is validated by CLI and smoke tests
+and will receive a full finalize review before archive.
+
+### Step 4: Refresh generated assets and end-to-end evidence
+
+- Done: [x]
+
+#### Objective
+
+Bring generated bootstrap/contract artifacts and smoke coverage in line with
+the new repo resource command contract.
+
+#### Details
+
+If bootstrap-managed instructions or skill text changes, edit
+`assets/bootstrap/` first and run `scripts/sync-bootstrap-assets` to refresh
+materialized outputs. If schemas or contract references change, run the
+repository's generation/sync command for those artifacts.
+
+Before archive, create or update GitHub follow-up issues for durable deferred
+items that do not already have suitable tracking issues, then record them in
+the plan outcome.
+
+#### Expected Files
+
+- `assets/bootstrap/`
+- `.agents/skills/`
+- `AGENTS.md`
+- `schema/`
+- `docs/specs/`
+- `tests/smoke/`
+
+#### Validation
+
+- `scripts/sync-bootstrap-assets` if bootstrap assets changed.
+- Contract/schema generation or sync command if schema references changed.
+- Relevant Go unit tests.
+- Relevant smoke tests for repo resource initialization.
+- `harness status` before marking the final step done.
+
+#### Execution Notes
+
+Regenerated contract schemas after adding bootstrap-result warnings and repo
+command descriptions, ran `scripts/sync-bootstrap-assets` to materialize
+`.harness/config.yaml` for this dogfood repository, reinstalled the dev
+harness, and validated the integrated change.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Generated artifacts and smoke coverage were validated
+directly; full candidate review remains required before archive.
+
+## Validation Strategy
+
+- Run focused unit tests for the new config loader, config init behavior, and
+  CLI command routing.
+- Run smoke coverage that exercises `harness repo init` in a disposable
+  workspace and verifies `.harness/config.yaml` creation and no-overwrite
+  behavior.
+- Run generated artifact sync/check commands for any touched bootstrap or
+  contract artifacts.
+- Run `harness status` at routine checkpoints and before archive.
+
+## Risks
+
+- Risk: The command regrouping touches user-facing CLI entrypoints and can
+  leave docs, tests, or managed bootstrap text stale.
+  - Mitigation: Update command routing, help, docs, and smoke tests together;
+    prefer the clean target design over compatibility shims.
+- Risk: The v1 config contract could accidentally become a broad customization
+  system.
+  - Mitigation: Keep the only required field as `version: 1`, avoid business
+    fields, and record concrete customization surfaces as follow-up issues.
+- Risk: Invalid config handling could be inconsistent across commands.
+  - Mitigation: Centralize loading/validation and make invalid config degrade
+    to warnings plus built-in defaults as a whole.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-06-06-repo-resource-config-manifest.md
+++ b/docs/plans/active/2026-06-06-repo-resource-config-manifest.md
@@ -351,6 +351,7 @@ Validation completed:
 - `scripts/sync-bootstrap-assets --check`
 - `go test ./tests/smoke`
 - `go test ./tests/smoke -run 'TestHelpShowsTopLevelUsage|TestInit|TestRepo|TestSkills|TestInstructions|TestStatusIdle'`
+- `go test ./tests/smoke -run 'TestSkillsInstall|TestInstructionsInstall|TestRepoInit|TestInit|TestRepoConfig|TestSkillsAndInstructions'`
 - `go test ./...`
 - `scripts/install-dev-harness`
 
@@ -364,6 +365,12 @@ Finalize review `review-001-full` requested two blocking fixes:
 
 Both were fixed in commit `4e168b4`. Delta repair review `review-002-delta`
 passed with zero findings.
+
+Final full review `review-003-full` then requested one blocking fix: granular
+`harness repo skills ...` and `harness repo instructions ...` commands skipped
+invalid repo config warnings. Commit `ae416fa` fixed the repo-scope warning
+behavior while keeping user-scope commands independent from repo config.
+Delta repair review `review-004-delta` passed with zero findings.
 
 ## Archive Summary
 

--- a/docs/plans/archived/2026-06-06-repo-resource-config-manifest.md
+++ b/docs/plans/archived/2026-06-06-repo-resource-config-manifest.md
@@ -372,20 +372,61 @@ invalid repo config warnings. Commit `ae416fa` fixed the repo-scope warning
 behavior while keeping user-scope commands independent from repo config.
 Delta repair review `review-004-delta` passed with zero findings.
 
+Archive-readiness review `review-005-full` then requested plan-only closeout
+repairs: the archive and outcome summaries still contained archive-time
+placeholder text, and deferred items had not been tied to durable follow-up
+issues. This finalize-fix records the archive handoff and follow-up issue
+links before a fresh finalize review.
+
+Fresh archive-readiness review `review-006-full` passed with zero findings
+after the closeout-summary repair.
+
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-06-07T00:37:59+08:00
+- Revision: 1
+- PR: PENDING_UNTIL_PUBLISH
+- Ready: The candidate satisfies the acceptance criteria, focused and full
+  validation passed, generated contract/bootstrap checks passed, and the only
+  remaining work is the post-archive publish/CI/sync handoff.
+- Merge Handoff: Archive the plan, commit the tracked archive move and summary
+  updates, push branch `codex/repo-resource-config-manifest`, open a PR for
+  issue #228, record publish evidence with the PR URL, run
+  `harness evidence refresh`, then wait at `execution/finalize/await_merge`
+  for explicit human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added the v1 `.harness/config.yaml` manifest contract with `version: 1` as
+  the minimal valid shape, missing-config default behavior, and invalid-config
+  warning plus whole-config fallback behavior.
+- Added `internal/repoconfig` and wired repo resource commands so malformed,
+  unsupported-version, or non-object config files warn clearly and fall back to
+  built-in defaults instead of blocking command execution.
+- Moved repo resource commands under the `harness repo ...` group:
+  `repo init`, `repo skills install|uninstall`,
+  `repo instructions install|uninstall`, and `repo config init`.
+- Updated `harness repo init` and `harness repo config init` to create
+  `.harness/config.yaml` when missing, preserve existing config files, support
+  dry-run behavior, and hard-error on obstructed config paths.
+- Updated docs, CLI contract/spec references, generated schemas, managed
+  bootstrap assets, root repo guidance, and smoke/unit coverage for the new
+  repo resource command shape and config manifest behavior.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- `harness repo config lint`; tracked separately in #235.
+- A broader `harness doctor` diagnostic; tracked separately in #236.
+- An agent-facing repo config guide/skill; tracked separately in #237 after the
+  first real customization field exists.
+- Concrete business customization fields or workflow-wide config consumption;
+  tracked separately in #229.
 
 ### Follow-Up Issues
 
-NONE
+- #229: Support custom harness path roots from `.harness/config`.
+- #235: Add `harness repo config lint`.
+- #236: Consider a broader `harness doctor` command.
+- #237: Add an agent-facing repo config guide after first customization fields.

--- a/docs/specs/bootstrap-install.md
+++ b/docs/specs/bootstrap-install.md
@@ -5,11 +5,13 @@
 Define the normative resource model for bootstrap installation and refresh.
 This spec owns:
 
-- `harness init`
-- `harness skills install|uninstall`
-- `harness instructions install|uninstall`
+- `harness repo init`
+- `harness repo skills install|uninstall`
+- `harness repo instructions install|uninstall`
+- `harness repo config init`
 - scope semantics for repository and user targets
 - managed ownership and version markers for bootstrap skills and instructions
+- repo config manifest creation and no-overwrite behavior
 - current agent-profile support boundaries
 
 The CLI contract should reference this spec for bootstrap semantics instead of
@@ -28,7 +30,7 @@ baseline Agent Skills format rather than a replacement for it.
 
 ## Resource Model
 
-Bootstrap resources split into two independently managed surfaces:
+Repo resources split into three managed surfaces:
 
 - `instructions`
   - a target instruction file such as `AGENTS.md`
@@ -37,18 +39,23 @@ Bootstrap resources split into two independently managed surfaces:
 - `skills`
   - a target skill directory containing zero or more easyharness-managed skill
     packages
+- `config`
+  - the tracked repo customization manifest at `.harness/config.yaml`
+  - a minimal v1 file containing `version: 1`
 
-`harness init` is the quick-start repo bootstrap entrypoint. It installs or
-refreshes both resources for the current repository in one idempotent action.
+`harness repo init` is the quick-start repo resource entrypoint. It installs
+or refreshes instructions and skills, and creates `.harness/config.yaml` when
+it is missing, in one idempotent action.
 
 ## Commands
 
-### `harness init`
+### `harness repo init`
 
 Purpose:
 
-- install or refresh the default bootstrap instructions and skills for the
-  current repository
+- install or refresh the default repo instructions and skills for the current
+  repository
+- create the minimal `.harness/config.yaml` v1 manifest when it is missing
 
 Contract:
 
@@ -56,13 +63,17 @@ Contract:
 - be safe to rerun idempotently
 - refresh managed bootstrap assets after an easyharness version upgrade
 - use the same underlying install logic as the resource commands
+- never overwrite an existing `.harness/config.yaml`
+- warn and continue with built-in defaults when an existing repo config is
+  invalid
 - support `--dry-run`
-- support `--agent`, `--dir`, and `--file` overrides for non-default layouts
+- support `--agent`, `--skills-dir`, and `--instructions-file` overrides for
+  non-default layouts
 - allow other commands such as `harness status` to reuse the same managed-asset
   comparison logic for non-blocking reminders about stale default repo
   bootstrap assets
 
-### `harness skills install|uninstall`
+### `harness repo skills install|uninstall`
 
 Purpose:
 
@@ -78,7 +89,7 @@ Contract:
 - uninstall only easyharness-managed skill packages
 - never silently overwrite unrelated user-owned skills
 
-### `harness instructions install|uninstall`
+### `harness repo instructions install|uninstall`
 
 Purpose:
 
@@ -95,6 +106,24 @@ Contract:
 - update or remove only the easyharness-managed block unless the whole target
   file is bootstrap-owned
 - never silently overwrite unrelated user-owned instruction content
+
+### `harness repo config init`
+
+Purpose:
+
+- create `.harness/config.yaml` without installing or refreshing other repo
+  resources
+
+Contract:
+
+- create `.harness/config.yaml` with exactly the minimal v1 content when it is
+  missing
+- support `--dry-run`
+- never overwrite an existing config file
+- warn and continue with built-in defaults when an existing repo config is
+  invalid
+- leave explicit validation commands such as `harness repo config lint` to
+  future work
 
 ## Scopes
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -29,11 +29,12 @@ The current command surface is:
 
 - `harness plan template`
 - `harness plan lint`
-- `harness init`
-- `harness skills install`
-- `harness skills uninstall`
-- `harness instructions install`
-- `harness instructions uninstall`
+- `harness repo init`
+- `harness repo skills install`
+- `harness repo skills uninstall`
+- `harness repo instructions install`
+- `harness repo instructions uninstall`
+- `harness repo config init`
 - `harness execute start`
 - `harness evidence submit`
 - `harness evidence refresh`
@@ -303,14 +304,14 @@ before the candidate is treated as ready to wait for merge approval.
 
 Purpose:
 
-- bootstrap or refresh repo/user instructions and skill packages without
-  mutating tracked plan lifecycle state
+- bootstrap or refresh repo/user instructions, skill packages, and repo config
+  manifests without mutating tracked plan lifecycle state
 
 Contract:
 
-- `harness init` is the quick-start repo bootstrap entrypoint
-- `harness skills ...` and `harness instructions ...` provide the granular
-  resource commands
+- `harness repo init` is the quick-start repo resource entrypoint
+- `harness repo skills ...`, `harness repo instructions ...`, and
+  `harness repo config ...` provide granular resource commands
 - bootstrap resource semantics, ownership/version rules, and support boundaries
   are defined in [Bootstrap Install](./bootstrap-install.md)
 - bootstrap commands share a JSON result envelope documented by the checked-in

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -10,9 +10,12 @@
   and `lightweight` plans, their markdown-led package layout, and local state
   expectations.
 - [Bootstrap Install](./bootstrap-install.md): normative bootstrap resource
-  model for `harness init`, `harness skills ...`, and
-  `harness instructions ...`, including ownership, version markers, and
-  support boundaries.
+  model for `harness repo init`, `harness repo skills ...`,
+  `harness repo instructions ...`, and `harness repo config ...`, including
+  ownership, version markers, and support boundaries.
+- [Repo Config](./repo-config.md): normative `.harness/config.yaml` v1
+  manifest contract, including missing/valid/invalid behavior and future
+  field-extension rules.
 - [CLI Contract](./cli-contract.md): agent-facing command surface and JSON
   contract, including how the bootstrap commands fit into the overall CLI.
 - [Contract Registry](./contract.md): normative guide to the checked-in JSON

--- a/docs/specs/repo-config.md
+++ b/docs/specs/repo-config.md
@@ -1,0 +1,63 @@
+# Repo Config
+
+## Purpose
+
+`.harness/config.yaml` is the tracked repo-level customization manifest for
+easyharness. It is an index and contract entrypoint, not a dumping ground for
+long prompts or hidden workflow behavior.
+
+The config root is:
+
+```text
+.harness/
+```
+
+The manifest file is:
+
+```text
+.harness/config.yaml
+```
+
+## Version 1
+
+The first supported config shape is intentionally minimal:
+
+```yaml
+version: 1
+```
+
+`version` is required when the file exists. The value must be integer `1`.
+No other fields are defined in v1.
+
+## Loading Behavior
+
+- missing `.harness/config.yaml` is valid and uses built-in defaults
+- valid v1 config is parsed and available to repo-resource consumers
+- invalid config produces an agent-facing warning, is ignored as a whole, and
+  falls back to built-in defaults
+
+Invalid config includes malformed YAML, non-object YAML, missing `version`,
+unsupported versions, and fields not defined by the current config version.
+
+Consumers must not partially consume invalid config. Whole-config fallback
+keeps precedence and debugging simple until concrete customization fields
+exist.
+
+## Repo Resource Initialization
+
+`harness repo init` creates `.harness/config.yaml` with the minimal v1 content
+when the file is missing. It must not overwrite an existing config file, even
+when that file is invalid.
+
+`harness repo config init` is the focused command for creating the same minimal
+config file without installing or refreshing other repo resources.
+
+## Future Fields
+
+Future customization fields should keep `.harness/config.yaml` as a manifest
+and index. Long-form customization text belongs in referenced
+`.harness/**/*.md` files rather than inline YAML.
+
+This v1 contract does not define review defaults, remote mappings, plan paths,
+instruction content customization, executable hooks, plugins, or provider
+mapping.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -85,12 +85,8 @@ func (a *App) Run(args []string) int {
 		return a.runReopen(args[1:])
 	case "status":
 		return a.runStatus(args[1:])
-	case "init":
-		return a.runInit(args[1:])
-	case "skills":
-		return a.runSkills(args[1:])
-	case "instructions":
-		return a.runInstructions(args[1:])
+	case "repo":
+		return a.runRepo(args[1:])
 	case "dashboard":
 		return a.runDashboard(args[1:])
 	case "ui":
@@ -358,17 +354,41 @@ func (a *App) runLandEntry(args []string) int {
 	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
-func (a *App) runInit(args []string) int {
-	fs := flag.NewFlagSet("harness init", flag.ContinueOnError)
+func (a *App) runRepo(args []string) int {
+	if len(args) == 0 {
+		a.printRepoUsage()
+		return 2
+	}
+	switch args[0] {
+	case "init":
+		return a.runRepoInit(args[1:])
+	case "skills":
+		return a.runRepoSkills(args[1:])
+	case "instructions":
+		return a.runRepoInstructions(args[1:])
+	case "config":
+		return a.runRepoConfig(args[1:])
+	case "-h", "--help", "help":
+		a.printRepoUsage()
+		return 0
+	default:
+		fmt.Fprintf(a.Stderr, "unknown repo subcommand %q\n\n", args[0])
+		a.printRepoUsage()
+		return 2
+	}
+}
+
+func (a *App) runRepoInit(args []string) int {
+	fs := flag.NewFlagSet("harness repo init", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
 	agent := fs.String("agent", "", "Agent profile name used for default targets. Defaults to codex.")
-	skillsDir := fs.String("dir", "", "Override the skills target directory.")
-	instructionsFile := fs.String("file", "", "Override the instructions target file.")
+	skillsDir := fs.String("skills-dir", "", "Override the skills target directory.")
+	instructionsFile := fs.String("instructions-file", "", "Override the instructions target file.")
 	dryRun := fs.Bool("dry-run", false, "Show the planned repository changes without writing files.")
 	fs.Usage = func() {
-		fmt.Fprintln(a.Stderr, "Usage: harness init [--agent <name>] [--dir <path>] [--file <path>] [--dry-run]")
+		fmt.Fprintln(a.Stderr, "Usage: harness repo init [--agent <name>] [--skills-dir <path>] [--instructions-file <path>] [--dry-run]")
 		fmt.Fprintln(a.Stderr)
-		fmt.Fprintln(a.Stderr, "Install or refresh the managed bootstrap instructions and skill pack for the current repository.")
+		fmt.Fprintln(a.Stderr, "Install or refresh the managed repo instructions, skill pack, and config manifest.")
 		fmt.Fprintln(a.Stderr)
 		fs.PrintDefaults()
 	}
@@ -396,52 +416,70 @@ func (a *App) runInit(args []string) int {
 	return a.writeJSONResult(result)
 }
 
-func (a *App) runSkills(args []string) int {
+func (a *App) runRepoSkills(args []string) int {
 	if len(args) == 0 {
-		a.printSkillsUsage()
+		a.printRepoSkillsUsage()
 		return 2
 	}
 	switch args[0] {
 	case "install":
-		return a.runSkillsInstall(args[1:])
+		return a.runRepoSkillsInstall(args[1:])
 	case "uninstall":
-		return a.runSkillsUninstall(args[1:])
+		return a.runRepoSkillsUninstall(args[1:])
 	case "-h", "--help", "help":
-		a.printSkillsUsage()
+		a.printRepoSkillsUsage()
 		return 0
 	default:
-		fmt.Fprintf(a.Stderr, "unknown skills subcommand %q\n\n", args[0])
-		a.printSkillsUsage()
+		fmt.Fprintf(a.Stderr, "unknown repo skills subcommand %q\n\n", args[0])
+		a.printRepoSkillsUsage()
 		return 2
 	}
 }
 
-func (a *App) runInstructions(args []string) int {
+func (a *App) runRepoInstructions(args []string) int {
 	if len(args) == 0 {
-		a.printInstructionsUsage()
+		a.printRepoInstructionsUsage()
 		return 2
 	}
 	switch args[0] {
 	case "install":
-		return a.runInstructionsInstall(args[1:])
+		return a.runRepoInstructionsInstall(args[1:])
 	case "uninstall":
-		return a.runInstructionsUninstall(args[1:])
+		return a.runRepoInstructionsUninstall(args[1:])
 	case "-h", "--help", "help":
-		a.printInstructionsUsage()
+		a.printRepoInstructionsUsage()
 		return 0
 	default:
-		fmt.Fprintf(a.Stderr, "unknown instructions subcommand %q\n\n", args[0])
-		a.printInstructionsUsage()
+		fmt.Fprintf(a.Stderr, "unknown repo instructions subcommand %q\n\n", args[0])
+		a.printRepoInstructionsUsage()
 		return 2
 	}
 }
 
-func (a *App) runSkillsInstall(args []string) int {
-	return a.runSkillsCommand("harness skills install", args, true)
+func (a *App) runRepoConfig(args []string) int {
+	if len(args) == 0 {
+		a.printRepoConfigUsage()
+		return 2
+	}
+	switch args[0] {
+	case "init":
+		return a.runRepoConfigInit(args[1:])
+	case "-h", "--help", "help":
+		a.printRepoConfigUsage()
+		return 0
+	default:
+		fmt.Fprintf(a.Stderr, "unknown repo config subcommand %q\n\n", args[0])
+		a.printRepoConfigUsage()
+		return 2
+	}
 }
 
-func (a *App) runSkillsUninstall(args []string) int {
-	return a.runSkillsCommand("harness skills uninstall", args, false)
+func (a *App) runRepoSkillsInstall(args []string) int {
+	return a.runSkillsCommand("harness repo skills install", args, true)
+}
+
+func (a *App) runRepoSkillsUninstall(args []string) int {
+	return a.runSkillsCommand("harness repo skills uninstall", args, false)
 }
 
 func (a *App) runSkillsCommand(name string, args []string, installOp bool) int {
@@ -485,12 +523,12 @@ func (a *App) runSkillsCommand(name string, args []string, installOp bool) int {
 	return a.writeJSONResult(service.UninstallSkills(opts))
 }
 
-func (a *App) runInstructionsInstall(args []string) int {
-	return a.runInstructionsCommand("harness instructions install", args, true)
+func (a *App) runRepoInstructionsInstall(args []string) int {
+	return a.runInstructionsCommand("harness repo instructions install", args, true)
 }
 
-func (a *App) runInstructionsUninstall(args []string) int {
-	return a.runInstructionsCommand("harness instructions uninstall", args, false)
+func (a *App) runRepoInstructionsUninstall(args []string) int {
+	return a.runInstructionsCommand("harness repo instructions uninstall", args, false)
 }
 
 func (a *App) runInstructionsCommand(name string, args []string, installOp bool) int {
@@ -548,6 +586,36 @@ func (a *App) runInstructionsCommand(name string, args []string, installOp bool)
 		return a.writeJSONResult(service.InstallInstructions(opts))
 	}
 	return a.writeJSONResult(service.UninstallInstructions(opts))
+}
+
+func (a *App) runRepoConfigInit(args []string) int {
+	fs := flag.NewFlagSet("harness repo config init", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	dryRun := fs.Bool("dry-run", false, "Show the planned repo config change without writing files.")
+	fs.Usage = func() {
+		fmt.Fprintln(a.Stderr, "Usage: harness repo config init [--dry-run]")
+		fmt.Fprintln(a.Stderr)
+		fmt.Fprintln(a.Stderr, "Create the minimal .harness/config.yaml manifest when it is missing.")
+		fmt.Fprintln(a.Stderr)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fs.Usage()
+		return 2
+	}
+	workdir, err := a.Getwd()
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
+		return 1
+	}
+	result := install.Service{Workdir: workdir}.InitConfig(install.Options{DryRun: *dryRun})
+	return a.writeJSONResult(result)
 }
 
 func (a *App) runDashboard(args []string) int {
@@ -1148,9 +1216,7 @@ func (a *App) printRootUsage() {
 	fmt.Fprintln(a.Stderr, "  archive         Freeze the current active plan")
 	fmt.Fprintln(a.Stderr, "  reopen          Restore the current archived plan")
 	fmt.Fprintln(a.Stderr, "  status          Summarize the current plan and local execution state")
-	fmt.Fprintln(a.Stderr, "  init            Install or refresh the managed bootstrap resources for the current repository")
-	fmt.Fprintln(a.Stderr, "  skills          Manage easyharness skill packages")
-	fmt.Fprintln(a.Stderr, "  instructions    Manage easyharness instruction files and managed blocks")
+	fmt.Fprintln(a.Stderr, "  repo            Manage repo-level easyharness resources")
 	fmt.Fprintln(a.Stderr, "  dashboard       Start the local machine-local dashboard home")
 	fmt.Fprintln(a.Stderr, "  ui              Start the local read-only harness UI workbench")
 }
@@ -1188,20 +1254,37 @@ func (a *App) printEvidenceUsage() {
 	fmt.Fprintln(a.Stderr, "  refresh    Refresh CI and sync evidence from a recorded PR")
 }
 
-func (a *App) printSkillsUsage() {
-	fmt.Fprintln(a.Stderr, "Usage: harness skills <subcommand> [flags]")
+func (a *App) printRepoUsage() {
+	fmt.Fprintln(a.Stderr, "Usage: harness repo <subcommand> [flags]")
+	fmt.Fprintln(a.Stderr)
+	fmt.Fprintln(a.Stderr, "Subcommands:")
+	fmt.Fprintln(a.Stderr, "  init          Install or refresh repo instructions, skills, and config")
+	fmt.Fprintln(a.Stderr, "  skills        Manage easyharness-managed skill packages")
+	fmt.Fprintln(a.Stderr, "  instructions  Manage easyharness instruction files and managed blocks")
+	fmt.Fprintln(a.Stderr, "  config        Manage the .harness/config.yaml manifest")
+}
+
+func (a *App) printRepoSkillsUsage() {
+	fmt.Fprintln(a.Stderr, "Usage: harness repo skills <subcommand> [flags]")
 	fmt.Fprintln(a.Stderr)
 	fmt.Fprintln(a.Stderr, "Subcommands:")
 	fmt.Fprintln(a.Stderr, "  install    Install or refresh easyharness-managed skill packages")
 	fmt.Fprintln(a.Stderr, "  uninstall  Remove easyharness-managed skill packages")
 }
 
-func (a *App) printInstructionsUsage() {
-	fmt.Fprintln(a.Stderr, "Usage: harness instructions <subcommand> [flags]")
+func (a *App) printRepoInstructionsUsage() {
+	fmt.Fprintln(a.Stderr, "Usage: harness repo instructions <subcommand> [flags]")
 	fmt.Fprintln(a.Stderr)
 	fmt.Fprintln(a.Stderr, "Subcommands:")
 	fmt.Fprintln(a.Stderr, "  install    Install or refresh the easyharness-managed bootstrap block")
 	fmt.Fprintln(a.Stderr, "  uninstall  Remove the easyharness-managed bootstrap block")
+}
+
+func (a *App) printRepoConfigUsage() {
+	fmt.Fprintln(a.Stderr, "Usage: harness repo config <subcommand> [flags]")
+	fmt.Fprintln(a.Stderr)
+	fmt.Fprintln(a.Stderr, "Subcommands:")
+	fmt.Fprintln(a.Stderr, "  init       Create the minimal .harness/config.yaml manifest")
 }
 
 func (a *App) printLandUsage() {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -309,14 +309,8 @@ func TestRootHelpMentionsVersionFlag(t *testing.T) {
 	if !strings.Contains(stderr.String(), "--version       Print JSON build information for the running harness binary") {
 		t.Fatalf("expected root help to mention --version, got %q", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "init            Install or refresh the managed bootstrap resources for the current repository") {
-		t.Fatalf("expected root help to mention init, got %q", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "skills          Manage easyharness skill packages") {
-		t.Fatalf("expected root help to mention skills, got %q", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "instructions    Manage easyharness instruction files and managed blocks") {
-		t.Fatalf("expected root help to mention instructions, got %q", stderr.String())
+	if !strings.Contains(stderr.String(), "repo            Manage repo-level easyharness resources") {
+		t.Fatalf("expected root help to mention repo, got %q", stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "dashboard       Start the local machine-local dashboard home") {
 		t.Fatalf("expected root help to mention dashboard, got %q", stderr.String())
@@ -418,16 +412,16 @@ func TestInitCommandReturnsJSON(t *testing.T) {
 	root := t.TempDir()
 	app.Getwd = func() (string, error) { return root, nil }
 
-	exitCode := app.Run([]string{"init", "--dry-run"})
+	exitCode := app.Run([]string{"repo", "init", "--dry-run"})
 	if exitCode != 0 {
-		t.Fatalf("init dry-run failed with %d: %s", exitCode, stderr.String())
+		t.Fatalf("repo init dry-run failed with %d: %s", exitCode, stderr.String())
 	}
 
 	var payload map[string]any
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("expected JSON init output: %v\n%s", err, stdout.String())
 	}
-	if payload["command"] != "init" {
+	if payload["command"] != "repo init" {
 		t.Fatalf("unexpected payload: %#v", payload)
 	}
 	if payload["mode"] != "dry_run" {
@@ -444,22 +438,50 @@ func TestInstructionsInstallCommandWritesManagedAssets(t *testing.T) {
 	app.Getwd = func() (string, error) { return root, nil }
 	app.UserHomeDir = func() (string, error) { return home, nil }
 
-	exitCode := app.Run([]string{"instructions", "install"})
+	exitCode := app.Run([]string{"repo", "instructions", "install"})
 	if exitCode != 0 {
-		t.Fatalf("instructions install failed with %d: %s", exitCode, stderr.String())
+		t.Fatalf("repo instructions install failed with %d: %s", exitCode, stderr.String())
 	}
 
 	var payload map[string]any
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("expected JSON instructions output: %v\n%s", err, stdout.String())
 	}
-	if payload["command"] != "instructions install" {
+	if payload["command"] != "repo instructions install" {
 		t.Fatalf("unexpected payload: %#v", payload)
 	}
 	if _, err := os.Stat(filepath.Join(root, "AGENTS.md")); err != nil {
 		t.Fatalf("expected AGENTS.md to be written: %v", err)
 	}
 	assertWatchlistAbsent(t, home)
+}
+
+func TestRepoConfigInitCommandWritesMinimalConfig(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+
+	exitCode := app.Run([]string{"repo", "config", "init"})
+	if exitCode != 0 {
+		t.Fatalf("repo config init failed with %d: %s", exitCode, stderr.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON config output: %v\n%s", err, stdout.String())
+	}
+	if payload["command"] != "repo config init" {
+		t.Fatalf("unexpected payload: %#v", payload)
+	}
+	configData, err := os.ReadFile(filepath.Join(root, ".harness/config.yaml"))
+	if err != nil {
+		t.Fatalf("read repo config: %v", err)
+	}
+	if string(configData) != "version: 1\n" {
+		t.Fatalf("expected minimal repo config, got:\n%s", configData)
+	}
 }
 
 func TestSkillsCommandRejectsInvalidScope(t *testing.T) {
@@ -469,7 +491,7 @@ func TestSkillsCommandRejectsInvalidScope(t *testing.T) {
 	root := t.TempDir()
 	app.Getwd = func() (string, error) { return root, nil }
 
-	exitCode := app.Run([]string{"skills", "install", "--scope", "bogus"})
+	exitCode := app.Run([]string{"repo", "skills", "install", "--scope", "bogus"})
 	if exitCode != 1 {
 		t.Fatalf("expected invalid scope exit code 1, got %d", exitCode)
 	}
@@ -478,7 +500,7 @@ func TestSkillsCommandRejectsInvalidScope(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
 		t.Fatalf("expected JSON skills output: %v\n%s", err, stdout.String())
 	}
-	if payload["command"] != "skills install" {
+	if payload["command"] != "repo skills install" {
 		t.Fatalf("unexpected payload: %#v", payload)
 	}
 	if ok, _ := payload["ok"].(bool); ok {
@@ -486,20 +508,41 @@ func TestSkillsCommandRejectsInvalidScope(t *testing.T) {
 	}
 }
 
-func TestSkillsHelpExitsZero(t *testing.T) {
+func TestRepoSkillsHelpExitsZero(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 	app := cli.New(stdout, stderr)
 
-	exitCode := app.Run([]string{"skills", "--help"})
+	exitCode := app.Run([]string{"repo", "skills", "--help"})
 	if exitCode != 0 {
 		t.Fatalf("expected help exit code 0, got %d", exitCode)
 	}
-	if !strings.Contains(stderr.String(), "Usage: harness skills") {
+	if !strings.Contains(stderr.String(), "Usage: harness repo skills") {
 		t.Fatalf("expected skills help text, got %q", stderr.String())
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("expected no stdout for skills help, got %q", stdout.String())
+	}
+}
+
+func TestOldRepoResourceCommandsAreRemoved(t *testing.T) {
+	for _, args := range [][]string{
+		{"init", "--dry-run"},
+		{"skills", "install"},
+		{"instructions", "install"},
+	} {
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		app := cli.New(stdout, stderr)
+		app.Getwd = func() (string, error) { return t.TempDir(), nil }
+
+		exitCode := app.Run(args)
+		if exitCode != 2 {
+			t.Fatalf("expected old command %v to be rejected with exit code 2, got %d", args, exitCode)
+		}
+		if !strings.Contains(stderr.String(), "unknown command") {
+			t.Fatalf("expected unknown command for %v, got %q", args, stderr.String())
+		}
 	}
 }
 
@@ -927,9 +970,9 @@ func TestInitDryRunDoesNotTouchWatchlist(t *testing.T) {
 	app.Getwd = func() (string, error) { return root, nil }
 	app.UserHomeDir = func() (string, error) { return home, nil }
 
-	exitCode := app.Run([]string{"init", "--dry-run"})
+	exitCode := app.Run([]string{"repo", "init", "--dry-run"})
 	if exitCode != 0 {
-		t.Fatalf("init --dry-run failed with %d: %s", exitCode, stderr.String())
+		t.Fatalf("repo init --dry-run failed with %d: %s", exitCode, stderr.String())
 	}
 	assertWatchlistAbsent(t, home)
 }
@@ -943,9 +986,9 @@ func TestSkillsInstallDryRunDoesNotTouchWatchlist(t *testing.T) {
 	app.Getwd = func() (string, error) { return root, nil }
 	app.UserHomeDir = func() (string, error) { return home, nil }
 
-	exitCode := app.Run([]string{"skills", "install", "--dry-run"})
+	exitCode := app.Run([]string{"repo", "skills", "install", "--dry-run"})
 	if exitCode != 0 {
-		t.Fatalf("skills install --dry-run failed with %d: %s", exitCode, stderr.String())
+		t.Fatalf("repo skills install --dry-run failed with %d: %s", exitCode, stderr.String())
 	}
 	assertWatchlistAbsent(t, home)
 }

--- a/internal/contracts/bootstrap.go
+++ b/internal/contracts/bootstrap.go
@@ -1,8 +1,8 @@
 package contracts
 
-// BootstrapResult is the JSON result returned by bootstrap resource commands
-// such as `harness init`, `harness skills install`, or
-// `harness instructions uninstall`.
+// BootstrapResult is the JSON result returned by repo resource commands such
+// as `harness repo init`, `harness repo skills install`, or
+// `harness repo instructions uninstall`.
 type BootstrapResult struct {
 	// OK reports whether the command succeeded.
 	OK bool `json:"ok"`
@@ -16,7 +16,7 @@ type BootstrapResult struct {
 	// Mode indicates whether the command applied changes or only planned them.
 	Mode string `json:"mode"`
 
-	// Resource identifies the managed bootstrap surface.
+	// Resource identifies the managed repo resource surface.
 	Resource string `json:"resource"`
 
 	// Operation identifies the resource action such as install or uninstall.
@@ -34,12 +34,16 @@ type BootstrapResult struct {
 	// NextAction lists the most relevant follow-up steps in priority order.
 	NextAction []NextAction `json:"next_actions"`
 
+	// Warnings lists non-blocking repo resource issues that did not prevent the
+	// command from continuing with built-in defaults.
+	Warnings []string `json:"warnings,omitempty"`
+
 	// Errors lists hard failures that prevented planning or writes.
 	Errors []ErrorDetail `json:"errors,omitempty"`
 }
 
-// BootstrapAction describes one path-level change planned or applied by a
-// bootstrap resource command.
+// BootstrapAction describes one path-level change planned or applied by a repo
+// resource command.
 type BootstrapAction struct {
 	// Path is the file or directory path touched by the action.
 	Path string `json:"path"`

--- a/internal/contracts/registry.go
+++ b/internal/contracts/registry.go
@@ -69,7 +69,7 @@ func SchemaRegistry() []SchemaEntry {
 			Group:       "command_results",
 			Path:        "schema/commands/bootstrap.result.schema.json",
 			Title:       "Bootstrap command result",
-			Description: "JSON output shared by bootstrap resource commands such as `harness init`, `harness skills install`, and `harness instructions uninstall`.",
+			Description: "JSON output shared by repo resource commands such as `harness repo init`, `harness repo skills install`, and `harness repo instructions uninstall`.",
 			Shape:       "output",
 			Type:        reflect.TypeFor[BootstrapResult](),
 		},

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -174,7 +174,7 @@ func (s Service) runSkillCommand(command, operation string, opts Options) Result
 	if err := s.applyWrites(writes, opts.DryRun); err != nil {
 		return s.errorResult(command, ResourceSkills, operation, scope, agent, opts.DryRun, "Unable to write the skills target.", []CommandError{*err})
 	}
-	return s.successResult(command, ResourceSkills, operation, scope, agent, opts.DryRun, writes)
+	return s.successResultWithWarnings(command, ResourceSkills, operation, scope, agent, opts.DryRun, writes, s.repoConfigWarnings(scope))
 }
 
 func (s Service) runInstructionsCommand(command, operation string, opts Options) Result {
@@ -213,7 +213,7 @@ func (s Service) runInstructionsCommand(command, operation string, opts Options)
 	if err := s.applyWrites(writes, opts.DryRun); err != nil {
 		return s.errorResult(command, ResourceInstructions, operation, scope, agent, opts.DryRun, "Unable to write the instructions target.", []CommandError{*err})
 	}
-	return s.successResult(command, ResourceInstructions, operation, scope, agent, opts.DryRun, writes)
+	return s.successResultWithWarnings(command, ResourceInstructions, operation, scope, agent, opts.DryRun, writes, s.repoConfigWarnings(scope))
 }
 
 func (s Service) resolveSkillsDir(agent, scope, override string) (string, error) {
@@ -853,6 +853,13 @@ func repoConfigWarningsForWorkdir(workdir string, warnings []string) []string {
 		result = append(result, replacer.Replace(warning))
 	}
 	return result
+}
+
+func (s Service) repoConfigWarnings(scope string) []string {
+	if scope != ScopeRepo {
+		return nil
+	}
+	return repoConfigWarningsForWorkdir(s.Workdir, repoconfig.Load(s.Workdir).Warnings)
 }
 
 func walkFiles(root string) ([]string, error) {

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -11,6 +11,7 @@ import (
 
 	bootstrapassets "github.com/catu-ai/easyharness/assets/bootstrap"
 	"github.com/catu-ai/easyharness/internal/contracts"
+	"github.com/catu-ai/easyharness/internal/repoconfig"
 	versioninfo "github.com/catu-ai/easyharness/internal/version"
 	"gopkg.in/yaml.v3"
 )
@@ -22,6 +23,7 @@ const (
 	ResourceBootstrap    = "bootstrap"
 	ResourceSkills       = "skills"
 	ResourceInstructions = "instructions"
+	ResourceConfig       = "config"
 
 	OperationInstall   = "install"
 	OperationUninstall = "uninstall"
@@ -78,7 +80,7 @@ func (s Service) Init(opts Options) Result {
 		resolvedScope = ScopeRepo
 	}
 	if resolvedScope != ScopeRepo {
-		return s.errorResult("init", ResourceBootstrap, OperationInstall, resolvedScope, normalizeAgent(opts.Agent), opts.DryRun, "Unsupported init scope.", []CommandError{{
+		return s.errorResult("repo init", ResourceBootstrap, OperationInstall, resolvedScope, normalizeAgent(opts.Agent), opts.DryRun, "Unsupported init scope.", []CommandError{{
 			Path:    "scope",
 			Message: fmt.Sprintf("supported init scope is %q", ScopeRepo),
 		}})
@@ -87,41 +89,57 @@ func (s Service) Init(opts Options) Result {
 	agent := normalizeAgent(opts.Agent)
 	instructionsFile, err := s.resolveInstructionsFile(agent, ScopeRepo, opts.InstructionsFile)
 	if err != nil {
-		return s.errorResult("init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, "Unable to resolve init targets.", []CommandError{{Path: "instructions.file", Message: err.Error()}})
+		return s.errorResult("repo init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, "Unable to resolve init targets.", []CommandError{{Path: "instructions.file", Message: err.Error()}})
 	}
 	skillsDir, err := s.resolveSkillsDir(agent, ScopeRepo, opts.SkillsDir)
 	if err != nil {
-		return s.errorResult("init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, "Unable to resolve init targets.", []CommandError{{Path: "skills.dir", Message: err.Error()}})
+		return s.errorResult("repo init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, "Unable to resolve init targets.", []CommandError{{Path: "skills.dir", Message: err.Error()}})
 	}
 
 	writes, errs := s.planInstructionsInstall(instructionsFile, skillsDir)
 	skillWrites, skillErrs := s.planSkillsInstall(skillsDir)
 	writes = append(writes, skillWrites...)
 	errs = append(errs, skillErrs...)
+	configWrites, configWarnings, configErrs := s.planRepoConfigInit()
+	writes = append(writes, configWrites...)
+	errs = append(errs, configErrs...)
 	if len(errs) > 0 {
-		return s.errorResult("init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, "Unable to prepare the bootstrap targets.", errs)
+		return s.errorResult("repo init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, "Unable to prepare the bootstrap targets.", errs)
 	}
 	if err := s.applyWrites(writes, opts.DryRun); err != nil {
-		return s.errorResult("init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, "Unable to write the bootstrap targets.", []CommandError{*err})
+		return s.errorResult("repo init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, "Unable to write the bootstrap targets.", []CommandError{*err})
 	}
 
-	return s.successResult("init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, writes)
+	return s.successResultWithWarnings("repo init", ResourceBootstrap, OperationInstall, resolvedScope, agent, opts.DryRun, writes, configWarnings)
 }
 
 func (s Service) InstallSkills(opts Options) Result {
-	return s.runSkillCommand("skills install", OperationInstall, opts)
+	return s.runSkillCommand("repo skills install", OperationInstall, opts)
 }
 
 func (s Service) UninstallSkills(opts Options) Result {
-	return s.runSkillCommand("skills uninstall", OperationUninstall, opts)
+	return s.runSkillCommand("repo skills uninstall", OperationUninstall, opts)
 }
 
 func (s Service) InstallInstructions(opts Options) Result {
-	return s.runInstructionsCommand("instructions install", OperationInstall, opts)
+	return s.runInstructionsCommand("repo instructions install", OperationInstall, opts)
 }
 
 func (s Service) UninstallInstructions(opts Options) Result {
-	return s.runInstructionsCommand("instructions uninstall", OperationUninstall, opts)
+	return s.runInstructionsCommand("repo instructions uninstall", OperationUninstall, opts)
+}
+
+func (s Service) InitConfig(opts Options) Result {
+	scope := ScopeRepo
+	agent := normalizeAgent(opts.Agent)
+	writes, warnings, errs := s.planRepoConfigInit()
+	if len(errs) > 0 {
+		return s.errorResult("repo config init", ResourceConfig, OperationInstall, scope, agent, opts.DryRun, "Unable to prepare the repo config target.", errs)
+	}
+	if err := s.applyWrites(writes, opts.DryRun); err != nil {
+		return s.errorResult("repo config init", ResourceConfig, OperationInstall, scope, agent, opts.DryRun, "Unable to write the repo config target.", []CommandError{*err})
+	}
+	return s.successResultWithWarnings("repo config init", ResourceConfig, OperationInstall, scope, agent, opts.DryRun, writes, warnings)
 }
 
 func (s Service) runSkillCommand(command, operation string, opts Options) Result {
@@ -548,6 +566,23 @@ func (s Service) planSkillsUninstall(targetDir string) ([]plannedWrite, []Comman
 	return writes, nil
 }
 
+func (s Service) planRepoConfigInit() ([]plannedWrite, []string, []CommandError) {
+	result := repoconfig.Load(s.Workdir)
+	if result.Exists {
+		return []plannedWrite{{
+			path:    result.Path,
+			kind:    ActionNoop,
+			details: "Repo config already exists and will not be overwritten.",
+		}}, repoConfigWarningsForWorkdir(s.Workdir, result.Warnings), nil
+	}
+	return []plannedWrite{{
+		path:    result.Path,
+		kind:    ActionCreate,
+		details: "Create the repo customization manifest with the minimal v1 config.",
+		content: []byte(repoconfig.DefaultContent),
+	}}, repoConfigWarningsForWorkdir(s.Workdir, result.Warnings), nil
+}
+
 func (s Service) renderCanonicalSkillFiles() (map[string]map[string]string, error) {
 	files, err := bootstrapassets.SkillFiles()
 	if err != nil {
@@ -602,6 +637,10 @@ func (s Service) applyWrites(writes []plannedWrite, dryRun bool) *CommandError {
 }
 
 func (s Service) successResult(command, resource, operation, scope, agent string, dryRun bool, writes []plannedWrite) Result {
+	return s.successResultWithWarnings(command, resource, operation, scope, agent, dryRun, writes, nil)
+}
+
+func (s Service) successResultWithWarnings(command, resource, operation, scope, agent string, dryRun bool, writes []plannedWrite, warnings []string) Result {
 	return Result{
 		OK:         true,
 		Command:    command,
@@ -613,6 +652,7 @@ func (s Service) successResult(command, resource, operation, scope, agent string
 		Agent:      agent,
 		Actions:    toActions(s.Workdir, writes),
 		NextAction: []NextAction{},
+		Warnings:   warnings,
 	}
 }
 
@@ -786,6 +826,18 @@ func pathLabel(workdir, path string) string {
 		return filepath.ToSlash(rel)
 	}
 	return filepath.Clean(path)
+}
+
+func repoConfigWarningsForWorkdir(workdir string, warnings []string) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+	replacer := strings.NewReplacer(filepath.ToSlash(workdir)+"/", "")
+	result := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		result = append(result, replacer.Replace(warning))
+	}
+	return result
 }
 
 func walkFiles(root string) ([]string, error) {

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -567,6 +567,21 @@ func (s Service) planSkillsUninstall(targetDir string) ([]plannedWrite, []Comman
 }
 
 func (s Service) planRepoConfigInit() ([]plannedWrite, []string, []CommandError) {
+	configPath := filepath.Join(s.Workdir, filepath.FromSlash(repoconfig.File))
+	info, statErr := os.Stat(configPath)
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return nil, nil, []CommandError{{
+			Path:    pathLabel(s.Workdir, configPath),
+			Message: fmt.Sprintf("inspect repo config target: %v", statErr),
+		}}
+	}
+	if statErr == nil && info.IsDir() {
+		return nil, nil, []CommandError{{
+			Path:    pathLabel(s.Workdir, configPath),
+			Message: "repo config target is a directory",
+		}}
+	}
+
 	result := repoconfig.Load(s.Workdir)
 	if result.Exists {
 		return []plannedWrite{{

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -54,6 +54,71 @@ func TestInitCreatesManagedInstructionsAndSkills(t *testing.T) {
 	if !strings.Contains(skillBody, "easyharness-version: v9.9.9") {
 		t.Fatalf("expected version metadata in skill frontmatter, got:\n%s", skillBody)
 	}
+
+	configData, err := os.ReadFile(filepath.Join(root, ".harness/config.yaml"))
+	if err != nil {
+		t.Fatalf("read repo config: %v", err)
+	}
+	if string(configData) != "version: 1\n" {
+		t.Fatalf("expected minimal repo config, got:\n%s", configData)
+	}
+}
+
+func TestInitPreservesExistingRepoConfigAndWarnsWhenInvalid(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".harness/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("version: 2\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	result := testService(root).Init(Options{})
+	if !result.OK {
+		t.Fatalf("expected init success despite invalid config, got %#v", result)
+	}
+	if len(result.Warnings) == 0 || !strings.Contains(strings.Join(result.Warnings, "\n"), "unsupported version 2") {
+		t.Fatalf("expected invalid-config warning, got %#v", result.Warnings)
+	}
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(configData) != "version: 2\n" {
+		t.Fatalf("expected existing config to be preserved, got:\n%s", configData)
+	}
+}
+
+func TestInitConfigCreatesMinimalConfig(t *testing.T) {
+	root := t.TempDir()
+
+	result := testService(root).InitConfig(Options{})
+	if !result.OK {
+		t.Fatalf("expected config init success, got %#v", result)
+	}
+	if result.Command != "repo config init" || result.Resource != ResourceConfig {
+		t.Fatalf("unexpected config init payload: %#v", result)
+	}
+	configData, err := os.ReadFile(filepath.Join(root, ".harness/config.yaml"))
+	if err != nil {
+		t.Fatalf("read repo config: %v", err)
+	}
+	if string(configData) != "version: 1\n" {
+		t.Fatalf("expected minimal repo config, got:\n%s", configData)
+	}
+}
+
+func TestInitConfigDryRunDoesNotWrite(t *testing.T) {
+	root := t.TempDir()
+
+	result := testService(root).InitConfig(Options{DryRun: true})
+	if !result.OK {
+		t.Fatalf("expected config init dry-run success, got %#v", result)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".harness/config.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("expected dry-run to leave config absent, got err=%v", err)
+	}
 }
 
 func TestInitRefreshesManagedBlockWithoutTouchingUserContent(t *testing.T) {

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -121,6 +121,36 @@ func TestInitConfigDryRunDoesNotWrite(t *testing.T) {
 	}
 }
 
+func TestInitConfigRejectsObstructedHarnessDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".harness"), []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write obstructing .harness file: %v", err)
+	}
+
+	result := testService(root).InitConfig(Options{})
+	if result.OK {
+		t.Fatalf("expected obstructed config init to fail, got %#v", result)
+	}
+	if len(result.Errors) == 0 || !strings.Contains(result.Errors[0].Message, "inspect repo config target") {
+		t.Fatalf("expected inspect error, got %#v", result.Errors)
+	}
+}
+
+func TestInitConfigRejectsConfigDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".harness/config.yaml"), 0o755); err != nil {
+		t.Fatalf("mkdir config directory: %v", err)
+	}
+
+	result := testService(root).InitConfig(Options{})
+	if result.OK {
+		t.Fatalf("expected config directory init to fail, got %#v", result)
+	}
+	if len(result.Errors) == 0 || !strings.Contains(result.Errors[0].Message, "repo config target is a directory") {
+		t.Fatalf("expected directory error, got %#v", result.Errors)
+	}
+}
+
 func TestInitRefreshesManagedBlockWithoutTouchingUserContent(t *testing.T) {
 	root := t.TempDir()
 	original := strings.Join([]string{

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -151,6 +151,62 @@ func TestInitConfigRejectsConfigDirectory(t *testing.T) {
 	}
 }
 
+func TestRepoSkillsAndInstructionsSurfaceInvalidConfigWarnings(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".harness/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("version: 2\n"), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+	svc := testService(root)
+
+	skills := svc.InstallSkills(Options{DryRun: true})
+	if !skills.OK {
+		t.Fatalf("expected skills install dry-run success, got %#v", skills)
+	}
+	if len(skills.Warnings) == 0 || !strings.Contains(strings.Join(skills.Warnings, "\n"), "unsupported version 2") {
+		t.Fatalf("expected skills invalid-config warning, got %#v", skills.Warnings)
+	}
+
+	instructions := svc.InstallInstructions(Options{DryRun: true})
+	if !instructions.OK {
+		t.Fatalf("expected instructions install dry-run success, got %#v", instructions)
+	}
+	if len(instructions.Warnings) == 0 || !strings.Contains(strings.Join(instructions.Warnings, "\n"), "unsupported version 2") {
+		t.Fatalf("expected instructions invalid-config warning, got %#v", instructions.Warnings)
+	}
+}
+
+func TestUserScopeSkillsAndInstructionsIgnoreRepoConfigWarnings(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".harness/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("version: 2\n"), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+	svc := testService(root)
+
+	skills := svc.InstallSkills(Options{Scope: ScopeUser, DryRun: true})
+	if !skills.OK {
+		t.Fatalf("expected user-scope skills install dry-run success, got %#v", skills)
+	}
+	if len(skills.Warnings) != 0 {
+		t.Fatalf("expected user-scope skills to ignore repo config warnings, got %#v", skills.Warnings)
+	}
+
+	instructions := svc.InstallInstructions(Options{Scope: ScopeUser, DryRun: true})
+	if !instructions.OK {
+		t.Fatalf("expected user-scope instructions install dry-run success, got %#v", instructions)
+	}
+	if len(instructions.Warnings) != 0 {
+		t.Fatalf("expected user-scope instructions to ignore repo config warnings, got %#v", instructions.Warnings)
+	}
+}
+
 func TestInitRefreshesManagedBlockWithoutTouchingUserContent(t *testing.T) {
 	root := t.TempDir()
 	original := strings.Join([]string{

--- a/internal/repoconfig/config.go
+++ b/internal/repoconfig/config.go
@@ -1,0 +1,100 @@
+package repoconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	Dir            = ".harness"
+	File           = ".harness/config.yaml"
+	CurrentVersion = 1
+	DefaultContent = "version: 1\n"
+)
+
+type Config struct {
+	Version int `yaml:"version"`
+}
+
+type LoadResult struct {
+	Config   Config
+	Path     string
+	Exists   bool
+	Valid    bool
+	Warnings []string
+}
+
+func Load(workdir string) LoadResult {
+	path := filepath.Join(workdir, filepath.FromSlash(File))
+	result := LoadResult{
+		Config: Config{Version: CurrentVersion},
+		Path:   path,
+		Valid:  true,
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result
+		}
+		return invalid(path, fmt.Sprintf("unable to read config: %v", err))
+	}
+	result.Exists = true
+
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return invalid(path, fmt.Sprintf("malformed YAML: %v", err))
+	}
+	if len(node.Content) != 1 || node.Content[0].Kind != yaml.MappingNode {
+		return invalid(path, "config must be a YAML object")
+	}
+	mapping := node.Content[0]
+	fields := map[string]*yaml.Node{}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key := strings.TrimSpace(mapping.Content[i].Value)
+		if key == "" {
+			return invalid(path, "config contains an empty field name")
+		}
+		if _, ok := fields[key]; ok {
+			return invalid(path, fmt.Sprintf("config contains duplicate field %q", key))
+		}
+		fields[key] = mapping.Content[i+1]
+	}
+	versionNode, ok := fields["version"]
+	if !ok {
+		return invalid(path, "missing required field version")
+	}
+	if versionNode.Kind != yaml.ScalarNode || versionNode.Tag != "!!int" {
+		return invalid(path, "field version must be the integer 1")
+	}
+	var version int
+	if err := versionNode.Decode(&version); err != nil {
+		return invalid(path, fmt.Sprintf("field version must be the integer 1: %v", err))
+	}
+	if version != CurrentVersion {
+		return invalid(path, fmt.Sprintf("unsupported version %d", version))
+	}
+	for key := range fields {
+		if key != "version" {
+			return invalid(path, fmt.Sprintf("unsupported field %q", key))
+		}
+	}
+
+	result.Config.Version = version
+	return result
+}
+
+func invalid(path, reason string) LoadResult {
+	return LoadResult{
+		Config: Config{Version: CurrentVersion},
+		Path:   path,
+		Exists: true,
+		Valid:  false,
+		Warnings: []string{
+			fmt.Sprintf("Ignoring %s because %s; using built-in defaults.", filepath.ToSlash(path), reason),
+		},
+	}
+}

--- a/internal/repoconfig/config_test.go
+++ b/internal/repoconfig/config_test.go
@@ -1,0 +1,77 @@
+package repoconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadMissingConfigUsesDefaults(t *testing.T) {
+	result := Load(t.TempDir())
+	if result.Exists {
+		t.Fatalf("expected missing config, got %#v", result)
+	}
+	if !result.Valid || len(result.Warnings) != 0 {
+		t.Fatalf("expected missing config to be valid defaults, got %#v", result)
+	}
+	if result.Config.Version != CurrentVersion {
+		t.Fatalf("expected default version %d, got %#v", CurrentVersion, result)
+	}
+}
+
+func TestLoadValidConfig(t *testing.T) {
+	root := t.TempDir()
+	writeConfig(t, root, DefaultContent)
+
+	result := Load(root)
+	if !result.Exists || !result.Valid {
+		t.Fatalf("expected valid existing config, got %#v", result)
+	}
+	if len(result.Warnings) != 0 {
+		t.Fatalf("expected no warnings, got %#v", result.Warnings)
+	}
+}
+
+func TestLoadInvalidConfigWarnsAndUsesDefaults(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "malformed", content: "version: [\n", want: "malformed YAML"},
+		{name: "non object", content: "- version\n", want: "YAML object"},
+		{name: "missing version", content: "name: repo\n", want: "missing required field version"},
+		{name: "unsupported version", content: "version: 2\n", want: "unsupported version 2"},
+		{name: "string version", content: "version: \"1\"\n", want: "field version must be the integer 1"},
+		{name: "unknown field", content: "version: 1\nreview: {}\n", want: "unsupported field"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeConfig(t, root, tc.content)
+
+			result := Load(root)
+			if !result.Exists || result.Valid {
+				t.Fatalf("expected invalid existing config, got %#v", result)
+			}
+			if result.Config.Version != CurrentVersion {
+				t.Fatalf("expected defaults after invalid config, got %#v", result)
+			}
+			warnings := strings.Join(result.Warnings, "\n")
+			if !strings.Contains(warnings, "Ignoring") || !strings.Contains(warnings, tc.want) || !strings.Contains(warnings, "using built-in defaults") {
+				t.Fatalf("unexpected warnings %#v", result.Warnings)
+			}
+		})
+	}
+}
+
+func writeConfig(t *testing.T, root, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(File))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -1323,10 +1323,10 @@ func idleResult(workdir string, currentPlan *runstate.CurrentPlan) Result {
 	}
 	if drift.Stale() {
 		result.Warnings = append(result.Warnings, buildIdleBootstrapDriftWarning(drift))
-		command := "harness init --dry-run"
+		command := "harness repo init --dry-run"
 		action := NextAction{
 			Command:     &command,
-			Description: "Optionally inspect the default repo bootstrap refresh with harness init --dry-run, then rerun harness init if you and the human want to update AGENTS.md and the managed skills.",
+			Description: "Optionally inspect the default repo resource refresh with harness repo init --dry-run, then rerun harness repo init if you and the human want to update AGENTS.md, the managed skills, and the repo config.",
 		}
 		result.NextAction = append([]NextAction{action}, result.NextAction...)
 	}

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -2872,7 +2872,7 @@ func TestStatusIdleSurfacesNonBlockingBootstrapReminderWhenManagedAssetsAreStale
 	if !strings.Contains(strings.Join(result.Warnings, "\n"), "non-blocking reminder") {
 		t.Fatalf("expected non-blocking reminder wording, got %#v", result.Warnings)
 	}
-	if len(result.NextAction) == 0 || result.NextAction[0].Command == nil || *result.NextAction[0].Command != "harness init --dry-run" {
+	if len(result.NextAction) == 0 || result.NextAction[0].Command == nil || *result.NextAction[0].Command != "harness repo init --dry-run" {
 		t.Fatalf("expected optional bootstrap refresh guidance first, got %#v", result.NextAction)
 	}
 	if !strings.Contains(result.NextAction[0].Description, "Optionally inspect") {

--- a/schema/commands/bootstrap.result.schema.json
+++ b/schema/commands/bootstrap.result.schema.json
@@ -25,7 +25,7 @@
         "kind",
         "details"
       ],
-      "description": "BootstrapAction describes one path-level change planned or applied by a bootstrap resource command."
+      "description": "BootstrapAction describes one path-level change planned or applied by a repo resource command."
     },
     "BootstrapResult": {
       "properties": {
@@ -47,7 +47,7 @@
         },
         "resource": {
           "type": "string",
-          "description": "Resource identifies the managed bootstrap surface."
+          "description": "Resource identifies the managed repo resource surface."
         },
         "operation": {
           "type": "string",
@@ -91,6 +91,13 @@
           ],
           "description": "NextAction lists the most relevant follow-up steps in priority order."
         },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Warnings lists non-blocking repo resource issues that did not prevent the command from continuing with built-in defaults."
+        },
         "errors": {
           "items": {
             "$ref": "#/$defs/ErrorDetail"
@@ -113,7 +120,7 @@
         "actions",
         "next_actions"
       ],
-      "description": "BootstrapResult is the JSON result returned by bootstrap resource commands such as `harness init`, `harness skills install`, or `harness instructions uninstall`."
+      "description": "BootstrapResult is the JSON result returned by repo resource commands such as `harness repo init`, `harness repo skills install`, or `harness repo instructions uninstall`."
     },
     "ErrorDetail": {
       "properties": {
@@ -163,5 +170,5 @@
     }
   },
   "title": "Bootstrap command result",
-  "description": "JSON output shared by bootstrap resource commands such as `harness init`, `harness skills install`, and `harness instructions uninstall`."
+  "description": "JSON output shared by repo resource commands such as `harness repo init`, `harness repo skills install`, and `harness repo instructions uninstall`."
 }

--- a/schema/index.json
+++ b/schema/index.json
@@ -127,7 +127,7 @@
       "group": "command_results",
       "surface": "public",
       "title": "Bootstrap command result",
-      "description": "JSON output shared by bootstrap resource commands such as `harness init`, `harness skills install`, and `harness instructions uninstall`.",
+      "description": "JSON output shared by repo resource commands such as `harness repo init`, `harness repo skills install`, and `harness repo instructions uninstall`.",
       "path": "schema/commands/bootstrap.result.schema.json",
       "id": "https://github.com/catu-ai/easyharness/tree/main/schema/commands/bootstrap.result.schema.json",
       "go_type": "github.com/catu-ai/easyharness/internal/contracts.BootstrapResult"

--- a/tests/smoke/release_docs_test.go
+++ b/tests/smoke/release_docs_test.go
@@ -20,7 +20,7 @@ func TestReleaseDocsPresentStableOnboardingSurface(t *testing.T) {
 	normalizedReadme := strings.Join(strings.Fields(readme), " ")
 	support.RequireContains(t, normalizedReadme, "Harnesses matter. Building one shouldn't be the project.")
 	support.RequireContains(t, normalizedReadme, "brew install easyharness")
-	support.RequireContains(t, normalizedReadme, "harness init")
+	support.RequireContains(t, normalizedReadme, "harness repo init")
 	support.RequireContains(t, normalizedReadme, "breaking changes may happen between releases")
 	support.RequireContains(t, readme, "./docs/development.md")
 	if strings.Contains(strings.ToLower(readme), "public alpha") {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -49,6 +49,7 @@ type bootstrapResult struct {
 		Path string `json:"path"`
 		Kind string `json:"kind"`
 	} `json:"actions"`
+	Warnings []string `json:"warnings"`
 }
 
 func TestHelpShowsTopLevelUsage(t *testing.T) {
@@ -71,9 +72,7 @@ func TestHelpShowsTopLevelUsage(t *testing.T) {
 	support.RequireContains(t, result.CombinedOutput(), "archive         Freeze the current active plan")
 	support.RequireContains(t, result.CombinedOutput(), "reopen          Restore the current archived plan")
 	support.RequireContains(t, result.CombinedOutput(), "status          Summarize the current plan and local execution state")
-	support.RequireContains(t, result.CombinedOutput(), "init            Install or refresh the managed bootstrap resources for the current repository")
-	support.RequireContains(t, result.CombinedOutput(), "skills          Manage easyharness skill packages")
-	support.RequireContains(t, result.CombinedOutput(), "instructions    Manage easyharness instruction files and managed blocks")
+	support.RequireContains(t, result.CombinedOutput(), "repo            Manage repo-level easyharness resources")
 }
 
 func TestLandHelpShowsRequiredBookkeepingContract(t *testing.T) {
@@ -162,7 +161,7 @@ func TestStatusReportsIdleWorkspace(t *testing.T) {
 func TestStatusIdleReportsNonBlockingBootstrapReminderWhenManagedAssetsAreStale(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
-	initResult := support.Run(t, workspace.Root, "init")
+	initResult := support.Run(t, workspace.Root, "repo", "init")
 	support.RequireSuccess(t, initResult)
 	support.RequireNoStderr(t, initResult)
 
@@ -180,7 +179,7 @@ func TestStatusIdleReportsNonBlockingBootstrapReminderWhenManagedAssetsAreStale(
 	if len(payload.Warnings) == 0 || !strings.Contains(strings.Join(payload.Warnings, "\n"), "non-blocking reminder") {
 		t.Fatalf("expected non-blocking bootstrap reminder, got %#v", payload.Warnings)
 	}
-	if len(payload.NextAction) == 0 || payload.NextAction[0].Command == nil || *payload.NextAction[0].Command != "harness init --dry-run" {
+	if len(payload.NextAction) == 0 || payload.NextAction[0].Command == nil || *payload.NextAction[0].Command != "harness repo init --dry-run" {
 		t.Fatalf("expected optional refresh command first, got %#v", payload.NextAction)
 	}
 }
@@ -188,7 +187,7 @@ func TestStatusIdleReportsNonBlockingBootstrapReminderWhenManagedAssetsAreStale(
 func TestStatusIdleReportsReminderWhenOnlyManagedInstructionsAreStale(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
-	initResult := support.Run(t, workspace.Root, "init")
+	initResult := support.Run(t, workspace.Root, "repo", "init")
 	support.RequireSuccess(t, initResult)
 	support.RequireNoStderr(t, initResult)
 
@@ -207,7 +206,7 @@ func TestStatusIdleReportsReminderWhenOnlyManagedInstructionsAreStale(t *testing
 func TestStatusIdleReportsReminderWhenOnlyManagedSkillsAreStale(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
-	initResult := support.Run(t, workspace.Root, "init")
+	initResult := support.Run(t, workspace.Root, "repo", "init")
 	support.RequireSuccess(t, initResult)
 	support.RequireNoStderr(t, initResult)
 
@@ -270,12 +269,12 @@ func staleManagedSkillAtPath(t *testing.T, skillPath string) {
 func TestInitBootstrapsFreshRepository(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
-	result := support.Run(t, workspace.Root, "init")
+	result := support.Run(t, workspace.Root, "repo", "init")
 	support.RequireSuccess(t, result)
 	support.RequireNoStderr(t, result)
 
 	payload := support.RequireJSONResult[bootstrapResult](t, result)
-	if !payload.OK || payload.Command != "init" {
+	if !payload.OK || payload.Command != "repo init" {
 		t.Fatalf("expected init payload, got %#v", payload)
 	}
 	if payload.Mode != "apply" || payload.Scope != "repo" || payload.Resource != "bootstrap" {
@@ -293,12 +292,19 @@ func TestInitBootstrapsFreshRepository(t *testing.T) {
 
 	support.RequireFileExists(t, workspace.Path(".agents/skills/harness-execute/SKILL.md"))
 	support.RequireFileExists(t, workspace.Path(".agents/skills/harness-reviewer/SKILL.md"))
+	configData, err := os.ReadFile(workspace.Path(".harness/config.yaml"))
+	if err != nil {
+		t.Fatalf("read repo config: %v", err)
+	}
+	if string(configData) != "version: 1\n" {
+		t.Fatalf("expected minimal repo config, got:\n%s", configData)
+	}
 }
 
 func TestInitDryRunDoesNotWriteRepositoryFiles(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
-	result := support.Run(t, workspace.Root, "init", "--dry-run")
+	result := support.Run(t, workspace.Root, "repo", "init", "--dry-run")
 	support.RequireSuccess(t, result)
 	support.RequireNoStderr(t, result)
 
@@ -312,16 +318,17 @@ func TestInitDryRunDoesNotWriteRepositoryFiles(t *testing.T) {
 
 	support.RequireFileMissing(t, workspace.Path("AGENTS.md"))
 	support.RequireFileMissing(t, workspace.Path(".agents"))
+	support.RequireFileMissing(t, workspace.Path(".harness/config.yaml"))
 }
 
 func TestInitRepeatRunReportsNoopActions(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
-	first := support.Run(t, workspace.Root, "init")
+	first := support.Run(t, workspace.Root, "repo", "init")
 	support.RequireSuccess(t, first)
 	support.RequireNoStderr(t, first)
 
-	second := support.Run(t, workspace.Root, "init")
+	second := support.Run(t, workspace.Root, "repo", "init")
 	support.RequireSuccess(t, second)
 	support.RequireNoStderr(t, second)
 
@@ -336,10 +343,57 @@ func TestInitRepeatRunReportsNoopActions(t *testing.T) {
 	}
 }
 
+func TestRepoInitPreservesExistingInvalidConfigWithWarning(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	configPath := workspace.Path(".harness/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("version: 2\n"), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+
+	result := support.Run(t, workspace.Root, "repo", "init")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[bootstrapResult](t, result)
+	if len(payload.Warnings) == 0 || !strings.Contains(strings.Join(payload.Warnings, "\n"), "unsupported version 2") {
+		t.Fatalf("expected invalid config warning, got %#v", payload.Warnings)
+	}
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(configData) != "version: 2\n" {
+		t.Fatalf("expected existing config to be preserved, got:\n%s", configData)
+	}
+}
+
+func TestRepoConfigInitCreatesMinimalConfig(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+
+	result := support.Run(t, workspace.Root, "repo", "config", "init")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+
+	payload := support.RequireJSONResult[bootstrapResult](t, result)
+	if !payload.OK || payload.Command != "repo config init" || payload.Resource != "config" {
+		t.Fatalf("unexpected config init payload: %#v", payload)
+	}
+	configData, err := os.ReadFile(workspace.Path(".harness/config.yaml"))
+	if err != nil {
+		t.Fatalf("read repo config: %v", err)
+	}
+	if string(configData) != "version: 1\n" {
+		t.Fatalf("expected minimal repo config, got:\n%s", configData)
+	}
+}
+
 func TestSkillsInstallRejectsInvalidScopeViaCLI(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
-	result := support.Run(t, workspace.Root, "skills", "install", "--scope", "bogus")
+	result := support.Run(t, workspace.Root, "repo", "skills", "install", "--scope", "bogus")
 	support.RequireExitCode(t, result, 1)
 	support.RequireNoStderr(t, result)
 
@@ -347,7 +401,7 @@ func TestSkillsInstallRejectsInvalidScopeViaCLI(t *testing.T) {
 	if payload.OK {
 		t.Fatalf("expected skills install failure payload, got %#v", payload)
 	}
-	if payload.Command != "skills install" || payload.Scope != "bogus" {
+	if payload.Command != "repo skills install" || payload.Scope != "bogus" {
 		t.Fatalf("unexpected invalid-scope payload: %#v", payload)
 	}
 }
@@ -371,7 +425,7 @@ func TestInstructionsInstallRejectsDuplicateManagedBlocksViaCLI(t *testing.T) {
 		t.Fatalf("write AGENTS.md: %v", err)
 	}
 
-	result := support.Run(t, workspace.Root, "instructions", "install")
+	result := support.Run(t, workspace.Root, "repo", "instructions", "install")
 	support.RequireExitCode(t, result, 1)
 	support.RequireNoStderr(t, result)
 
@@ -379,7 +433,7 @@ func TestInstructionsInstallRejectsDuplicateManagedBlocksViaCLI(t *testing.T) {
 	if payload.OK {
 		t.Fatalf("expected duplicate-block instructions failure, got %#v", payload)
 	}
-	if payload.Command != "instructions install" || payload.Scope != "repo" {
+	if payload.Command != "repo instructions install" || payload.Scope != "repo" {
 		t.Fatalf("unexpected duplicate-block payload: %#v", payload)
 	}
 }
@@ -387,7 +441,7 @@ func TestInstructionsInstallRejectsDuplicateManagedBlocksViaCLI(t *testing.T) {
 func TestSkillsInstallBootstrapsOnlySkills(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
-	result := support.Run(t, workspace.Root, "skills", "install")
+	result := support.Run(t, workspace.Root, "repo", "skills", "install")
 	support.RequireSuccess(t, result)
 	support.RequireNoStderr(t, result)
 
@@ -406,7 +460,7 @@ func TestSkillsInstallRecoversAfterApplyWriteFailure(t *testing.T) {
 		t.Fatalf("write blocking .agents file: %v", err)
 	}
 
-	failed := support.Run(t, workspace.Root, "skills", "install")
+	failed := support.Run(t, workspace.Root, "repo", "skills", "install")
 	support.RequireExitCode(t, failed, 1)
 	support.RequireNoStderr(t, failed)
 
@@ -419,7 +473,7 @@ func TestSkillsInstallRecoversAfterApplyWriteFailure(t *testing.T) {
 		t.Fatalf("remove blocking .agents file: %v", err)
 	}
 
-	retry := support.Run(t, workspace.Root, "skills", "install")
+	retry := support.Run(t, workspace.Root, "repo", "skills", "install")
 	support.RequireSuccess(t, retry)
 	support.RequireNoStderr(t, retry)
 
@@ -432,7 +486,7 @@ func TestSkillsInstallRecoversAfterApplyWriteFailure(t *testing.T) {
 
 func TestInitRecoversAfterMidFlightFailure(t *testing.T) {
 	workspace := support.NewWorkspace(t)
-	initial := support.Run(t, workspace.Root, "init")
+	initial := support.Run(t, workspace.Root, "repo", "init")
 	support.RequireSuccess(t, initial)
 	support.RequireNoStderr(t, initial)
 
@@ -449,7 +503,7 @@ func TestInitRecoversAfterMidFlightFailure(t *testing.T) {
 		t.Fatalf("chmod blocked skill file: %v", err)
 	}
 
-	failed := support.Run(t, workspace.Root, "init")
+	failed := support.Run(t, workspace.Root, "repo", "init")
 	support.RequireExitCode(t, failed, 1)
 	support.RequireNoStderr(t, failed)
 
@@ -463,7 +517,7 @@ func TestInitRecoversAfterMidFlightFailure(t *testing.T) {
 		t.Fatalf("chmod blocked skill file: %v", err)
 	}
 
-	retry := support.Run(t, workspace.Root, "init")
+	retry := support.Run(t, workspace.Root, "repo", "init")
 	support.RequireSuccess(t, retry)
 	support.RequireNoStderr(t, retry)
 
@@ -496,7 +550,7 @@ func TestInstructionsInstallRefreshesExistingManagedBlockAndThenNoops(t *testing
 		t.Fatalf("write AGENTS.md: %v", err)
 	}
 
-	refresh := support.Run(t, workspace.Root, "instructions", "install")
+	refresh := support.Run(t, workspace.Root, "repo", "instructions", "install")
 	support.RequireSuccess(t, refresh)
 	support.RequireNoStderr(t, refresh)
 
@@ -512,7 +566,7 @@ func TestInstructionsInstallRefreshesExistingManagedBlockAndThenNoops(t *testing
 		t.Fatalf("expected refreshed managed block, got:\n%s", agentsBody)
 	}
 
-	second := support.Run(t, workspace.Root, "instructions", "install")
+	second := support.Run(t, workspace.Root, "repo", "instructions", "install")
 	support.RequireSuccess(t, second)
 	support.RequireNoStderr(t, second)
 
@@ -528,12 +582,12 @@ func TestInstructionsInstallRefreshesExistingManagedBlockAndThenNoops(t *testing
 func TestInitSupportsExplicitOverrideTargetsViaCLI(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 
-	result := support.Run(t, workspace.Root, "init", "--agent", "claude", "--dir", ".claude/skills", "--file", "CLAUDE.md")
+	result := support.Run(t, workspace.Root, "repo", "init", "--agent", "claude", "--skills-dir", ".claude/skills", "--instructions-file", "CLAUDE.md")
 	support.RequireSuccess(t, result)
 	support.RequireNoStderr(t, result)
 
 	payload := support.RequireJSONResult[bootstrapResult](t, result)
-	if !payload.OK || payload.Command != "init" || payload.Resource != "bootstrap" {
+	if !payload.OK || payload.Command != "repo init" || payload.Resource != "bootstrap" {
 		t.Fatalf("unexpected init override payload: %#v", payload)
 	}
 	instructionsPath := workspace.Path("CLAUDE.md")
@@ -564,7 +618,7 @@ func TestInitSupportsExplicitOverrideTargetsViaCLI(t *testing.T) {
 		t.Fatalf("write stale custom skill file: %v", err)
 	}
 
-	refresh := support.Run(t, workspace.Root, "init", "--agent", "claude", "--dir", ".claude/skills", "--file", "CLAUDE.md")
+	refresh := support.Run(t, workspace.Root, "repo", "init", "--agent", "claude", "--skills-dir", ".claude/skills", "--instructions-file", "CLAUDE.md")
 	support.RequireSuccess(t, refresh)
 	support.RequireNoStderr(t, refresh)
 
@@ -593,14 +647,14 @@ func TestSkillsAndInstructionsInstallSupportUserScopeViaCLI(t *testing.T) {
 
 	skillsResult := support.RunWithOptions(t, support.RunOptions{
 		Workdir: workspace.Root,
-		Args:    []string{"skills", "install", "--scope", "user"},
+		Args:    []string{"repo", "skills", "install", "--scope", "user"},
 		Env:     []string{"CODEX_HOME=" + codexHome},
 	})
 	support.RequireSuccess(t, skillsResult)
 	support.RequireNoStderr(t, skillsResult)
 
 	skillsPayload := support.RequireJSONResult[bootstrapResult](t, skillsResult)
-	if !skillsPayload.OK || skillsPayload.Command != "skills install" || skillsPayload.Scope != "user" {
+	if !skillsPayload.OK || skillsPayload.Command != "repo skills install" || skillsPayload.Scope != "user" {
 		t.Fatalf("unexpected user-scope skills payload: %#v", skillsPayload)
 	}
 	support.RequireFileExists(t, filepath.Join(codexHome, "skills/harness-discovery/SKILL.md"))
@@ -609,14 +663,14 @@ func TestSkillsAndInstructionsInstallSupportUserScopeViaCLI(t *testing.T) {
 
 	instructionsResult := support.RunWithOptions(t, support.RunOptions{
 		Workdir: workspace.Root,
-		Args:    []string{"instructions", "install", "--scope", "user"},
+		Args:    []string{"repo", "instructions", "install", "--scope", "user"},
 		Env:     []string{"CODEX_HOME=" + codexHome},
 	})
 	support.RequireSuccess(t, instructionsResult)
 	support.RequireNoStderr(t, instructionsResult)
 
 	instructionsPayload := support.RequireJSONResult[bootstrapResult](t, instructionsResult)
-	if !instructionsPayload.OK || instructionsPayload.Command != "instructions install" || instructionsPayload.Scope != "user" {
+	if !instructionsPayload.OK || instructionsPayload.Command != "repo instructions install" || instructionsPayload.Scope != "user" {
 		t.Fatalf("unexpected user-scope instructions payload: %#v", instructionsPayload)
 	}
 	support.RequireFileExists(t, filepath.Join(codexHome, "AGENTS.md"))
@@ -625,7 +679,7 @@ func TestSkillsAndInstructionsInstallSupportUserScopeViaCLI(t *testing.T) {
 
 	skillsUninstall := support.RunWithOptions(t, support.RunOptions{
 		Workdir: workspace.Root,
-		Args:    []string{"skills", "uninstall", "--scope", "user"},
+		Args:    []string{"repo", "skills", "uninstall", "--scope", "user"},
 		Env:     []string{"CODEX_HOME=" + codexHome},
 	})
 	support.RequireSuccess(t, skillsUninstall)
@@ -633,7 +687,7 @@ func TestSkillsAndInstructionsInstallSupportUserScopeViaCLI(t *testing.T) {
 
 	instructionsUninstall := support.RunWithOptions(t, support.RunOptions{
 		Workdir: workspace.Root,
-		Args:    []string{"instructions", "uninstall", "--scope", "user"},
+		Args:    []string{"repo", "instructions", "uninstall", "--scope", "user"},
 		Env:     []string{"CODEX_HOME=" + codexHome},
 	})
 	support.RequireSuccess(t, instructionsUninstall)
@@ -649,14 +703,14 @@ func TestSkillsAndInstructionsInstallSupportExplicitOverrideTargetsViaCLI(t *tes
 	skillPath := workspace.Path(filepath.Join(skillsDir, "harness-discovery/SKILL.md"))
 	instructionsPath := workspace.Path(instructionsFile)
 
-	skillsInstall := support.Run(t, workspace.Root, "skills", "install", "--agent", "claude", "--dir", skillsDir)
+	skillsInstall := support.Run(t, workspace.Root, "repo", "skills", "install", "--agent", "claude", "--dir", skillsDir)
 	support.RequireSuccess(t, skillsInstall)
 	support.RequireNoStderr(t, skillsInstall)
 	support.RequireFileExists(t, skillPath)
 	support.RequireFileMissing(t, workspace.Path(".agents/skills"))
 	support.RequireFileMissing(t, workspace.Path("AGENTS.md"))
 
-	instructionsInstall := support.Run(t, workspace.Root, "instructions", "install", "--agent", "claude", "--file", instructionsFile, "--dir", skillsDir)
+	instructionsInstall := support.Run(t, workspace.Root, "repo", "instructions", "install", "--agent", "claude", "--file", instructionsFile, "--dir", skillsDir)
 	support.RequireSuccess(t, instructionsInstall)
 	support.RequireNoStderr(t, instructionsInstall)
 	support.RequireFileExists(t, instructionsPath)
@@ -681,11 +735,11 @@ func TestSkillsAndInstructionsInstallSupportExplicitOverrideTargetsViaCLI(t *tes
 		t.Fatalf("write stale override instructions file: %v", err)
 	}
 
-	skillsRefresh := support.Run(t, workspace.Root, "skills", "install", "--agent", "claude", "--dir", skillsDir)
+	skillsRefresh := support.Run(t, workspace.Root, "repo", "skills", "install", "--agent", "claude", "--dir", skillsDir)
 	support.RequireSuccess(t, skillsRefresh)
 	support.RequireNoStderr(t, skillsRefresh)
 
-	instructionsRefresh := support.Run(t, workspace.Root, "instructions", "install", "--agent", "claude", "--file", instructionsFile, "--dir", skillsDir)
+	instructionsRefresh := support.Run(t, workspace.Root, "repo", "instructions", "install", "--agent", "claude", "--file", instructionsFile, "--dir", skillsDir)
 	support.RequireSuccess(t, instructionsRefresh)
 	support.RequireNoStderr(t, instructionsRefresh)
 
@@ -705,11 +759,11 @@ func TestSkillsAndInstructionsInstallSupportExplicitOverrideTargetsViaCLI(t *tes
 		t.Fatalf("expected override instructions refresh to replace stale version marker, got:\n%s", refreshedInstructions)
 	}
 
-	skillsUninstall := support.Run(t, workspace.Root, "skills", "uninstall", "--agent", "claude", "--dir", skillsDir)
+	skillsUninstall := support.Run(t, workspace.Root, "repo", "skills", "uninstall", "--agent", "claude", "--dir", skillsDir)
 	support.RequireSuccess(t, skillsUninstall)
 	support.RequireNoStderr(t, skillsUninstall)
 
-	instructionsUninstall := support.Run(t, workspace.Root, "instructions", "uninstall", "--agent", "claude", "--file", instructionsFile)
+	instructionsUninstall := support.Run(t, workspace.Root, "repo", "instructions", "uninstall", "--agent", "claude", "--file", instructionsFile)
 	support.RequireSuccess(t, instructionsUninstall)
 	support.RequireNoStderr(t, instructionsUninstall)
 	support.RequireFileMissing(t, skillPath)
@@ -735,7 +789,7 @@ func TestInstructionsInstallRejectsOutOfOrderManagedMarkersViaCLI(t *testing.T) 
 		t.Fatalf("write malformed AGENTS.md: %v", err)
 	}
 
-	result := support.Run(t, workspace.Root, "instructions", "install")
+	result := support.Run(t, workspace.Root, "repo", "instructions", "install")
 	support.RequireExitCode(t, result, 1)
 	support.RequireNoStderr(t, result)
 


### PR DESCRIPTION
## What Changed

This PR introduces the first repo-level harness config manifest contract and groups repo resources under `harness repo ...`.

`.harness/config.yaml` is now the tracked manifest entrypoint with a minimal v1 shape:

```yaml
version: 1
```

`harness repo init` creates that config file alongside managed instructions and skills when it is missing, while preserving existing config files. A focused `harness repo config init` command can create only the config manifest. Malformed, unsupported-version, or non-object config files now produce clear warnings and fall back to built-in defaults instead of blocking repo-resource commands.

The old top-level `harness init`, `harness skills ...`, and `harness instructions ...` command shapes were removed in favor of the nested repo resource group.

Closes #228.

## Confidence

- Config loading and command behavior are covered by focused unit tests for missing, valid, malformed, unsupported-version, non-object, dry-run, no-overwrite, and obstructed-path cases.
- CLI and smoke tests cover the new `harness repo ...` routing and removed old command shapes.
- Contract and bootstrap generated artifacts were refreshed and checked with the repo sync scripts.
- Full smoke coverage and `go test ./...` passed locally before archive.
- Harness finalize review passed after implementation repairs and archive-readiness closeout repairs.

## Handoff

Follow-up scope has been split into issues:

- #229 for concrete repo config customization fields such as path roots.
- #235 for `harness repo config lint`.
- #236 for a broader `harness doctor` diagnostic.
- #237 for an agent-facing repo config guide after real customization fields exist.
