### PR TITLE
Stabilize release GitHub CLI auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
 
       - name: Publish release assets
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
@@ -126,6 +127,7 @@ jobs:
 
       - name: Verify published release namespace
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EASYHARNESS_RUN_LIVE_GH_SMOKE: "1"
           EASYHARNESS_LIVE_GH_REPO: ${{ github.repository }}
@@ -166,6 +168,7 @@ jobs:
     permissions:
       contents: read
     env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       EASYHARNESS_RUN_LIVE_BREW_SMOKE: "1"
     steps:

--- a/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
+++ b/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
@@ -82,7 +82,7 @@ while the Homebrew smoke test inspected the previous Homebrew-capable release
 
 ### Step 1: Confirm and Validate the Auth Fix Candidate
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -117,11 +117,33 @@ As of plan creation, PR #252 contains commit
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Implemented before formal plan approval in PR #252, then brought under the
+tracked plan before closeout. The candidate explicitly wires `GH_TOKEN` for
+release workflow steps that call `gh`, maps `GITHUB_TOKEN` to `GH_TOKEN` in
+`scripts/releaseverify` when needed, and adds fake-`gh` smoke coverage for the
+fallback.
+
+After approval, the branch was synced with latest `origin/main` via merge
+commit `2689b84ac3821c2923ca2caa71a9d1849c50f0fe`.
+
+Validation:
+
+- `harness plan lint docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md`
+- `go test ./tests/smoke -run 'TestReleaseWorkflowWiresHomebrewTapPublishing|TestVerifyReleaseNamespace|TestVersionTagWorkflowUsesRepositoryVersionFile' -count=1`
+- PR #252 CI `Go Test` succeeded for head
+  `2689b84ac3821c2923ca2caa71a9d1849c50f0fe` in run
+  `https://github.com/catu-ai/easyharness/actions/runs/27289996283`.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+Delta review `review-001-delta` anchored at
+`f1cf3cdd7038452b137eac6633166f51b7cb6e3d` passed with 0 findings.
+
+- `correctness`: no findings; reviewer verified token precedence, fallback
+  behavior, workflow coverage, and fake-`gh` regression coverage.
+- `release_safety`: no findings; reviewer verified v0.4.3 provenance remains
+  unchanged, Homebrew previous-version upgrade semantics remain intact, and
+  release rerun work is deferred until after merge approval.
 
 ### Step 2: Publish and Archive the Merge-Ready Candidate
 

--- a/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
+++ b/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
@@ -1,8 +1,10 @@
 ---
 template_version: 0.2.0
-created_at: 2026-06-11T00:10:48+08:00
+created_at: "2026-06-11T00:10:48+08:00"
+approved_at: "2026-06-11T00:15:51+08:00"
 source_type: direct_request
-source_refs: ["PR #252 release GitHub CLI auth follow-up"]
+source_refs:
+    - 'PR #252 release GitHub CLI auth follow-up'
 size: S
 ---
 

