### PR TITLE
Add CLI help topic for repo config customization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,14 @@ The default harness split in this repository is:
 
 If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
 
+## Harness Product Help
+
+When easyharness product behavior, command concepts, or repo customization
+syntax is unclear, use `harness help` or `harness help <topic>` from the
+installed binary. Use command `--help` for syntax and flags. Keep low-frequency
+topic guidance in `harness help` instead of copying it into this managed
+agreement.
+
 ## Harness Workflow
 
 For harness-managed work that is not already clear enough to execute directly:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,9 +128,9 @@ If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
 
 When easyharness product behavior, command concepts, or repo customization
 syntax is unclear, use `harness help` or `harness help <topic>` from the
-installed binary. Use command `--help` for syntax and flags. Keep low-frequency
-topic guidance in `harness help` instead of copying it into this managed
-agreement.
+installed binary. Use command `--help` for syntax and flags. After reading
+topic guidance, apply it to the requested outcome and report the effective
+result back to the human.
 
 ## Harness Workflow
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The current v0.2 harness surface centers on a few core ideas:
 - command-owned runtime state, reviews, and evidence live under the local
   runtime root resolved with `harness repo config get paths.local_runtime`
 - the CLI reports one canonical `state.current_node`
+- agents can use `harness help <topic>` for on-demand product guidance that
+  does not belong in always-loaded repo instructions or skills
 - `harness dashboard` is the built-in machine-local home for watched workspaces
 - `harness ui` opens the current repository in that same dashboard-owned UI family
 - agents use repo-local skills instead of reconstructing workflow from shell
@@ -165,6 +167,7 @@ The root CLI currently ships:
 - `harness evidence submit`
 - `harness evidence refresh`
 - `harness status`
+- `harness help [topic ...]`
 - `harness dashboard`
 - `harness ui`
 - `harness review start`

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -35,9 +35,9 @@ If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
 
 When easyharness product behavior, command concepts, or repo customization
 syntax is unclear, use `harness help` or `harness help <topic>` from the
-installed binary. Use command `--help` for syntax and flags. Keep low-frequency
-topic guidance in `harness help` instead of copying it into this managed
-agreement.
+installed binary. Use command `--help` for syntax and flags. After reading
+topic guidance, apply it to the requested outcome and report the effective
+result back to the human.
 
 ## Harness Workflow
 

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -31,6 +31,14 @@ The default harness split in this repository is:
 
 If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
 
+## Harness Product Help
+
+When easyharness product behavior, command concepts, or repo customization
+syntax is unclear, use `harness help` or `harness help <topic>` from the
+installed binary. Use command `--help` for syntax and flags. Keep low-frequency
+topic guidance in `harness help` instead of copying it into this managed
+agreement.
+
 ## Harness Workflow
 
 For harness-managed work that is not already clear enough to execute directly:

--- a/assets/help/embed.go
+++ b/assets/help/embed.go
@@ -1,0 +1,20 @@
+package helpassets
+
+import (
+	"embed"
+	"io/fs"
+	"strings"
+)
+
+var (
+	//go:embed *.md repo/*.md
+	embeddedAssets embed.FS
+)
+
+func Read(name string) (string, error) {
+	data, err := fs.ReadFile(embeddedAssets, name)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(data), "\n") + "\n", nil
+}

--- a/assets/help/repo.md
+++ b/assets/help/repo.md
@@ -1,0 +1,4 @@
+Repo Help
+
+Repo help topics cover repository-owned easyharness resources and
+customization surfaces that an agent may need to inspect on demand.

--- a/assets/help/repo/config.md
+++ b/assets/help/repo/config.md
@@ -1,0 +1,69 @@
+Repo Config Customization
+
+Use this topic when a human asks to customize where easyharness stores plans,
+local runtime state, or repo-defined review dimensions. The expected
+interaction is that humans describe the outcome they want, agents read this
+help, edit `.harness/config.yaml` when needed, verify the effective values,
+and report the result back to the human.
+
+`.harness/config.yaml` is a tracked repo-level manifest and index. It should
+stay small. Long-form customization text belongs in referenced `.harness/**/*.md`
+files, not inline YAML.
+
+The smallest valid config is:
+
+```yaml
+version: 1
+```
+
+Version 1 supports optional `paths` fields:
+
+```yaml
+version: 1
+paths:
+  plans:
+    active: docs/plans/active
+    archived: docs/plans/archived
+  local_runtime: .local/harness
+  review:
+    dimensions: .harness/review/dimensions
+```
+
+All path fields are optional. Omitted fields use built-in defaults.
+
+Path meanings:
+
+- `paths.plans.active`: tracked active plan root
+- `paths.plans.archived`: tracked standard archived plan root
+- `paths.local_runtime`: disposable command-owned runtime root
+- `paths.review.dimensions`: repo-defined review dimensions root
+
+Path values must be repo-relative slash-separated paths. Do not use empty
+paths, absolute paths, `~`, backslashes, paths outside the repository, the
+repository root itself, or overlapping configured roots.
+
+After editing config, verify effective values with:
+
+```bash
+harness repo config list
+harness repo config get paths.plans.active
+harness repo config get paths.plans.archived
+harness repo config get paths.local_runtime
+harness repo config get paths.review.dimensions
+```
+
+If `.harness/config.yaml` is missing, easyharness uses built-in defaults. If
+the file exists but is invalid, commands warn the agent, ignore the whole
+config, and use built-in defaults instead of partially consuming it.
+
+Repo-defined review dimensions are Markdown files directly under the resolved
+`paths.review.dimensions` root, which defaults to:
+
+```text
+.harness/review/dimensions
+```
+
+Each review dimension file has YAML frontmatter with exactly `name` and
+`description`, followed by the reviewer instruction body. Use
+`harness review dimensions list` to see available dimensions and
+`harness review dimensions instructions <name>` to read the full instruction.

--- a/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
+++ b/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
@@ -223,10 +223,13 @@ Delta review `review-001-delta` found one duplicated important issue across
 `harness help -h` were routed as unknown help topics instead of command syntax
 help. Added regression coverage for both forms, implemented `printHelpUsage`,
 and verified the repaired behavior with `go test -count=1 ./internal/cli
-./internal/helptopics ./internal/repoconfig`, `go test ./tests/smoke -run
-TestHelpShowsTopLevelUsage -count=1`, `scripts/install-dev-harness`, and
-manual probes for `harness help --help`, `harness help -h`, and
-`harness help repo config`. Follow-up delta review is pending.
+./internal/helptopics ./internal/repoconfig`, `scripts/install-dev-harness`,
+and manual probes for `harness help --help`, `harness help -h`, and
+`harness help repo config`. `go test ./tests/smoke -run
+TestHelpShowsTopLevelUsage -count=1` also passed, but only covers the existing
+root help smoke path rather than the repaired help-subcommand flags.
+Follow-up delta review `review-002-delta` passed with one non-blocking tests
+finding about this smoke-evidence wording, which this note corrects.
 
 ### Step 3: Write repo config agent guidance and see-also pointers
 

--- a/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
+++ b/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
@@ -218,7 +218,15 @@ observed before the interrupt.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+Delta review `review-001-delta` found one duplicated important issue across
+`correctness` and `docs-consistency`: `harness help --help` and
+`harness help -h` were routed as unknown help topics instead of command syntax
+help. Added regression coverage for both forms, implemented `printHelpUsage`,
+and verified the repaired behavior with `go test -count=1 ./internal/cli
+./internal/helptopics ./internal/repoconfig`, `go test ./tests/smoke -run
+TestHelpShowsTopLevelUsage -count=1`, `scripts/install-dev-harness`, and
+manual probes for `harness help --help`, `harness help -h`, and
+`harness help repo config`. Follow-up delta review is pending.
 
 ### Step 3: Write repo config agent guidance and see-also pointers
 
@@ -283,7 +291,7 @@ change remains pending Step 2 closeout review.
 
 ### Step 4: Track the broader help-system follow-up
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -317,11 +325,17 @@ Record the issue URL in the plan before archive.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Created follow-up issue https://github.com/catu-ai/easyharness/issues/254
+for the broader `harness help` topic system, including topic coverage policy,
+command `--help` integration, alias/equivalence decisions, and whether any
+topic content should be generated from specs. Labeled it `enhancement` and
+`state/accepted`, then added the required triage rationale comment explaining
+why it stays outside this minimal repo-config help slice.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 4 only creates and records the deferred follow-up
+issue; no repository behavior changes are introduced by this step.
 
 ## Validation Strategy
 
@@ -375,4 +389,4 @@ PENDING_UNTIL_ARCHIVE
 
 ### Follow-Up Issues
 
-PENDING_UNTIL_ARCHIVE
+- https://github.com/catu-ai/easyharness/issues/254

--- a/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
+++ b/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
@@ -230,6 +230,17 @@ TestHelpShowsTopLevelUsage -count=1` also passed, but only covers the existing
 root help smoke path rather than the repaired help-subcommand flags.
 Follow-up delta review `review-002-delta` passed with one non-blocking tests
 finding about this smoke-evidence wording, which this note corrects.
