### PR TITLE
Add repo config query commands

### DIFF
--- a/.agents/skills/harness-execute/SKILL.md
+++ b/.agents/skills/harness-execute/SKILL.md
@@ -70,7 +70,8 @@ when it is genuinely impractical, and record the reason in the step's
    approved for execution, stay in `harness-execute` and open that plan from
    `plan_path`.
    Active work uses a tracked plan even when the profile is lightweight; only
-   archived lightweight snapshots move under the configured local runtime root.
+   archived lightweight snapshots move under the local runtime root resolved by
+   `harness repo config get paths.local_runtime`.
    If status still resolves to `plan`, do not start execution until approval is
    explicit and `harness plan approve --by human` has been recorded.
 3. Identify the active or next plan step.
@@ -157,5 +158,6 @@ Execute is done when:
   Red/Green/Refactor loop was not practical.
 - Do not rely on chat memory when `harness status`, the tracked plan, or local
   artifacts can tell you the truth more directly.
-- Do not archive based on memory alone; use the current plan plus configured
-  local runtime artifacts.
+- Do not archive based on memory alone; use the current plan plus local runtime
+  artifacts under the root resolved by
+  `harness repo config get paths.local_runtime`.

--- a/.agents/skills/harness-execute/references/closeout-and-archive.md
+++ b/.agents/skills/harness-execute/references/closeout-and-archive.md
@@ -19,9 +19,9 @@ Archive is a freeze-and-summarize step, not just a file move.
    - `Review Summary`
    - `Archive Summary`
    - `Outcome Summary`
-  - for lightweight work, the active plan is still tracked before archive,
-    while the archived snapshot later moves under the local runtime root
-    resolved by `harness repo config get paths.local_runtime`
+   - for lightweight work, the active plan is still tracked before archive,
+     while the archived snapshot later moves under the local runtime root
+     resolved by `harness repo config get paths.local_runtime`
 6. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
    with durable handoff details before archive. Issue links are fine, but the
    main rule is that it must not stay `NONE`.

--- a/.agents/skills/harness-execute/references/closeout-and-archive.md
+++ b/.agents/skills/harness-execute/references/closeout-and-archive.md
@@ -10,17 +10,18 @@ Archive is a freeze-and-summarize step, not just a file move.
    - If `status` returns `blockers`, fix those first instead of learning them
      from a failing `harness archive`.
 3. Make sure acceptance criteria are checked and steps are completed.
-4. Read the latest finalize review artifacts under the configured local
-   runtime root and confirm the branch really is in
+4. Read the latest finalize review artifacts under the local runtime root
+   resolved by `harness repo config get paths.local_runtime` and confirm the
+   branch really is in
    `execution/finalize/archive` rather than still needing review or repair.
 5. Update the tracked plan's durable summaries from those artifacts:
    - `Validation Summary`
    - `Review Summary`
    - `Archive Summary`
    - `Outcome Summary`
-   - for lightweight work, the active plan is still tracked before archive,
-     while the archived snapshot later moves under the configured local runtime
-     root
+  - for lightweight work, the active plan is still tracked before archive,
+    while the archived snapshot later moves under the local runtime root
+    resolved by `harness repo config get paths.local_runtime`
 6. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
    with durable handoff details before archive. Issue links are fine, but the
    main rule is that it must not stay `NONE`.

--- a/.agents/skills/harness-plan/SKILL.md
+++ b/.agents/skills/harness-plan/SKILL.md
@@ -27,9 +27,9 @@ Use this skill to create or update the tracked plan that will drive execution.
      `XXS` bounded low-risk work such as README/docs/comments/copy cleanup, a
      very small CI condition tweak, or another tiny fix whose blast radius is
      easy to explain
-   - even in lightweight mode, keep the active plan under the configured
-     active plan root and use the field plus archive behavior to distinguish
-     the profile
+   - even in lightweight mode, keep the active plan under the active plan root
+     resolved by `harness repo config get paths.plans.active` and use the
+     field plus archive behavior to distinguish the profile
    - if the slice touches normative contract meaning, core runtime state,
      review/archive/evidence semantics, release safety, security-sensitive
      logic, or another non-trivial risk surface, stay on the standard
@@ -69,7 +69,8 @@ Use this skill to create or update the tracked plan that will drive execution.
      design notes
    - lightweight plans should avoid supplements by default; if one is truly
      needed, keep it minimal and remember that its archived snapshot belongs
-     under the configured local runtime root, not tracked git
+     under the local runtime root resolved by
+     `harness repo config get paths.local_runtime`, not tracked git
 7. Reread the plan as if the chat history were unavailable. Fix anything that
    still depends on hidden context.
 8. Run `harness plan lint <plan-path>`.
@@ -96,8 +97,9 @@ The plan is ready when:
   recorded
 - when the plan is lightweight, a future agent could still explain why
   lightweight was eligible, know that lightweight is only for `XXS` work, know
-  that archive snapshots move under the configured local runtime root, and know
-  that archive-time breadcrumb guidance remains required
+  that archive snapshots move under the local runtime root resolved by
+  `harness repo config get paths.local_runtime`, and know that archive-time
+  breadcrumb guidance remains required
 - when the plan is sized `XXL`, the plan or approval handoff makes clear that
   the human explicitly confirmed not splitting it further yet and that obvious
   spillover moved into `Deferred Items` or follow-up issues where appropriate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,8 @@ Keep easyharness-specific guidance outside the managed markers.
 
 1. Humans steer. Agents execute.
 2. Approved scope lives in a git-tracked plan.
-3. Raw execution trajectory lives under the configured local runtime root and
-   is disposable.
+3. Raw execution trajectory lives under the local runtime root resolved with
+   `harness repo config get paths.local_runtime`, and is disposable.
 4. Durable summaries, contracts, and behavior changes must be written back to
    tracked docs or code before archive.
 5. Evidence beats memory. Use `harness status`, tracked plans, and owned local
@@ -107,14 +107,18 @@ Keep easyharness-specific guidance outside the managed markers.
 
 The default harness split in this repository is:
 
-- configured active and archived plan roots, defaulting to
-  `docs/plans/active/` and `docs/plans/archived/`: markdown-led plan
-  packages, durable step closeout, archive-ready summaries, and any matching
+- active plan root, resolved with
+  `harness repo config get paths.plans.active` and defaulting to
+  `docs/plans/active/`: active markdown-led plan packages and any matching
   `supplements/` companion directories
-- configured local runtime root, defaulting to `.local/harness/`: disposable
-  runtime state, review artifacts, evidence artifacts, and trajectory
-- configured local runtime root's `plans/archived/`, defaulting to
-  `.local/harness/plans/archived/`: archived lightweight plan snapshots
+- archived plan root, resolved with
+  `harness repo config get paths.plans.archived` and defaulting to
+  `docs/plans/archived/`: standard archived plan packages and durable
+  closeout summaries
+- local runtime root, resolved with
+  `harness repo config get paths.local_runtime` and defaulting to
+  `.local/harness/`: disposable runtime state, review artifacts, evidence
+  artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
 - `docs/specs/`: normative harness contracts
 - `.agents/skills`: repo-local harness workflow skills
 
@@ -138,8 +142,9 @@ approves it, the agent should record that boundary with
 
 For approved low-risk work that explicitly uses `workflow_profile:
 lightweight`, keep the same workflow shape but store the active plan under the
-configured active plan root like any other plan. Only the archived lightweight
-snapshot moves under the configured local runtime root. That
+active plan root resolved by `harness repo config get paths.plans.active` like
+any other plan. Only the archived lightweight snapshot moves under the local
+runtime root resolved by `harness repo config get paths.local_runtime`. That
 shortcut does not remove human steering, low-risk eligibility checks, or the
 requirement to leave a repo-visible breadcrumb such as a readable PR body
 merge memo.
@@ -244,9 +249,10 @@ When entering the repository or resuming after compaction:
 1. Read `README.md` if you need repository purpose or setup context.
 2. Run `harness status`.
 3. If `harness status` reports a current plan artifact, open that plan.
-   Active work always uses a tracked plan under the configured active plan
-   root; archived lightweight candidates may live under the configured local
-   runtime root.
+   Active work always uses a tracked plan under the active plan root resolved
+   by `harness repo config get paths.plans.active`; archived lightweight
+   candidates may live under the local runtime root resolved by
+   `harness repo config get paths.local_runtime`.
    If status reports `idle`, there is no current plan to resume yet.
 4. Most resumed work should continue in `harness-execute`.
 5. Switch only when `harness status` and the workflow boundary clearly call for

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ The root CLI currently ships:
 - `harness repo instructions install`
 - `harness repo instructions uninstall`
 - `harness repo config init`
+- `harness repo config get <key>`
+- `harness repo config list [prefix]`
 - `harness execute start`
 - `harness evidence submit`
 - `harness status`

--- a/README.md
+++ b/README.md
@@ -133,10 +133,11 @@ The repository workflow is built around that posture:
 
 The current v0.2 harness surface centers on a few core ideas:
 
-- tracked plans live under configured active and archived plan roots
-  defaulting to `docs/plans/active/` and `docs/plans/archived/`
-- command-owned runtime state, reviews, and evidence live under the configured
-  local runtime root, defaulting to `.local/harness/`
+- tracked plans live under active and archived plan roots resolved with
+  `harness repo config get paths.plans.active` and
+  `harness repo config get paths.plans.archived`
+- command-owned runtime state, reviews, and evidence live under the local
+  runtime root resolved with `harness repo config get paths.local_runtime`
 - the CLI reports one canonical `state.current_node`
 - `harness dashboard` is the built-in machine-local home for watched workspaces
 - `harness ui` opens the current repository in that same dashboard-owned UI family

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -2,8 +2,8 @@
 
 1. Humans steer. Agents execute.
 2. Approved scope lives in a git-tracked plan.
-3. Raw execution trajectory lives under the configured local runtime root and
-   is disposable.
+3. Raw execution trajectory lives under the local runtime root resolved with
+   `harness repo config get paths.local_runtime`, and is disposable.
 4. Durable summaries, contracts, and behavior changes must be written back to
    tracked docs or code before archive.
 5. Evidence beats memory. Use `harness status`, tracked plans, and owned local
@@ -14,14 +14,18 @@
 
 The default harness split in this repository is:
 
-- configured active and archived plan roots, defaulting to
-  `docs/plans/active/` and `docs/plans/archived/`: markdown-led plan
-  packages, durable step closeout, archive-ready summaries, and any matching
+- active plan root, resolved with
+  `harness repo config get paths.plans.active` and defaulting to
+  `docs/plans/active/`: active markdown-led plan packages and any matching
   `supplements/` companion directories
-- configured local runtime root, defaulting to `.local/harness/`: disposable
-  runtime state, review artifacts, evidence artifacts, and trajectory
-- configured local runtime root's `plans/archived/`, defaulting to
-  `.local/harness/plans/archived/`: archived lightweight plan snapshots
+- archived plan root, resolved with
+  `harness repo config get paths.plans.archived` and defaulting to
+  `docs/plans/archived/`: standard archived plan packages and durable
+  closeout summaries
+- local runtime root, resolved with
+  `harness repo config get paths.local_runtime` and defaulting to
+  `.local/harness/`: disposable runtime state, review artifacts, evidence
+  artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
 - `docs/specs/`: normative harness contracts
 - `.agents/skills/`: repo-local harness workflow skills
 
@@ -45,8 +49,9 @@ approves it, the agent should record that boundary with
 
 For approved low-risk work that explicitly uses `workflow_profile:
 lightweight`, keep the same workflow shape but store the active plan under the
-configured active plan root like any other plan. Only the archived lightweight
-snapshot moves under the configured local runtime root. That
+active plan root resolved by `harness repo config get paths.plans.active` like
+any other plan. Only the archived lightweight snapshot moves under the local
+runtime root resolved by `harness repo config get paths.local_runtime`. That
 shortcut does not remove human steering, low-risk eligibility checks, or the
 requirement to leave a repo-visible breadcrumb such as a readable PR body
 merge memo.
@@ -151,9 +156,10 @@ When entering the repository or resuming after compaction:
 1. Read `README.md` if you need repository purpose or setup context.
 2. Run `harness status`.
 3. If `harness status` reports a current plan artifact, open that plan.