--- a/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
+++ b/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
@@ -1,0 +1,245 @@
+---
+template_version: 0.2.0
+created_at: 2026-06-11T00:10:48+08:00
+source_type: direct_request
+source_refs: ["PR #252 release GitHub CLI auth follow-up"]
+size: S
+---
+
+# Stabilize release GitHub CLI auth
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Stabilize the release workflow's GitHub CLI authentication so the
+`v0.4.3` release Homebrew verification can complete reliably after the
+release-auth fix lands on `main`.
+
+The immediate candidate is PR #252,
+`https://github.com/catu-ai/easyharness/pull/252`, which was opened after
+the `v0.4.3` release published assets successfully but the release workflow's
+`Verify Homebrew Install` job repeatedly failed with GitHub API 401 errors
+while the Homebrew smoke test inspected the previous Homebrew-capable release
+(`v0.4.2`) before upgrading to `v0.4.3`.
+
+## Scope
+
+### In Scope
+
+- Make GitHub CLI token handling explicit for release workflow steps that use
+  `gh`.
+- Keep the Homebrew smoke test's upgrade-path semantics: it may inspect the
+  previous Homebrew-capable release before testing upgrade to the target
+  release.
+- Add or preserve regression coverage showing that release verification passes
+  a usable `GH_TOKEN` to `gh` when only `GITHUB_TOKEN` is available.
+- Validate the candidate locally and through PR CI.
+- After approval and merge, rerun `release.yml` from fixed `main` with
+  `version=v0.4.3` and verify the release workflow, especially
+  `Verify Homebrew Install`, completes successfully.
+- Archive the plan with the final PR, merge, release rerun, and Homebrew
+  verification evidence.
+
+### Out of Scope
+
+- Changing release artifact contents for `v0.4.3`.
+- Changing the `v0.4.3` tag target or rebuilding the already-published assets
+  from a different commit.
+- Removing the Homebrew smoke test's previous-version install and upgrade
+  coverage.
+- Broad release workflow redesign beyond the token handling needed to unblock
+  this release verification.
+- Changing repository secrets or replacing GitHub Actions authentication with a
+  new credential system.
+
+## Acceptance Criteria
+
+- [ ] Release workflow steps that invoke `gh` provide `GH_TOKEN` explicitly, or
+  the release verifier maps `GITHUB_TOKEN` to `GH_TOKEN` before invoking `gh`.
+- [ ] Tests cover the token fallback behavior and the release workflow wiring.
+- [ ] `go test ./...` passes locally for the candidate.
+- [ ] PR #252 CI passes.
+- [ ] After PR #252 lands, `release.yml` is rerun from `main` with
+  `version=v0.4.3`.
+- [ ] The rerun release workflow succeeds, including `Verify Homebrew Install`.
+- [ ] The archived plan records release URL, workflow run URL, and Homebrew tap
+  verification evidence.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Confirm and Validate the Auth Fix Candidate
+
+- Done: [ ]
+
+#### Objective
+
+Confirm that the existing candidate PR #252 cleanly fixes the GitHub CLI token
+handling problem without changing release or Homebrew upgrade semantics.
+
+#### Details
+
+The candidate should preserve the reason `v0.4.2` is inspected: the live
+Homebrew smoke test validates upgrade from the previous Homebrew-capable
+release to the requested release. The fix should instead make authentication
+unambiguous for `gh` by passing `GH_TOKEN` in release workflow environments and
+by ensuring `scripts/releaseverify` maps `GITHUB_TOKEN` to `GH_TOKEN` when
+needed.
+
+As of plan creation, PR #252 contains commit
+`af9e02b41e7e2dfb427883b63d1709e9341cf72d`.
+
+#### Expected Files
+
+- `.github/workflows/release.yml`
+- `scripts/releaseverify/main.go`
+- `tests/smoke/homebrew_formula_test.go`
+- `tests/smoke/verify_release_namespace_test.go`
+
+#### Validation
+
+- `go test ./tests/smoke -run 'TestReleaseWorkflowWiresHomebrewTapPublishing|TestVerifyReleaseNamespace|TestVersionTagWorkflowUsesRepositoryVersionFile' -count=1`
+- `go test ./scripts/releaseverify -count=1`
+- `go test ./...`
+- PR #252 `Go Test` check succeeds.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Land PR #252
+
+- Done: [ ]
+
+#### Objective
+
+After human approval, merge PR #252 and record normal harness land evidence.
+
+#### Details
+
+This step should not start until the plan is approved and execution is
+recorded. The controller should verify PR #252 is up to date, CI is green, and
+the diff still matches the scoped token-handling fix before merge.
+
+#### Expected Files
+
+- No additional code files are expected unless PR #252 needs a small rebase or
+  review fix.
+
+#### Validation
+
+- PR #252 is merged to `main`.
+- Local primary checkout is fast-forwarded to the merge commit.
+- `harness land complete` returns the repository to `idle`.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Rerun and Verify the v0.4.3 Release Workflow
+
+- Done: [ ]
+
+#### Objective
+
+Rerun `release.yml` from fixed `main` for `version=v0.4.3` and verify the
+previously failing Homebrew verification job now succeeds.
+
+#### Details
+
+The release workflow checks out the requested release tag for release-source
+artifact work while running smoke code from the root checkout. This is why
+rerunning `release.yml` from the fixed `main` branch can validate the auth fix
+without moving the `v0.4.3` tag or changing release artifact provenance.
+
+If GitHub CLI or GitHub API calls fail again with 401, collect the exact job
+log and distinguish auth flake from release asset, tag, or Homebrew formula
+problems before retrying.
+
+#### Expected Files
+
+- No repository file changes are expected in this step.
+
+#### Validation
+
+- `gh workflow run release.yml --ref main -f version=v0.4.3` starts a release
+  workflow run.
+- The release run succeeds.
+- `Verify Homebrew Install` succeeds.
+- `gh release view v0.4.3 --repo catu-ai/easyharness --json tagName,url,assets`
+  confirms the release remains published with the expected assets.
+- The Homebrew tap formula remains at `version "0.4.3"` and points to
+  `v0.4.3` assets.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+Use layered validation:
+
+- local Go/smoke tests for workflow wiring and release verifier behavior
+- PR #252 CI for repository-wide regression coverage
+- post-merge release workflow rerun for the real `v0.4.3` release path
+- release and Homebrew tap inspection to confirm published state remains
+  coherent after rerun
+
+## Risks
+
+- Risk: The fix is validated in PR CI but not in the actual release workflow.
+  - Mitigation: Treat the `v0.4.3` release workflow rerun as required
+    acceptance evidence before archive.
+- Risk: A repeated 401 is misread as a broken release artifact or formula.
+  - Mitigation: Preserve exact job logs and compare against release asset and
+    tap formula state before changing release artifacts.
+- Risk: Rerunning release workflow accidentally changes release provenance.
+  - Mitigation: Run with `--ref main -f version=v0.4.3`; the workflow verifies
+    the release-source checkout matches the `v0.4.3` tag before building or
+    uploading.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
+++ b/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
@@ -61,16 +61,16 @@ while the Homebrew smoke test inspected the previous Homebrew-capable release
 
 ## Acceptance Criteria
 