+Finalize review `review-003-full` then found one important docs-consistency
+issue: unknown help topics below a leaf, such as
+`harness help repo config missing`, did not print useful available topics even
+though the contract promised nearest-topic recovery. It also found one minor
+tests issue: root-help tests did not pin the new top-level `help` command line.
+Added regression coverage for both cases, changed leaf-child unknown topics to
+fall back to the root topic list, and verified with `go test -count=1
+./internal/cli ./internal/helptopics ./internal/repoconfig`, `go test -count=1
+./tests/smoke -run TestHelpShowsTopLevelUsage`, `scripts/install-dev-harness`,
+and manual probes for `harness help repo config missing`, `harness --help`, and
+`harness help --help`. Follow-up finalize review is pending.
 
 ### Step 3: Write repo config agent guidance and see-also pointers
 

--- a/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
+++ b/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
@@ -65,37 +65,37 @@ the human who asked for the customization.
 
 ## Acceptance Criteria
 
-- [ ] `harness help` exits successfully and prints a plain-text topic index
+- [x] `harness help` exits successfully and prints a plain-text topic index
       that includes `repo`.
-- [ ] `harness help repo` exits successfully, prints any repo parent topic
+- [x] `harness help repo` exits successfully, prints any repo parent topic
       body, and includes a generated "Available subtopics" section containing
       `config`.
-- [ ] `harness help repo config` exits successfully and prints a plain-text
+- [x] `harness help repo config` exits successfully and prints a plain-text
       agent guide for repo config customization.
-- [ ] Help topic output is not JSON and does not expose Markdown examples
+- [x] Help topic output is not JSON and does not expose Markdown examples
       through escaped JSON strings.
-- [ ] Long-form help bodies are sourced from packaged assets under a dedicated
+- [x] Long-form help bodies are sourced from packaged assets under a dedicated
       help asset tree, separate from `assets/bootstrap/`.
-- [ ] The program-owned help registry defines topic IDs, summaries, asset
+- [x] The program-owned help registry defines topic IDs, summaries, asset
       bindings, and parent/child relationships.
-- [ ] Every non-leaf help topic prints immediate subtopics from the registry;
+- [x] Every non-leaf help topic prints immediate subtopics from the registry;
       Markdown help assets do not manually list available subtopics.
-- [ ] Unknown help topics fail clearly with a non-zero exit code and show the
+- [x] Unknown help topics fail clearly with a non-zero exit code and show the
       nearest useful available topics.
-- [ ] `harness repo --help` and `harness repo config --help` remain command
+- [x] `harness repo --help` and `harness repo config --help` remain command
       syntax help and include a concise see-also pointer to
       `harness help repo config`.
-- [ ] The repo config help topic tells agents that humans express intent,
+- [x] The repo config help topic tells agents that humans express intent,
       agents read help/config guidance, agents edit `.harness/config.yaml`,
       and agents report the effective result back to the human.
-- [ ] The repo config help topic covers supported v1 fields,
+- [x] The repo config help topic covers supported v1 fields,
       `harness repo config get/list` verification, path safety constraints,
       invalid-config fallback/warning behavior, and repo review dimension file
       placement at a useful high level.
-- [ ] Tests cover root help, parent help with generated subtopics, leaf topic
+- [x] Tests cover root help, parent help with generated subtopics, leaf topic
       rendering, unknown topic errors, asset-backed body loading, and see-also
       text in relevant command help.
-- [ ] A follow-up GitHub issue exists for the broader `harness help` topic
+- [x] A follow-up GitHub issue exists for the broader `harness help` topic
       system, including topic coverage policy and deeper `--help` integration,
       and is recorded in this plan before archive.
 
@@ -381,25 +381,84 @@ issue; no repository behavior changes are introduced by this step.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+Passed:
+
+- `harness plan lint docs/plans/active/2026-06-16-cli-help-repo-config-topic.md`
+- `go test -count=1 ./internal/cli ./internal/helptopics ./internal/repoconfig`
+- `go test -count=1 ./internal/cli ./internal/helptopics ./internal/repoconfig ./internal/reviewdimensions`
+- `go test -count=1 ./tests/smoke -run TestHelpShowsTopLevelUsage`
+- `scripts/install-dev-harness`
+- manual probes for `harness help`, `harness help repo`,
+  `harness help repo config`, `harness help --help`, `harness help -h`,
+  `harness help repo missing`, `harness help repo config missing`,
+  `harness repo --help`, and `harness repo config --help`
+
+A broader `go test ./...` run was attempted during execution. It passed
+through core packages, e2e, and resilience output, then was interrupted after
+the smoke package stayed quiet for several minutes. No assertion failure was
+observed before the interrupt, but this candidate does not claim a clean full
+suite pass.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Step-closeout review `review-001-delta` found one duplicated important issue:
+`harness help --help` and `harness help -h` were treated as unknown topics
+instead of command syntax help. The repair added syntax-help handling and
+regression coverage. Follow-up `review-002-delta` passed with one minor
+evidence wording note, which was corrected in the plan.
+
+Finalize review `review-003-full` found one important issue: unknown help
+topics below a leaf did not show the documented recovery topics. It also found
+one minor root-help coverage gap. The repair added leaf-child recovery fallback
+to root topics plus root-help discoverability assertions. Follow-up
+`review-004-full` passed with no findings across correctness, tests,
+docs-consistency, agent-UX, and risk-scan.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: to be opened for branch `codex/cli-help-repo-config-topic` after
+  archive.
+- Ready: yes; all tracked steps are complete, archive blockers are addressed,
+  focused validation passed, and finalize review `review-004-full` passed with
+  no findings.
+- Merge Handoff: after archive, commit the archive move and summary updates,
+  push the branch, open a PR, record publish evidence, refresh CI/sync
+  evidence, and wait for `harness status` to reach
+  `execution/finalize/await_merge` before asking for explicit human merge
+  approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added a minimal plain-text `harness help` topic surface with root topic
+  index, `repo` parent topic, and `repo config` customization guide.
+- Added packaged help assets under `assets/help/`, separate from bootstrap
+  install assets.
+- Added a program-owned help topic registry and renderer that owns topic paths,
+  summaries, asset bindings, parent/child relationships, and generated
+  subtopic listings for non-leaf topics.
+- Added CLI routing and syntax help behavior for `harness help`, including
+  `harness help --help` and `harness help -h`.
+- Added concise see-also pointers from `harness repo --help` and
+  `harness repo config --help` to `harness help repo config`.
+- Updated README, CLI contract, and repo config spec to document the
+  concept-oriented help topic boundary without implying that every command
+  needs a matching long-form topic.
+- Added focused tests for topic rendering, asset-backed bodies, generated
+  subtopic lists, unknown-topic recovery, command syntax help, root-help
+  discoverability, and repo/config see-also pointers.
+- Created follow-up issue https://github.com/catu-ai/easyharness/issues/254
+  for the broader help topic system and coverage policy.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- A broad `harness help` taxonomy for every command was intentionally not
+  delivered.
+- Command `--help` output was not made equivalent to topic help.
+- No JSON or schema contract was added for help topic output.
+- No repo config mutation command, config lint command, or new repo config
+  field was added.
 
 ### Follow-Up Issues
 