-   Active work always uses a tracked plan under the configured active plan
-   root; archived lightweight candidates may live under the configured local
-   runtime root.
+   Active work always uses a tracked plan under the active plan root resolved
+   by `harness repo config get paths.plans.active`; archived lightweight
+   candidates may live under the local runtime root resolved by
+   `harness repo config get paths.local_runtime`.
    If status reports `idle`, there is no current plan to resume yet.
 4. Most resumed work should continue in `harness-execute`.
 5. Switch only when `harness status` and the workflow boundary clearly call for

--- a/assets/bootstrap/skills/harness-execute/SKILL.md
+++ b/assets/bootstrap/skills/harness-execute/SKILL.md
@@ -67,7 +67,8 @@ when it is genuinely impractical, and record the reason in the step's
    approved for execution, stay in `harness-execute` and open that plan from
    `plan_path`.
    Active work uses a tracked plan even when the profile is lightweight; only
-   archived lightweight snapshots move under the configured local runtime root.
+   archived lightweight snapshots move under the local runtime root resolved by
+   `harness repo config get paths.local_runtime`.
    If status still resolves to `plan`, do not start execution until approval is
    explicit and `harness plan approve --by human` has been recorded.
 3. Identify the active or next plan step.
@@ -154,5 +155,6 @@ Execute is done when:
   Red/Green/Refactor loop was not practical.
 - Do not rely on chat memory when `harness status`, the tracked plan, or local
   artifacts can tell you the truth more directly.
-- Do not archive based on memory alone; use the current plan plus configured
-  local runtime artifacts.
+- Do not archive based on memory alone; use the current plan plus local runtime
+  artifacts under the root resolved by
+  `harness repo config get paths.local_runtime`.

--- a/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
+++ b/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
@@ -19,9 +19,9 @@ Archive is a freeze-and-summarize step, not just a file move.
    - `Review Summary`
    - `Archive Summary`
    - `Outcome Summary`
-  - for lightweight work, the active plan is still tracked before archive,
-    while the archived snapshot later moves under the local runtime root
-    resolved by `harness repo config get paths.local_runtime`
+   - for lightweight work, the active plan is still tracked before archive,
+     while the archived snapshot later moves under the local runtime root
+     resolved by `harness repo config get paths.local_runtime`
 6. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
    with durable handoff details before archive. Issue links are fine, but the
    main rule is that it must not stay `NONE`.

--- a/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
+++ b/assets/bootstrap/skills/harness-execute/references/closeout-and-archive.md
@@ -10,17 +10,18 @@ Archive is a freeze-and-summarize step, not just a file move.
    - If `status` returns `blockers`, fix those first instead of learning them
      from a failing `harness archive`.
 3. Make sure acceptance criteria are checked and steps are completed.
-4. Read the latest finalize review artifacts under the configured local
-   runtime root and confirm the branch really is in
+4. Read the latest finalize review artifacts under the local runtime root
+   resolved by `harness repo config get paths.local_runtime` and confirm the
+   branch really is in
    `execution/finalize/archive` rather than still needing review or repair.
 5. Update the tracked plan's durable summaries from those artifacts:
    - `Validation Summary`
    - `Review Summary`
    - `Archive Summary`
    - `Outcome Summary`
-   - for lightweight work, the active plan is still tracked before archive,
-     while the archived snapshot later moves under the configured local runtime
-     root
+  - for lightweight work, the active plan is still tracked before archive,
+    while the archived snapshot later moves under the local runtime root
+    resolved by `harness repo config get paths.local_runtime`
 6. If `## Deferred Items` still contains real items, replace `Follow-Up Issues`
    with durable handoff details before archive. Issue links are fine, but the
    main rule is that it must not stay `NONE`.

--- a/assets/bootstrap/skills/harness-plan/SKILL.md
+++ b/assets/bootstrap/skills/harness-plan/SKILL.md
@@ -24,9 +24,9 @@ Use this skill to create or update the tracked plan that will drive execution.
      `XXS` bounded low-risk work such as README/docs/comments/copy cleanup, a
      very small CI condition tweak, or another tiny fix whose blast radius is
      easy to explain
-   - even in lightweight mode, keep the active plan under the configured
-     active plan root and use the field plus archive behavior to distinguish
-     the profile
+   - even in lightweight mode, keep the active plan under the active plan root
+     resolved by `harness repo config get paths.plans.active` and use the
+     field plus archive behavior to distinguish the profile
    - if the slice touches normative contract meaning, core runtime state,
      review/archive/evidence semantics, release safety, security-sensitive
      logic, or another non-trivial risk surface, stay on the standard
@@ -66,7 +66,8 @@ Use this skill to create or update the tracked plan that will drive execution.
      design notes
    - lightweight plans should avoid supplements by default; if one is truly
      needed, keep it minimal and remember that its archived snapshot belongs
-     under the configured local runtime root, not tracked git
+     under the local runtime root resolved by
+     `harness repo config get paths.local_runtime`, not tracked git
 7. Reread the plan as if the chat history were unavailable. Fix anything that
    still depends on hidden context.
 8. Run `harness plan lint <plan-path>`.
@@ -93,8 +94,9 @@ The plan is ready when:
   recorded
 - when the plan is lightweight, a future agent could still explain why
   lightweight was eligible, know that lightweight is only for `XXS` work, know
-  that archive snapshots move under the configured local runtime root, and know
-  that archive-time breadcrumb guidance remains required
+  that archive snapshots move under the local runtime root resolved by
+  `harness repo config get paths.local_runtime`, and know that archive-time
+  breadcrumb guidance remains required
 - when the plan is sized `XXL`, the plan or approval handoff makes clear that
   the human explicitly confirmed not splitting it further yet and that obvious
   spillover moved into `Deferred Items` or follow-up issues where appropriate

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -72,7 +72,7 @@ the behavior stable as `.harness/config.yaml` grows deeper over time.
       prefix in deterministic order.
 - [x] Docs and help describe `get` as exact scalar lookup and `list` as prefix
       enumeration.
-- [ ] Agent-facing docs and skills that need the resolved active, archived, or
+- [x] Agent-facing docs and skills that need the resolved active, archived, or
       local runtime roots point to `harness repo config get ...` instead of
       asking agents to infer configured roots.
 
@@ -231,7 +231,7 @@ implemented and reviewed in Step 2; no new production behavior was introduced.
 
 ### Step 4: Replace configured-root inference guidance
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -293,7 +293,12 @@ and `go test ./internal/repoconfig ./internal/cli`.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+Delta review `review-006-delta` passed with no blocking findings and one
+minor docs-consistency finding: the lightweight note in
+`closeout-and-archive.md` was misindented after the root-guidance edit. Fixed
+the bootstrap source, reran `scripts/sync-bootstrap-assets`, and validated the
+materialized `.agents/skills/` copy. Follow-up delta review
+`review-007-delta` passed with no findings.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -378,6 +378,8 @@ materialized `.agents/skills/` copy. Follow-up delta review
   transition catalog still carried the prior text. Revision 3 reopens the
   candidate in `finalize-fix` mode to sync that catalog and rerun focused/full
   validation before re-archive.
+- Revision 3 repair review `review-010-delta` passed with no tests or
+  docs-consistency findings after the catalog sync and full validation.
 
 ## Archive Summary
 
@@ -390,8 +392,8 @@ materialized `.agents/skills/` copy. Follow-up delta review
   bootstrap-sync, stale-guidance search, direct config-get probes, and plan
   lint validation passed. The revision-3 CI repair synced the e2e transition
   catalog with the updated state-transition spec and the focused catalog test
-  passed locally; full validation and final repair review must pass before
-  re-archive.
+  plus full `go test ./...` passed locally. Revision 3 repair review
+  `review-010-delta` passed with no findings.
 - Merge Handoff: Re-archive revision 3, commit the archive move and closeout
   updates, push PR #243, refresh publish/CI/sync evidence, and wait for
   explicit human merge approval once `harness status` reaches

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -344,6 +344,12 @@ materialized `.agents/skills/` copy. Follow-up delta review
   - `git diff --check`
   - `go test ./internal/repoconfig ./internal/cli`
   - `go test ./internal/repoconfig ./internal/cli ./tests/smoke`
+- Reopened revision 3 CI repair validation:
+  - `gh run view 27151499234 --log-failed`
+  - `go test ./tests/e2e -run TestCanonicalTransitionCatalogMatchesTrackedSpecMatrix -count=1`
+  - `harness plan lint docs/plans/active/2026-06-08-add-repo-config-query-commands.md`
+  - `git diff --check`
+  - full `go test ./...` after the catalog repair
 
 ## Review Summary
 
@@ -367,20 +373,26 @@ materialized `.agents/skills/` copy. Follow-up delta review
   next finalize review.
 - Finalize repair recheck `review-009-delta` passed with no findings after the
   closeout summaries were refreshed.
+- Post-push CI failed because `docs/specs/state-transitions.md` changed the
+  `idle -> plan` required-input wording but the maintained e2e canonical
+  transition catalog still carried the prior text. Revision 3 reopens the
+  candidate in `finalize-fix` mode to sync that catalog and rerun focused/full
+  validation before re-archive.
 
 ## Archive Summary
 
-- Archived At: 2026-06-09T00:21:11+08:00
-- Revision: 2
+- Archived At: pending revision-3 re-archive
+- Revision: 3
 - PR: https://github.com/catu-ai/easyharness/pull/243
 - Ready: Acceptance criteria are satisfied, including the reopened Step 4
   criterion that agent-facing docs and skills point to
   `harness repo config get ...` for concrete path roots. Focused unit, smoke,
   bootstrap-sync, stale-guidance search, direct config-get probes, and plan
-  lint validation passed. Finalize repair recheck `review-009-delta` passed
-  with no findings after repairing the stale summary placeholders found by
-  `review-008-full`.
-- Merge Handoff: Re-archive revision 2, commit the archive move and closeout
+  lint validation passed. The revision-3 CI repair synced the e2e transition
+  catalog with the updated state-transition spec and the focused catalog test
+  passed locally; full validation and final repair review must pass before
+  re-archive.
+- Merge Handoff: Re-archive revision 3, commit the archive move and closeout
   updates, push PR #243, refresh publish/CI/sync evidence, and wait for
   explicit human merge approval once `harness status` reaches
   `execution/finalize/await_merge`.
@@ -406,6 +418,9 @@ materialized `.agents/skills/` copy. Follow-up delta review
   `harness repo config get paths.local_runtime`,
   `harness repo config get paths.plans.active`, and
   `harness repo config get paths.plans.archived` lookups.
+- Synced the maintained e2e transition catalog with the updated
+  `idle -> plan` state-transition wording so `go test ./...` can enforce the
+  spec/catalog match.
 
 ### Not Delivered
 

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -125,7 +125,7 @@ steps.
 
 ### Step 2: Implement query commands
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -183,7 +183,8 @@ plain-text `get`, `list`, prefixed `list`, and non-leaf `get` behavior.
 Delta review `review-001-delta` found one blocking tests finding: `list`
 coverage did not directly prove custom/partial resolved output or invalid
 config fallback warning placement. Added CLI-level coverage for both cases and