-- [ ] Release workflow steps that invoke `gh` provide `GH_TOKEN` explicitly, or
+- [x] Release workflow steps that invoke `gh` provide `GH_TOKEN` explicitly, or
   the release verifier maps `GITHUB_TOKEN` to `GH_TOKEN` before invoking `gh`.
-- [ ] Tests cover the token fallback behavior and the release workflow wiring.
-- [ ] `go test ./...` passes locally for the candidate.
-- [ ] PR #252 CI passes.
-- [ ] PR #252 is published, in sync with its branch, and CI passes.
-- [ ] The archived plan records PR, CI, sync, and merge-readiness evidence.
-- [ ] The candidate reaches `execution/finalize/await_merge` and waits for
+- [x] Tests cover the token fallback behavior and the release workflow wiring.
+- [x] `go test ./...` passes locally for the candidate.
+- [x] PR #252 CI passes.
+- [x] PR #252 is published, in sync with its branch, and CI passes.
+- [x] The archived plan records PR, CI, sync, and merge-readiness evidence.
+- [x] The candidate reaches `execution/finalize/await_merge` and waits for
   explicit human merge approval.
-- [ ] The archived handoff clearly states that after PR #252 lands,
+- [x] The archived handoff clearly states that after PR #252 lands,
   `release.yml` must be rerun from `main` with `version=v0.4.3`, and that the
   rerun must verify `Verify Homebrew Install`.
 
@@ -229,25 +229,61 @@ Use layered validation:
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `harness plan lint docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md`
+  passed during planning and closeout.
+- Focused release-auth smoke validation passed:
+  `go test ./tests/smoke -run 'TestReleaseWorkflowWiresHomebrewTapPublishing|TestVerifyReleaseNamespace|TestVersionTagWorkflowUsesRepositoryVersionFile' -count=1`.
+- `go test ./scripts/releaseverify -count=1` passed; that package has no
+  standalone test files, but it still compiles.
+- Full repository validation passed locally during candidate review:
+  `go test ./...`.
+- PR #252 CI passed repeatedly after each pushed repair. The latest observed
+  pre-archive run for the current PR head `7c42f320e124857e419717592aba4cbd22c4cc02`
+  was `https://github.com/catu-ai/easyharness/actions/runs/27291661103`,
+  with `Go Test` succeeding in 5m32s.
+- Final PR head, CI, and sync evidence are recorded through harness publish,
+  CI, and sync evidence after archive.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step delta review `review-001-delta` passed with 0 findings. Reviewers
+  checked correctness and release safety.
+- Finalize review `review-002-full` found that Step 2 closeout was still local
+  and that the PR body did not explicitly name `Verify Homebrew Install` as
+  the post-merge verification target. Both findings were fixed by committing
+  Step 2 notes and updating the PR body.
+- Finalize review `review-003-full` found stale wording that treated a
+  superseded PR head/run as final evidence. The plan now states that final PR
+  head, CI, and sync facts belong to harness evidence after archive.
+- Finalize repair review `review-004-full` passed with 0 findings.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+Archived as a merge-ready candidate for PR #252. The candidate intentionally
+stops before merge and waits for explicit human merge approval.
+
+Post-merge handoff: after PR #252 lands, rerun `release.yml` from `main` with
+`version=v0.4.3` and verify that the rerun succeeds, including the
+`Verify Homebrew Install` job. This rerun should validate the release smoke fix
+without moving the `v0.4.3` tag or changing release artifact provenance.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Release workflow `gh` calls now receive explicit `GH_TOKEN` alongside
+  `GITHUB_TOKEN`.
+- `scripts/releaseverify` maps a non-empty `GITHUB_TOKEN` into missing or empty
+  `GH_TOKEN` for child `gh` invocations while preserving an existing non-empty
+  `GH_TOKEN`.
+- Smoke tests cover workflow wiring and fake-`gh` fallback behavior.
+- PR #252 body includes explicit post-merge release verification instructions
+  for `release.yml`, `version=v0.4.3`, and `Verify Homebrew Install`.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+The actual `v0.4.3` release workflow rerun is not performed before merge. It
+must happen after PR #252 lands on `main`, per the post-merge handoff.
 
 ### Follow-Up Issues
 