--- a/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
+++ b/docs/plans/active/2026-06-16-cli-help-repo-config-topic.md
@@ -1,0 +1,378 @@
+---
+template_version: 0.2.0
+created_at: "2026-06-16T23:12:24+08:00"
+approved_at: "2026-06-16T23:14:36+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/237
+size: S
+---
+
+# Add CLI Help Topic for Repo Config Customization
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Add a minimal `harness help` topic surface so agents in customer repositories
+can discover repo config customization guidance from the installed
+`easyharness` binary alone.
+
+This slice is not a broad documentation system. It should provide just enough
+plain-text, CLI-discoverable help for an agent to understand how to customize
+`.harness/config.yaml`, verify effective values, and explain the result back to
+the human who asked for the customization.
+
+## Scope
+
+### In Scope
+
+- Add a root `harness help` command that prints available help topics.
+- Add `harness help repo` as a short parent topic for repo-related help.
+- Add `harness help repo config` as the agent-facing repo config
+  customization guide.
+- Print help topic content as plain text, not JSON.
+- Store long-form help topic bodies in packaged assets, not Go string
+  literals.
+- Maintain the topic tree, topic summaries, and generated "Available
+  subtopics" sections in program code.
+- Ensure every non-leaf help topic prints its immediate available subtopics
+  from the program-maintained registry instead of duplicating those lists in
+  Markdown assets.
+- Keep `--help` as command syntax help, with small see-also pointers from the
+  relevant repo command help to `harness help repo config`.
+- Cover the minimal command behavior and asset-backed rendering with focused
+  tests.
+- Create or update a follow-up GitHub issue before archive for the broader
+  help topic system and coverage policy.
+
+### Out of Scope
+
+- Building a complete help taxonomy for all harness commands.
+- Requiring every command to have a matching `harness help ...` topic.
+- Making `harness repo --help` or other command `--help` output equivalent to
+  `harness help repo`.
+- JSON output, schemas, or stable machine-readable contracts for help topics.
+- Putting repo config customization details into the managed `AGENTS.md` block
+  or managed skill pack.
+- Teaching human maintainers to hand-write `.harness/config.yaml` directly as
+  the primary interaction model.
+- Config mutation commands, config lint, or new repo config fields.
+
+## Acceptance Criteria
+
+- [ ] `harness help` exits successfully and prints a plain-text topic index
+      that includes `repo`.
+- [ ] `harness help repo` exits successfully, prints any repo parent topic
+      body, and includes a generated "Available subtopics" section containing
+      `config`.
+- [ ] `harness help repo config` exits successfully and prints a plain-text
+      agent guide for repo config customization.
+- [ ] Help topic output is not JSON and does not expose Markdown examples
+      through escaped JSON strings.
+- [ ] Long-form help bodies are sourced from packaged assets under a dedicated
+      help asset tree, separate from `assets/bootstrap/`.
+- [ ] The program-owned help registry defines topic IDs, summaries, asset
+      bindings, and parent/child relationships.
+- [ ] Every non-leaf help topic prints immediate subtopics from the registry;
+      Markdown help assets do not manually list available subtopics.
+- [ ] Unknown help topics fail clearly with a non-zero exit code and show the
+      nearest useful available topics.
+- [ ] `harness repo --help` and `harness repo config --help` remain command
+      syntax help and include a concise see-also pointer to
+      `harness help repo config`.
+- [ ] The repo config help topic tells agents that humans express intent,
+      agents read help/config guidance, agents edit `.harness/config.yaml`,
+      and agents report the effective result back to the human.
+- [ ] The repo config help topic covers supported v1 fields,
+      `harness repo config get/list` verification, path safety constraints,
+      invalid-config fallback/warning behavior, and repo review dimension file
+      placement at a useful high level.
+- [ ] Tests cover root help, parent help with generated subtopics, leaf topic
+      rendering, unknown topic errors, asset-backed body loading, and see-also
+      text in relevant command help.
+- [ ] A follow-up GitHub issue exists for the broader `harness help` topic
+      system, including topic coverage policy and deeper `--help` integration,
+      and is recorded in this plan before archive.
+
+## Deferred Items
+
+- A broader `harness help` topic system and coverage policy is deferred to a
+  follow-up issue. That work should decide how many product concepts deserve
+  topic docs, how command syntax help should point into topic help, and whether
+  any content should be generated from specs.
+- More help topics beyond `repo` and `repo config` are deferred until each
+  topic has a real agent-facing need.
+- Aliases that make command `--help` output equivalent to topic help are
+  deferred. This slice keeps command syntax help and topic docs distinct.
+
+## Work Breakdown
+
+### Step 1: Define the help topic contract
+
+- Done: [x]
+
+#### Objective
+
+Document the minimal `harness help` behavior and the boundary between command
+syntax help and agent-facing topic docs.
+
+#### Details
+
+The contract should say that `harness help` topics are plain-text product and
+workflow guidance for agents, not script-facing JSON APIs and not a mirror of
+every command. Command `--help` remains short syntax help.
+
+Record the generated-subtopic rule: every non-leaf help topic prints immediate
+available subtopics from the program-maintained registry, while Markdown assets
+own only body content.
+
+#### Expected Files
+
+- `docs/specs/cli-contract.md`
+- `docs/specs/repo-config.md`
+- `README.md`
+
+#### Validation
+
+- Specs and README explain how an agent discovers repo config customization
+  guidance without teaching humans to hand-author config as the primary flow.
+- The documented scope does not imply that all commands need matching help
+  topics in this slice.
+
+#### Execution Notes
+
+Documented `harness help [topic ...]` as a plain-text, agent-facing topic
+surface distinct from command syntax `--help`. Updated the CLI contract,
+repo-config spec, and README to record the asset-backed body rule,
+program-owned topic registry, generated non-leaf subtopic sections, and the
+initial `repo` / `repo config` topic scope.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 records the approved help-topic contract in
+docs. The implemented command behavior and repo-config guide content are
+covered by later step validation and review.
+
+### Step 2: Implement asset-backed help topics
+
+- Done: [x]
+
+#### Objective
+
+Add the minimal help topic registry, asset loading, and CLI routing for
+`harness help`, `harness help repo`, and `harness help repo config`.
+
+#### Details
+
+Use a dedicated packaged help asset tree such as `assets/help/`. Keep it
+separate from `assets/bootstrap/` because these docs are read by the installed
+binary on demand; they are not repo resources installed into customer
+repositories.
+
+The registry should own:
+
+- topic path, such as `repo` or `repo config`
+- one-line summary for generated indexes
+- optional body asset path
+- parent/child relationships
+
+Unknown topics should fail clearly and show the nearest useful available
+topics so agents can recover without guessing.
+
+#### Expected Files
+
+- `assets/help/`
+- `internal/cli/app.go`
+- `internal/cli/app_test.go`
+- a small internal help package if useful
+
+#### Validation
+
+- Focused tests cover successful root, parent, and leaf topic rendering.
+- Tests prove non-leaf subtopics are generated from the registry, not copied
+  from Markdown assets.
+- Tests cover unknown topic behavior and plain-text output.
+
+#### Execution Notes
+
+Added a dedicated `assets/help/` package for packaged help assets and a small
+`internal/helptopics` renderer with a program-owned registry for topic paths,
+summaries, asset bindings, and generated child-topic listings. Wired
+`harness help`, `harness help repo`, and `harness help repo config` through the
+CLI as stdout plain-text topic output while keeping `harness --help` on the
+existing command-usage surface.
+
+Validation passed with `go test ./internal/cli ./internal/helptopics
+./internal/repoconfig`, `scripts/install-dev-harness`, and manual probes for
+`harness help`, `harness help repo`, `harness help repo config`,
+`harness help repo missing`, `harness repo --help`, and
+`harness repo config --help`. A broader `go test ./...` run passed through
+core packages, e2e, and resilience output but was interrupted after
+`tests/smoke` stayed quiet for several minutes; no assertion failure was
+observed before the interrupt.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Write repo config agent guidance and see-also pointers
+
+- Done: [x]
+
+#### Objective
+
+Create the `repo config` help body and make relevant command syntax help point
+agents toward it without expanding managed prompts or skills.
+
+#### Details
+
+The guide should assume the human asks for an outcome, not for YAML lessons.
+It should instruct agents to inspect the topic help, edit `.harness/config.yaml`
+when needed, verify effective values with `harness repo config get/list`, and
+report the resulting configuration back to the human.
+
+The guide should include useful examples while staying concise enough for
+terminal reading. It should cover:
+
+- `.harness/config.yaml` as tracked manifest/index
+- `version: 1`
+- optional `paths` fields and their meanings
+- safe repo-relative path rules
+- whole-config fallback on invalid config, with agent-facing warnings
+- effective value verification through `harness repo config get/list`
+- review dimension root and Markdown file format at a high level
+
+Relevant command syntax help should get short see-also lines, not long topic
+content.
+
+#### Expected Files
+
+- `assets/help/repo.md`
+- `assets/help/repo/config.md`
+- `internal/cli/app.go`
+- `internal/cli/app_test.go`
+- `docs/specs/repo-config.md`
+
+#### Validation
+
+- `harness help repo config` is readable as plain terminal text.
+- The guide does not duplicate generated available-subtopic lists in Markdown.
+- `harness repo --help` and `harness repo config --help` still read as command
+  help and point to `harness help repo config`.
+
+#### Execution Notes
+
+Wrote the `repo` parent topic and `repo config` agent guide as packaged
+plain-text Markdown-ish assets. The guide frames the intended human-agent
+interaction, documents the v1 config shape and path constraints, points agents
+to `harness repo config get/list` for verification, and summarizes
+repo-defined review dimension placement. Added concise see-also pointers from
+`harness repo --help` and `harness repo config --help` to
+`harness help repo config`.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 3 supplies topic text and see-also pointers that
+are exercised by the Step 2 CLI/help tests and manual probes; the behavior
+change remains pending Step 2 closeout review.
+
+### Step 4: Track the broader help-system follow-up
+
+- Done: [ ]
+
+#### Objective
+
+Create or update a GitHub issue for the larger `harness help` system so this
+slice can stay intentionally narrow.
+
+#### Details
+
+The follow-up should cover the broader questions that discovery intentionally
+left out:
+
+- topic taxonomy beyond repo config customization
+- when a concept deserves `harness help ...`
+- how command `--help` should point to topic help
+- whether command aliases or equivalence rules are desirable
+- whether any topic content should be generated from specs
+
+Record the issue URL in the plan before archive.
+
+#### Expected Files
+
+- this plan file
+- GitHub issue tracker
+
+#### Validation
+
+- A follow-up issue exists and is listed in `Outcome Summary / Follow-Up
+  Issues` before archive.
+- The current implementation remains scoped to `repo` and `repo config` help
+  topics.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Run focused Go tests for the CLI and any new help package.
+- Run `harness plan lint` before approval and repeat it after material plan
+  updates.
+- After implementation, reinstall the dev harness with
+  `scripts/install-dev-harness` before manual CLI probes.
+- Manually probe `harness help`, `harness help repo`,
+  `harness help repo config`, an unknown topic, `harness repo --help`, and
+  `harness repo config --help`.
+- Use text search to confirm available-subtopic lists are not duplicated in
+  Markdown help assets.
+
+## Risks
+
+- Risk: `harness help` could accidentally become a promise to mirror every CLI
+  command.
+  - Mitigation: Define topic help as concept-oriented, keep this slice scoped
+    to repo config customization, and defer coverage policy to a follow-up
+    issue.
+- Risk: Help output could become hard for agents to consume if represented as
+  JSON.
+  - Mitigation: Make `harness help` plain text only in this slice and keep
+    script-facing behavior with existing command surfaces.
+- Risk: Markdown assets could drift from the topic tree.
+  - Mitigation: Keep subtopic discovery in the program registry and test that
+    non-leaf output appends generated subtopics.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+PENDING_UNTIL_ARCHIVE