-reran `go test ./internal/repoconfig ./internal/cli` successfully.
+reran `go test ./internal/repoconfig ./internal/cli` successfully. Follow-up
+delta review `review-002-delta` passed with no findings.
 
 ### Step 3: Prove script-facing behavior
 

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -1,0 +1,257 @@
+---
+template_version: 0.2.0
+created_at: "2026-06-08T22:40:18+08:00"
+approved_at: "2026-06-08T22:43:17+08:00"
+source_type: direct_request
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/241
+size: S
+---
+
+# Add Repo Config Query Commands
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Add a small read-only CLI surface for agents and scripts to query resolved
+repo config values without inferring path roots from docs or built-in defaults.
+
+The command shape should follow the useful part of `git config`: exact scalar
+lookups belong to `get`, while prefix enumeration belongs to `list`. This keeps
+the behavior stable as `.harness/config.yaml` grows deeper over time.
+
+## Scope
+
+### In Scope
+
+- Add `harness repo config get <key>` for resolved scalar config values.
+- Add `harness repo config list [prefix]` for resolved leaf-key enumeration.
+- Support the currently defined path keys:
+  - `paths.plans.active`
+  - `paths.plans.archived`
+  - `paths.local_runtime`
+- Preserve existing repo config loading behavior for missing config, partial
+  config, and invalid-config whole-config fallback.
+- Update CLI help, specs, docs, and tests for the new command behavior.
+- Keep stdout script-friendly and deterministic.
+
+### Out of Scope
+
+- JSON output or a `--json` flag.
+- Mutating config values.
+- Adding new `.harness/config.yaml` fields.
+- Repo config lint behavior beyond the existing load/fallback model.
+- Alternate root-level command aliases such as `harness config get`.
+
+## Acceptance Criteria
+
+- [ ] `harness repo config get paths.local_runtime` prints only the resolved
+      value plus a trailing newline.
+- [ ] `harness repo config get paths.plans.active` and
+      `harness repo config get paths.plans.archived` print their resolved
+      values plus trailing newlines.
+- [ ] Missing `.harness/config.yaml` returns built-in defaults.
+- [ ] Partially specified path config returns explicit values for configured
+      keys and built-in defaults for omitted keys.
+- [ ] Invalid repo config follows the existing whole-config fallback model and
+      returns default resolved values while preserving agent-facing warnings.
+- [ ] Unknown keys fail clearly with a non-zero exit code.
+- [ ] `get` rejects non-leaf config objects such as `paths` with a clear
+      message that points users to `harness repo config list paths`.
+- [ ] `harness repo config list` prints all supported resolved leaf entries as
+      `key=value` lines in deterministic order.
+- [ ] `harness repo config list paths` prints resolved leaf entries under that
+      prefix in deterministic order.
+- [ ] Docs and help describe `get` as exact scalar lookup and `list` as prefix
+      enumeration.
+
+## Deferred Items
+
+- JSON output for config queries remains deferred until an agent or script
+  workflow needs structured source metadata.
+- Query commands for future config fields should be added when those fields
+  become part of the repo config contract.
+
+## Work Breakdown
+
+### Step 1: Define resolved config query behavior
+
+- Done: [x]
+
+#### Objective
+
+Document the command semantics for scalar lookup, prefix listing, invalid
+config fallback, and non-leaf rejection.
+
+#### Details
+
+Use the Git-inspired split discussed during discovery:
+
+- `get <key>` is an exact scalar lookup and should never return an object blob.
+- `list [prefix]` enumerates resolved leaf keys and values.
+- non-leaf `get` requests fail with a suggestion to use `list <prefix>`.
+- output is plain text only in this slice.
+
+The command remains under `harness repo config` because the values are
+repo-level config, not global/user harness config.
+
+#### Expected Files
+
+- `docs/specs/cli-contract.md`
+- `docs/specs/repo-config.md`
+
+#### Validation
+
+- Specs name the supported command shape and the out-of-scope JSON behavior is
+  not implied.
+
+#### Execution Notes
+
+Defined the query-command contract in `docs/specs/cli-contract.md` and
+`docs/specs/repo-config.md`: `get` is exact scalar lookup, `list` is
+deterministic prefix enumeration, non-leaf `get` fails clearly, and this slice
+does not define JSON output.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 only records the approved CLI semantics in
+normative docs; behavior is covered by later implementation and validation
+steps.
+
+### Step 2: Implement query commands
+
+- Done: [ ]
+
+#### Objective
+
+Wire `harness repo config get` and `harness repo config list` into the CLI
+using the existing resolved `repoconfig.Load` behavior.
+
+#### Details
+
+Keep implementation small and data-driven enough that future config fields can
+add supported leaves without duplicating switch-heavy command code everywhere.
+
+Default stdout should be:
+
+```text
+.local/harness
+```
+
+for `get paths.local_runtime`, and:
+
+```text
+paths.plans.active=docs/plans/active
+paths.plans.archived=docs/plans/archived
+paths.local_runtime=.local/harness
+```
+
+for `list` under the default config.
+
+Warnings from invalid config should remain agent-facing diagnostics rather than
+being silently lost.
+
+#### Expected Files
+
+- `internal/cli/app.go`
+- `internal/cli/app_test.go`
+- `internal/repoconfig/config.go`
+- `internal/repoconfig/config_test.go`
+
+#### Validation
+
+- Unit tests cover successful `get`, missing config defaults, partial config
+  defaults, invalid config fallback, unknown keys, non-leaf rejection, full
+  list, and prefixed list.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Prove script-facing behavior
+
+- Done: [ ]
+
+#### Objective
+
+Add or update smoke/end-to-end coverage that exercises the command through the
+real harness binary shape.
+
+#### Details
+
+Prefer focused smoke coverage unless existing e2e helpers make custom
+workspaces simpler. The test should verify plain-text stdout rather than JSON.
+
+#### Expected Files
+
+- `tests/smoke/smoke_test.go`
+- `tests/e2e/custom_path_roots_test.go`
+
+#### Validation
+
+- Relevant Go test packages pass locally.
+- Direct manual probes for `get` and `list` show the expected plain-text
+  output.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run focused unit tests for `internal/repoconfig` and `internal/cli`.
+- Run the smoke or e2e tests that cover the new query commands.
+- Reinstall the dev harness if Go CLI code changes before relying on direct
+  `harness` probes.
+- Manually verify the final command outputs for default and custom config.
+
+## Risks
+
+- Risk: `get` behavior could become ambiguous if it returns object-like
+  content for non-leaf keys.
+  - Mitigation: Make non-leaf `get` a clear error and reserve enumeration for
+    `list`.
+- Risk: warnings from invalid config could corrupt script-friendly stdout.
+  - Mitigation: Keep resolved values on stdout and diagnostics on stderr.
+- Risk: future config fields could require a different query shape.
+  - Mitigation: Keep the initial registry of queryable leaves simple and make
+    `list` prefix-based so deeper future fields fit the same model.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -322,8 +322,6 @@ materialized `.agents/skills/` copy. Follow-up delta review
 
 ## Validation Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 - `go test ./internal/repoconfig ./internal/cli`
 - `scripts/install-dev-harness`
 - Manual probes after reinstall:
@@ -333,10 +331,21 @@ UPDATE_REQUIRED_AFTER_REOPEN
   - `harness repo config get paths`
 - `go test ./tests/smoke`
 - `go test ./internal/repoconfig ./internal/cli ./tests/smoke`
+- Reopened Step 4 validation:
+  - `scripts/sync-bootstrap-assets`
+  - `scripts/sync-bootstrap-assets --check`
+  - strict `rg` search for stale configured-root guidance in README,
+    `AGENTS.md`, bootstrap assets, materialized skills, and specs
+  - direct probes:
+    - `harness repo config get paths.local_runtime`
+    - `harness repo config get paths.plans.active`
+    - `harness repo config get paths.plans.archived`
+  - `harness plan lint docs/plans/active/2026-06-08-add-repo-config-query-commands.md`
+  - `git diff --check`
+  - `go test ./internal/repoconfig ./internal/cli`
+  - `go test ./internal/repoconfig ./internal/cli ./tests/smoke`
 
 ## Review Summary
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Step 2 delta review `review-001-delta` found one blocking tests gap around
   `list` custom/fallback coverage. The gap was fixed with CLI-level tests.
@@ -346,25 +355,36 @@ UPDATE_REQUIRED_AFTER_REOPEN
 - Finalize docs recheck `review-004-delta` passed after updating README.
 - Final repaired-candidate full review `review-005-full` passed with zero
   blocking and zero non-blocking findings.
+- Reopened Step 4 delta review `review-006-delta` passed with one minor
+  docs-consistency finding: a lightweight closeout note was misindented in the
+  bootstrap and materialized closeout reference.
+- Follow-up Step 4 recheck `review-007-delta` passed with no findings after
+  fixing the indentation and rerunning `scripts/sync-bootstrap-assets`.
+- Reopened finalize review `review-008-full` found no correctness issues, but
+  requested changes because the archive-facing summaries still carried
+  stale reopen placeholders. This repair replaces those placeholders with the
+  current revision-2 validation, review, archive, and outcome record before the
+  next finalize review.
 
 ## Archive Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
-- Archived At: 2026-06-08T23:22:04+08:00
-- Revision: 1
+- Archived At: pending revision-2 re-archive
+- Revision: 2
 - PR: https://github.com/catu-ai/easyharness/pull/243