--- a/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
+++ b/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
@@ -147,7 +147,7 @@ Delta review `review-001-delta` anchored at
 
 ### Step 2: Publish and Archive the Merge-Ready Candidate
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -175,11 +175,30 @@ the `v0.4.3` release workflow rerun is post-merge work.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+PR #252 is published at
+`https://github.com/catu-ai/easyharness/pull/252`.
+
+The branch was synced with latest `origin/main`
+(`f1cf3cdd7038452b137eac6633166f51b7cb6e3d`) by merge commit
+`2689b84ac3821c2923ca2caa71a9d1849c50f0fe`.
+
+Latest pre-archive PR CI succeeded for head
+`7d7e9f795a4eebaee4917058b0379d9ec7b9e6eb`:
+
+- run: `https://github.com/catu-ai/easyharness/actions/runs/27290410337`
+- job: `Go Test`
+- result: success in 5m42s
+
+Post-merge handoff remains required: after PR #252 is merged, rerun
+`release.yml` from `main` with `version=v0.4.3` and verify
+`Verify Homebrew Install`.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 2 only records publish/sync/CI readiness and the
+post-merge release rerun handoff. The behavior-changing release-auth fix
+already passed step-bound delta review `review-001-delta`; finalize review
+will cover the full archived candidate.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
+++ b/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
@@ -182,12 +182,16 @@ The branch was synced with latest `origin/main`
 (`f1cf3cdd7038452b137eac6633166f51b7cb6e3d`) by merge commit
 `2689b84ac3821c2923ca2caa71a9d1849c50f0fe`.
 
-Latest pre-archive PR CI succeeded for head
-`7d7e9f795a4eebaee4917058b0379d9ec7b9e6eb`:
+PR CI was observed passing during closeout, including the repair run for the
+committed Step 2 notes:
 
-- run: `https://github.com/catu-ai/easyharness/actions/runs/27290410337`
+- run: `https://github.com/catu-ai/easyharness/actions/runs/27291218500`
 - job: `Go Test`
-- result: success in 5m42s
+- result: success in 4m12s
+
+Final PR head, CI, and sync facts must be recorded through harness
+publish/CI/sync evidence after archive, so this tracked note does not pretend
+to be the final remote evidence after later archive commits.
 
 Post-merge handoff remains required: after PR #252 is merged, rerun
 `release.yml` from `main` with `version=v0.4.3` and verify

--- a/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
+++ b/docs/plans/active/2026-06-11-stabilize-release-gh-cli-auth.md
@@ -16,9 +16,9 @@ supplements. -->
 
 ## Goal
 
-Stabilize the release workflow's GitHub CLI authentication so the
-`v0.4.3` release Homebrew verification can complete reliably after the
-release-auth fix lands on `main`.
+Stabilize the release workflow's GitHub CLI authentication and produce a
+merge-ready candidate so the `v0.4.3` release Homebrew verification can be
+rerun after the release-auth fix lands on `main`.
 
 The immediate candidate is PR #252,
 `https://github.com/catu-ai/easyharness/pull/252`, which was opened after
@@ -39,11 +39,11 @@ while the Homebrew smoke test inspected the previous Homebrew-capable release
 - Add or preserve regression coverage showing that release verification passes
   a usable `GH_TOKEN` to `gh` when only `GITHUB_TOKEN` is available.
 - Validate the candidate locally and through PR CI.
-- After approval and merge, rerun `release.yml` from fixed `main` with
-  `version=v0.4.3` and verify the release workflow, especially
-  `Verify Homebrew Install`, completes successfully.
-- Archive the plan with the final PR, merge, release rerun, and Homebrew
-  verification evidence.
+- Publish and archive the candidate with PR, CI, and sync evidence until it is
+  waiting for human merge approval.
+- Record the required post-merge handoff: after PR #252 lands, rerun
+  `release.yml` from fixed `main` with `version=v0.4.3` and verify
+  `Verify Homebrew Install`.
 
 ### Out of Scope
 