--- a/docs/plans/archived/2026-06-16-cli-help-repo-config-topic.md
+++ b/docs/plans/archived/2026-06-16-cli-help-repo-config-topic.md
@@ -416,6 +416,8 @@ docs-consistency, agent-UX, and risk-scan.
 
 ## Archive Summary
 
+- Archived At: 2026-06-16T23:51:59+08:00
+- Revision: 1
 - PR: to be opened for branch `codex/cli-help-repo-config-topic` after
   archive.
 - Ready: yes; all tracked steps are complete, archive blockers are addressed,

--- a/docs/plans/archived/2026-06-16-cli-help-repo-config-topic.md
+++ b/docs/plans/archived/2026-06-16-cli-help-repo-config-topic.md
@@ -43,8 +43,13 @@ the human who asked for the customization.
 - Ensure every non-leaf help topic prints its immediate available subtopics
   from the program-maintained registry instead of duplicating those lists in
   Markdown assets.
+- Keep the normative help topic contract in an independent help spec, with
+  the CLI and repo-config specs linking to that contract instead of duplicating
+  it.
 - Keep `--help` as command syntax help, with small see-also pointers from the
   relevant repo command help to `harness help repo config`.
+- Add a small managed `AGENTS.md` cue telling agents to use `harness help`
+  when easyharness product behavior or customization syntax is unclear.
 - Cover the minimal command behavior and asset-backed rendering with focused
   tests.
 - Create or update a follow-up GitHub issue before archive for the broader
@@ -58,7 +63,7 @@ the human who asked for the customization.
   `harness help repo`.
 - JSON output, schemas, or stable machine-readable contracts for help topics.
 - Putting repo config customization details into the managed `AGENTS.md` block
-  or managed skill pack.
+  or managed skill pack; the managed block only gets a discovery cue.
 - Teaching human maintainers to hand-write `.harness/config.yaml` directly as
   the primary interaction model.
 - Config mutation commands, config lint, or new repo config fields.
@@ -92,6 +97,11 @@ the human who asked for the customization.
       `harness repo config get/list` verification, path safety constraints,
       invalid-config fallback/warning behavior, and repo review dimension file
       placement at a useful high level.
+- [x] A standalone help spec owns the normative `harness help` topic contract,
+      while the CLI and repo-config specs link to it.
+- [x] The managed `AGENTS.md` block tells agents to use `harness help` for
+      unclear product behavior or customization syntax without copying help
+      topic content into the always-loaded agreement.
 - [x] Tests cover root help, parent help with generated subtopics, leaf topic
       rendering, unknown topic errors, asset-backed body loading, and see-also
       text in relevant command help.
@@ -134,7 +144,11 @@ own only body content.
 #### Expected Files
 
 - `docs/specs/cli-contract.md`
+- `docs/specs/help.md`
+- `docs/specs/index.md`
 - `docs/specs/repo-config.md`
+- `assets/bootstrap/agents-managed-block.md`
+- `AGENTS.md`
 - `README.md`
 
 #### Validation
@@ -151,6 +165,13 @@ surface distinct from command syntax `--help`. Updated the CLI contract,
 repo-config spec, and README to record the asset-backed body rule,
 program-owned topic registry, generated non-leaf subtopic sections, and the
 initial `repo` / `repo config` topic scope.
+
+Revision 2 extracted the topic contract into standalone
+`docs/specs/help.md`, linked the CLI and repo-config specs to it, and added a
+small bootstrap-managed `AGENTS.md` cue telling agents to use `harness help`
+when product behavior, command concepts, or repo customization syntax is
+unclear. The managed cue deliberately avoids copying low-frequency help topic
+content into the always-loaded agreement.
 
 #### Review Notes
 
@@ -383,7 +404,10 @@ issue; no repository behavior changes are introduced by this step.
 
 Passed:
 
+- `scripts/sync-bootstrap-assets --check`
 - `harness plan lint docs/plans/active/2026-06-16-cli-help-repo-config-topic.md`
+- `go test -count=1 ./internal/cli ./internal/helptopics ./internal/repoconfig ./internal/bootstrapsync ./internal/install`
+- `go test -count=1 ./tests/smoke -run TestSyncBootstrapAssetsCheckPassesForCurrentRepo`
 - `go test -count=1 ./internal/cli ./internal/helptopics ./internal/repoconfig`
 - `go test -count=1 ./internal/cli ./internal/helptopics ./internal/repoconfig ./internal/reviewdimensions`
 - `go test -count=1 ./tests/smoke -run TestHelpShowsTopLevelUsage`
@@ -414,17 +438,27 @@ to root topics plus root-help discoverability assertions. Follow-up
 `review-004-full` passed with no findings across correctness, tests,
 docs-consistency, agent-UX, and risk-scan.
 
+Revision 2 was reopened from `await_merge` after human feedback requested an
+independent help spec and a managed `AGENTS.md` discovery cue for `harness
+help`. Delta finalize review `review-005-delta` passed with no findings across
+docs-consistency, agent-UX, tests, and risk-scan.
+
 ## Archive Summary
 
-- Archived At: 2026-06-16T23:51:59+08:00
-- Revision: 1
-- PR: to be opened for branch `codex/cli-help-repo-config-topic` after
-  archive.
-- Ready: yes; all tracked steps are complete, archive blockers are addressed,
-  focused validation passed, and finalize review `review-004-full` passed with
+- Archived At: 2026-06-17T10:03:25+08:00
+- Revision: 2
+
+Revision 1 was archived at 2026-06-16T23:51:59+08:00 and published through PR
+https://github.com/catu-ai/easyharness/pull/255, then reopened in
+`finalize-fix` mode after human feedback clarified that help needs its own
+spec and a managed `AGENTS.md` discoverability cue.
+
+- PR: https://github.com/catu-ai/easyharness/pull/255
+- Ready: yes; all tracked steps remain complete, revision 2 focused
+  validation passed, and delta finalize review `review-005-delta` passed with
   no findings.
 - Merge Handoff: after archive, commit the archive move and summary updates,
-  push the branch, open a PR, record publish evidence, refresh CI/sync
+  push the branch, update the PR memo if needed, refresh publish/CI/sync
   evidence, and wait for `harness status` to reach
   `execution/finalize/await_merge` before asking for explicit human merge
   approval.
@@ -437,6 +471,9 @@ docs-consistency, agent-UX, and risk-scan.
   index, `repo` parent topic, and `repo config` customization guide.
 - Added packaged help assets under `assets/help/`, separate from bootstrap
   install assets.
+- Added standalone `docs/specs/help.md` as the normative help topic contract,
+  with CLI and repo-config specs linking to it instead of duplicating the same
+  rules.
 - Added a program-owned help topic registry and renderer that owns topic paths,
   summaries, asset bindings, parent/child relationships, and generated
   subtopic listings for non-leaf topics.
@@ -447,6 +484,9 @@ docs-consistency, agent-UX, and risk-scan.
 - Updated README, CLI contract, and repo config spec to document the
   concept-oriented help topic boundary without implying that every command
   needs a matching long-form topic.
+- Added a bootstrap-managed `AGENTS.md` product-help cue telling agents to use
+  `harness help` when easyharness behavior or repo customization syntax is
+  unclear, while leaving detailed topic content in binary-shipped help.
 - Added focused tests for topic rendering, asset-backed bodies, generated
   subtopic lists, unknown-topic recovery, command syntax help, root-help
   discoverability, and repo/config see-also pointers.
@@ -458,6 +498,8 @@ docs-consistency, agent-UX, and risk-scan.
 - A broad `harness help` taxonomy for every command was intentionally not
   delivered.
 - Command `--help` output was not made equivalent to topic help.