-- Ready: Acceptance criteria are satisfied, focused unit and smoke validation
-  passed, and the final repaired-candidate full review passed.
-- Merge Handoff: Publish evidence is recorded for PR #243. Refresh CI and sync
-  evidence after the branch is current with `origin/main` and GitHub checks
-  finish, then wait for explicit human merge approval.
+- Ready: Acceptance criteria are satisfied, including the reopened Step 4
+  criterion that agent-facing docs and skills point to
+  `harness repo config get ...` for concrete path roots. Focused unit, smoke,
+  bootstrap-sync, stale-guidance search, direct config-get probes, and plan
+  lint validation passed. Finalize review is being rerun after repairing the
+  stale summary placeholders found by `review-008-full`.
+- Merge Handoff: Re-archive revision 2, commit the archive move and closeout
+  updates, push PR #243, refresh publish/CI/sync evidence, and wait for
+  explicit human merge approval once `harness status` reaches
+  `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Added plain-text `harness repo config get <key>` for resolved scalar repo
   config values.
@@ -377,17 +397,19 @@ UPDATE_REQUIRED_AFTER_REOPEN
   spec.
 - Added unit and smoke coverage for default, custom/partial, invalid fallback,
   non-leaf, unknown-key, and script-facing output behavior.
+- Replaced ambiguous configured-root guidance in agent-facing README/specs,
+  bootstrap-managed skills, materialized `.agents/skills/`, and the managed
+  root `AGENTS.md` block with concrete
+  `harness repo config get paths.local_runtime`,
+  `harness repo config get paths.plans.active`, and
+  `harness repo config get paths.plans.archived` lookups.
 
 ### Not Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - JSON output, config mutation, new config fields, and root-level aliases were
   intentionally out of scope.
 
 ### Follow-Up Issues
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - No new follow-up issues were created. JSON output remains deferred until a
   concrete agent or script workflow needs structured source metadata. Query

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -365,6 +365,8 @@ materialized `.agents/skills/` copy. Follow-up delta review
   stale reopen placeholders. This repair replaces those placeholders with the
   current revision-2 validation, review, archive, and outcome record before the
   next finalize review.
+- Finalize repair recheck `review-009-delta` passed with no findings after the
+  closeout summaries were refreshed.
 
 ## Archive Summary
 
@@ -375,8 +377,9 @@ materialized `.agents/skills/` copy. Follow-up delta review
   criterion that agent-facing docs and skills point to
   `harness repo config get ...` for concrete path roots. Focused unit, smoke,
   bootstrap-sync, stale-guidance search, direct config-get probes, and plan
-  lint validation passed. Finalize review is being rerun after repairing the
-  stale summary placeholders found by `review-008-full`.
+  lint validation passed. Finalize repair recheck `review-009-delta` passed
+  with no findings after repairing the stale summary placeholders found by
+  `review-008-full`.
 - Merge Handoff: Re-archive revision 2, commit the archive move and closeout
   updates, push PR #243, refresh publish/CI/sync evidence, and wait for
   explicit human merge approval once `harness status` reaches

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -188,7 +188,7 @@ delta review `review-002-delta` passed with no findings.
 
 ### Step 3: Prove script-facing behavior
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -213,11 +213,15 @@ workspaces simpler. The test should verify plain-text stdout rather than JSON.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added smoke coverage for the real CLI shape: custom/partial config `get`,
+full `list`, prefixed `list`, non-leaf `get` failure, and invalid-config
+fallback with warning diagnostics on stderr. Validation passed with
+`go test ./tests/smoke` and the focused unit packages remained green.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 3 adds direct smoke coverage for behavior already
+implemented and reviewed in Step 2; no new production behavior was introduced.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -180,7 +180,10 @@ plain-text `get`, `list`, prefixed `list`, and non-leaf `get` behavior.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+Delta review `review-001-delta` found one blocking tests finding: `list`
+coverage did not directly prove custom/partial resolved output or invalid
+config fallback warning placement. Added CLI-level coverage for both cases and
+reran `go test ./internal/repoconfig ./internal/cli` successfully.
 
 ### Step 3: Prove script-facing behavior
 

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -5,6 +5,7 @@ approved_at: "2026-06-08T22:43:17+08:00"
 source_type: direct_request
 source_refs:
     - https://github.com/catu-ai/easyharness/issues/241
+    - https://github.com/catu-ai/easyharness/pull/239
 size: S
 ---
 
@@ -38,6 +39,8 @@ the behavior stable as `.harness/config.yaml` grows deeper over time.
 - Preserve existing repo config loading behavior for missing config, partial
   config, and invalid-config whole-config fallback.
 - Update CLI help, specs, docs, and tests for the new command behavior.
+- Replace agent-facing docs and skills that still ask agents to infer
+  configured path roots with concrete `harness repo config get ...` commands.
 - Keep stdout script-friendly and deterministic.
 
 ### Out of Scope
@@ -69,6 +72,9 @@ the behavior stable as `.harness/config.yaml` grows deeper over time.
       prefix in deterministic order.
 - [x] Docs and help describe `get` as exact scalar lookup and `list` as prefix
       enumeration.
+- [ ] Agent-facing docs and skills that need the resolved active, archived, or
+      local runtime roots point to `harness repo config get ...` instead of
+      asking agents to infer configured roots.
 
 ## Deferred Items
 
@@ -223,6 +229,72 @@ fallback with warning diagnostics on stderr. Validation passed with
 NO_STEP_REVIEW_NEEDED: Step 3 adds direct smoke coverage for behavior already
 implemented and reviewed in Step 2; no new production behavior was introduced.
 
+### Step 4: Replace configured-root inference guidance
+
+- Done: [ ]
+
+#### Objective
+
+Update docs and harness skill assets so agents use
+`harness repo config get <key>` when they need concrete path roots introduced
+around PR #239.
+
+#### Details
+
+PR #239 made docs and skills accurately refer to configured active/archive plan
+roots and configured local runtime roots, but that wording can leave agents
+guessing whether the concrete value is `.local/harness`, `docs/plans/active`,
+or a repo override. This reopened step should remove that uncertainty wherever
+the workflow text expects an agent or script to act on a concrete root.
+
+Use these commands as the canonical lookup surface:
+
+```bash
+harness repo config get paths.local_runtime
+harness repo config get paths.plans.active
+harness repo config get paths.plans.archived
+```
+
+For easyharness-managed skill pack changes, edit `assets/bootstrap/` and run
+`scripts/sync-bootstrap-assets` so the materialized `.agents/skills/` copies
+and managed root `AGENTS.md` block are refreshed from source.
+
+#### Expected Files
+
+- `assets/bootstrap/`
+- `.agents/skills/`
+- `AGENTS.md`
+- `docs/`
+
+#### Validation
+
+- Text search shows agent-facing configured-root guidance now points to the
+  query commands where concrete values are needed.
+- `scripts/sync-bootstrap-assets` is run if bootstrap-managed assets change.
+- Focused tests or lint commands pass for touched surfaces.
+
+#### Execution Notes
+
+Replaced ambiguous configured-root guidance in managed bootstrap assets,
+materialized skills, `AGENTS.md`, README, and specs with command-first
+lookups:
+
+- `harness repo config get paths.local_runtime`
+- `harness repo config get paths.plans.active`
+- `harness repo config get paths.plans.archived`
+
+Edited bootstrap sources under `assets/bootstrap/` and reran
+`scripts/sync-bootstrap-assets` so `.agents/skills/` and the managed root
+`AGENTS.md` block match the distributed source. A strict text search for
+ambiguous configured-root phrases returned no hits; remaining `configured`
+mentions are repo-config contract text or unrelated setup prose. Validation
+passed with `harness plan lint`, `git diff --check`, direct config-get probes,
+and `go test ./internal/repoconfig ./internal/cli`.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
 ## Validation Strategy
 
 - Run focused unit tests for `internal/repoconfig` and `internal/cli`.
@@ -245,6 +317,8 @@ implemented and reviewed in Step 2; no new production behavior was introduced.
 
 ## Validation Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - `go test ./internal/repoconfig ./internal/cli`
 - `scripts/install-dev-harness`
 - Manual probes after reinstall:
@@ -257,6 +331,8 @@ implemented and reviewed in Step 2; no new production behavior was introduced.
 
 ## Review Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - Step 2 delta review `review-001-delta` found one blocking tests gap around
   `list` custom/fallback coverage. The gap was fixed with CLI-level tests.
 - Step 2 follow-up delta review `review-002-delta` passed with no findings.
@@ -267,6 +343,8 @@ implemented and reviewed in Step 2; no new production behavior was introduced.
   blocking and zero non-blocking findings.
 
 ## Archive Summary
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Archived At: 2026-06-08T23:22:04+08:00
 - Revision: 1
@@ -280,6 +358,8 @@ implemented and reviewed in Step 2; no new production behavior was introduced.
 ## Outcome Summary
 
 ### Delivered
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Added plain-text `harness repo config get <key>` for resolved scalar repo
   config values.
@@ -295,10 +375,14 @@ implemented and reviewed in Step 2; no new production behavior was introduced.
 
 ### Not Delivered
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - JSON output, config mutation, new config fields, and root-level aliases were
   intentionally out of scope.
 
 ### Follow-Up Issues
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - No new follow-up issues were created. JSON output remains deferred until a
   concrete agent or script workflow needs structured source metadata. Query

--- a/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/active/2026-06-08-add-repo-config-query-commands.md
@@ -171,7 +171,12 @@ being silently lost.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added resolved query helpers to `internal/repoconfig` and wired
+`harness repo config get|list` through the CLI. Followed Red/Green/Refactor:
+new unit tests first failed for missing helpers/subcommands, then passed after
+implementation. Focused validation passed with `go test ./internal/repoconfig
+./internal/cli`, and manual probes after `scripts/install-dev-harness` showed
+plain-text `get`, `list`, prefixed `list`, and non-leaf `get` behavior.
 
 #### Review Notes
 

--- a/docs/plans/archived/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/archived/2026-06-08-add-repo-config-query-commands.md
@@ -383,7 +383,7 @@ materialized `.agents/skills/` copy. Follow-up delta review
 
 ## Archive Summary
 
-- Archived At: pending revision-3 re-archive
+- Archived At: 2026-06-09T00:33:51+08:00
 - Revision: 3
 - PR: https://github.com/catu-ai/easyharness/pull/243
 - Ready: Acceptance criteria are satisfied, including the reopened Step 4

--- a/docs/plans/archived/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/archived/2026-06-08-add-repo-config-query-commands.md
@@ -270,12 +270,12 @@ implemented and reviewed in Step 2; no new production behavior was introduced.
 
 - Archived At: 2026-06-08T23:22:04+08:00
 - Revision: 1
-- PR: To be opened after archive commit and push.
+- PR: https://github.com/catu-ai/easyharness/pull/243
 - Ready: Acceptance criteria are satisfied, focused unit and smoke validation
   passed, and the final repaired-candidate full review passed.
-- Merge Handoff: After archive, commit the tracked archive move, push
-  `codex/repo-config-query-commands`, open a PR, record publish evidence with
-  the PR URL, and refresh CI/sync evidence before waiting for merge approval.
+- Merge Handoff: Publish evidence is recorded for PR #243. Refresh CI and sync
+  evidence after the branch is current with `origin/main` and GitHub checks
+  finish, then wait for explicit human merge approval.
 
 ## Outcome Summary
 

--- a/docs/plans/archived/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/archived/2026-06-08-add-repo-config-query-commands.md
@@ -50,24 +50,24 @@ the behavior stable as `.harness/config.yaml` grows deeper over time.
 
 ## Acceptance Criteria
 
-- [ ] `harness repo config get paths.local_runtime` prints only the resolved
+- [x] `harness repo config get paths.local_runtime` prints only the resolved
       value plus a trailing newline.
-- [ ] `harness repo config get paths.plans.active` and
+- [x] `harness repo config get paths.plans.active` and
       `harness repo config get paths.plans.archived` print their resolved
       values plus trailing newlines.
-- [ ] Missing `.harness/config.yaml` returns built-in defaults.
-- [ ] Partially specified path config returns explicit values for configured
+- [x] Missing `.harness/config.yaml` returns built-in defaults.
+- [x] Partially specified path config returns explicit values for configured
       keys and built-in defaults for omitted keys.
-- [ ] Invalid repo config follows the existing whole-config fallback model and
+- [x] Invalid repo config follows the existing whole-config fallback model and
       returns default resolved values while preserving agent-facing warnings.
-- [ ] Unknown keys fail clearly with a non-zero exit code.
-- [ ] `get` rejects non-leaf config objects such as `paths` with a clear
+- [x] Unknown keys fail clearly with a non-zero exit code.
+- [x] `get` rejects non-leaf config objects such as `paths` with a clear
       message that points users to `harness repo config list paths`.
-- [ ] `harness repo config list` prints all supported resolved leaf entries as
+- [x] `harness repo config list` prints all supported resolved leaf entries as
       `key=value` lines in deterministic order.
-- [ ] `harness repo config list paths` prints resolved leaf entries under that
+- [x] `harness repo config list paths` prints resolved leaf entries under that
       prefix in deterministic order.
-- [ ] Docs and help describe `get` as exact scalar lookup and `list` as prefix
+- [x] Docs and help describe `get` as exact scalar lookup and `list` as prefix
       enumeration.
 
 ## Deferred Items
@@ -245,26 +245,62 @@ implemented and reviewed in Step 2; no new production behavior was introduced.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `go test ./internal/repoconfig ./internal/cli`
+- `scripts/install-dev-harness`
+- Manual probes after reinstall:
+  - `harness repo config get paths.local_runtime`
+  - `harness repo config list`
+  - `harness repo config list paths.plans`
+  - `harness repo config get paths`
+- `go test ./tests/smoke`
+- `go test ./internal/repoconfig ./internal/cli ./tests/smoke`
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step 2 delta review `review-001-delta` found one blocking tests gap around
+  `list` custom/fallback coverage. The gap was fixed with CLI-level tests.
+- Step 2 follow-up delta review `review-002-delta` passed with no findings.
+- Finalize full review `review-003-full` found one blocking docs consistency
+  gap: README's command-surface list omitted `repo config get/list`.
+- Finalize docs recheck `review-004-delta` passed after updating README.
+- Final repaired-candidate full review `review-005-full` passed with zero
+  blocking and zero non-blocking findings.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-06-08T23:22:04+08:00
+- Revision: 1
+- PR: To be opened after archive commit and push.
+- Ready: Acceptance criteria are satisfied, focused unit and smoke validation
+  passed, and the final repaired-candidate full review passed.
+- Merge Handoff: After archive, commit the tracked archive move, push
+  `codex/repo-config-query-commands`, open a PR, record publish evidence with
+  the PR URL, and refresh CI/sync evidence before waiting for merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added plain-text `harness repo config get <key>` for resolved scalar repo
+  config values.
+- Added plain-text `harness repo config list [prefix]` for deterministic
+  resolved leaf enumeration.
+- Preserved missing, partial, and invalid repo config behavior through the
+  existing whole-config fallback loader, with script-facing values on stdout
+  and warnings/errors on stderr.
+- Documented the command shape in README, the CLI contract, and the repo config
+  spec.
+- Added unit and smoke coverage for default, custom/partial, invalid fallback,
+  non-leaf, unknown-key, and script-facing output behavior.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- JSON output, config mutation, new config fields, and root-level aliases were
+  intentionally out of scope.
 
 ### Follow-Up Issues
 
-NONE
+- No new follow-up issues were created. JSON output remains deferred until a
+  concrete agent or script workflow needs structured source metadata. Query
+  support for future config fields should be added when those fields enter the
+  repo config contract.

--- a/docs/plans/archived/2026-06-08-add-repo-config-query-commands.md
+++ b/docs/plans/archived/2026-06-08-add-repo-config-query-commands.md
@@ -370,7 +370,7 @@ materialized `.agents/skills/` copy. Follow-up delta review
 
 ## Archive Summary
 
-- Archived At: pending revision-2 re-archive
+- Archived At: 2026-06-09T00:21:11+08:00
 - Revision: 2
 - PR: https://github.com/catu-ai/easyharness/pull/243
 - Ready: Acceptance criteria are satisfied, including the reopened Step 4

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -117,10 +117,10 @@ Commands that rewrite CLI-owned JSON runstate must protect those files against
 interrupted or overlapping writes.
 
 - write the current-plan pointer and any plan-local `state.json` under the
-  configured local runtime root through atomic replacement in the destination
-  directory
+  local runtime root resolved by `harness repo config get paths.local_runtime`
+  through atomic replacement in the destination directory
 - acquire a shared per-plan state-mutation lock before loading and rewriting
-  the configured local runtime root's `plans/<plan-stem>/state.json`
+  the resolved local runtime root's `plans/<plan-stem>/state.json`
 - fail with a clear contention error when that state lock is already held
   instead of waiting silently or risking a stale overwrite
 
@@ -208,9 +208,12 @@ and current state for read-only stateful commands.
 `artifacts` is optional and command-specific. Omit it when there are no stable
 artifact paths or IDs worth returning.
 
-`plan_path` may point to a tracked active plan under the configured active plan
-root, a tracked standard archive under the configured archived plan root, or a
-lightweight local archive under the configured local runtime root.
+`plan_path` may point to a tracked active plan under the active plan root
+resolved by `harness repo config get paths.plans.active`, a tracked standard
+archive under the archived plan root resolved by
+`harness repo config get paths.plans.archived`, or a lightweight local archive
+under the local runtime root resolved by
+`harness repo config get paths.local_runtime`.
 
 When a matching `supplements/<plan-stem>/` directory exists for that markdown
 plan, commands may also surface it through command-specific `artifacts`
@@ -421,8 +424,9 @@ Contract:
   the author's back
 - in lightweight mode, seed `workflow_profile: lightweight`, a shorter
   single-step low-risk authoring shape, and guidance that the active plan
-  still lives under the configured active plan root while the archive goes to
-  the local lightweight archive path
+  still lives under the active plan root resolved by
+  `harness repo config get paths.plans.active` while the archive goes to the
+  local lightweight archive path
 - lightweight authoring must only be available for `size: XXS`; command UX may
   enforce that either by requiring an explicit `XXS` size or by rendering the
   lightweight template with explicit `size: XXS`
@@ -547,8 +551,9 @@ Contract:
 - when remote observation says to wait, repair, use manual evidence, or treat
   the candidate as invalidated, do not also include an immediate
   `harness evidence refresh` command in status next actions
-- if no current plan is active but the current-plan pointer under the
-  configured local runtime root records a landed candidate, return
+- if no current plan is active but the current-plan pointer under the local
+  runtime root resolved by `harness repo config get paths.local_runtime`
+  records a landed candidate, return
   `state.current_node: idle` with landed context in `artifacts`
 - when the current plan uses the lightweight profile, remind the controller to
   leave the agreed repo-visible breadcrumb, such as a readable PR body merge
@@ -883,8 +888,9 @@ Contract:
 - reject the command with a clear error when the current active plan still
   lacks recorded approval
 - persist the execution-start milestone in plan-local runtime state
-- update the current-plan pointer under the configured local runtime root to
-  point at the active tracked plan
+- update the current-plan pointer under the local runtime root resolved by
+  `harness repo config get paths.local_runtime` to point at the active tracked
+  plan
 - return the shared v0.2 envelope with the post-command
   `state.current_node`, `facts.revision`, transition-relevant `artifacts`, and
   actionable `next_actions`
@@ -950,16 +956,18 @@ Contract:
 - require the pre-archive `Archive Summary` to include structured `PR`,
   `Ready`, and `Merge Handoff` lines
 - move the plan from its active path to its archived path:
-  - configured active plan root -> configured archived plan root for
-    `standard`
-  - configured active plan root -> lightweight archived snapshot root under the
-    configured local runtime root for `lightweight`
+  - active plan root resolved by `harness repo config get paths.plans.active`
+    -> archived plan root resolved by
+    `harness repo config get paths.plans.archived` for `standard`
+  - active plan root resolved by `harness repo config get paths.plans.active`
+    -> lightweight archived snapshot root under the local runtime root resolved
+    by `harness repo config get paths.local_runtime` for `lightweight`
 - when a matching `supplements/<plan-stem>/` directory exists, move it with
   the markdown plan to the corresponding archived root
-- for `lightweight`, that archived root is the local snapshot path under
-  the configured local runtime root, not tracked git
-- update the current-plan pointer under the configured local runtime root to
-  the archived plan path
+- for `lightweight`, that archived root is the local snapshot path under the
+  resolved local runtime root, not tracked git
+- update the current-plan pointer under the local runtime root resolved by
+  `harness repo config get paths.local_runtime` to the archived plan path
 - keep publish, CI, and sync follow-up out of the archive gate; those belong to
   `execution/finalize/publish`
 - return the shared v0.2 envelope with `state.current_node` set to the
@@ -972,7 +980,8 @@ Contract:
 Important note:
 
 - `harness archive` changes tracked files locally for both profiles because the
-  active tracked plan is removed from the configured active plan root
+  active tracked plan is removed from the active plan root resolved by
+  `harness repo config get paths.plans.active`
 - the controller agent should commit and push the archive change before
   treating the candidate as truly waiting for merge approval
 - the controller agent should also update the agreed repo-visible breadcrumb
@@ -1017,8 +1026,8 @@ Contract:
 - preserve archive audit history via explicit update-required placeholders
 - clear stale review and land control-plane signals from the prior archived
   candidate
-- update the current-plan pointer under the configured local runtime root back
-  to the active path
+- update the current-plan pointer under the local runtime root resolved by
+  `harness repo config get paths.local_runtime` back to the active path
 - return the shared v0.2 envelope with the reopened post-command node,
   `facts.revision`, `facts.reopen_mode`, transition artifacts, and actionable
   `next_actions`
@@ -1043,8 +1052,9 @@ Contract:
 - require the current plan to already be archived before accepting evidence
 - support `--kind <ci|publish|sync>` with JSON payloads documented in
   `--help`
-- write a timestamped evidence artifact under the configured local runtime
-  root's `plans/<plan-stem>/evidence/<kind>/`
+- write a timestamped evidence artifact under the local runtime root resolved
+  by `harness repo config get paths.local_runtime`, inside
+  `plans/<plan-stem>/evidence/<kind>/`
 - let later status and land-readiness checks discover the latest evidence
   directly from append-only evidence artifacts instead of storing a pointer in
   `state.json`
@@ -1110,8 +1120,8 @@ Contract:
 
 - require prior `harness land --pr <url>` for the same archived candidate
 - persist local completion metadata in plan-local runtime state
-- rewrite the current-plan pointer under the configured local runtime root so
-  `plan_path` is cleared
+- rewrite the current-plan pointer under the local runtime root resolved by
+  `harness repo config get paths.local_runtime` so `plan_path` is cleared
 - record `last_landed_plan_path` and `last_landed_at` for worktree handoff
 - leave archived plan content untouched; this is local-state cleanup only
 - return the shared v0.2 envelope with `state.current_node: idle`,

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -35,6 +35,8 @@ The current command surface is:
 - `harness repo instructions install`
 - `harness repo instructions uninstall`
 - `harness repo config init`
+- `harness repo config get <key>`
+- `harness repo config list [prefix]`
 - `harness execute start`
 - `harness evidence submit`
 - `harness evidence refresh`
@@ -317,6 +319,10 @@ Contract:
   are defined in [Bootstrap Install](./bootstrap-install.md)
 - bootstrap commands share a JSON result envelope documented by the checked-in
   contract registry and may omit workflow `state`
+- read-only repo config query commands are plain-text exceptions:
+  `harness repo config get <key>` prints one resolved scalar value, while
+  `harness repo config list [prefix]` prints resolved `key=value` leaf entries
+  in deterministic order
 
 Recommended next action:
 

--- a/docs/specs/contract.md
+++ b/docs/specs/contract.md
@@ -26,7 +26,8 @@ The schema registry currently covers:
 - JSON command inputs such as review and evidence payloads
 - read-only UI resource payloads served by `harness ui`
 - shared reusable JSON shapes
-- CLI-owned runtime JSON artifacts under the configured local runtime root
+- CLI-owned runtime JSON artifacts under the local runtime root resolved by
+  `harness repo config get paths.local_runtime`
 
 The registry does not cover the markdown tracked-plan schema.
 
@@ -49,8 +50,8 @@ In `schema/index.json`, these entries are marked with `"surface": "public"`.
 ### CLI-Owned Runtime Artifacts
 
 Schemas under `schema/artifacts/` describe harness-owned runtime files such as
-the current-plan pointer and plan-local `state.json` under the configured local
-runtime root.
+the current-plan pointer and plan-local `state.json` under the local runtime
+root resolved by `harness repo config get paths.local_runtime`.
 
 They are documented so agents and developers can inspect current runtime state
 without reverse-engineering Go structs, but they are still CLI-owned runtime

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -6,49 +6,60 @@ This document defines the normative v0.2 plan contract for `easyharness`.
 
 In v0.2, standard and lightweight plans share one markdown schema, but the
 durable planning unit is a markdown-led plan package rather than a lone file.
-Active plans for both profiles live in tracked markdown under the configured
-active plan root, which defaults to `docs/plans/active/`, and may carry
-approval-scoped companion material under a matching `supplements/<plan-stem>/`
-directory. Lightweight diverges only at archive time, when the archived
-snapshot moves into command-owned local storage. Runtime lifecycle, milestone
-timestamps, review rounds, evidence history, and resolved node state live in
-the configured local runtime root, which defaults to `.local/harness/`.
+Active plans for both profiles live in tracked markdown under the active plan
+root resolved by `harness repo config get paths.plans.active`, which defaults
+to `docs/plans/active/`, and may carry approval-scoped companion material
+under a matching `supplements/<plan-stem>/` directory. Lightweight diverges
+only at archive time, when the archived snapshot moves into command-owned
+local storage. Runtime lifecycle, milestone timestamps, review rounds,
+evidence history, and resolved node state live in the local runtime root
+resolved by `harness repo config get paths.local_runtime`, which defaults to
+`.local/harness/`.
+Agents and scripts that need concrete resolved roots should query them with
+`harness repo config get paths.plans.active`,
+`harness repo config get paths.plans.archived`, and
+`harness repo config get paths.local_runtime` instead of inferring defaults.
 
 ## Directory Layout
 
-Tracked plan locations live in the configured active and archived plan roots,
-which default to:
+Tracked plan locations live in the active and archived plan roots resolved by
+`harness repo config get paths.plans.active` and
+`harness repo config get paths.plans.archived`, which default to:
 
 - `docs/plans/active/`
 - `docs/plans/archived/`
 
-Tracked plan package companion locations live under the matching configured
-plan root, defaulting to:
+Tracked plan package companion locations live under the matching plan root
+resolved by `harness repo config get paths.plans.active` or
+`harness repo config get paths.plans.archived`, defaulting to:
 
 - `docs/plans/active/supplements/<plan-stem>/`
 - `docs/plans/archived/supplements/<plan-stem>/`
 
-Lightweight local archived snapshots live under the configured local runtime
-root, defaulting to:
+Lightweight local archived snapshots live under the local runtime root
+resolved by `harness repo config get paths.local_runtime`, defaulting to:
 
 - `.local/harness/plans/archived/<plan-stem>.md`
 - `.local/harness/plans/archived/supplements/<plan-stem>/`
 
 There is no local active lightweight plan path in v0.2. Both `standard` and
-`lightweight` active plans live under the configured active plan root.
+`lightweight` active plans live under the active plan root resolved by
+`harness repo config get paths.plans.active`.
 
 The markdown file remains the canonical plan path for status resolution,
 current-plan pointers, and most command artifacts. When a matching
 `supplements/<plan-stem>/` directory exists, it is part of the same approved
 plan package and must move with the markdown plan during archive and reopen.
 
-Command-owned local artifacts live under the configured local runtime root,
-defaulting to:
+Command-owned local artifacts live under the local runtime root resolved by
+`harness repo config get paths.local_runtime`, defaulting to:
 
 - `.local/harness/current-plan.json`
 - `.local/harness/plans/<plan-stem>/state.json`
 - `.local/harness/plans/<plan-stem>/reviews/`
 - `.local/harness/plans/<plan-stem>/evidence/`
+
+Use that command before reading command-owned local artifacts.
 
 Tracked plans remain durable repository history for active work and standard
 archives. Their optional `supplements/` directories are execution input during
@@ -125,8 +136,9 @@ Where:
 - `short-topic` is a compact kebab-case topic slug
 
 The file stem is the durable identifier used by command-owned local state under
-the configured local runtime root. With the default runtime root, that looks
-like:
+the local runtime root resolved by
+`harness repo config get paths.local_runtime`. With the default runtime root,
+that looks like:
 
 - `.local/harness/plans/<plan-stem>/...`
 - matching `supplements/<plan-stem>/` package directories
@@ -224,9 +236,11 @@ approved_at: 2026-03-17T10:30:00+08:00
   - omitted means `standard`
   - `standard` must not be written explicitly; omitting the field preserves
     the current standard behavior
-  - tracked plans under the configured active plan root may set this field
-    only to `lightweight`
-  - tracked plans under the configured archived plan root must omit this field
+  - tracked plans under the active plan root resolved by
+    `harness repo config get paths.plans.active` may set this field only to
+    `lightweight`
+  - tracked plans under the archived plan root resolved by
+    `harness repo config get paths.plans.archived` must omit this field
   - local archived plans under the lightweight archived snapshot root must set
     it to `lightweight`
 
@@ -470,8 +484,9 @@ The lightweight profile is not eligible when any of these are true:
 Lightweight plans should normally avoid `supplements/`. If a lightweight plan
 temporarily needs one, keep it minimal, treat it with the same approval
 governance as the markdown plan, and ensure archive writes it only to
-the lightweight archived snapshot supplements root under the configured local
-runtime root rather than treating it as durable tracked history.
+the lightweight archived snapshot supplements root under the local runtime root
+resolved by `harness repo config get paths.local_runtime` rather than treating
+it as durable tracked history.
 
 When there is any doubt, escalate to the standard tracked-plan workflow.
 
@@ -479,7 +494,8 @@ When there is any doubt, escalate to the standard tracked-plan workflow.
 
 An active plan must satisfy all of these:
 
-- the file lives under the configured active plan root
+- the file lives under the active plan root resolved by
+  `harness repo config get paths.plans.active`
 - the file does not live inside the active root's `supplements/` subtree
 - lightweight does not create a separate local active-plan location
 - the required frontmatter fields are present
@@ -502,9 +518,10 @@ An active plan must satisfy all of these:
 An archived plan must satisfy all of these:
 
 - the file lives under either:
-  - the configured archived plan root
-  - the lightweight archived snapshot root under the configured local runtime
-    root
+  - the archived plan root resolved by
+    `harness repo config get paths.plans.archived`
+  - the lightweight archived snapshot root under the local runtime root
+    resolved by `harness repo config get paths.local_runtime`
 - any optional `workflow_profile` field is compatible with the path:
   - tracked archived plans must omit `workflow_profile`
   - local archived plans require `workflow_profile: lightweight`
@@ -558,10 +575,11 @@ tracked archive summary. It is no longer tracked as frontmatter.
 active:
 
 - move the file from the archived path back to the corresponding active path:
-  - configured archived plan root -> configured active plan root for
-    `standard`
-  - lightweight archived snapshot root -> configured active plan root for
-    `lightweight`
+  - archived plan root resolved by
+    `harness repo config get paths.plans.archived` -> active plan root
+    resolved by `harness repo config get paths.plans.active` for `standard`
+  - lightweight archived snapshot root -> active plan root resolved by
+    `harness repo config get paths.plans.active` for `lightweight`
 - move the matching `supplements/<plan-stem>/` directory with the markdown
   plan when it exists
 - preserve prior archive-time wording
@@ -598,10 +616,12 @@ Mode-specific rules:
 - missing required step subsections
 - unsupported `workflow_profile` values
 - plans stored outside:
-  - the configured active plan root
-  - the configured archived plan root
-  - the lightweight archived snapshot root under the configured local runtime
-    root
+  - the active plan root resolved by
+    `harness repo config get paths.plans.active`
+  - the archived plan root resolved by
+    `harness repo config get paths.plans.archived`
+  - the lightweight archived snapshot root under the local runtime root
+    resolved by `harness repo config get paths.local_runtime`
 - plan markdown stored under a `supplements/` subtree
 - plans whose path and `workflow_profile` disagree
 - supplements paths that are present but are not directories

--- a/docs/specs/proposals/harness-ui-steering-surface.md
+++ b/docs/specs/proposals/harness-ui-steering-surface.md
@@ -49,8 +49,9 @@ The UI should complement `harness status`, not replace it.
 
 - provide a clear human steering surface for the current machine-local
   dashboard and the selected watched workspace
-- stay grounded in existing tracked files and runtime artifacts under each
-  workspace's configured local runtime root
+- stay grounded in existing tracked files and runtime artifacts under the
+  local runtime root resolved for each workspace with
+  `harness repo config get paths.local_runtime`
 - make `next actions`, blockers, and review state easy to understand
 - show plans, tracked diffs, review artifacts, and recent trajectory in one
   dense local workbench once a workspace is selected
@@ -81,8 +82,9 @@ marketing-style dashboard:
 - collapsible bottom status drawer
 
 The dashboard should read from the machine-local watchlist plus
-`harness status`, tracked plan files, git diff, and artifacts under the
-configured local runtime root for the selected workspace. It should present
+`harness status`, tracked plan files, git diff, and artifacts under the local
+runtime root resolved for the selected workspace with
+`harness repo config get paths.local_runtime`. It should present
 those sources through one machine-local entrypoint and one dense
 document-oriented workspace surface instead of inventing new product-only
 state.
@@ -426,9 +428,12 @@ and evidence, not as a permanent global action catalog.
 The UI should read from durable or already-owned sources:
 
 - `harness status`
-- tracked plan files under the configured active and archived plan roots
+- tracked plan files under the roots resolved by
+  `harness repo config get paths.plans.active` and
+  `harness repo config get paths.plans.archived`
 - tracked git state and diff
-- current-plan pointer under the configured local runtime root
+- current-plan pointer under the root resolved by
+  `harness repo config get paths.local_runtime`
 - review artifacts
 - evidence artifacts
 - other harness-owned local metadata

--- a/docs/specs/proposals/testing-structure.md
+++ b/docs/specs/proposals/testing-structure.md
@@ -188,7 +188,8 @@ Why `resilience` instead of `chaos`:
 
 Typical `easyharness` resilience coverage should include:
 
-- corrupted current-plan pointers under the configured local runtime root
+- corrupted current-plan pointers under the local runtime root resolved by
+  `harness repo config get paths.local_runtime`
 - missing or unreadable review aggregate artifacts
 - archive operations that fail mid-write and must roll back cleanly
 - conflicting active plans or ambiguous current-plan pointers

--- a/docs/specs/repo-config.md
+++ b/docs/specs/repo-config.md
@@ -83,6 +83,32 @@ when that file is invalid.
 `harness repo config init` is the focused command for creating the same minimal
 config file without installing or refreshing other repo resources.
 
+## Repo Config Queries
+
+`harness repo config get <key>` is the focused command for reading one resolved
+scalar config value. It returns effective values after applying the same load
+model used by other repo config consumers: missing config uses built-in
+defaults, omitted optional fields use defaults, and invalid config is ignored
+as a whole with a warning while defaults are used.
+
+Supported v1 scalar keys are:
+
+- `paths.plans.active`
+- `paths.plans.archived`
+- `paths.local_runtime`
+
+`get` only returns leaf values. Object keys such as `paths` or `paths.plans`
+must fail clearly instead of returning YAML, JSON, or another structured blob.
+Use `harness repo config list [prefix]` to enumerate resolved leaf keys under
+an object prefix.
+
+`harness repo config list` prints all supported resolved leaf entries as
+deterministically ordered `key=value` lines. `harness repo config list paths`
+prints the same shape filtered to the `paths` prefix.
+
+These query commands are intentionally plain-text and script-friendly. This
+version does not define JSON output, source metadata, or config mutation.
+
 ## Future Fields
 
 Future customization fields should keep `.harness/config.yaml` as a manifest

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -56,10 +56,12 @@ latest `current_node`.
 CLI-owned runstate files must stay parseable even when commands run close
 together or a process exits during persistence.
 
-- the current-plan pointer under the configured local runtime root must be
-  written with atomic replacement rather than in-place overwrite writes
-- each plan-local `state.json` under the configured local runtime root must
-  also use atomic replacement
+- the current-plan pointer under the local runtime root resolved by
+  `harness repo config get paths.local_runtime` must be written with atomic
+  replacement rather than in-place overwrite writes
+- each plan-local `state.json` under the local runtime root resolved by
+  `harness repo config get paths.local_runtime` must also use atomic
+  replacement
 - any command that mutates a plan-local `state.json` must acquire a shared
   per-plan state-mutation lock before it loads and rewrites that file
 - if the per-plan state lock is already held, the command should fail with a
@@ -92,11 +94,14 @@ resolving the snapshot.
 
 Tracked active plans remain the durable source of scope, step closeout, and
 archive summaries for both profiles. Lightweight work uses the same schema and
-the same configured active-plan root, but its archived snapshot moves under
-the configured local runtime root so the workflow can stay lightweight for
-narrow low-risk changes. Runtime trajectory, milestone timestamps, and
-external-fact capture also belong in the configured local runtime root. There
-is no separate local active lightweight plan path in this model.
+the same active-plan root resolved by
+`harness repo config get paths.plans.active`, but its archived snapshot moves
+under the local runtime root resolved by
+`harness repo config get paths.local_runtime` so the workflow can stay
+lightweight for narrow low-risk changes. Runtime trajectory, milestone
+timestamps, and external-fact capture also belong in the resolved local
+runtime root. There is no separate local active lightweight plan path in this
+model.
 
 ### Explicit Command Boundaries
 
@@ -135,11 +140,18 @@ root
 - archive-time summaries and outcome notes
 
 For active work in both profiles, this plan artifact is a tracked file under
-the configured active plan root, which defaults to `docs/plans/active/`.
-Standard archives stay tracked under the configured archived plan root, which
+the active plan root resolved by
+`harness repo config get paths.plans.active`, which defaults to
+`docs/plans/active/`. Standard archives stay tracked under the archived plan
+root resolved by `harness repo config get paths.plans.archived`, which
 defaults to `docs/plans/archived/`. Lightweight archived snapshots move under
-the configured local runtime root, defaulting to
+the local runtime root resolved by
+`harness repo config get paths.local_runtime`, defaulting to
 `.local/harness/plans/archived/` for the snapshot directory.
+Agents and scripts should resolve these roots with
+`harness repo config get paths.plans.active`,
+`harness repo config get paths.plans.archived`, and
+`harness repo config get paths.local_runtime` instead of inferring defaults.
 
 ### Command-Owned Runtime Artifacts Own
 
@@ -148,8 +160,9 @@ the configured local runtime root, defaulting to
 - review round metadata, submission-tracking data, reviewer submissions, and
   persisted review decisions, including optional reviewer-provided finding
   locations preserved in submission and decision artifacts
-- append-only timeline event indexes under the configured local runtime root,
-  defaulting to `.local/harness/plans/<plan-stem>/events.jsonl`
+- append-only timeline event indexes under the local runtime root resolved by
+  `harness repo config get paths.local_runtime`, defaulting to
+  `.local/harness/plans/<plan-stem>/events.jsonl`
 - append-only `ci`, `publish`, and `sync` evidence records
 - archive milestones
 - reopen milestones, including the explicit reopen mode
@@ -177,15 +190,18 @@ v0.2 assumes one active plan artifact per repository.
 
 Resolution rules:
 
-- if more than one active tracked plan exists under the configured active plan
-  root, state resolution is invalid and should fail rather than guess
-- lightweight archived snapshots under the configured local runtime root do not
-  count as active-plan candidates
-- if the current-plan pointer under the configured local runtime root points
-  to the sole active plan path and that path still exists, that plan is current
-- otherwise, if exactly one active tracked plan exists under
-  the configured active plan root, that plan is current for `plan` and
-  `execution/...` nodes
+- if more than one active tracked plan exists under the active plan root
+  resolved by `harness repo config get paths.plans.active`, state resolution
+  is invalid and should fail rather than guess
+- lightweight archived snapshots under the local runtime root resolved by
+  `harness repo config get paths.local_runtime` do not count as active-plan
+  candidates
+- if the current-plan pointer under the local runtime root resolved by
+  `harness repo config get paths.local_runtime` points to the sole active plan
+  path and that path still exists, that plan is current
+- otherwise, if exactly one active tracked plan exists under the active plan
+  root resolved by `harness repo config get paths.plans.active`, that plan is
+  current for `plan` and `execution/...` nodes
 - if no active plan exists, CLI-owned archived or landed context may still
   identify the current archived candidate or the most recent landed candidate
 

--- a/docs/specs/state-transitions.md
+++ b/docs/specs/state-transitions.md
@@ -22,7 +22,7 @@ the normative transition matrix.
 
 | From | To | Driver | Required inputs | Notes |
 | --- | --- | --- | --- | --- |
-| `idle` | `plan` | Derived from current plan presence | Execution-start is absent, and exactly one active tracked plan exists under the configured active plan root | The current-plan pointer under the configured local runtime root may resume or confirm the sole active plan, but it must not bypass the one-active-plan invariant. Lightweight local archives under the configured local runtime root are not active-plan candidates. |
+| `idle` | `plan` | Derived from current plan presence | Execution-start is absent, and exactly one active tracked plan exists under the active plan root resolved by `harness repo config get paths.plans.active` | The current-plan pointer under the local runtime root resolved by `harness repo config get paths.local_runtime` may resume or confirm the sole active plan, but it must not bypass the one-active-plan invariant. Lightweight local archives under the resolved local runtime root are not active-plan candidates. |
 | `plan` | `execution/step-<n>/implement` | `harness execute start` | Current plan is approved for execution and has at least one unfinished step | The CLI records the execution-start milestone; the first unfinished step becomes current. |
 
 ## Step Execution Loop
@@ -53,7 +53,7 @@ the normative transition matrix.
 
 | From | To | Driver | Required inputs | Notes |
 | --- | --- | --- | --- | --- |
-| `execution/finalize/archive` | `execution/finalize/publish` | `harness archive` | Finalize review is satisfied, archive closeout is ready, and no unresolved earlier-step closeout debt remains | `archive` moves the active tracked plan to the configured archived plan root for `standard` plans or snapshots it under the configured local runtime root for `lightweight` plans, then records archive metadata. |
+| `execution/finalize/archive` | `execution/finalize/publish` | `harness archive` | Finalize review is satisfied, archive closeout is ready, and no unresolved earlier-step closeout debt remains | `archive` moves the active tracked plan to the archived plan root resolved by `harness repo config get paths.plans.archived` for `standard` plans or snapshots it under the local runtime root resolved by `harness repo config get paths.local_runtime` for `lightweight` plans, then records archive metadata. |
 | `execution/finalize/publish` | `execution/finalize/await_merge` | Derived from latest publish, CI, and sync evidence | Publish evidence identifies the candidate, CI is good enough or explicit `not_applied`, sync is acceptable or explicit `not_applied`, and no unresolved fix condition remains | `await_merge` is a merge-ready state, not merely an archived state. |
 | `execution/finalize/publish` | `execution/finalize/fix` | `harness reopen --mode finalize-fix` | Archived candidate has been invalidated but does not justify a new step | Reopen is the command-owned reversal of archive-time assumptions for either profile. |
 | `execution/finalize/publish` | `execution/finalize/fix` | `harness reopen --mode new-step` | Archived candidate has been invalidated and the change deserves a new unfinished step | Status stays in finalize-scope repair until the first new unfinished step is actually added. |

--- a/docs/specs/watchlist-contract.md
+++ b/docs/specs/watchlist-contract.md
@@ -255,7 +255,8 @@ The explicit user-facing membership-removal action is `unwatch`.
 - remove the selected workspace record from the machine-local watchlist
 - preserve unrelated workspace records in the same watchlist file
 - leave the watched repository, git worktree, tracked plan files, and
-  workflow artifacts under the configured local runtime root untouched
+  workflow artifacts under the local runtime root resolved by
+  `harness repo config get paths.local_runtime` untouched
 
 `Unwatch` does not mean `harness archive`. It must not advance, reopen,
 archive, land, or otherwise mutate harness workflow state. It also must not

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/lifecycle"
 	"github.com/catu-ai/easyharness/internal/plan"
 	"github.com/catu-ai/easyharness/internal/remote"
+	"github.com/catu-ai/easyharness/internal/repoconfig"
 	"github.com/catu-ai/easyharness/internal/review"
 	"github.com/catu-ai/easyharness/internal/runstate"
 	"github.com/catu-ai/easyharness/internal/status"
@@ -464,6 +465,10 @@ func (a *App) runRepoConfig(args []string) int {
 	switch args[0] {
 	case "init":
 		return a.runRepoConfigInit(args[1:])
+	case "get":
+		return a.runRepoConfigGet(args[1:])
+	case "list":
+		return a.runRepoConfigList(args[1:])
 	case "-h", "--help", "help":
 		a.printRepoConfigUsage()
 		return 0
@@ -616,6 +621,86 @@ func (a *App) runRepoConfigInit(args []string) int {
 	}
 	result := install.Service{Workdir: workdir}.InitConfig(install.Options{DryRun: *dryRun})
 	return a.writeJSONResult(result)
+}
+
+func (a *App) runRepoConfigGet(args []string) int {
+	fs := flag.NewFlagSet("harness repo config get", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(a.Stderr, "Usage: harness repo config get <key>")
+		fmt.Fprintln(a.Stderr)
+		fmt.Fprintln(a.Stderr, "Print one resolved scalar repo config value.")
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		return 2
+	}
+	workdir, err := a.Getwd()
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
+		return 1
+	}
+	result := repoconfig.Load(workdir)
+	a.printRepoConfigWarnings(result.Warnings)
+	value, err := result.Config.GetScalar(fs.Arg(0))
+	if err != nil {
+		fmt.Fprintln(a.Stderr, err)
+		return 1
+	}
+	fmt.Fprintln(a.Stdout, value)
+	return 0
+}
+
+func (a *App) runRepoConfigList(args []string) int {
+	fs := flag.NewFlagSet("harness repo config list", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(a.Stderr, "Usage: harness repo config list [prefix]")
+		fmt.Fprintln(a.Stderr)
+		fmt.Fprintln(a.Stderr, "Print resolved repo config leaf entries as key=value lines.")
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() > 1 {
+		fs.Usage()
+		return 2
+	}
+	workdir, err := a.Getwd()
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
+		return 1
+	}
+	prefix := ""
+	if fs.NArg() == 1 {
+		prefix = fs.Arg(0)
+	}
+	result := repoconfig.Load(workdir)
+	a.printRepoConfigWarnings(result.Warnings)
+	entries, err := result.Config.ListResolved(prefix)
+	if err != nil {
+		fmt.Fprintln(a.Stderr, err)
+		return 1
+	}
+	for _, entry := range entries {
+		fmt.Fprintf(a.Stdout, "%s=%s\n", entry.Key, entry.Value)
+	}
+	return 0
+}
+
+func (a *App) printRepoConfigWarnings(warnings []string) {
+	for _, warning := range warnings {
+		fmt.Fprintln(a.Stderr, warning)
+	}
 }
 
 func (a *App) runDashboard(args []string) int {
@@ -1285,6 +1370,8 @@ func (a *App) printRepoConfigUsage() {
 	fmt.Fprintln(a.Stderr)
 	fmt.Fprintln(a.Stderr, "Subcommands:")
 	fmt.Fprintln(a.Stderr, "  init       Create the minimal .harness/config.yaml manifest")
+	fmt.Fprintln(a.Stderr, "  get        Print one resolved scalar repo config value")
+	fmt.Fprintln(a.Stderr, "  list       Print resolved repo config leaf entries")
 }
 
 func (a *App) printLandUsage() {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -617,6 +617,63 @@ func TestRepoConfigListFiltersByPrefix(t *testing.T) {
 	}
 }
 
+func TestRepoConfigListUsesResolvedCustomValues(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	writeCLIRepoConfig(t, root, `version: 1
+paths:
+  plans:
+    active: workflow/plans/open
+  local_runtime: tmp/harness-runtime
+`)
+
+	exitCode := app.Run([]string{"repo", "config", "list"})
+	if exitCode != 0 {
+		t.Fatalf("repo config list failed with %d: %s", exitCode, stderr.String())
+	}
+	want := strings.Join([]string{
+		"paths.plans.active=workflow/plans/open",
+		"paths.plans.archived=docs/plans/archived",
+		"paths.local_runtime=tmp/harness-runtime",
+		"",
+	}, "\n")
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got %q", stderr.String())
+	}
+}
+
+func TestRepoConfigListWarnsAndUsesDefaultsForInvalidConfig(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	writeCLIRepoConfig(t, root, "version: 2\n")
+
+	exitCode := app.Run([]string{"repo", "config", "list", "paths"})
+	if exitCode != 0 {
+		t.Fatalf("repo config list failed with %d: %s", exitCode, stderr.String())
+	}
+	want := strings.Join([]string{
+		"paths.plans.active=docs/plans/active",
+		"paths.plans.archived=docs/plans/archived",
+		"paths.local_runtime=.local/harness",
+		"",
+	}, "\n")
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if !strings.Contains(stderr.String(), "Ignoring") || !strings.Contains(stderr.String(), "using built-in defaults") {
+		t.Fatalf("expected invalid config warning, got %q", stderr.String())
+	}
+}
+
 func TestRepoConfigListRejectsUnknownPrefix(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -484,6 +484,158 @@ func TestRepoConfigInitCommandWritesMinimalConfig(t *testing.T) {
 	}
 }
 
+func TestRepoConfigGetPrintsResolvedScalar(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+
+	exitCode := app.Run([]string{"repo", "config", "get", "paths.local_runtime"})
+	if exitCode != 0 {
+		t.Fatalf("repo config get failed with %d: %s", exitCode, stderr.String())
+	}
+	if got, want := stdout.String(), ".local/harness\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr, got %q", stderr.String())
+	}
+}
+
+func TestRepoConfigGetUsesPartialConfigDefaults(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	writeCLIRepoConfig(t, root, `version: 1
+paths:
+  plans:
+    active: workflow/plans/open
+`)
+
+	exitCode := app.Run([]string{"repo", "config", "get", "paths.plans.archived"})
+	if exitCode != 0 {
+		t.Fatalf("repo config get failed with %d: %s", exitCode, stderr.String())
+	}
+	if got, want := stdout.String(), "docs/plans/archived\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRepoConfigGetWarnsAndUsesDefaultsForInvalidConfig(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	writeCLIRepoConfig(t, root, "version: 2\n")
+
+	exitCode := app.Run([]string{"repo", "config", "get", "paths.plans.active"})
+	if exitCode != 0 {
+		t.Fatalf("repo config get failed with %d: %s", exitCode, stderr.String())
+	}
+	if got, want := stdout.String(), "docs/plans/active\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if !strings.Contains(stderr.String(), "Ignoring") || !strings.Contains(stderr.String(), "using built-in defaults") {
+		t.Fatalf("expected invalid config warning, got %q", stderr.String())
+	}
+}
+
+func TestRepoConfigGetRejectsObjectsAndUnknownKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  string
+		want string
+	}{
+		{name: "object", key: "paths", want: "harness repo config list paths"},
+		{name: "unknown", key: "paths.missing", want: "unknown repo config key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout := new(bytes.Buffer)
+			stderr := new(bytes.Buffer)
+			app := cli.New(stdout, stderr)
+			root := t.TempDir()
+			app.Getwd = func() (string, error) { return root, nil }
+
+			exitCode := app.Run([]string{"repo", "config", "get", tc.key})
+			if exitCode == 0 {
+				t.Fatalf("expected failure, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected no stdout, got %q", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("stderr = %q, want substring %q", stderr.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestRepoConfigListPrintsResolvedEntries(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+
+	exitCode := app.Run([]string{"repo", "config", "list"})
+	if exitCode != 0 {
+		t.Fatalf("repo config list failed with %d: %s", exitCode, stderr.String())
+	}
+	want := strings.Join([]string{
+		"paths.plans.active=docs/plans/active",
+		"paths.plans.archived=docs/plans/archived",
+		"paths.local_runtime=.local/harness",
+		"",
+	}, "\n")
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRepoConfigListFiltersByPrefix(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+
+	exitCode := app.Run([]string{"repo", "config", "list", "paths.plans"})
+	if exitCode != 0 {
+		t.Fatalf("repo config list failed with %d: %s", exitCode, stderr.String())
+	}
+	want := strings.Join([]string{
+		"paths.plans.active=docs/plans/active",
+		"paths.plans.archived=docs/plans/archived",
+		"",
+	}, "\n")
+	if got := stdout.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRepoConfigListRejectsUnknownPrefix(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+
+	exitCode := app.Run([]string{"repo", "config", "list", "missing"})
+	if exitCode == 0 {
+		t.Fatalf("expected failure, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "unknown repo config prefix") {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
 func TestSkillsCommandRejectsInvalidScope(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -2755,6 +2907,17 @@ func approvePlanInFile(t *testing.T, path, approvedAt string) {
 		}
 	}
 	t.Fatalf("created_at frontmatter line not found in %s", path)
+}
+
+func writeCLIRepoConfig(t *testing.T, root, content string) {
+	t.Helper()
+	path := filepath.Join(root, ".harness", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir repo config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write repo config: %v", err)
+	}
 }
 
 func watchlistPathForHome(home string) string {

--- a/internal/repoconfig/config.go
+++ b/internal/repoconfig/config.go
@@ -34,6 +34,11 @@ type PlanPathsConfig struct {
 	Archived string `yaml:"archived,omitempty"`
 }
 
+type ConfigEntry struct {
+	Key   string
+	Value string
+}
+
 type LoadResult struct {
 	Config   Config
 	Path     string
@@ -118,6 +123,53 @@ func DefaultConfig() Config {
 			},
 			LocalRuntime: DefaultLocalRuntimeRoot,
 		},
+	}
+}
+
+func (c Config) GetScalar(key string) (string, error) {
+	for _, entry := range c.resolvedEntries() {
+		if key == entry.Key {
+			return entry.Value, nil
+		}
+	}
+	if isConfigObjectKey(key) {
+		return "", fmt.Errorf("%s is a config object, not a scalar value; use `harness repo config list %s` to list resolved keys under it", key, key)
+	}
+	return "", fmt.Errorf("unknown repo config key %q", key)
+}
+
+func (c Config) ListResolved(prefix string) ([]ConfigEntry, error) {
+	prefix = strings.TrimSpace(prefix)
+	entries := c.resolvedEntries()
+	if prefix == "" {
+		return entries, nil
+	}
+	filtered := []ConfigEntry{}
+	for _, entry := range entries {
+		if entry.Key == prefix || strings.HasPrefix(entry.Key, prefix+".") {
+			filtered = append(filtered, entry)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("unknown repo config prefix %q", prefix)
+	}
+	return filtered, nil
+}
+
+func (c Config) resolvedEntries() []ConfigEntry {
+	return []ConfigEntry{
+		{Key: "paths.plans.active", Value: c.Paths.Plans.Active},
+		{Key: "paths.plans.archived", Value: c.Paths.Plans.Archived},
+		{Key: "paths.local_runtime", Value: c.Paths.LocalRuntime},
+	}
+}
+
+func isConfigObjectKey(key string) bool {
+	switch strings.TrimSpace(key) {
+	case "paths", "paths.plans":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/repoconfig/config_test.go
+++ b/internal/repoconfig/config_test.go
@@ -126,6 +126,90 @@ func TestLoadInvalidConfigWarnsAndUsesDefaults(t *testing.T) {
 	}
 }
 
+func TestGetScalarReturnsResolvedValues(t *testing.T) {
+	root := t.TempDir()
+	writeConfig(t, root, `version: 1
+paths:
+  plans:
+    active: workflow/plans/open
+  local_runtime: tmp/harness-runtime
+`)
+
+	result := Load(root)
+	for _, tc := range []struct {
+		key  string
+		want string
+	}{
+		{key: "paths.plans.active", want: "workflow/plans/open"},
+		{key: "paths.plans.archived", want: DefaultArchivedPlansRoot},
+		{key: "paths.local_runtime", want: "tmp/harness-runtime"},
+	} {
+		got, err := result.Config.GetScalar(tc.key)
+		if err != nil {
+			t.Fatalf("GetScalar(%q) returned error: %v", tc.key, err)
+		}
+		if got != tc.want {
+			t.Fatalf("GetScalar(%q) = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestGetScalarRejectsObjectsAndUnknownKeys(t *testing.T) {
+	config := DefaultConfig()
+
+	if _, err := config.GetScalar("paths"); err == nil || !strings.Contains(err.Error(), "object") || !strings.Contains(err.Error(), "harness repo config list paths") {
+		t.Fatalf("expected object error with list hint, got %v", err)
+	}
+	if _, err := config.GetScalar("paths.plans"); err == nil || !strings.Contains(err.Error(), "object") || !strings.Contains(err.Error(), "harness repo config list paths.plans") {
+		t.Fatalf("expected nested object error with list hint, got %v", err)
+	}
+	if _, err := config.GetScalar("paths.missing"); err == nil || !strings.Contains(err.Error(), "unknown repo config key") {
+		t.Fatalf("expected unknown key error, got %v", err)
+	}
+}
+
+func TestListResolvedEntries(t *testing.T) {
+	config := DefaultConfig()
+
+	entries, err := config.ListResolved("")
+	if err != nil {
+		t.Fatalf("ListResolved returned error: %v", err)
+	}
+	want := []ConfigEntry{
+		{Key: "paths.plans.active", Value: DefaultActivePlansRoot},
+		{Key: "paths.plans.archived", Value: DefaultArchivedPlansRoot},
+		{Key: "paths.local_runtime", Value: DefaultLocalRuntimeRoot},
+	}
+	if len(entries) != len(want) {
+		t.Fatalf("expected %d entries, got %#v", len(want), entries)
+	}
+	for i := range want {
+		if entries[i] != want[i] {
+			t.Fatalf("entry %d = %#v, want %#v", i, entries[i], want[i])
+		}
+	}
+
+	entries, err = config.ListResolved("paths.plans")
+	if err != nil {
+		t.Fatalf("ListResolved(paths.plans) returned error: %v", err)
+	}
+	if len(entries) != 2 || entries[0].Key != "paths.plans.active" || entries[1].Key != "paths.plans.archived" {
+		t.Fatalf("unexpected paths.plans entries: %#v", entries)
+	}
+
+	entries, err = config.ListResolved("paths.local_runtime")
+	if err != nil {
+		t.Fatalf("ListResolved(paths.local_runtime) returned error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Key != "paths.local_runtime" {
+		t.Fatalf("unexpected scalar-prefixed entries: %#v", entries)
+	}
+
+	if _, err := config.ListResolved("missing"); err == nil || !strings.Contains(err.Error(), "unknown repo config prefix") {
+		t.Fatalf("expected unknown prefix error, got %v", err)
+	}
+}
+
 func writeConfig(t *testing.T, root, content string) {
 	t.Helper()
 	path := filepath.Join(root, filepath.FromSlash(File))

--- a/tests/e2e/coverage_test.go
+++ b/tests/e2e/coverage_test.go
@@ -23,7 +23,7 @@ type scenarioCoverage struct {
 }
 
 var canonicalTransitionFamilies = []transitionFamily{
-	{ID: "idle_to_plan", From: "idle", To: "plan", Driver: "Derived from current plan presence", RequiredInputs: "Execution-start is absent, and exactly one active tracked plan exists under the configured active plan root"},
+	{ID: "idle_to_plan", From: "idle", To: "plan", Driver: "Derived from current plan presence", RequiredInputs: "Execution-start is absent, and exactly one active tracked plan exists under the active plan root resolved by `harness repo config get paths.plans.active`"},
 	{ID: "plan_self", From: "plan", To: "plan", Driver: "state-preserving", RequiredInputs: "state-preserving update"},
 	{ID: "plan_to_step_implement", From: "plan", To: "execution/step-<n>/implement", Driver: "harness execute start", RequiredInputs: "Current plan is approved for execution and has at least one unfinished step"},
 	{ID: "step_implement_self", From: "execution/step-<n>/implement", To: "execution/step-<n>/implement", Driver: "state-preserving", RequiredInputs: "state-preserving update"},

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -390,6 +390,74 @@ func TestRepoConfigInitCreatesMinimalConfig(t *testing.T) {
 	}
 }
 
+func TestRepoConfigQueriesResolvedValuesViaCLI(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	workspace.WriteFile(t, ".harness/config.yaml", []byte(`version: 1
+paths:
+  plans:
+    active: workflow/plans/open
+  local_runtime: tmp/harness-runtime
+`))
+
+	get := support.Run(t, workspace.Root, "repo", "config", "get", "paths.local_runtime")
+	support.RequireSuccess(t, get)
+	support.RequireNoStderr(t, get)
+	if get.Stdout != "tmp/harness-runtime\n" {
+		t.Fatalf("unexpected get stdout:\n%s", get.Stdout)
+	}
+
+	list := support.Run(t, workspace.Root, "repo", "config", "list")
+	support.RequireSuccess(t, list)
+	support.RequireNoStderr(t, list)
+	wantList := strings.Join([]string{
+		"paths.plans.active=workflow/plans/open",
+		"paths.plans.archived=docs/plans/archived",
+		"paths.local_runtime=tmp/harness-runtime",
+		"",
+	}, "\n")
+	if list.Stdout != wantList {
+		t.Fatalf("unexpected list stdout:\n%s", list.Stdout)
+	}
+
+	prefixed := support.Run(t, workspace.Root, "repo", "config", "list", "paths.plans")
+	support.RequireSuccess(t, prefixed)
+	support.RequireNoStderr(t, prefixed)
+	wantPrefixed := strings.Join([]string{
+		"paths.plans.active=workflow/plans/open",
+		"paths.plans.archived=docs/plans/archived",
+		"",
+	}, "\n")
+	if prefixed.Stdout != wantPrefixed {
+		t.Fatalf("unexpected prefixed list stdout:\n%s", prefixed.Stdout)
+	}
+
+	objectGet := support.Run(t, workspace.Root, "repo", "config", "get", "paths")
+	support.RequireExitCode(t, objectGet, 1)
+	if objectGet.Stdout != "" {
+		t.Fatalf("expected object get to keep stdout empty, got %q", objectGet.Stdout)
+	}
+	support.RequireContains(t, objectGet.Stderr, "harness repo config list paths")
+}
+
+func TestRepoConfigQueryInvalidConfigWarnsOnStderr(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	workspace.WriteFile(t, ".harness/config.yaml", []byte("version: 2\n"))
+
+	result := support.Run(t, workspace.Root, "repo", "config", "list", "paths")
+	support.RequireSuccess(t, result)
+	want := strings.Join([]string{
+		"paths.plans.active=docs/plans/active",
+		"paths.plans.archived=docs/plans/archived",
+		"paths.local_runtime=.local/harness",
+		"",
+	}, "\n")
+	if result.Stdout != want {
+		t.Fatalf("unexpected stdout:\n%s", result.Stdout)
+	}
+	support.RequireContains(t, result.Stderr, "Ignoring")
+	support.RequireContains(t, result.Stderr, "using built-in defaults")
+}
+
 func TestSkillsInstallRejectsInvalidScopeViaCLI(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 


### PR DESCRIPTION
## What Changed

- Added plain-text `harness repo config get <key>` for resolved scalar repo config values.
- Added plain-text `harness repo config list [prefix]` for deterministic resolved leaf enumeration.
- Preserved existing missing, partial, and invalid repo config fallback behavior, with values on stdout and diagnostics on stderr.
- Updated README, CLI contract, repo config spec, and tracked harness plan closeout.

## Confidence

- `go test ./internal/repoconfig ./internal/cli`
- `scripts/install-dev-harness`
- Manual probes for `get`, `list`, prefixed `list`, and non-leaf `get` failure
- `go test ./tests/smoke`
- `go test ./internal/repoconfig ./internal/cli ./tests/smoke`
- Harness step/finalize reviews passed after repairing one tests coverage gap and one README docs gap.

Closes #241