@@ -64,11 +64,13 @@ while the Homebrew smoke test inspected the previous Homebrew-capable release
 - [ ] Tests cover the token fallback behavior and the release workflow wiring.
 - [ ] `go test ./...` passes locally for the candidate.
 - [ ] PR #252 CI passes.
-- [ ] After PR #252 lands, `release.yml` is rerun from `main` with
-  `version=v0.4.3`.
-- [ ] The rerun release workflow succeeds, including `Verify Homebrew Install`.
-- [ ] The archived plan records release URL, workflow run URL, and Homebrew tap
-  verification evidence.
+- [ ] PR #252 is published, in sync with its branch, and CI passes.
+- [ ] The archived plan records PR, CI, sync, and merge-readiness evidence.
+- [ ] The candidate reaches `execution/finalize/await_merge` and waits for
+  explicit human merge approval.
+- [ ] The archived handoff clearly states that after PR #252 lands,
+  `release.yml` must be rerun from `main` with `version=v0.4.3`, and that the
+  rerun must verify `Verify Homebrew Install`.
 
 ## Deferred Items
 
@@ -119,19 +121,21 @@ PENDING_STEP_EXECUTION
 
 PENDING_STEP_REVIEW
 
-### Step 2: Land PR #252
+### Step 2: Publish and Archive the Merge-Ready Candidate
 
 - Done: [ ]
 
 #### Objective
 
-After human approval, merge PR #252 and record normal harness land evidence.
+Publish the scoped fix as PR #252, record CI and sync evidence, and archive the
+candidate at `wait_for_merge_approval` without merging it.
 
 #### Details
 
-This step should not start until the plan is approved and execution is
-recorded. The controller should verify PR #252 is up to date, CI is green, and
-the diff still matches the scoped token-handling fix before merge.
+This step should not merge PR #252. The controller should verify PR #252 is up
+to date, CI is green, and the diff still matches the scoped token-handling fix.
+The archive handoff must say that merge approval is still required and that
+the `v0.4.3` release workflow rerun is post-merge work.
 
 #### Expected Files
 
@@ -140,52 +144,10 @@ the diff still matches the scoped token-handling fix before merge.
 
 #### Validation
 
-- PR #252 is merged to `main`.
-- Local primary checkout is fast-forwarded to the merge commit.
-- `harness land complete` returns the repository to `idle`.
-
-#### Execution Notes
-
-PENDING_STEP_EXECUTION
-
-#### Review Notes
-
-PENDING_STEP_REVIEW
-
-### Step 3: Rerun and Verify the v0.4.3 Release Workflow
-
-- Done: [ ]
-
-#### Objective
-
-Rerun `release.yml` from fixed `main` for `version=v0.4.3` and verify the
-previously failing Homebrew verification job now succeeds.
-
-#### Details
-
-The release workflow checks out the requested release tag for release-source
-artifact work while running smoke code from the root checkout. This is why
-rerunning `release.yml` from the fixed `main` branch can validate the auth fix
-without moving the `v0.4.3` tag or changing release artifact provenance.
-
-If GitHub CLI or GitHub API calls fail again with 401, collect the exact job
-log and distinguish auth flake from release asset, tag, or Homebrew formula
-problems before retrying.
-
-#### Expected Files
-
-- No repository file changes are expected in this step.
-
-#### Validation
-
-- `gh workflow run release.yml --ref main -f version=v0.4.3` starts a release
-  workflow run.
-- The release run succeeds.
-- `Verify Homebrew Install` succeeds.
-- `gh release view v0.4.3 --repo catu-ai/easyharness --json tagName,url,assets`
-  confirms the release remains published with the expected assets.
-- The Homebrew tap formula remains at `version "0.4.3"` and points to
-  `v0.4.3` assets.
+- PR #252 is open, in sync, and has passing CI.
+- Harness publish/sync evidence records the PR URL, head commit, and CI result.
+- The plan is archived and `harness status` reaches
+  `execution/finalize/await_merge`.
 
 #### Execution Notes
 
@@ -201,22 +163,22 @@ Use layered validation:
 
 - local Go/smoke tests for workflow wiring and release verifier behavior
 - PR #252 CI for repository-wide regression coverage