+- Detailed repo config customization guidance was not copied into the managed
+  `AGENTS.md` block or managed skills.
 - No JSON or schema contract was added for help topic output.
 - No repo config mutation command, config lint command, or new repo config
   field was added.

--- a/docs/plans/archived/2026-06-16-cli-help-repo-config-topic.md
+++ b/docs/plans/archived/2026-06-16-cli-help-repo-config-topic.md
@@ -173,6 +173,11 @@ when product behavior, command concepts, or repo customization syntax is
 unclear. The managed cue deliberately avoids copying low-frequency help topic
 content into the always-loaded agreement.
 
+Revision 3 refined that managed cue after PR feedback: because the text is
+copied into customer `AGENTS.md` files, it now gives only agent-facing action
+guidance and no longer explains the internal reason for keeping topic content
+out of the managed block.
+
 #### Review Notes
 
 NO_STEP_REVIEW_NEEDED: Step 1 records the approved help-topic contract in
@@ -406,6 +411,7 @@ Passed:
 
 - `scripts/sync-bootstrap-assets --check`
 - `harness plan lint docs/plans/active/2026-06-16-cli-help-repo-config-topic.md`
+- `go test -count=1 ./internal/bootstrapsync ./internal/install ./internal/cli ./internal/helptopics`
 - `go test -count=1 ./internal/cli ./internal/helptopics ./internal/repoconfig ./internal/bootstrapsync ./internal/install`
 - `go test -count=1 ./tests/smoke -run TestSyncBootstrapAssetsCheckPassesForCurrentRepo`
 - `go test -count=1 ./internal/cli ./internal/helptopics ./internal/repoconfig`
@@ -443,10 +449,20 @@ independent help spec and a managed `AGENTS.md` discovery cue for `harness
 help`. Delta finalize review `review-005-delta` passed with no findings across
 docs-consistency, agent-UX, tests, and risk-scan.
 
+Revision 3 was reopened from `await_merge` after PR feedback noted that the
+managed `AGENTS.md` cue should not explain internal doc-placement choices to
+end users. Delta finalize review `review-006-delta` passed with no findings
+across docs-consistency and agent-UX.
+
 ## Archive Summary
 
-- Archived At: 2026-06-17T10:03:25+08:00
-- Revision: 2
+- Archived At: 2026-06-17T22:28:22+08:00
+- Revision: 3
+
+Revision 2 was archived at 2026-06-17T10:03:25+08:00 and published through PR
+https://github.com/catu-ai/easyharness/pull/255, then reopened in
+`finalize-fix` mode after PR feedback requested more user-facing managed
+`AGENTS.md` wording.
 
 Revision 1 was archived at 2026-06-16T23:51:59+08:00 and published through PR
 https://github.com/catu-ai/easyharness/pull/255, then reopened in
@@ -454,8 +470,8 @@ https://github.com/catu-ai/easyharness/pull/255, then reopened in
 spec and a managed `AGENTS.md` discoverability cue.
 
 - PR: https://github.com/catu-ai/easyharness/pull/255
-- Ready: yes; all tracked steps remain complete, revision 2 focused
-  validation passed, and delta finalize review `review-005-delta` passed with
+- Ready: yes; all tracked steps remain complete, revision 3 focused
+  validation passed, and delta finalize review `review-006-delta` passed with
   no findings.
 - Merge Handoff: after archive, commit the archive move and summary updates,
   push the branch, update the PR memo if needed, refresh publish/CI/sync
@@ -486,7 +502,8 @@ spec and a managed `AGENTS.md` discoverability cue.
   needs a matching long-form topic.
 - Added a bootstrap-managed `AGENTS.md` product-help cue telling agents to use
   `harness help` when easyharness behavior or repo customization syntax is
-  unclear, while leaving detailed topic content in binary-shipped help.
+  unclear, then apply the guidance and report the effective result back to the
+  human.
 - Added focused tests for topic rendering, asset-backed bodies, generated
   subtopic lists, unknown-topic recovery, command syntax help, root-help
   discoverability, and repo/config see-also pointers.

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -95,8 +95,8 @@ start the local read-only UI server rather than returning a workflow-state
 JSON envelope.
 
 `harness help [topic ...]` is a plain-text exception because it renders
-agent-facing product guidance rather than workflow state. Help topic output is
-not JSON and is not a stable machine-readable contract.
+agent-facing product guidance rather than workflow state. Its topic contract
+lives in [Help Topics](./help.md).
 
 The bootstrap commands described in [Bootstrap Install](./bootstrap-install.md)
 are JSON-first, but they may omit workflow `state` because they manage
@@ -120,17 +120,9 @@ Every command must have complete `--help` text that explains:
 Skills may refer to `harness --help` or `harness <subcommand> --help`, but the
 CLI should remain understandable without repository-specific prompt text.
 
-`harness help` is separate from command syntax help. Command `--help` remains
-the surface for usage, flags, required inputs, and side effects. `harness help`
-topics are on-demand plain-text product guidance for narrower concepts that an
-agent may need to understand while working in a customer repository. Help
-topics are not required for every command.
-
-Long-form help topic bodies should live in packaged help assets rather than Go
-string literals. The program-owned help registry owns topic paths, one-line
-summaries, and parent/child relationships. Every non-leaf help topic must print
-an "Available subtopics" section generated from that registry; Markdown help
-assets must not duplicate subtopic lists.
+`harness help` is separate from command syntax help. The detailed topic
+contract, topic asset rules, and generated subtopic behavior live in
+[Help Topics](./help.md).
 
 ### Crash-Safe Runstate Writes
 
@@ -354,41 +346,6 @@ Recommended next action:
   to apply a previewed bootstrap change
 - open the target instructions file or skills directory to review the installed
   contract
-
-### `harness help [topic ...]`
-
-Purpose:
-
-- let agents discover low-frequency product guidance from the installed binary
-  without loading that guidance into managed `AGENTS.md` blocks or skills
-
-Contract:
-
-- `harness help` prints a plain-text topic index
-- `harness help <topic ...>` prints plain-text guidance for the selected topic
-- output is for agents and humans reading a terminal; it is not JSON and does
-  not define a schema
-- topic bodies come from packaged help assets
-- the program-owned help registry owns topic paths, summaries, asset bindings,
-  and parent/child relationships
-- every non-leaf topic prints immediate available subtopics generated from the
-  registry
-- unknown topics fail with a non-zero exit code and print the nearest useful
-  available topics
-- command `--help` output remains command syntax help; it may include concise
-  see-also pointers into `harness help` topics
-
-The initial help topic set is intentionally narrow:
-
-- `harness help repo`
-- `harness help repo config`
-
-Recommended next action:
-
-- when a human asks for repo customization and the exact config shape is
-  unclear, run `harness help repo config`, apply the requested customization,
-  verify effective values with `harness repo config get` or
-  `harness repo config list`, and summarize the result back to the human
 
 ### `harness dashboard`
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -43,6 +43,7 @@ The current command surface is:
 - `harness evidence submit`
 - `harness evidence refresh`
 - `harness status`
+- `harness help [topic ...]`
 - `harness dashboard`
 - `harness ui`
 - `harness review start`
@@ -93,6 +94,10 @@ because it is a binary probe rather than a workflow-state command.
 start the local read-only UI server rather than returning a workflow-state
 JSON envelope.
 
+`harness help [topic ...]` is a plain-text exception because it renders
+agent-facing product guidance rather than workflow state. Help topic output is
+not JSON and is not a stable machine-readable contract.
+
 The bootstrap commands described in [Bootstrap Install](./bootstrap-install.md)
 are JSON-first, but they may omit workflow `state` because they manage
 bootstrap assets rather than the tracked plan lifecycle.
@@ -114,6 +119,18 @@ Every command must have complete `--help` text that explains:
 
 Skills may refer to `harness --help` or `harness <subcommand> --help`, but the
 CLI should remain understandable without repository-specific prompt text.
+
+`harness help` is separate from command syntax help. Command `--help` remains
+the surface for usage, flags, required inputs, and side effects. `harness help`
+topics are on-demand plain-text product guidance for narrower concepts that an
+agent may need to understand while working in a customer repository. Help
+topics are not required for every command.
+
+Long-form help topic bodies should live in packaged help assets rather than Go
+string literals. The program-owned help registry owns topic paths, one-line
+summaries, and parent/child relationships. Every non-leaf help topic must print
+an "Available subtopics" section generated from that registry; Markdown help
+assets must not duplicate subtopic lists.
 
 ### Crash-Safe Runstate Writes
 
@@ -337,6 +354,41 @@ Recommended next action:
   to apply a previewed bootstrap change
 - open the target instructions file or skills directory to review the installed
   contract