-- post-merge release workflow rerun for the real `v0.4.3` release path
-- release and Homebrew tap inspection to confirm published state remains
-  coherent after rerun
+- harness publish/sync evidence to prove the PR is merge-ready
+- post-merge handoff evidence describing the required `v0.4.3` release rerun
 
 ## Risks
 
 - Risk: The fix is validated in PR CI but not in the actual release workflow.
   - Mitigation: Treat the `v0.4.3` release workflow rerun as required
-    acceptance evidence before archive.
+    post-merge handoff work and record it in the archive before waiting for
+    merge approval.
 - Risk: A repeated 401 is misread as a broken release artifact or formula.
   - Mitigation: Preserve exact job logs and compare against release asset and
     tap formula state before changing release artifacts.
 - Risk: Rerunning release workflow accidentally changes release provenance.
-  - Mitigation: Run with `--ref main -f version=v0.4.3`; the workflow verifies
-    the release-source checkout matches the `v0.4.3` tag before building or
-    uploading.
+  - Mitigation: The handoff should instruct the landing agent to run with
+    `--ref main -f version=v0.4.3`; the workflow verifies the release-source
+    checkout matches the `v0.4.3` tag before building or uploading.
 
 ## Validation Summary
 

--- a/docs/plans/archived/2026-06-11-stabilize-release-gh-cli-auth.md
+++ b/docs/plans/archived/2026-06-11-stabilize-release-gh-cli-auth.md
@@ -259,13 +259,17 @@ Use layered validation:
 
 ## Archive Summary
 
-Archived as a merge-ready candidate for PR #252. The candidate intentionally
-stops before merge and waits for explicit human merge approval.
-
-Post-merge handoff: after PR #252 lands, rerun `release.yml` from `main` with
-`version=v0.4.3` and verify that the rerun succeeds, including the
-`Verify Homebrew Install` job. This rerun should validate the release smoke fix
-without moving the `v0.4.3` tag or changing release artifact provenance.
+- Archived At: 2026-06-11T01:06:06+08:00
+- Revision: 1
+- PR: PR #252 is published at
+  `https://github.com/catu-ai/easyharness/pull/252`.
+- Ready: The candidate is merge-ready after local validation, passing PR CI,
+  and finalize review; it intentionally stops before merge and waits for
+  explicit human merge approval.
+- Merge Handoff: After PR #252 lands, rerun `release.yml` from `main` with
+  `version=v0.4.3` and verify that the rerun succeeds, including the
+  `Verify Homebrew Install` job. This rerun should validate the release smoke
+  fix without moving the `v0.4.3` tag or changing release artifact provenance.
 
 ## Outcome Summary
 

--- a/docs/plans/archived/2026-06-11-stabilize-release-gh-cli-auth.md
+++ b/docs/plans/archived/2026-06-11-stabilize-release-gh-cli-auth.md
@@ -197,6 +197,12 @@ Post-merge handoff remains required: after PR #252 is merged, rerun
 `release.yml` from `main` with `version=v0.4.3` and verify
 `Verify Homebrew Install`.
 
+Reopened after merge approval because `origin/main` advanced with PR #251
+before GitHub accepted the merge. The branch was refreshed by merging
+`origin/main` at `df56b0ffc3e7d5bc3ca06121221d564a6a8f46f6` into PR #252.
+This was a sync-only finalize repair; the release-auth code and post-merge
+handoff did not change.
+
 #### Review Notes
 
 NO_STEP_REVIEW_NEEDED: Step 2 only records publish/sync/CI readiness and the
@@ -237,12 +243,25 @@ Use layered validation:
   standalone test files, but it still compiles.
 - Full repository validation passed locally during candidate review:
   `go test ./...`.
-- PR #252 CI passed repeatedly after each pushed repair. The latest observed
-  pre-archive run for the current PR head `7c42f320e124857e419717592aba4cbd22c4cc02`
-  was `https://github.com/catu-ai/easyharness/actions/runs/27291661103`,
-  with `Go Test` succeeding in 5m32s.
+- PR #252 CI passed repeatedly during revision 1 closeout. The historical
+  pre-reopen run for head `7c42f320e124857e419717592aba4cbd22c4cc02` was
+  `https://github.com/catu-ai/easyharness/actions/runs/27291661103`, with
+  `Go Test` succeeding in 5m32s.
 - Final PR head, CI, and sync evidence are recorded through harness publish,
   CI, and sync evidence after archive.