+
+### `harness help [topic ...]`
+
+Purpose:
+
+- let agents discover low-frequency product guidance from the installed binary
+  without loading that guidance into managed `AGENTS.md` blocks or skills
+
+Contract:
+
+- `harness help` prints a plain-text topic index
+- `harness help <topic ...>` prints plain-text guidance for the selected topic
+- output is for agents and humans reading a terminal; it is not JSON and does
+  not define a schema
+- topic bodies come from packaged help assets
+- the program-owned help registry owns topic paths, summaries, asset bindings,
+  and parent/child relationships
+- every non-leaf topic prints immediate available subtopics generated from the
+  registry
+- unknown topics fail with a non-zero exit code and print the nearest useful
+  available topics
+- command `--help` output remains command syntax help; it may include concise
+  see-also pointers into `harness help` topics
+
+The initial help topic set is intentionally narrow:
+
+- `harness help repo`
+- `harness help repo config`
+
+Recommended next action:
+
+- when a human asks for repo customization and the exact config shape is
+  unclear, run `harness help repo config`, apply the requested customization,
+  verify effective values with `harness repo config get` or
+  `harness repo config list`, and summarize the result back to the human
 
 ### `harness dashboard`
 

--- a/docs/specs/help.md
+++ b/docs/specs/help.md
@@ -1,0 +1,81 @@
+# Help Topics
+
+## Purpose
+
+`harness help` exposes low-frequency, agent-facing product guidance from the
+installed binary. It is for concepts and workflows an agent may need on demand
+inside a customer repository, without loading that guidance into every
+repository prompt, managed `AGENTS.md` block, or managed skill.
+
+Human maintainers do not need to learn the underlying config or topic details
+as their primary workflow. The intended interaction is:
+
+1. The human asks for an outcome.
+2. The agent runs `harness help` or `harness help <topic ...>` when the
+   easyharness product detail is unclear.
+3. The agent applies the change or uses the guidance.
+4. The agent reports the result back to the human.
+
+## Command Boundary
+
+`harness help` is topic documentation, not command syntax help.
+
+- `harness <command> --help` remains the surface for usage, flags, required
+  inputs, side effects, and short see-also pointers.
+- `harness help [topic ...]` prints plain-text product guidance for selected
+  topics.
+- `harness help --help` and `harness help -h` print syntax help for the help
+  command itself.
+- Help topics are concept-oriented. They are not required for every command
+  and should not become a mirror of the CLI command tree.
+
+## Output Contract
+
+Help topic output is plain text for agents and humans reading a terminal. It is
+not JSON and does not define a stable machine-readable schema.
+
+Topic text may use Markdown-like examples and code fences, but callers should
+treat the output as human-readable guidance rather than structured data.
+
+Unknown topics fail with a non-zero exit code and print a useful recovery list:
+
+- if the nearest valid parent has subtopics, print those subtopics
+- if the unknown path extends below a leaf, print the root available topics
+
+## Topic Assets and Registry
+
+Long-form help topic bodies live in packaged help assets under `assets/help/`,
+not in Go string literals and not under `assets/bootstrap/`.
+
+The program-owned help registry owns:
+
+- topic paths, such as `repo` or `repo config`
+- one-line topic summaries
+- asset bindings
+- parent/child relationships
+
+Every non-leaf topic prints an `Available subtopics` section generated from
+the registry. Markdown assets must not manually list available subtopics.
+
+## Managed Instructions Boundary
+
+Managed `AGENTS.md` blocks may tell agents that `harness help` exists and when
+to use it. They should not copy low-frequency topic content into the managed
+agreement.
+
+This keeps always-loaded instructions small while preserving a binary-shipped
+way for agents to discover product details in repositories that only installed
+`easyharness`.
+
+## Initial Topics
+
+The initial topic set is intentionally narrow:
+
+- `harness help repo`
+- `harness help repo config`
+
+`harness help repo config` is the agent-facing entrypoint for repo config
+customization. When a human asks for repo customization and the exact config
+shape is unclear, the agent should read that topic, apply the requested
+customization, verify effective values with `harness repo config get` or
+`harness repo config list`, and summarize the result back to the human.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -18,6 +18,9 @@
   field-extension rules.
 - [CLI Contract](./cli-contract.md): agent-facing command surface and JSON
   contract, including how the bootstrap commands fit into the overall CLI.
+- [Help Topics](./help.md): normative contract for plain-text
+  `harness help` topic guidance, including the command-help boundary,
+  asset-backed topic bodies, and generated subtopic discovery.
 - [Contract Registry](./contract.md): normative guide to the checked-in JSON
   Schema registry, its ownership model, the public-vs-runtime boundary, and
   what is intentionally not rendered as duplicated markdown.

--- a/docs/specs/repo-config.md
+++ b/docs/specs/repo-config.md
@@ -177,6 +177,25 @@ prints the same shape filtered to the `paths` prefix.
 These query commands are intentionally plain-text and script-friendly. This
 version does not define JSON output, source metadata, or config mutation.
 
+## Agent Help
+
+Agents can read the installed binary's repo config customization guide with:
+
+```bash
+harness help repo config
+```
+
+That help topic is the agent-facing entrypoint for customer repository
+customization. The intended interaction is that a human asks for an outcome,
+the agent reads the help topic when the config shape is unclear, edits
+`.harness/config.yaml`, verifies the effective values with
+`harness repo config get` or `harness repo config list`, and reports the result
+back to the human.
+
+The help topic is deliberately not installed into the managed `AGENTS.md`
+block or skill pack. It is low-frequency product guidance exposed on demand by
+the binary.
+
 ## Future Fields
 
 Future customization fields should keep `.harness/config.yaml` as a manifest

--- a/docs/specs/repo-config.md
+++ b/docs/specs/repo-config.md
@@ -192,9 +192,10 @@ the agent reads the help topic when the config shape is unclear, edits
 `harness repo config get` or `harness repo config list`, and reports the result
 back to the human.
 
-The help topic is deliberately not installed into the managed `AGENTS.md`
-block or skill pack. It is low-frequency product guidance exposed on demand by
-the binary.
+The low-frequency help topic body is deliberately not installed into the
+managed `AGENTS.md` block or skill pack. Managed instructions may point agents
+to `harness help`, but the detailed product guidance stays exposed on demand by
+the binary. The general help-topic rules live in [Help Topics](./help.md).
 
 ## Future Fields
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/catu-ai/easyharness/internal/contracts"
 	"github.com/catu-ai/easyharness/internal/dashboard"
 	"github.com/catu-ai/easyharness/internal/evidence"
+	"github.com/catu-ai/easyharness/internal/helptopics"
 	"github.com/catu-ai/easyharness/internal/install"
 	"github.com/catu-ai/easyharness/internal/lifecycle"
 	"github.com/catu-ai/easyharness/internal/plan"