+- Reopen validation after syncing PR #252 with `origin/main` at
+  `df56b0ffc3e7d5bc3ca06121221d564a6a8f46f6`:
+  - focused release-auth smoke test passed:
+    `go test ./tests/smoke -run 'TestReleaseWorkflowWiresHomebrewTapPublishing|TestVerifyReleaseNamespace|TestVersionTagWorkflowUsesRepositoryVersionFile' -count=1`
+  - release verifier package compile passed:
+    `go test ./scripts/releaseverify -count=1`
+  - affected package sweep passed:
+    `go test ./internal/... ./cmd/... ./scripts/releaseverify ./tests/smoke -run 'TestReleaseWorkflowWiresHomebrewTapPublishing|TestVerifyReleaseNamespace|TestVersionTagWorkflowUsesRepositoryVersionFile' -count=1`
+  - full local `go test ./...` was attempted after the sync merge, but the
+    local installer smoke `TestInstallDevHarnessDefaultsToUserLocalBin`
+    exceeded a 3 minute focused rerun timeout in this worktree. Final merge
+    readiness for the refreshed branch depends on the post-push PR CI `Go Test`
+    result.
 
 ## Review Summary
 
@@ -256,11 +275,17 @@ Use layered validation:
   superseded PR head/run as final evidence. The plan now states that final PR
   head, CI, and sync facts belong to harness evidence after archive.
 - Finalize repair review `review-004-full` passed with 0 findings.
+- Reopened finalize repair after PR #251 advanced `main`; finalize review
+  `review-005-full` found two sync-readiness wording findings in the plan:
+  the wrong `origin/main` SHA and stale "current PR head" wording for
+  revision-1 CI evidence.
+- Follow-up finalize review `review-006-full` passed with 0 findings after
+  those sync-readiness findings were fixed.
 
 ## Archive Summary
 
-- Archived At: 2026-06-11T01:06:06+08:00
-- Revision: 1
+- Archived At: 2026-06-11T09:56:10+08:00
+- Revision: 2
 - PR: PR #252 is published at
   `https://github.com/catu-ai/easyharness/pull/252`.
 - Ready: The candidate is merge-ready after local validation, passing PR CI,
@@ -270,6 +295,10 @@ Use layered validation:
   `version=v0.4.3` and verify that the rerun succeeds, including the
   `Verify Homebrew Install` job. This rerun should validate the release smoke
   fix without moving the `v0.4.3` tag or changing release artifact provenance.
+- Reopen Repair: Revision 2 refreshed PR #252 against `origin/main` after PR
+  #251 landed and invalidated the previous sync evidence. No release-auth scope
+  changed; final PR head, CI, sync, and merge-ready evidence must be recorded
+  again after re-archive.
 
 ## Outcome Summary
 

--- a/scripts/releaseverify/main.go
+++ b/scripts/releaseverify/main.go
@@ -216,9 +216,39 @@ func sha256File(path string) (string, error) {
 
 func runGH(args ...string) ([]byte, error) {
 	cmd := exec.Command("gh", args...)
+	cmd.Env = ghEnv(os.Environ())
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("%v failed: %w\n%s", args, err, strings.TrimSpace(string(output)))
 	}
 	return output, nil
+}
+
+func ghEnv(env []string) []string {
+	ghTokenIndex := -1
+	githubToken := ""
+	for i, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "GH_TOKEN":
+			ghTokenIndex = i
+		case "GITHUB_TOKEN":
+			if value != "" {
+				githubToken = value
+			}
+		}
+	}
+	if githubToken == "" {
+		return env
+	}
+	if ghTokenIndex == -1 {
+		return append(env, "GH_TOKEN="+githubToken)
+	}
+	if strings.TrimPrefix(env[ghTokenIndex], "GH_TOKEN=") == "" {
+		env[ghTokenIndex] = "GH_TOKEN=" + githubToken
+	}
+	return env
 }

--- a/tests/smoke/homebrew_formula_test.go
+++ b/tests/smoke/homebrew_formula_test.go
@@ -224,6 +224,8 @@ func TestReleaseWorkflowWiresHomebrewTapPublishing(t *testing.T) {
 	support.RequireContains(t, workflow, `--checksums dist/release-source/dist/release/SHA256SUMS`)
 	support.RequireContains(t, workflow, `--output dist/homebrew/easyharness.rb`)
 	support.RequireContains(t, workflow, "- name: Verify published release namespace\n        env:")
+	support.RequireContains(t, workflow, `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`)
+	support.RequireContains(t, workflow, `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`)
 	support.RequireContains(t, workflow, "run: go test ./tests/smoke -run TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled -count=1")
 	if strings.Contains(workflow, "working-directory: dist/release-source\n        run: go test ./tests/smoke -run TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled -count=1") {
 		t.Fatalf("expected namespace verification to run from the root checkout so main-branch smoke fixes apply to release reruns")
@@ -235,6 +237,7 @@ func TestReleaseWorkflowWiresHomebrewTapPublishing(t *testing.T) {
 	support.RequireContains(t, workflow, `--version "${{ steps.release-version.outputs.version }}"`)
 	support.RequireContains(t, workflow, `verify-homebrew-install:`)
 	support.RequireContains(t, workflow, `runs-on: macos-latest`)
+	support.RequireContains(t, workflow, `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`)
 	support.RequireContains(t, workflow, `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`)
 	support.RequireContains(t, workflow, `EASYHARNESS_RUN_LIVE_BREW_SMOKE: "1"`)
 	support.RequireContains(t, workflow, `go-version-file: go.mod`)

--- a/tests/smoke/verify_release_namespace_test.go
+++ b/tests/smoke/verify_release_namespace_test.go
@@ -70,6 +70,47 @@ func TestVerifyReleaseNamespaceWithFakeGHDownloadsAndChecksums(t *testing.T) {
 	support.RequireContains(t, string(logData), "release download v0.1.0-alpha.4 -R catu-ai/easyharness -D "+downloadDir+" --clobber -p SHA256SUMS -p "+archiveName)
 }
 
+func TestVerifyReleaseNamespaceMapsGitHubTokenToGHToken(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("verify-release-namespace smoke test requires a POSIX shell")
+	}
+
+	repo := "catu-ai/easyharness"
+	tag := "v0.1.0-alpha.4"
+	fakeGHDir := fakeGHReleaseDir(
+		t,
+		repo,
+		tag,
+		map[string][]byte{
+			"SHA256SUMS": []byte(""),
+		},
+	)
+
+	result := runCommand(
+		t,
+		support.RepoRoot(t),
+		envWithOverrides(t, map[string]string{
+			"GH_TOKEN":     "",
+			"GITHUB_TOKEN": "fallback-token",
+			"PATH":         installerPath(t, fakeGHDir),
+		}),
+		"/bin/bash",
+		filepath.Join(support.RepoRoot(t), "scripts", "verify-release-namespace"),
+		"--repo", repo,
+		"--tag", tag,
+		"--asset", "SHA256SUMS",
+	)
+	if result.ExitCode != 0 {
+		t.Fatalf("verify-release-namespace failed with exit %d\nstdout:\n%s\nstderr:\n%s", result.ExitCode, result.Stdout, result.Stderr)
+	}
+
+	logData, err := os.ReadFile(filepath.Join(fakeGHDir, "gh.log"))
+	if err != nil {
+		t.Fatalf("read fake gh log: %v", err)
+	}
+	support.RequireContains(t, string(logData), "GH_TOKEN=fallback-token")
+}
+
 func TestVerifyReleaseNamespaceFailsWhenAssetIsMissing(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("verify-release-namespace smoke test requires a POSIX shell")
@@ -294,6 +335,7 @@ repo_json=%q
 release_json=%q
 assets_dir=%q
 
+printf 'GH_TOKEN=%%s\n' "${GH_TOKEN:-}" >> "$log_file"
 printf '%%s\n' "$*" >> "$log_file"
 
 if [[ "$#" -ge 4 && "$1" == "repo" && "$2" == "view" ]]; then


### PR DESCRIPTION
## Summary
- pass `GH_TOKEN` explicitly to release workflow steps that invoke `gh`
- make `scripts/releaseverify` map `GITHUB_TOKEN` to `GH_TOKEN` when needed
- add smoke coverage for the token fallback used by the release verifier

## Context
The v0.4.3 release published successfully, but the Homebrew verification job repeatedly failed with `HTTP 401: Requires authentication` while the smoke test used `gh` to inspect the previous Homebrew-capable release (`v0.4.2`) before testing upgrade to `v0.4.3`.

After this lands, rerun `release.yml` from `main` for `version=v0.4.3` so the root-checkout smoke fixes apply while the release assets still come from the v0.4.3 tag.

## Tests
- `go test ./tests/smoke -run 'TestReleaseWorkflowWiresHomebrewTapPublishing|TestVerifyReleaseNamespace|TestVersionTagWorkflowUsesRepositoryVersionFile' -count=1`
- `go test ./scripts/releaseverify -count=1`
- `go test ./...`


## Post-merge release verification
After this PR lands, rerun `release.yml` from `main` with `version=v0.4.3` and verify that the rerun succeeds, including the `Verify Homebrew Install` job.