@@ -94,7 +95,9 @@ func (a *App) Run(args []string) int {
 		return a.runDashboard(args[1:])
 	case "ui":
 		return a.runUI(args[1:])
-	case "-h", "--help", "help":
+	case "help":
+		return a.runHelp(args[1:])
+	case "-h", "--help":
 		a.printRootUsage()
 		return 0
 	default:
@@ -102,6 +105,19 @@ func (a *App) Run(args []string) int {
 		a.printRootUsage()
 		return 2
 	}
+}
+
+func (a *App) runHelp(args []string) int {
+	if err := helptopics.Render(a.Stdout, args); err != nil {
+		var unknown helptopics.UnknownTopicError
+		if errors.As(err, &unknown) {
+			helptopics.WriteUnknown(a.Stderr, unknown)
+			return 2
+		}
+		fmt.Fprintf(a.Stderr, "%v\n", err)
+		return 1
+	}
+	return 0
 }
 
 func (a *App) runVersion(args []string) int {
@@ -1424,6 +1440,7 @@ func (a *App) printRootUsage() {
 	fmt.Fprintln(a.Stderr, "  reopen          Restore the current archived plan")
 	fmt.Fprintln(a.Stderr, "  status          Summarize the current plan and local execution state")
 	fmt.Fprintln(a.Stderr, "  repo            Manage repo-level easyharness resources")
+	fmt.Fprintln(a.Stderr, "  help            Read agent-facing product guidance topics")
 	fmt.Fprintln(a.Stderr, "  dashboard       Start the local machine-local dashboard home")
 	fmt.Fprintln(a.Stderr, "  ui              Start the local read-only harness UI workbench")
 }
@@ -1478,6 +1495,9 @@ func (a *App) printRepoUsage() {
 	fmt.Fprintln(a.Stderr, "  skills        Manage easyharness-managed skill packages")
 	fmt.Fprintln(a.Stderr, "  instructions  Manage easyharness instruction files and managed blocks")
 	fmt.Fprintln(a.Stderr, "  config        Manage the .harness/config.yaml manifest")
+	fmt.Fprintln(a.Stderr)
+	fmt.Fprintln(a.Stderr, "See also:")
+	fmt.Fprintln(a.Stderr, "  harness help repo config")
 }
 
 func (a *App) printRepoSkillsUsage() {
@@ -1504,6 +1524,9 @@ func (a *App) printRepoConfigUsage() {
 	fmt.Fprintln(a.Stderr, "  refresh    Refresh .harness/config.yaml to the current canonical shape")
 	fmt.Fprintln(a.Stderr, "  get        Print one resolved scalar repo config value")
 	fmt.Fprintln(a.Stderr, "  list       Print resolved repo config leaf entries")
+	fmt.Fprintln(a.Stderr)
+	fmt.Fprintln(a.Stderr, "See also:")
+	fmt.Fprintln(a.Stderr, "  harness help repo config")
 }
 
 func (a *App) printLandUsage() {

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -108,6 +108,13 @@ func (a *App) Run(args []string) int {
 }
 
 func (a *App) runHelp(args []string) int {
+	if len(args) == 1 {
+		switch args[0] {
+		case "-h", "--help", "help":
+			a.printHelpUsage()
+			return 0
+		}
+	}
 	if err := helptopics.Render(a.Stdout, args); err != nil {
 		var unknown helptopics.UnknownTopicError
 		if errors.As(err, &unknown) {
@@ -1443,6 +1450,14 @@ func (a *App) printRootUsage() {
 	fmt.Fprintln(a.Stderr, "  help            Read agent-facing product guidance topics")
 	fmt.Fprintln(a.Stderr, "  dashboard       Start the local machine-local dashboard home")
 	fmt.Fprintln(a.Stderr, "  ui              Start the local read-only harness UI workbench")
+}
+
+func (a *App) printHelpUsage() {
+	fmt.Fprintln(a.Stderr, "Usage: harness help [topic ...]")
+	fmt.Fprintln(a.Stderr)
+	fmt.Fprintln(a.Stderr, "Print plain-text agent-facing product guidance topics.")
+	fmt.Fprintln(a.Stderr)
+	helptopics.Render(a.Stderr, nil)
 }
 
 func (a *App) printPlanUsage() {

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -313,6 +313,9 @@ func TestRootHelpMentionsVersionFlag(t *testing.T) {
 	if !strings.Contains(stderr.String(), "repo            Manage repo-level easyharness resources") {
 		t.Fatalf("expected root help to mention repo, got %q", stderr.String())
 	}
+	if !strings.Contains(stderr.String(), "help            Read agent-facing product guidance topics") {
+		t.Fatalf("expected root help to mention help topics, got %q", stderr.String())
+	}
 	if !strings.Contains(stderr.String(), "dashboard       Start the local machine-local dashboard home") {
 		t.Fatalf("expected root help to mention dashboard, got %q", stderr.String())
 	}
@@ -440,6 +443,26 @@ func TestHelpUnknownTopicShowsNearestAvailableTopics(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "Available subtopics:") || !strings.Contains(stderr.String(), "config") {
 		t.Fatalf("expected nearest subtopic recovery, got %q", stderr.String())
+	}
+}
+
+func TestHelpUnknownLeafChildShowsNearestAvailableTopics(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"help", "repo", "config", "missing"})
+	if exitCode == 0 {
+		t.Fatalf("expected unknown topic to fail, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout for unknown topic, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `unknown help topic "repo config missing"`) {
+		t.Fatalf("expected unknown topic message, got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Available topics:") || !strings.Contains(stderr.String(), "repo") {
+		t.Fatalf("expected nearest useful topics, got %q", stderr.String())
 	}
 }
 

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -344,6 +344,33 @@ func TestHelpRootListsTopicsAsPlainText(t *testing.T) {
 	}
 }
 
+func TestHelpCommandHelpExitsZero(t *testing.T) {
+	for _, args := range [][]string{
+		{"help", "--help"},
+		{"help", "-h"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			stdout := new(bytes.Buffer)
+			stderr := new(bytes.Buffer)
+			app := cli.New(stdout, stderr)
+
+			exitCode := app.Run(args)
+			if exitCode != 0 {
+				t.Fatalf("expected help usage exit code 0, got %d", exitCode)
+			}
+			if !strings.Contains(stderr.String(), "Usage: harness help [topic ...]") {
+				t.Fatalf("expected help command usage, got %q", stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "Available topics:") {
+				t.Fatalf("expected topic discovery hint, got %q", stderr.String())
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("expected no stdout for syntax help, got %q", stdout.String())
+			}
+		})
+	}
+}
+
 func TestHelpParentPrintsGeneratedSubtopics(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -321,6 +321,101 @@ func TestRootHelpMentionsVersionFlag(t *testing.T) {
 	}
 }
 
+func TestHelpRootListsTopicsAsPlainText(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"help"})
+	if exitCode != 0 {
+		t.Fatalf("expected help exit code 0, got %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Harness Help") || !strings.Contains(stdout.String(), "Available topics:") {
+		t.Fatalf("expected root help topic index, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "repo") {
+		t.Fatalf("expected root help to list repo topic, got %q", stdout.String())
+	}
+	if json.Valid(stdout.Bytes()) || strings.Contains(stdout.String(), `\"`) {
+		t.Fatalf("expected plain text help output, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr for help, got %q", stderr.String())
+	}
+}
+
+func TestHelpParentPrintsGeneratedSubtopics(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"help", "repo"})
+	if exitCode != 0 {
+		t.Fatalf("expected repo help exit code 0, got %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Repo Help") {
+		t.Fatalf("expected repo help body, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Available subtopics:") || !strings.Contains(stdout.String(), "config") {
+		t.Fatalf("expected generated repo subtopics, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr for repo help, got %q", stderr.String())
+	}
+}
+
+func TestHelpRepoConfigPrintsAgentGuide(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"help", "repo", "config"})
+	if exitCode != 0 {
+		t.Fatalf("expected repo config help exit code 0, got %d: %s", exitCode, stderr.String())
+	}
+	for _, want := range []string{
+		"Repo Config Customization",
+		"version: 1",
+		"harness repo config get paths.plans.active",
+		"harness repo config list",
+		".harness/review/dimensions",
+		"humans describe the outcome",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected repo config help to contain %q, got %q", want, stdout.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "Available subtopics:") {
+		t.Fatalf("expected leaf topic not to list subtopics, got %q", stdout.String())
+	}
+	if json.Valid(stdout.Bytes()) || strings.Contains(stdout.String(), `\"`) {
+		t.Fatalf("expected plain text repo config help, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr for repo config help, got %q", stderr.String())
+	}
+}
+
+func TestHelpUnknownTopicShowsNearestAvailableTopics(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"help", "repo", "missing"})
+	if exitCode == 0 {
+		t.Fatalf("expected unknown topic to fail, got stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout for unknown topic, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `unknown help topic "repo missing"`) {
+		t.Fatalf("expected unknown topic message, got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Available subtopics:") || !strings.Contains(stderr.String(), "config") {
+		t.Fatalf("expected nearest subtopic recovery, got %q", stderr.String())
+	}
+}
+
 func TestDashboardHelpExitsZero(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -808,6 +903,26 @@ func TestRepoSkillsHelpExitsZero(t *testing.T) {
 	}
 }
 
+func TestRepoHelpPointsToRepoConfigTopic(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"repo", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected help exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "Usage: harness repo") {
+		t.Fatalf("expected repo help text, got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "harness help repo config") {
+		t.Fatalf("expected repo help see-also, got %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout for repo help, got %q", stdout.String())
+	}
+}
+
 func TestRepoConfigHelpExitsZero(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
@@ -819,6 +934,9 @@ func TestRepoConfigHelpExitsZero(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "Usage: harness repo config") || !strings.Contains(stderr.String(), "refresh") {
 		t.Fatalf("expected config help text, got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "harness help repo config") {
+		t.Fatalf("expected repo config help see-also, got %q", stderr.String())
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("expected no stdout for config help, got %q", stdout.String())

--- a/internal/helptopics/topics.go
+++ b/internal/helptopics/topics.go
@@ -33,9 +33,10 @@ type node struct {
 }
 
 type UnknownTopicError struct {
-	Path      []string
-	Nearest   []string
-	Subtopics []Topic
+	Path         []string
+	Nearest      []string
+	Subtopics    []Topic
+	RootFallback bool
 }
 
 func (e UnknownTopicError) Error() string {
@@ -49,10 +50,17 @@ func Render(w io.Writer, path []string) error {
 	for i, segment := range path {
 		next := current.children[segment]
 		if next == nil {
+			subtopics := childTopics(current)
+			rootFallback := false
+			if len(subtopics) == 0 {
+				subtopics = childTopics(root)
+				rootFallback = true
+			}
 			return UnknownTopicError{
-				Path:      path,
-				Nearest:   nearest,
-				Subtopics: childTopics(current),
+				Path:         path,
+				Nearest:      nearest,
+				Subtopics:    subtopics,
+				RootFallback: rootFallback,
 			}
 		}
 		current = next
@@ -88,7 +96,7 @@ func WriteUnknown(w io.Writer, err UnknownTopicError) {
 	if len(err.Subtopics) == 0 {
 		return
 	}
-	if len(err.Nearest) == 0 {
+	if len(err.Nearest) == 0 || err.RootFallback {
 		writeTopicList(w, "Available topics:", err.Subtopics)
 		return
 	}

--- a/internal/helptopics/topics.go
+++ b/internal/helptopics/topics.go
@@ -1,0 +1,154 @@
+package helptopics
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	helpassets "github.com/catu-ai/easyharness/assets/help"
+)
+
+type Topic struct {
+	Path    []string
+	Summary string
+	Asset   string
+}
+
+var registry = []Topic{
+	{
+		Path:    []string{"repo"},
+		Summary: "Repository resources and customization guidance.",
+		Asset:   "repo.md",
+	},
+	{
+		Path:    []string{"repo", "config"},
+		Summary: "Customize .harness/config.yaml and repo-defined harness paths.",
+		Asset:   "repo/config.md",
+	},
+}
+
+type node struct {
+	topic    *Topic
+	children map[string]*node
+}
+
+type UnknownTopicError struct {
+	Path      []string
+	Nearest   []string
+	Subtopics []Topic
+}
+
+func (e UnknownTopicError) Error() string {
+	return fmt.Sprintf("unknown help topic %q", strings.Join(e.Path, " "))
+}
+
+func Render(w io.Writer, path []string) error {
+	root := buildTree()
+	current := root
+	var nearest []string
+	for i, segment := range path {
+		next := current.children[segment]
+		if next == nil {
+			return UnknownTopicError{
+				Path:      path,
+				Nearest:   nearest,
+				Subtopics: childTopics(current),
+			}
+		}
+		current = next
+		nearest = path[:i+1]
+	}
+
+	if len(path) == 0 {
+		fmt.Fprintln(w, "Harness Help")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Use `harness help <topic>` to read agent-facing product guidance.")
+		fmt.Fprintln(w)
+		writeTopicList(w, "Available topics:", childTopics(current))
+		return nil
+	}
+
+	if current.topic != nil && strings.TrimSpace(current.topic.Asset) != "" {
+		body, err := helpassets.Read(current.topic.Asset)
+		if err != nil {
+			return fmt.Errorf("read help topic %q: %w", strings.Join(path, " "), err)
+		}
+		fmt.Fprint(w, body)
+	}
+	children := childTopics(current)
+	if len(children) > 0 {
+		fmt.Fprintln(w)
+		writeTopicList(w, "Available subtopics:", children)
+	}
+	return nil
+}
+
+func WriteUnknown(w io.Writer, err UnknownTopicError) {
+	fmt.Fprintf(w, "%s\n\n", err.Error())
+	if len(err.Subtopics) == 0 {
+		return
+	}
+	if len(err.Nearest) == 0 {
+		writeTopicList(w, "Available topics:", err.Subtopics)
+		return
+	}
+	writeTopicList(w, "Available subtopics:", err.Subtopics)
+}
+
+func buildTree() *node {
+	root := &node{children: map[string]*node{}}
+	for i := range registry {
+		topic := &registry[i]
+		current := root
+		for _, segment := range topic.Path {
+			if current.children == nil {
+				current.children = map[string]*node{}
+			}
+			if current.children[segment] == nil {
+				current.children[segment] = &node{children: map[string]*node{}}
+			}
+			current = current.children[segment]
+		}
+		current.topic = topic
+	}
+	return root
+}
+
+func childTopics(parent *node) []Topic {
+	if parent == nil || len(parent.children) == 0 {
+		return nil
+	}
+	topics := make([]Topic, 0, len(parent.children))
+	for name, child := range parent.children {
+		if child.topic != nil {
+			topics = append(topics, *child.topic)
+			continue
+		}
+		topics = append(topics, Topic{Path: []string{name}})
+	}
+	sortTopics(topics)
+	return topics
+}
+
+func sortTopics(topics []Topic) {
+	for i := 1; i < len(topics); i++ {
+		for j := i; j > 0 && topicKey(topics[j]) < topicKey(topics[j-1]); j-- {
+			topics[j], topics[j-1] = topics[j-1], topics[j]
+		}
+	}
+}
+
+func topicKey(topic Topic) string {
+	return strings.Join(topic.Path, " ")
+}
+
+func writeTopicList(w io.Writer, title string, topics []Topic) {
+	if len(topics) == 0 {
+		return
+	}
+	fmt.Fprintln(w, title)
+	for _, topic := range topics {
+		name := topic.Path[len(topic.Path)-1]
+		fmt.Fprintf(w, "  %-8s %s\n", name, topic.Summary)
+	}
+}

--- a/internal/helptopics/topics_test.go
+++ b/internal/helptopics/topics_test.go
@@ -1,0 +1,50 @@
+package helptopics
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	helpassets "github.com/catu-ai/easyharness/assets/help"
+)
+
+func TestRenderParentAddsGeneratedSubtopicsOutsideAssetBody(t *testing.T) {
+	body, err := helpassets.Read("repo.md")
+	if err != nil {
+		t.Fatalf("read asset: %v", err)
+	}
+	if strings.Contains(body, "Available subtopics:") || strings.Contains(body, "config    Customize") {
+		t.Fatalf("repo help asset should not duplicate generated subtopics:\n%s", body)
+	}
+
+	var out bytes.Buffer
+	if err := Render(&out, []string{"repo"}); err != nil {
+		t.Fatalf("render repo help: %v", err)
+	}
+	if !strings.Contains(out.String(), "Repo Help") {
+		t.Fatalf("expected repo body, got:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "Available subtopics:") || !strings.Contains(out.String(), "config") {
+		t.Fatalf("expected generated subtopics, got:\n%s", out.String())
+	}
+}
+
+func TestUnknownTopicReportsNearestSubtopics(t *testing.T) {
+	var out bytes.Buffer
+	err := Render(&out, []string{"repo", "missing"})
+	if err == nil {
+		t.Fatalf("expected unknown topic error")
+	}
+
+	var unknown UnknownTopicError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("expected UnknownTopicError, got %T %[1]v", err)
+	}
+	if got := strings.Join(unknown.Nearest, " "); got != "repo" {
+		t.Fatalf("nearest = %q, want repo", got)
+	}
+	if len(unknown.Subtopics) != 1 || strings.Join(unknown.Subtopics[0].Path, " ") != "repo config" {
+		t.Fatalf("unexpected subtopics: %#v", unknown.Subtopics)
+	}
+}

--- a/internal/helptopics/topics_test.go
+++ b/internal/helptopics/topics_test.go
@@ -48,3 +48,25 @@ func TestUnknownTopicReportsNearestSubtopics(t *testing.T) {
 		t.Fatalf("unexpected subtopics: %#v", unknown.Subtopics)
 	}
 }
+
+func TestUnknownLeafChildFallsBackToRootTopics(t *testing.T) {
+	var out bytes.Buffer
+	err := Render(&out, []string{"repo", "config", "missing"})
+	if err == nil {
+		t.Fatalf("expected unknown topic error")
+	}
+
+	var unknown UnknownTopicError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("expected UnknownTopicError, got %T %[1]v", err)
+	}
+	if got := strings.Join(unknown.Nearest, " "); got != "repo config" {
+		t.Fatalf("nearest = %q, want repo config", got)
+	}
+	if !unknown.RootFallback {
+		t.Fatalf("expected root fallback for leaf child")
+	}
+	if len(unknown.Subtopics) != 1 || strings.Join(unknown.Subtopics[0].Path, " ") != "repo" {
+		t.Fatalf("unexpected fallback topics: %#v", unknown.Subtopics)
+	}
+}


### PR DESCRIPTION
## What Changed

- Added a minimal plain-text `harness help` topic surface with `harness help`, `harness help repo`, and `harness help repo config`.
- Added packaged help assets under `assets/help/` and a program-owned topic registry that generates non-leaf subtopic lists.
- Kept command `--help` as syntax help while adding see-also pointers from `harness repo --help` and `harness repo config --help`.
- Added standalone `docs/specs/help.md` as the normative help-topic contract, with CLI and repo-config specs linking to it instead of duplicating the rules.
- Added a bootstrap-managed `AGENTS.md` cue telling agents to use `harness help` when easyharness behavior or repo customization syntax is unclear, then apply the guidance and report the effective result back to the human.
- Tracked broader help-system design in #254.

## Confidence

- Bootstrap-managed output is in sync: `scripts/sync-bootstrap-assets --check`.
- Focused Go tests pass for CLI/help/bootstrap/install surfaces: `go test -count=1 ./internal/bootstrapsync ./internal/install ./internal/cli ./internal/helptopics`.
- Bootstrap sync smoke coverage passes: `go test -count=1 ./tests/smoke -run TestSyncBootstrapAssetsCheckPassesForCurrentRepo`.
- Earlier focused help behavior checks passed for root/parent/leaf help, command syntax help, see-also text, and unknown-topic recovery.
- Finalize review `review-004-full` passed with no findings for revision 1; revision 2 delta finalize review `review-005-delta` passed with no findings; revision 3 delta finalize review `review-006-delta` passed with no findings across docs-consistency and agent-UX.

A broader `go test ./...` run was attempted earlier and reached core packages, e2e, and resilience successfully, then was interrupted while `tests/smoke` stayed quiet. This PR does not claim a clean full-suite pass.
