### PR TITLE
Speed up smoke validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,5 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Build embedded UI assets
-        run: scripts/build-embedded-ui
-
-      - name: Run tests
-        run: go test ./...
+      - name: Run development validation
+        run: scripts/validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,15 +90,11 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Build embedded UI assets
-        working-directory: dist/release-source
-        run: scripts/build-embedded-ui
-
-      - name: Run tests
+      - name: Run publish validation
         env:
           EASYHARNESS_HOMEBREW_TAP_TOKEN: ""
         working-directory: dist/release-source
-        run: go test ./...
+        run: scripts/validate
 
       - name: Build release artifacts
         run: dist/release-source/scripts/build-release --version "${{ steps.release-version.outputs.version }}" --output-dir dist/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
           EASYHARNESS_LIVE_GH_REPO: ${{ github.repository }}
           EASYHARNESS_LIVE_GH_TAG: ${{ steps.release-version.outputs.version }}
           EASYHARNESS_LIVE_GH_ASSET: easyharness_${{ steps.release-version.outputs.version }}_linux_amd64.zip
-        run: go test ./tests/smoke -run TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled -count=1
+        run: go test ./tests/release -run TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled -count=1
 
       - name: Render Homebrew formula
         run: |
@@ -207,4 +207,4 @@ jobs:
         env:
           EASYHARNESS_LIVE_GH_REPO: ${{ github.repository }}
           EASYHARNESS_LIVE_GH_TAG: ${{ steps.release-version.outputs.version }}
-        run: go test ./tests/smoke -run TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled -count=1
+        run: go test ./tests/release -run TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled -count=1

--- a/docs/development.md
+++ b/docs/development.md
@@ -69,6 +69,28 @@ Repo-level UI development also expects `pnpm` to be available locally. If it
 is missing, install Node.js and pnpm before rerunning the embedded UI build or
 development installer.
 
+## Go Validation
+
+For routine local validation, build the embedded UI assets and run the default
+Go suite:
+
+```bash
+scripts/build-embedded-ui
+go test ./...
+```
+
+The default `go test ./...` path includes package tests, quick smoke coverage,
+release script/namespace checks, E2E tests, and resilience tests. It does not
+run the cold installer or release-archive smoke tests that are tagged as slow.
+
+Run the explicit slow smoke path when changing installer behavior, release
+archive construction, wrapper PATH behavior, or when preparing a release that
+needs packaging confidence beyond the default suite:
+
+```bash
+go test -tags slow_smoke ./tests/installer ./tests/release -count=1
+```
+
 ## UI Development
 
 When changing the embedded UI shell under `web/`, rebuild the production UI

--- a/docs/development.md
+++ b/docs/development.md
@@ -69,27 +69,28 @@ Repo-level UI development also expects `pnpm` to be available locally. If it
 is missing, install Node.js and pnpm before rerunning the embedded UI build or
 development installer.
 
-## Go Validation
+## Validation
 
-For routine local validation, build the embedded UI assets and run the default
-Go suite:
-
-```bash
-scripts/build-embedded-ui
-go test ./...
-```
-
-The default `go test ./...` path includes package tests, quick smoke coverage,
-release script/namespace checks, E2E tests, and resilience tests. It does not
-run the cold installer or release-archive smoke tests that are tagged as slow.
-
-Run the explicit slow smoke path when changing installer behavior, release
-archive construction, wrapper PATH behavior, or when preparing a release that
-needs packaging confidence beyond the default suite:
+For routine local development validation, run:
 
 ```bash
-go test -tags slow_smoke ./tests/installer ./tests/release -count=1
+scripts/validate
 ```
+
+That profile builds the embedded UI assets and then runs the default Go suite:
+package tests, ordinary smoke coverage, release script/namespace checks, E2E
+tests, and resilience tests. It does not run installer or release archive
+smoke tests that require explicit release-readiness coverage.
+
+For release-ready validation, including `VERSION` PRs and any release PR before
+merge, run:
+
+```bash
+scripts/validate-release
+```
+
+That profile includes ordinary development validation and then runs the
+purpose-tagged installer and release archive smoke suites.
 
 ## UI Development
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -85,7 +85,7 @@ for about 419.75s.
 
 ### Step 1: Define and Implement the Validation Split
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -147,7 +147,8 @@ the slow installer package or tagged release archive tests.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` passed on 2026-06-19 with `correctness` and `tests`
+reviewer slots. Both reviewers reported no findings.
 
 ### Step 2: Add Command Timeouts and Reduce Repeated Cold Work
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -259,7 +259,23 @@ or release-only command instead of hiding the cost inside `go test ./...`.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Updated durable validation docs in `docs/development.md`, `docs/releasing.md`,
+and `docs/specs/proposals/testing-structure.md` to describe the quick default
+path and the explicit slow smoke command:
+`go test -tags slow_smoke ./tests/installer ./tests/release -count=1`.
+
+The first full documented slow-smoke attempt exposed that installer tests were
+forcing a temporary empty `GOMODCACHE`, which made parallel cold installs depend
+on fresh network downloads and hit Go proxy TLS timeouts. Repaired this by
+leaving `GOMODCACHE` on the normal warmed default unless a test explicitly
+overrides it.
+
+Validation: doc/workflow smoke tests passed with
+`go test ./tests/smoke ./tests/release -run 'TestReleaseDocsPresentStableOnboardingSurface|TestCIWorkflowBuildsEmbeddedUIBeforeGoTests|TestReleaseWorkflowWiresHomebrewTapPublishing' -count=1`.
+The full documented slow path passed in about 3:01.16:
+`go test -tags slow_smoke ./tests/installer ./tests/release -count=1`
+reported `tests/installer` at 180.956s and `tests/release` at 92.849s.
+Focused quick validation passed with `go test ./tests/smoke ./tests/release ./tests/support`.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -1,0 +1,296 @@
+---
+template_version: 0.2.0
+created_at: "2026-06-18T23:54:11+08:00"
+approved_at: "2026-06-18T23:56:10+08:00"
+source_type: issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/257
+size: M
+---
+
+# Speed Up Smoke Validation
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Make routine validation fast and predictable again by separating quick
+package-local tests from slower binary-driven smoke coverage, while keeping the
+full installer and release confidence checks available on an explicit path.
+
+Issue 257 was opened because `tests/smoke` dominated `go test ./...` during
+release validation and could exceed Go's default 10 minute package timeout.
+Discovery on 2026-06-18 confirmed the problem still exists: a partial
+`go test -json -count=1 -timeout=20m ./tests/smoke` run was stopped after
+completed tests had already accumulated 430.24s, and the release-build smoke
+tests had not started yet. The five completed installer tests alone accounted
+for about 419.75s.
+
+## Scope
+
+### In Scope
+
+- Split the current smoke coverage into an explicit quick/default validation
+  path and one or more slow opt-in smoke paths for installer and release
+  workflows.
+- Keep important installer, wrapper PATH, release archive, and live release
+  workflow coverage, but make slow cold-path tests intentional rather than an
+  accidental part of every quick validation run.
+- Add focused subprocess timeouts to smoke/support helpers so a stuck command
+  fails with a useful command-level diagnostic.
+- Reduce repeated cold `scripts/install-dev-harness` work where coverage can be
+  preserved with lighter fixtures, shared setup, or narrower tests.
+- Update CI, release workflow, and docs so agents and humans know which command
+  is the ordinary quick validation path and which command runs full slow smoke
+  coverage.
+
+### Out of Scope
+
+- Changing `harness` product behavior outside what is necessary to keep tests
+  passing after the validation split.
+- Preserving old command shapes or compatibility aliases for any test scripts
+  introduced by this work.
+- Removing installer or release smoke coverage merely to make validation look
+  faster.
+- Reworking unrelated Playwright UI smoke scripts except where docs need to
+  describe the overall validation split accurately.
+
+## Acceptance Criteria
+
+- [ ] The ordinary quick validation command no longer runs the full cold
+      installer and release smoke suite by accident.
+- [ ] Full slow smoke coverage remains available through an explicit command or
+      documented command set.
+- [ ] `go test ./...` or its documented replacement no longer requires raising
+      the package timeout just to get past the old monolithic `tests/smoke`
+      package.
+- [ ] Smoke subprocess failures identify the specific slow or stuck command
+      instead of surfacing only as a Go package-level timeout.
+- [ ] CI and release workflow validation match the documented quick/full split.
+- [ ] Documentation no longer describes the current full `tests/smoke` package
+      as fast repo-level smoke coverage unless the implementation makes that
+      true again.
+
+## Deferred Items
+
+- Broader test taxonomy changes beyond issue 257, such as adding a complete
+  end-to-end or resilience suite, remain deferred unless they are the smallest
+  clean way to express this validation split.
+
+## Work Breakdown
+
+### Step 1: Define and Implement the Validation Split
+
+- Done: [ ]
+
+#### Objective
+
+Separate quick smoke/default validation from slow installer and release smoke
+coverage in code and command structure.
+
+#### Details
+
+Use a clean target shape rather than compatibility shims. The exact mechanics
+can be chosen during execution, but the preferred shape is:
+
+- keep fast package-local and lightweight smoke coverage in the default path;
+- move cold installer and release archive checks into clearly named slow smoke
+  packages or build-tagged suites;
+- update any workflow references that currently assume live release smoke tests
+  live under `./tests/smoke`;
+- avoid leaving a monolithic package where unrelated smoke tests block each
+  other from package-level parallelism.
+
+The resulting commands should be understandable from the repository alone. If a
+new script such as `scripts/test-quick` or `scripts/test-smoke` is introduced,
+it should be short, explicit, and tested or smoke-checked where practical.
+
+#### Expected Files
+
+- `tests/smoke/**`
+- `tests/installer/**`
+- `tests/release/**`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `scripts/test-*` if scripts are the cleanest command surface
+
+#### Validation
+
+- Run the new quick validation command and confirm it excludes the slow cold
+  installer/release path.
+- Run focused moved-package tests or build-tagged suites to confirm the
+  preserved smoke coverage still executes.
+- Use `go test -list` or the equivalent command output to verify workflow test
+  references still point at real tests.
+
+#### Execution Notes
+
+Implemented the first validation split. Cold installer smoke moved from
+`tests/smoke` to `tests/installer` behind `//go:build slow_smoke`; release
+script/namespace/Homebrew smoke moved to `tests/release`, and release archive
+construction moved behind `slow_smoke` inside that package. Shared command,
+fixture, PATH, version-field, and ordering helpers were promoted into
+`tests/support` so quick smoke, release smoke, and opt-in installer smoke no
+longer depend on one monolithic package.
+
+Updated release workflow live smoke invocations to run the moved release tests
+from `./tests/release`. Validation:
+`go test -list . ./tests/smoke ./tests/release`,
+`go test -tags slow_smoke -list . ./tests/installer ./tests/release`,
+`go test ./tests/smoke ./tests/release`, and `go test ./...` all pass. The
+default `go test ./...` run completed in about 1:07.51 and no longer executed
+the slow installer package or tagged release archive tests.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Add Command Timeouts and Reduce Repeated Cold Work
+
+- Done: [ ]
+
+#### Objective
+
+Make smoke helpers fail at the command boundary when subprocesses hang, and
+reduce avoidable repeated cold installer cost without weakening coverage.
+
+#### Details
+
+The current `tests/support.Run` helper uses `exec.Command` without a context,
+and many smoke tests use direct `exec.Command` calls. Introduce a small,
+consistent timeout mechanism for harness subprocesses and the slow smoke
+helpers. Keep timeout values generous enough for real release/installer work,
+but short enough that a stuck command points at the offending command.
+
+Installer smoke should keep at least one true cold `scripts/install-dev-harness`
+end-to-end check. Other wrapper PATH behavior tests should avoid rebuilding the
+embedded UI and Go binary repeatedly when the same confidence can be achieved
+with a prepared binary, a shared fixture, or a smaller wrapper fixture.
+
+#### Expected Files
+
+- `tests/support/run.go`
+- `tests/support/binary.go`
+- `tests/smoke/**`
+- `tests/installer/**`
+- `tests/release/**`
+- `scripts/install-dev-harness` only if a tiny test-only-neutral improvement is
+  needed to make the split clean
+
+#### Validation
+
+- Add or update focused tests that prove timeout diagnostics include the command
+  and captured output when a subprocess exceeds its timeout.
+- Run the installer-focused slow smoke command and compare elapsed time against
+  the issue 257 baseline enough to show repeated cold work was reduced.
+- Confirm at least one cold installer path still runs `scripts/install-dev-harness`
+  end to end.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Update Documentation, Workflows, and Evidence
+
+- Done: [ ]
+
+#### Objective
+
+Make the new validation contract durable in CI, release workflow, and docs, and
+record evidence that issue 257's failure mode is addressed.
+
+#### Details
+
+Update docs that currently imply `go test ./tests/smoke -count=1` is fast
+repo-level smoke coverage if that is no longer the command shape. The release
+checklist should tell maintainers which quick validation to run before merge
+and when to run the full slow smoke path.
+
+The CI and release workflows should follow the same split. If full slow smoke
+is too expensive for every PR, keep that explicit and leave a documented manual
+or release-only command instead of hiding the cost inside `go test ./...`.
+
+#### Expected Files
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `docs/releasing.md`
+- `docs/development.md`
+- `docs/specs/proposals/testing-structure.md`
+- `docs/plans/active/2026-06-18-speed-up-smoke-validation.md`
+
+#### Validation
+
+- Run the documented quick validation command.
+- Run the documented slow smoke command or a focused representative subset if
+  the full slow command remains intentionally long.
+- Run `harness plan lint docs/plans/active/2026-06-18-speed-up-smoke-validation.md`.
+- Record elapsed-time evidence in this plan before archive.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Use `go test -list` before and after the split to confirm tests moved into
+  the intended command surfaces.
+- Run quick validation with elapsed-time output and confirm it avoids the old
+  monolithic smoke timeout risk.
+- Run the slow smoke command or focused slow suites to prove installer and
+  release confidence checks still exist.
+- Run workflow/documentation checks as plain file inspection plus relevant Go
+  smoke tests that assert workflow wiring where such tests already exist.
+
+## Risks
+
+- Risk: The split could make important installer or release coverage less
+  visible.
+  - Mitigation: Keep explicit slow smoke commands and update CI/release docs so
+    the coverage is opt-in by design, not forgotten.
+- Risk: Reducing repeated installer work could accidentally stop testing the
+  real cold install path.
+  - Mitigation: Preserve at least one true cold installer smoke and convert only
+    narrower wrapper behavior checks to lighter fixtures.
+- Risk: New timeout values could be too aggressive on slower machines.
+  - Mitigation: Choose conservative defaults, include useful diagnostics, and
+    allow only intentional opt-in overrides if the repository already has a
+    clear pattern for that.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -193,7 +193,24 @@ with a prepared binary, a shared fixture, or a smaller wrapper fixture.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added default command-level timeouts to `tests/support.Run`,
+`tests/support.RunWithOptions`, and the generic smoke command helpers. Timeout
+failures now include the command plus captured stdout/stderr, and
+`tests/support` has a self-spawning regression test that proves the diagnostic
+includes timeout text and child process output.
+
+Removed global test environment mutation from installer cache setup and marked
+the opt-in installer tests parallel. The full installer slow-smoke package now
+passes with `go test -tags slow_smoke ./tests/installer -count=1` in about
+3:29.01. That keeps a true cold `scripts/install-dev-harness` path while
+materially reducing wall-clock time from the earlier serial baseline, where the
+first five installer tests alone had already accumulated roughly 7 minutes.
+
+Validation: `go test ./tests/support ./tests/smoke ./tests/release`,
+`go test -tags slow_smoke ./tests/release -run TestBuildReleaseHelpUsesStableExampleVersion -count=1`,
+`go test -tags slow_smoke ./tests/installer -count=1`, and `go test ./...`
+all pass. The final default `go test ./...` run completed in about 1:30.78
+with `tests/e2e` uncached.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -471,14 +471,18 @@ reviewer slots reporting no findings.
 ## Validation Summary
 
 Ordinary development validation is now `scripts/validate`, which builds
-embedded UI assets and runs `go test ./...`. It passed locally after Step 4.
+embedded UI assets and runs `go test ./...`. It passed locally after Step 4,
+and after the finalize repair it also passed when invoked from `docs/` as
+`../scripts/validate`, proving the profile anchors Go tests to the repository
+root instead of the caller directory.
 
 Full release-ready validation is now `scripts/validate-release`, which runs
 `scripts/validate` and then the purpose-tagged installer and release archive
-smoke suites. It passed locally after Step 4; the installer profile ran with
-`go test -tags installer_smoke ./tests/installer -count=1` in 250.429s, and
-the release archive profile ran with
-`go test -tags release_smoke ./tests/release -count=1` in 66.450s.
+smoke suites. It passed locally after Step 4, and again after the finalize
+repair with warmed installer Corepack/pnpm caches; the latest installer
+profile ran with `go test -tags installer_smoke ./tests/installer -count=1`
+in 182.964s, and the latest release archive profile ran with
+`go test -tags release_smoke ./tests/release -count=1` in 113.788s.
 
 Focused validation also passed:
 `go test -list . ./tests/smoke ./tests/release`,
@@ -486,6 +490,10 @@ Focused validation also passed:
 `go test -tags release_smoke -list . ./tests/release`,
 `go test ./tests/smoke ./tests/release -count=1`, and
 `harness plan lint docs/plans/active/2026-06-18-speed-up-smoke-validation.md`.
+Finalize repair validation also covered
+`go test ./tests/smoke -run 'TestSyncContractArtifactsCheckFailsOnStaleGeneratedFiles|TestSyncContractArtifactsCheckFailsOnDeprecatedGeneratedDocs|TestValidationScriptsDefineDevelopmentAndReleaseProfiles|TestValidationProfileTagsSelectReleaseReadySmokeTests|TestCIWorkflowUsesDevelopmentValidationProfile' -count=1`,
+`go test ./tests/support -count=1`, and
+`go test -tags installer_smoke ./tests/installer -run 'TestInstallDevHarnessWrapperSkipsOtherManagedWrappersOnPathOutsideWorktree' -count=1`.
 Timeout regression tests still cover the command helper repairs from revision
 1, and the current profile tests prove the user-facing scripts plus functional
 build tags select the intended release-ready smoke tests.
@@ -512,19 +520,27 @@ tests did not prove the functional build tags selected the intended tests.
 Both were repaired in the active plan and smoke test coverage before follow-up
 review.
 
+Finalize review `review-018-full` found three archive-blocking issues and one
+duplicate non-blocking issue: the validation scripts ran Go tests from the
+caller directory instead of the repository root, installer smoke could still
+fall through to a live Corepack/pnpm download from temporary homes, and the
+Archive Summary still said the Step 4 repair review was pending. The repairs
+anchor validation scripts to `repo_root`, share warmed installer Corepack and
+pnpm caches, and update the archive handoff text before follow-up review.
+
 ## Archive Summary
 
 - Archived At: PENDING_ARCHIVE
 - Revision: 2
-Ready for archive once the Step 4 follow-up review and finalize review pass.
+Ready for archive once the finalize repair review passes.
 The active plan contains checked acceptance criteria, completed tracked steps
-through Step 4 implementation, validation evidence, review history, and no
-deferred follow-up issue requirement beyond the existing broader test-taxonomy
-deferral. No supplements were used.
+through Step 4, validation evidence, review history through
+`review-018-full`, and no deferred follow-up issue requirement beyond the
+existing broader test-taxonomy deferral. No supplements were used.
 
 - PR: NONE
-- Ready: Pending Step 4 repair review, finalize review, archive, publish/CI,
-  and sync evidence.
+- Ready: Pending finalize repair review, archive, publish/CI, and sync
+  evidence.
 - Merge Handoff: After archive, update PR #259 for issue 257, record
   publish/CI/sync evidence, and wait for explicit human merge approval.
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -99,15 +99,15 @@ validation.
 - [x] Documentation no longer describes the current full `tests/smoke` package
       as fast repo-level smoke coverage unless the implementation makes that
       true again.
-- [ ] User-facing validation commands are named by purpose rather than runtime,
+- [x] User-facing validation commands are named by purpose rather than runtime,
       with an ordinary development profile and a full release-ready profile.
-- [ ] Opt-in installer and release test tags use functional names instead of
+- [x] Opt-in installer and release test tags use functional names instead of
       `slow_smoke`.
-- [ ] `VERSION` and release PR documentation requires the full release-ready
+- [x] `VERSION` and release PR documentation requires the full release-ready
       validation profile before merge.
-- [ ] The release workflow is documented as post-merge publish validation, not
+- [x] The release workflow is documented as post-merge publish validation, not
       as a substitute for release-ready PR validation.
-- [ ] CI, docs, and tests avoid relying on an agent or maintainer's subjective
+- [x] CI, docs, and tests avoid relying on an agent or maintainer's subjective
       judgment that a release-adjacent change is "small".
 
 ## Deferred Items
@@ -406,7 +406,26 @@ profile.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added purpose-named validation entrypoints. `scripts/validate` now owns the
+ordinary development profile by building embedded UI assets and running
+`go test ./...`; CI invokes that script directly. `scripts/validate-release`
+includes `scripts/validate`, then runs installer smoke with
+`installer_smoke` and release archive smoke with `release_smoke`.
+
+Renamed the opt-in build tags from duration language to functional meaning and
+updated release/development docs plus workflow smoke assertions. `VERSION` and
+release PR guidance now requires `scripts/validate-release` before merge, and
+the post-merge Release workflow is described as publish validation from the
+packaged source tree rather than a substitute for PR validation.
+
+Validation passed:
+`go test -list . ./tests/smoke ./tests/release`;
+`go test -tags installer_smoke -list . ./tests/installer`;
+`go test -tags release_smoke -list . ./tests/release`;
+`go test ./tests/smoke ./tests/release -count=1`;
+`scripts/validate`; and `scripts/validate-release`. The release-ready profile
+ran installer smoke in 250.429s and release archive smoke in 66.450s after the
+ordinary development validation portion passed.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -463,33 +463,27 @@ PENDING_STEP_REVIEW
 
 ## Validation Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
+Ordinary development validation is now `scripts/validate`, which builds
+embedded UI assets and runs `go test ./...`. It passed locally after Step 4.
 
-Quick/default validation is split from slow smoke coverage. The documented
-quick path, `scripts/build-embedded-ui` plus `go test ./...`, passed after the
-split and again after finalize repairs. The latest `go test ./...` run passed
-with default packages, including `tests/e2e` at 68.486s, `tests/smoke` at
-13.938s, and default `tests/release` at 2.391s.
+Full release-ready validation is now `scripts/validate-release`, which runs
+`scripts/validate` and then the purpose-tagged installer and release archive
+smoke suites. It passed locally after Step 4; the installer profile ran with
+`go test -tags installer_smoke ./tests/installer -count=1` in 250.429s, and
+the release archive profile ran with
+`go test -tags release_smoke ./tests/release -count=1` in 66.450s.
 
-Explicit slow smoke coverage remains available with
-`go test -tags slow_smoke ./tests/installer ./tests/release -count=1`. The
-latest full slow run passed with `tests/installer` at 157.887s and
-`tests/release` at 90.183s. Earlier slow runs also proved the release archive
-path after timeout repairs.
-
-Focused validation covered the repaired timeout surfaces:
-`go test ./tests/support ./tests/smoke`,
-`go test ./tests/smoke -run 'TestSyncBootstrapAssetsCheckPassesForCurrentRepo|TestSyncContractArtifacts' -count=1`,
-`go test ./tests/release`, and
-`go test -tags slow_smoke ./tests/release -count=1` all passed. Timeout
-regression tests cover both generic command helpers and harness command
-helpers, and default smoke, release archive, live release, git, gh, tar,
-downloaded/installed harness, and build-binary setup subprocesses now use
-timeout-aware helpers or contexts.
+Focused validation also passed:
+`go test -list . ./tests/smoke ./tests/release`,
+`go test -tags installer_smoke -list . ./tests/installer`,
+`go test -tags release_smoke -list . ./tests/release`,
+`go test ./tests/smoke ./tests/release -count=1`, and
+`harness plan lint docs/plans/active/2026-06-18-speed-up-smoke-validation.md`.
+Timeout regression tests still cover the command helper repairs from revision
+1, and the current profile tests prove the user-facing scripts plus functional
+build tags select the intended release-ready smoke tests.
 
 ## Review Summary
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 Step reviews passed after targeted repairs:
 `review-001-delta` passed the validation split, `review-003-delta` passed the
@@ -504,51 +498,55 @@ subprocesses plus installer slow-smoke repeatability. The final full review
 round, `review-015-full`, passed with correctness, tests, docs-consistency,
 and risk-scan slots reporting no findings.
 
+After revision 2 reopened the plan for the purpose-named validation profile
+repair, Step 4 review `review-016-delta` found two blocking issues: closeout
+summaries still described the old duration-oriented contract, and automated
+tests did not prove the functional build tags selected the intended tests.
+Both were repaired in the active plan and smoke test coverage before follow-up
+review.
+
 ## Archive Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
-- Archived At: 2026-06-19T01:37:41+08:00
-- Revision: 1
-Ready for archive once the final post-repair review passes. The active plan
-contains checked acceptance criteria, completed tracked steps, validation
-evidence, review history, and no deferred follow-up issue requirement beyond
-the existing broader test-taxonomy deferral. No supplements were used.
+- Archived At: PENDING_ARCHIVE
+- Revision: 2
+Ready for archive once the Step 4 follow-up review and finalize review pass.
+The active plan contains checked acceptance criteria, completed tracked steps
+through Step 4 implementation, validation evidence, review history, and no
+deferred follow-up issue requirement beyond the existing broader test-taxonomy
+deferral. No supplements were used.
 
 - PR: NONE
-- Ready: All tracked steps are complete, acceptance criteria are checked, quick
-  and slow validation pass, and final full review passed with no findings.
-- Merge Handoff: After archive, publish this branch as a PR for issue 257,
-  record publish/CI/sync evidence, and wait for explicit human merge approval.
+- Ready: Pending Step 4 repair review, finalize review, archive, publish/CI,
+  and sync evidence.
+- Merge Handoff: After archive, update PR #259 for issue 257, record
+  publish/CI/sync evidence, and wait for explicit human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
-- Default validation no longer runs the cold installer and release archive
-  smoke suite by accident.
-- Slow installer and release coverage moved behind the explicit
-  `slow_smoke` command while release workflow live smoke references point at
-  the moved release package.
+- Ordinary development validation no longer runs installer and release archive
+  smoke coverage by accident.
+- User-facing validation commands are now named by purpose:
+  `scripts/validate` for daily development and `scripts/validate-release` for
+  full release-ready validation.
+- Installer and release archive smoke coverage moved behind functional build
+  tags, `installer_smoke` and `release_smoke`, invoked by
+  `scripts/validate-release`.
 - Smoke command helpers gained conservative command-level timeouts with
   captured stdout/stderr diagnostics.
 - Installer smoke tests now run in parallel with shared setup and warmed
   dependencies, while preserving real `scripts/install-dev-harness` coverage.
-- Documentation now describes the quick/default and explicit slow validation
-  paths in development, release, and testing-structure docs.
+- Documentation now requires `scripts/validate-release` for `VERSION` and
+  release PRs before merge, and describes the post-merge Release workflow as
+  publish validation rather than a substitute for release-ready PR validation.
 
 ### Not Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 No product behavior changes were delivered outside the validation split. A
 broader end-to-end test taxonomy remains outside this issue slice.
 
 ### Follow-Up Issues
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - https://github.com/catu-ai/easyharness/issues/258 tracks the broader
   validation taxonomy work that remains outside issue 257.

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -152,7 +152,7 @@ reviewer slots. Both reviewers reported no findings.
 
 ### Step 2: Add Command Timeouts and Reduce Repeated Cold Work
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -214,7 +214,11 @@ with `tests/e2e` uncached.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-002-delta` found one blocking tests issue and one minor tests issue:
+the timeout regression covered `RunCommandWithTimeout` but not
+`RunWithOptions`, and the nested timeout used `50ms`. Repaired both by adding a
+`RunWithOptions` timeout regression and increasing the nested timeout to
+`500ms`. Follow-up `review-003-delta` passed with no findings.
 
 ### Step 3: Update Documentation, Workflows, and Evidence
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -332,7 +332,7 @@ layout. Follow-up `review-005-delta` passed with no findings.
 
 ### Step 4: Replace Duration-Based Smoke Selection with Validation Profiles
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -429,7 +429,14 @@ ordinary development validation portion passed.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-016-delta` found two blocking issues: the active plan closeout
+summaries still described the old duration-oriented validation contract, and
+the smoke tests did not prove `installer_smoke` and `release_smoke` selected
+the intended tests. Repaired both by rewriting the current closeout summaries
+and adding `TestValidationProfileTagsSelectReleaseReadySmokeTests`.
+
+Follow-up `review-017-delta` passed with `docs-consistency` and `tests`
+reviewer slots reporting no findings.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -470,6 +470,8 @@ reviewer slots reporting no findings.
 
 ## Validation Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 Ordinary development validation is now `scripts/validate`, which builds
 embedded UI assets and runs `go test ./...`. It passed locally after Step 4,
 and after the finalize repair it also passed when invoked from `docs/` as
@@ -494,6 +496,10 @@ Finalize repair validation also covered
 `go test ./tests/smoke -run 'TestSyncContractArtifactsCheckFailsOnStaleGeneratedFiles|TestSyncContractArtifactsCheckFailsOnDeprecatedGeneratedDocs|TestValidationScriptsDefineDevelopmentAndReleaseProfiles|TestValidationProfileTagsSelectReleaseReadySmokeTests|TestCIWorkflowUsesDevelopmentValidationProfile' -count=1`,
 `go test ./tests/support -count=1`, and
 `go test -tags installer_smoke ./tests/installer -run 'TestInstallDevHarnessWrapperSkipsOtherManagedWrappersOnPathOutsideWorktree' -count=1`.
+Revision 3 CI repair validation covered
+`go test ./tests/smoke -run 'TestBuildEmbeddedUIScriptFailsWithActionableMessageWhenNodeIsMissingButPnpmExists|TestBuildEmbeddedUIScriptFailsWithActionableMessageWhenPnpmIsMissing|TestSyncContractArtifactsCheckFailsOnStaleGeneratedFiles|TestSyncContractArtifactsCheckFailsOnDeprecatedGeneratedDocs' -count=1`,
+`go test -tags installer_smoke ./tests/installer -run 'TestInstallDevHarnessWrapperSkipsOtherManagedWrappersOnPathOutsideWorktree' -count=1`,
+and `scripts/validate`.
 Timeout regression tests still cover the command helper repairs from revision
 1, and the current profile tests prove the user-facing scripts plus functional
 build tags select the intended release-ready smoke tests.
@@ -530,19 +536,25 @@ pnpm caches, and update the archive handoff text before follow-up review.
 Follow-up `review-019-delta` passed with correctness, tests, docs-consistency,
 and risk-scan slots reporting no findings.
 
+After revision 3 reopened the archived candidate for a CI failure,
+`CopyInstallerFixture` stopped copying `web/node_modules` so smoke fixtures do
+not traverse pnpm's CI symlink forest. The local `scripts/validate` run and
+focused CI-failure smoke tests passed before revision 3 repair review.
+
 ## Archive Summary
 
-- Archived At: 2026-06-20T00:30:40+08:00
-- Revision: 2
-Ready for archive after `review-019-delta` passed. The active plan contains
-checked acceptance criteria, completed tracked steps through Step 4,
-validation evidence, review history through the finalize repair review, and no
-deferred follow-up issue requirement beyond the existing broader test-taxonomy
-deferral. No supplements were used.
+- Archived At: PENDING_ARCHIVE
+- Revision: 3
+Ready for archive once the revision 3 CI-failure repair review passes. The
+active plan contains checked acceptance criteria, completed tracked steps
+through Step 4, validation evidence through the CI repair, review history
+through the finalize repair review, and no deferred follow-up issue
+requirement beyond the existing broader test-taxonomy deferral. No supplements
+were used.
 
 - PR: NONE
-- Ready: Ready to archive; after archive, update PR #259 and refresh
-  publish/CI/sync evidence.
+- Ready: Pending revision 3 repair review, archive, PR update, and refreshed
+  CI/sync evidence.
 - Merge Handoff: After archive, update PR #259 for issue 257, record
   publish/CI/sync evidence, and wait for explicit human merge approval.
 
@@ -568,10 +580,14 @@ deferral. No supplements were used.
 
 ### Not Delivered
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 No product behavior changes were delivered outside the validation split. A
 broader end-to-end test taxonomy remains outside this issue slice.
 
 ### Follow-Up Issues
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - https://github.com/catu-ai/easyharness/issues/258 tracks the broader
   validation taxonomy work that remains outside issue 257.

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -362,6 +362,13 @@ contains checked acceptance criteria, completed tracked steps, validation
 evidence, review history, and no deferred follow-up issue requirement beyond
 the existing broader test-taxonomy deferral. No supplements were used.
 
+- PR: NONE
+- Ready: All tracked steps are complete, acceptance criteria are checked, quick
+  and slow validation pass, and final repair review is expected to confirm no
+  remaining blockers before archive.
+- Merge Handoff: After archive, publish this branch as a PR for issue 257,
+  record publish/CI/sync evidence, and wait for explicit human merge approval.
+
 ## Outcome Summary
 
 ### Delivered

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -392,4 +392,5 @@ broader end-to-end test taxonomy remains outside this issue slice.
 
 ### Follow-Up Issues
 
-NONE
+- https://github.com/catu-ai/easyharness/issues/258 tracks the broader
+  validation taxonomy work that remains outside issue 257.

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -276,6 +276,11 @@ The full documented slow path passed in about 3:01.16:
 `go test -tags slow_smoke ./tests/installer ./tests/release -count=1`
 reported `tests/installer` at 180.956s and `tests/release` at 92.849s.
 Focused quick validation passed with `go test ./tests/smoke ./tests/release ./tests/support`.
+After `review-004-delta` flagged that the exact documented quick path was not
+recorded, ran `scripts/build-embedded-ui` and `go test ./...`; they passed in
+about 3.520s and 1:15.78 respectively. The same review also flagged that the
+testing-structure proposal layout omitted `tests/release/` and
+`tests/installer/`; the layout now includes both.
 
 #### Review Notes
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -61,17 +61,17 @@ for about 419.75s.
 
 ## Acceptance Criteria
 
-- [ ] The ordinary quick validation command no longer runs the full cold
+- [x] The ordinary quick validation command no longer runs the full cold
       installer and release smoke suite by accident.
-- [ ] Full slow smoke coverage remains available through an explicit command or
+- [x] Full slow smoke coverage remains available through an explicit command or
       documented command set.
-- [ ] `go test ./...` or its documented replacement no longer requires raising
+- [x] `go test ./...` or its documented replacement no longer requires raising
       the package timeout just to get past the old monolithic `tests/smoke`
       package.
-- [ ] Smoke subprocess failures identify the specific slow or stuck command
+- [x] Smoke subprocess failures identify the specific slow or stuck command
       instead of surfacing only as a Go package-level timeout.
-- [ ] CI and release workflow validation match the documented quick/full split.
-- [ ] Documentation no longer describes the current full `tests/smoke` package
+- [x] CI and release workflow validation match the documented quick/full split.
+- [x] Documentation no longer describes the current full `tests/smoke` package
       as fast repo-level smoke coverage unless the implementation makes that
       true again.
 
@@ -222,7 +222,7 @@ the timeout regression covered `RunCommandWithTimeout` but not
 
 ### Step 3: Update Documentation, Workflows, and Evidence
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -284,7 +284,12 @@ testing-structure proposal layout omitted `tests/release/` and
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-004-delta` found one blocking tests issue and one minor
+docs-consistency issue: the Step 3 notes had not recorded the exact documented
+quick path, and the testing-structure proposal layout omitted `tests/release/`
+and `tests/installer/`. Repaired both by recording
+`scripts/build-embedded-ui` plus `go test ./...` evidence and updating the
+layout. Follow-up `review-005-delta` passed with no findings.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -319,25 +319,69 @@ layout. Follow-up `review-005-delta` passed with no findings.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+Quick/default validation is split from slow smoke coverage. The documented
+quick path, `scripts/build-embedded-ui` plus `go test ./...`, passed after the
+split and again after finalize repairs. The latest `go test ./...` run passed
+with default packages, including `tests/e2e` at 68.486s, `tests/smoke` at
+13.938s, and default `tests/release` at 2.391s.
+
+Explicit slow smoke coverage remains available with
+`go test -tags slow_smoke ./tests/installer ./tests/release -count=1`. The
+latest full slow run passed with `tests/installer` at 157.887s and
+`tests/release` at 90.183s. Earlier slow runs also proved the release archive
+path after timeout repairs.
+
+Focused validation covered the repaired timeout surfaces:
+`go test ./tests/support ./tests/smoke`,
+`go test ./tests/smoke -run 'TestSyncBootstrapAssetsCheckPassesForCurrentRepo|TestSyncContractArtifacts' -count=1`,
+`go test ./tests/release`, and
+`go test -tags slow_smoke ./tests/release -count=1` all passed. Timeout
+regression tests cover both generic command helpers and harness command
+helpers, and default smoke, release archive, live release, git, gh, tar,
+downloaded/installed harness, and build-binary setup subprocesses now use
+timeout-aware helpers or contexts.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+Step reviews passed after targeted repairs:
+`review-001-delta` passed the validation split, `review-003-delta` passed the
+timeout regression repair for `RunWithOptions`, and `review-005-delta` passed
+the documentation/evidence repair for the exact quick path and test layout.
+
+Finalize review intentionally found additional timeout gaps. Repairs were
+made and re-reviewed for release archive subprocesses (`review-008-delta`
+passed after the live release follow-up), default smoke subprocesses
+(`review-011-delta` passed after the tar stderr fix), and support setup
+subprocesses plus installer slow-smoke repeatability. The final full review
+round before archive must pass after the last support and summary repair.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+Ready for archive once the final post-repair review passes. The active plan
+contains checked acceptance criteria, completed tracked steps, validation
+evidence, review history, and no deferred follow-up issue requirement beyond
+the existing broader test-taxonomy deferral. No supplements were used.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Default validation no longer runs the cold installer and release archive
+  smoke suite by accident.
+- Slow installer and release coverage moved behind the explicit
+  `slow_smoke` command while release workflow live smoke references point at
+  the moved release package.
+- Smoke command helpers gained conservative command-level timeouts with
+  captured stdout/stderr diagnostics.
+- Installer smoke tests now run in parallel with shared setup and warmed
+  dependencies, while preserving real `scripts/install-dev-harness` coverage.
+- Documentation now describes the quick/default and explicit slow validation
+  paths in development, release, and testing-structure docs.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+No product behavior changes were delivered outside the validation split. A
+broader end-to-end test taxonomy remains outside this issue slice.
 
 ### Follow-Up Issues
 

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -470,8 +470,6 @@ reviewer slots reporting no findings.
 
 ## Validation Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 Ordinary development validation is now `scripts/validate`, which builds
 embedded UI assets and runs `go test ./...`. It passed locally after Step 4,
 and after the finalize repair it also passed when invoked from `docs/` as
@@ -540,6 +538,9 @@ After revision 3 reopened the archived candidate for a CI failure,
 `CopyInstallerFixture` stopped copying `web/node_modules` so smoke fixtures do
 not traverse pnpm's CI symlink forest. The local `scripts/validate` run and
 focused CI-failure smoke tests passed before revision 3 repair review.
+`review-020-delta` found that reopen summary markers still remained in
+archive-facing summaries; those markers were removed before the follow-up
+review.
 
 ## Archive Summary
 
@@ -580,14 +581,10 @@ were used.
 
 ### Not Delivered
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 No product behavior changes were delivered outside the validation split. A
 broader end-to-end test taxonomy remains outside this issue slice.
 
 ### Follow-Up Issues
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - https://github.com/catu-ai/easyharness/issues/258 tracks the broader
   validation taxonomy work that remains outside issue 257.

--- a/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/active/2026-06-18-speed-up-smoke-validation.md
@@ -5,6 +5,7 @@ approved_at: "2026-06-18T23:56:10+08:00"
 source_type: issue
 source_refs:
     - https://github.com/catu-ai/easyharness/issues/257
+    - https://github.com/catu-ai/easyharness/pull/259
 size: M
 ---
 
@@ -18,9 +19,10 @@ supplements. -->
 
 ## Goal
 
-Make routine validation fast and predictable again by separating quick
-package-local tests from slower binary-driven smoke coverage, while keeping the
-full installer and release confidence checks available on an explicit path.
+Make routine validation fast and predictable again by separating ordinary
+development validation from full release-ready validation, while keeping the
+installer and release confidence checks available through purpose-named,
+deterministic entrypoints.
 
 Issue 257 was opened because `tests/smoke` dominated `go test ./...` during
 release validation and could exceed Go's default 10 minute package timeout.
@@ -30,6 +32,14 @@ completed tests had already accumulated 430.24s, and the release-build smoke
 tests had not started yet. The five completed installer tests alone accounted
 for about 419.75s.
 
+Revision 2 reopened the archived PR because the first implementation framed
+the split as quick versus slow. That made the release/installer checks
+available, but the human clarified that test selection should not depend on a
+subjective judgment that a change is "small" or on duration-oriented names
+such as `slow_smoke`. The remaining work is to express the split as two clear
+validation profiles: ordinary development validation and full release-ready
+validation.
+
 ## Scope
 
 ### In Scope
@@ -37,6 +47,14 @@ for about 419.75s.
 - Split the current smoke coverage into an explicit quick/default validation
   path and one or more slow opt-in smoke paths for installer and release
   workflows.
+- Replace the duration-oriented validation framing with purpose-oriented
+  validation profiles: ordinary development validation and full release-ready
+  validation.
+- Provide simple script entrypoints for those profiles so humans and agents do
+  not need to remember build tags or make subjective risk calls for `VERSION`
+  and release PRs.
+- Rename opt-in build tags away from `slow_smoke` toward functional meaning,
+  such as release and installer smoke coverage.
 - Keep important installer, wrapper PATH, release archive, and live release
   workflow coverage, but make slow cold-path tests intentional rather than an
   accidental part of every quick validation run.
@@ -47,6 +65,9 @@ for about 419.75s.
 - Update CI, release workflow, and docs so agents and humans know which command
   is the ordinary quick validation path and which command runs full slow smoke
   coverage.
+- Update release guidance so `VERSION` and release PRs use the release-ready
+  validation profile before merge, while the post-merge Release workflow
+  remains publish validation.
 
 ### Out of Scope
 
@@ -58,6 +79,10 @@ for about 419.75s.
   faster.
 - Reworking unrelated Playwright UI smoke scripts except where docs need to
   describe the overall validation split accurately.
+- Adding a complex path-filter matrix that tries to infer every possible
+  release or installer surface. The intended rule is simpler: ordinary
+  development uses the default profile; release-ready work, including
+  `VERSION` PRs, uses the full release profile.
 
 ## Acceptance Criteria
 
@@ -74,12 +99,26 @@ for about 419.75s.
 - [x] Documentation no longer describes the current full `tests/smoke` package
       as fast repo-level smoke coverage unless the implementation makes that
       true again.
+- [ ] User-facing validation commands are named by purpose rather than runtime,
+      with an ordinary development profile and a full release-ready profile.
+- [ ] Opt-in installer and release test tags use functional names instead of
+      `slow_smoke`.
+- [ ] `VERSION` and release PR documentation requires the full release-ready
+      validation profile before merge.
+- [ ] The release workflow is documented as post-merge publish validation, not
+      as a substitute for release-ready PR validation.
+- [ ] CI, docs, and tests avoid relying on an agent or maintainer's subjective
+      judgment that a release-adjacent change is "small".
 
 ## Deferred Items
 
 - Broader test taxonomy changes beyond issue 257, such as adding a complete
   end-to-end or resilience suite, remain deferred unless they are the smallest
   clean way to express this validation split.
+- Fine-grained path-specific validation profiles remain deferred. This plan
+  should not introduce separate release-surface and installer-surface CI
+  matrices unless they become the simplest way to express the two approved
+  profiles.
 
 ## Work Breakdown
 
@@ -291,14 +330,96 @@ and `tests/installer/`. Repaired both by recording
 `scripts/build-embedded-ui` plus `go test ./...` evidence and updating the
 layout. Follow-up `review-005-delta` passed with no findings.
 
+### Step 4: Replace Duration-Based Smoke Selection with Validation Profiles
+
+- Done: [ ]
+
+#### Objective
+
+Turn the reopened split into two purpose-named validation profiles so release
+readiness is deterministic and not hidden behind subjective "small change" or
+"slow test" judgment.
+
+#### Details
+
+The approved direction is:
+
+- ordinary development validation: a default profile for normal feature,
+  documentation, and bug-fix work;
+- full release-ready validation: a profile for `VERSION` PRs, release PRs, and
+  pre-release confidence checks.
+
+Add simple script entrypoints so humans and agents do not need to remember
+build tags directly. Preferred names are:
+
+- `scripts/validate`
+- `scripts/validate-release`
+
+`scripts/validate` should run the ordinary development profile, currently
+expected to include `scripts/build-embedded-ui` and `go test ./...`.
+
+`scripts/validate-release` should include `scripts/validate` and then run the
+installer and release archive/package smoke coverage that is intentionally
+outside ordinary development validation.
+
+Rename `slow_smoke` build tags to functional names. The exact names can be
+chosen during implementation, but the intended meaning is release smoke and
+installer smoke, not generic slowness. A likely clean shape is:
+
+- `//go:build release_smoke` for release archive/package construction tests;
+- `//go:build installer_smoke` for installer and wrapper PATH tests;
+- `scripts/validate-release` invokes the needed tags/packages directly.
+
+Update documentation and workflow checks so `VERSION` and release PRs are
+instructed to run the release-ready validation profile before merge. The
+post-merge Release workflow should remain described as publish validation: it
+builds and publishes from the tag, verifies published release assets, and
+checks Homebrew behavior after assets exist.
+
+Do not add a path-filter matrix for this step unless it becomes simpler than
+the two-profile rule. The accepted model is deliberately coarse: ordinary
+development gets the default profile; release-ready work gets the full release
+profile.
+
+#### Expected Files
+
+- `scripts/validate`
+- `scripts/validate-release`
+- `tests/installer/**`
+- `tests/release/**`
+- `docs/releasing.md`
+- `docs/development.md`
+- `docs/specs/proposals/testing-structure.md`
+- `.github/workflows/ci.yml` if CI should call `scripts/validate` instead of
+  spelling out its commands
+- `docs/plans/active/2026-06-18-speed-up-smoke-validation.md`
+
+#### Validation
+
+- Run `scripts/validate`.
+- Run `scripts/validate-release`.
+- Run `go test -list` with the new functional tags to confirm installer and
+  release archive tests are reachable through the expected profile.
+- Run focused docs/workflow smoke tests that assert release checklist and CI
+  guidance.
+- Run `harness plan lint docs/plans/active/2026-06-18-speed-up-smoke-validation.md`.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
 ## Validation Strategy
 
 - Use `go test -list` before and after the split to confirm tests moved into
   the intended command surfaces.
-- Run quick validation with elapsed-time output and confirm it avoids the old
-  monolithic smoke timeout risk.
-- Run the slow smoke command or focused slow suites to prove installer and
-  release confidence checks still exist.
+- Run ordinary development validation with elapsed-time output and confirm it
+  avoids the old monolithic smoke timeout risk.
+- Run the full release-ready validation profile to prove installer and release
+  confidence checks still exist.
 - Run workflow/documentation checks as plain file inspection plus relevant Go
   smoke tests that assert workflow wiring where such tests already exist.
 
@@ -306,8 +427,9 @@ layout. Follow-up `review-005-delta` passed with no findings.
 
 - Risk: The split could make important installer or release coverage less
   visible.
-  - Mitigation: Keep explicit slow smoke commands and update CI/release docs so
-    the coverage is opt-in by design, not forgotten.
+  - Mitigation: Keep explicit release-ready validation commands and update
+    release docs so `VERSION` and release PRs use the full profile before
+    merge.
 - Risk: Reducing repeated installer work could accidentally stop testing the
   real cold install path.
   - Mitigation: Preserve at least one true cold installer smoke and convert only
@@ -316,8 +438,13 @@ layout. Follow-up `review-005-delta` passed with no findings.
   - Mitigation: Choose conservative defaults, include useful diagnostics, and
     allow only intentional opt-in overrides if the repository already has a
     clear pattern for that.
+- Risk: Functional profiles could grow into another ambiguous taxonomy.
+  - Mitigation: Keep this step to two user-facing profiles and defer
+    fine-grained path-specific matrices to follow-up work.
 
 ## Validation Summary
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 Quick/default validation is split from slow smoke coverage. The documented
 quick path, `scripts/build-embedded-ui` plus `go test ./...`, passed after the
@@ -343,6 +470,8 @@ timeout-aware helpers or contexts.
 
 ## Review Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 Step reviews passed after targeted repairs:
 `review-001-delta` passed the validation split, `review-003-delta` passed the
 timeout regression repair for `RunWithOptions`, and `review-005-delta` passed
@@ -357,6 +486,8 @@ round, `review-015-full`, passed with correctness, tests, docs-consistency,
 and risk-scan slots reporting no findings.
 
 ## Archive Summary
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Archived At: 2026-06-19T01:37:41+08:00
 - Revision: 1
@@ -375,6 +506,8 @@ the existing broader test-taxonomy deferral. No supplements were used.
 
 ### Delivered
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - Default validation no longer runs the cold installer and release archive
   smoke suite by accident.
 - Slow installer and release coverage moved behind the explicit
@@ -389,10 +522,14 @@ the existing broader test-taxonomy deferral. No supplements were used.
 
 ### Not Delivered
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 No product behavior changes were delivered outside the validation split. A
 broader end-to-end test taxonomy remains outside this issue slice.
 
 ### Follow-Up Issues
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - https://github.com/catu-ai/easyharness/issues/258 tracks the broader
   validation taxonomy work that remains outside issue 257.

--- a/docs/plans/archived/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/archived/2026-06-18-speed-up-smoke-validation.md
@@ -353,10 +353,13 @@ made and re-reviewed for release archive subprocesses (`review-008-delta`
 passed after the live release follow-up), default smoke subprocesses
 (`review-011-delta` passed after the tar stderr fix), and support setup
 subprocesses plus installer slow-smoke repeatability. The final full review
-round before archive must pass after the last support and summary repair.
+round, `review-015-full`, passed with correctness, tests, docs-consistency,
+and risk-scan slots reporting no findings.
 
 ## Archive Summary
 
+- Archived At: 2026-06-19T01:37:41+08:00
+- Revision: 1
 Ready for archive once the final post-repair review passes. The active plan
 contains checked acceptance criteria, completed tracked steps, validation
 evidence, review history, and no deferred follow-up issue requirement beyond
@@ -364,8 +367,7 @@ the existing broader test-taxonomy deferral. No supplements were used.
 
 - PR: NONE
 - Ready: All tracked steps are complete, acceptance criteria are checked, quick
-  and slow validation pass, and final repair review is expected to confirm no
-  remaining blockers before archive.
+  and slow validation pass, and final full review passed with no findings.
 - Merge Handoff: After archive, publish this branch as a PR for issue 257,
   record publish/CI/sync evidence, and wait for explicit human merge approval.
 

--- a/docs/plans/archived/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/archived/2026-06-18-speed-up-smoke-validation.md
@@ -527,20 +527,22 @@ fall through to a live Corepack/pnpm download from temporary homes, and the
 Archive Summary still said the Step 4 repair review was pending. The repairs
 anchor validation scripts to `repo_root`, share warmed installer Corepack and
 pnpm caches, and update the archive handoff text before follow-up review.
+Follow-up `review-019-delta` passed with correctness, tests, docs-consistency,
+and risk-scan slots reporting no findings.
 
 ## Archive Summary
 
-- Archived At: PENDING_ARCHIVE
+- Archived At: 2026-06-20T00:30:40+08:00
 - Revision: 2
-Ready for archive once the finalize repair review passes.
-The active plan contains checked acceptance criteria, completed tracked steps
-through Step 4, validation evidence, review history through
-`review-018-full`, and no deferred follow-up issue requirement beyond the
-existing broader test-taxonomy deferral. No supplements were used.
+Ready for archive after `review-019-delta` passed. The active plan contains
+checked acceptance criteria, completed tracked steps through Step 4,
+validation evidence, review history through the finalize repair review, and no
+deferred follow-up issue requirement beyond the existing broader test-taxonomy
+deferral. No supplements were used.
 
 - PR: NONE
-- Ready: Pending finalize repair review, archive, publish/CI, and sync
-  evidence.
+- Ready: Ready to archive; after archive, update PR #259 and refresh
+  publish/CI/sync evidence.
 - Merge Handoff: After archive, update PR #259 for issue 257, record
   publish/CI/sync evidence, and wait for explicit human merge approval.
 

--- a/docs/plans/archived/2026-06-18-speed-up-smoke-validation.md
+++ b/docs/plans/archived/2026-06-18-speed-up-smoke-validation.md
@@ -540,22 +540,21 @@ not traverse pnpm's CI symlink forest. The local `scripts/validate` run and
 focused CI-failure smoke tests passed before revision 3 repair review.
 `review-020-delta` found that reopen summary markers still remained in
 archive-facing summaries; those markers were removed before the follow-up
-review.
+review. Follow-up `review-021-delta` passed with no findings.
 
 ## Archive Summary
 
-- Archived At: PENDING_ARCHIVE
+- Archived At: 2026-06-20T00:44:19+08:00
 - Revision: 3
-Ready for archive once the revision 3 CI-failure repair review passes. The
-active plan contains checked acceptance criteria, completed tracked steps
-through Step 4, validation evidence through the CI repair, review history
-through the finalize repair review, and no deferred follow-up issue
-requirement beyond the existing broader test-taxonomy deferral. No supplements
-were used.
+Ready for archive after `review-021-delta` passed. The active plan contains
+checked acceptance criteria, completed tracked steps through Step 4,
+validation evidence through the CI repair, review history through revision 3
+repair review, and no deferred follow-up issue requirement beyond the existing
+broader test-taxonomy deferral. No supplements were used.
 
 - PR: NONE
-- Ready: Pending revision 3 repair review, archive, PR update, and refreshed
-  CI/sync evidence.
+- Ready: Ready to archive; after archive, update PR #259 and refresh CI/sync
+  evidence.
 - Merge Handoff: After archive, update PR #259 for issue 257, record
   publish/CI/sync evidence, and wait for explicit human merge approval.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -60,18 +60,23 @@ remain, and whether a post-publication repair is needed.
 1. Decide the next release version, such as `0.0.0`, and update the
    root `VERSION` file in a dedicated release PR.
 2. Make sure `main` is up to date, run `scripts/build-embedded-ui`, and then
-   run `go test ./...` in the release PR before merge.
-3. If you want an extra local packaging check before merge, run
+   run `go test ./...` in the release PR before merge. This is the quick
+   release-PR validation path and intentionally skips slow tagged installer and
+   release-archive smoke tests.
+3. If the release PR changes installer behavior, wrapper PATH behavior, release
+   archive construction, or you want full local packaging confidence, also run
+   `go test -tags slow_smoke ./tests/installer ./tests/release -count=1`.
+4. If you want an extra local packaging check before merge, run
    `scripts/build-release --version "v$(cat VERSION)"`.
-4. Merge the release PR to `main`.
-5. Confirm the `Tag Release From VERSION` workflow created the matching git
+5. Merge the release PR to `main`.
+6. Confirm the `Tag Release From VERSION` workflow created the matching git
    tag, for example `v0.0.0`, and then dispatched the `Release`
    workflow for that tag.
-6. Confirm the `Release` workflow uploaded the release archives and
+7. Confirm the `Release` workflow uploaded the release archives and
    `SHA256SUMS` file.
-7. If the Homebrew tap token is configured, confirm the workflow updated
+8. If the Homebrew tap token is configured, confirm the workflow updated
    `Formula/easyharness.rb` in `catu-ai/homebrew-tap`.
-8. Confirm the release workflow's Homebrew verification job passed.
+9. Confirm the release workflow's Homebrew verification job passed.
    It should stage a local `catu-ai/tap` checkout from the rendered formula,
    install an earlier compatible release when one exists, upgrade to the
    current release with `brew upgrade catu-ai/tap/easyharness`, and pass
@@ -145,4 +150,7 @@ The formula name remains `easyharness`, while the installed binary remains
 
 Release and CI jobs use the Go version recorded in `go.mod`, which is currently
 `go 1.25.0`. They also install Node.js/pnpm so the embedded UI assets are
-built before Go tests and release packaging consume them.
+built before Go tests and release packaging consume them. CI and release PR
+validation use the quick default `go test ./...` path; slow smoke coverage is
+available locally with
+`go test -tags slow_smoke ./tests/installer ./tests/release -count=1`.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -59,24 +59,21 @@ remain, and whether a post-publication repair is needed.
 
 1. Decide the next release version, such as `0.0.0`, and update the
    root `VERSION` file in a dedicated release PR.
-2. Make sure `main` is up to date, run `scripts/build-embedded-ui`, and then
-   run `go test ./...` in the release PR before merge. This is the quick
-   release-PR validation path and intentionally skips slow tagged installer and
-   release-archive smoke tests.
-3. If the release PR changes installer behavior, wrapper PATH behavior, release
-   archive construction, or you want full local packaging confidence, also run
-   `go test -tags slow_smoke ./tests/installer ./tests/release -count=1`.
-4. If you want an extra local packaging check before merge, run
+2. Make sure `main` is up to date and run `scripts/validate-release` in the
+   release PR before merge. This is the release-ready validation profile for
+   `VERSION` PRs and includes ordinary development validation plus installer
+   and release archive smoke coverage.
+3. If you want an extra local packaging check before merge, run
    `scripts/build-release --version "v$(cat VERSION)"`.
-5. Merge the release PR to `main`.
-6. Confirm the `Tag Release From VERSION` workflow created the matching git
+4. Merge the release PR to `main`.
+5. Confirm the `Tag Release From VERSION` workflow created the matching git
    tag, for example `v0.0.0`, and then dispatched the `Release`
    workflow for that tag.
-7. Confirm the `Release` workflow uploaded the release archives and
+6. Confirm the `Release` workflow uploaded the release archives and
    `SHA256SUMS` file.
-8. If the Homebrew tap token is configured, confirm the workflow updated
+7. If the Homebrew tap token is configured, confirm the workflow updated
    `Formula/easyharness.rb` in `catu-ai/homebrew-tap`.
-9. Confirm the release workflow's Homebrew verification job passed.
+8. Confirm the release workflow's Homebrew verification job passed.
    It should stage a local `catu-ai/tap` checkout from the rendered formula,
    install an earlier compatible release when one exists, upgrade to the
    current release with `brew upgrade catu-ai/tap/easyharness`, and pass
@@ -150,7 +147,8 @@ The formula name remains `easyharness`, while the installed binary remains
 
 Release and CI jobs use the Go version recorded in `go.mod`, which is currently
 `go 1.25.0`. They also install Node.js/pnpm so the embedded UI assets are
-built before Go tests and release packaging consume them. CI and release PR
-validation use the quick default `go test ./...` path; slow smoke coverage is
-available locally with
-`go test -tags slow_smoke ./tests/installer ./tests/release -count=1`.
+built before Go tests and release packaging consume them. Ordinary CI uses
+`scripts/validate` for the development validation profile. `VERSION` and
+release PRs use `scripts/validate-release` before merge. The post-merge
+`Release` workflow reruns publish validation from the packaged source tree, but
+that workflow is not a substitute for release-ready PR validation.

--- a/docs/specs/proposals/testing-structure.md
+++ b/docs/specs/proposals/testing-structure.md
@@ -219,6 +219,13 @@ tests/
     legacy-review-round/
   smoke/
     smoke_test.go
+  release/
+    release_version_file_test.go
+    verify_release_namespace_test.go
+    homebrew_formula_test.go
+    release_build_test.go       # slow_smoke
+  installer/
+    install_dev_harness_test.go # slow_smoke
   e2e/
     happy_path_test.go
     review_round_test.go

--- a/docs/specs/proposals/testing-structure.md
+++ b/docs/specs/proposals/testing-structure.md
@@ -115,7 +115,7 @@ Execution model:
 
 - in-process
 - may use temporary files or directories
-- should remain fast and be part of the default `go test ./...` path
+- should remain part of the ordinary `scripts/validate` development profile
 
 Examples in the current repository include plan linting, plan parsing, status
 state inference, review round artifact logic, and archive/reopen behavior.
@@ -141,7 +141,8 @@ Characteristics:
 - fast runtime
 - real binary execution
 - shallow assertions compared with end-to-end tests
-- slow cold-path coverage uses the `slow_smoke` build tag
+- release-readiness cold-path coverage uses functional build tags such as
+  `installer_smoke` and `release_smoke`
 
 Typical smoke coverage for `easyharness` should include:
 
@@ -150,7 +151,7 @@ Typical smoke coverage for `easyharness` should include:
 - `harness plan template`
 - a minimal `plan template -> plan lint` roundtrip
 - release script and release namespace checks under `tests/release/`
-- opt-in installer and release archive checks with `-tags slow_smoke`
+- opt-in installer and release archive checks through `scripts/validate-release`
 
 ### End-to-End Tests
 
@@ -223,9 +224,9 @@ tests/
     release_version_file_test.go
     verify_release_namespace_test.go
     homebrew_formula_test.go
-    release_build_test.go       # slow_smoke
+    release_build_test.go       # release_smoke
   installer/
-    install_dev_harness_test.go # slow_smoke
+    install_dev_harness_test.go # installer_smoke
   e2e/
     happy_path_test.go
     review_round_test.go
@@ -293,21 +294,22 @@ If future scope introduces external services or a UI, the taxonomy may expand.
 
 Recommended commands:
 
-- `go test ./...`
-  - default package-local, quick smoke, release script/namespace, E2E, and
-    resilience suite
+- `scripts/validate`
+  - ordinary development validation: embedded UI assets plus default
+    package-local, smoke, release script/namespace, E2E, and resilience suite
 - `go test ./tests/smoke -count=1`
   - focused fast CLI smoke coverage
 - `go test ./tests/release -count=1`
   - focused release script, namespace, and Homebrew smoke coverage
-- `go test -tags slow_smoke ./tests/installer ./tests/release -count=1`
-  - explicit cold installer and release archive smoke coverage
+- `scripts/validate-release`
+  - full release-ready validation: ordinary development validation plus
+    purpose-tagged installer and release archive smoke coverage
 - `go test ./tests/e2e -count=1`
   - real binary workflow coverage
 - `go test ./tests/resilience -count=1`
   - deterministic failure-injection coverage
 
-Optional wrapper scripts may exist, for example:
+Other optional wrapper scripts may exist, for example:
 
 - `scripts/test-smoke`
 - `scripts/test-e2e`

--- a/docs/specs/proposals/testing-structure.md
+++ b/docs/specs/proposals/testing-structure.md
@@ -125,11 +125,15 @@ state inference, review round artifact logic, and archive/reopen behavior.
 Location:
 
 - `tests/smoke/`
+- `tests/release/` for release script, namespace, and Homebrew smoke checks
+- `tests/installer/` for installer and wrapper smoke checks
 
 Purpose:
 
 - provide a fast confidence check that the binary starts and the most critical
   user-visible paths are not obviously broken
+- keep cold installer and release-archive coverage available without making it
+  part of every default validation run
 
 Characteristics:
 
@@ -137,6 +141,7 @@ Characteristics:
 - fast runtime
 - real binary execution
 - shallow assertions compared with end-to-end tests
+- slow cold-path coverage uses the `slow_smoke` build tag
 
 Typical smoke coverage for `easyharness` should include:
 
@@ -144,6 +149,8 @@ Typical smoke coverage for `easyharness` should include:
 - `harness status`
 - `harness plan template`
 - a minimal `plan template -> plan lint` roundtrip
+- release script and release namespace checks under `tests/release/`
+- opt-in installer and release archive checks with `-tags slow_smoke`
 
 ### End-to-End Tests
 
@@ -280,9 +287,14 @@ If future scope introduces external services or a UI, the taxonomy may expand.
 Recommended commands:
 
 - `go test ./...`
-  - default package-local suite
+  - default package-local, quick smoke, release script/namespace, E2E, and
+    resilience suite
 - `go test ./tests/smoke -count=1`
-  - fast repo-level smoke coverage
+  - focused fast CLI smoke coverage
+- `go test ./tests/release -count=1`
+  - focused release script, namespace, and Homebrew smoke coverage
+- `go test -tags slow_smoke ./tests/installer ./tests/release -count=1`
+  - explicit cold installer and release archive smoke coverage
 - `go test ./tests/e2e -count=1`
   - real binary workflow coverage
 - `go test ./tests/resilience -count=1`
@@ -331,9 +343,6 @@ The first repo-level cases should be:
 
 ## Open Questions
 
-- whether `go test ./...` should eventually include `tests/smoke` by default
-  or keep repo-level suites opt-in
-- whether any repo-level suite should use build tags such as `resilience`
-  instead of dedicated package paths
-- whether future release packaging should add a separate release-verification
-  smoke path distinct from repository development smoke coverage
+- whether future release packaging should add a separate live
+  release-verification smoke path distinct from repository development smoke
+  coverage

--- a/scripts/validate
+++ b/scripts/validate
@@ -3,5 +3,6 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
+cd "${repo_root}"
 "${repo_root}/scripts/build-embedded-ui"
 go test ./...

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+"${repo_root}/scripts/build-embedded-ui"
+go test ./...

--- a/scripts/validate-release
+++ b/scripts/validate-release
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+"${repo_root}/scripts/validate"
+go test -tags installer_smoke ./tests/installer -count=1
+go test -tags release_smoke ./tests/release -count=1

--- a/scripts/validate-release
+++ b/scripts/validate-release
@@ -3,6 +3,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 
+cd "${repo_root}"
 "${repo_root}/scripts/validate"
 go test -tags installer_smoke ./tests/installer -count=1
 go test -tags release_smoke ./tests/release -count=1

--- a/tests/installer/install_dev_harness_test.go
+++ b/tests/installer/install_dev_harness_test.go
@@ -1,57 +1,36 @@
-package smoke_test
+//go:build slow_smoke
+
+package installer_test
 
 import (
-	"bytes"
-	"context"
-	"errors"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/catu-ai/easyharness/tests/support"
 )
 
-type commandResult struct {
-	Stdout   string
-	Stderr   string
-	ExitCode int
-}
-
-var installerCacheDirs struct {
-	once       sync.Once
-	goCache    string
-	goModCache string
-	err        error
-}
-
-func (r commandResult) CombinedOutput() string {
-	return r.Stdout + r.Stderr
-}
-
 func TestInstallDevHarnessDefaultsToUserLocalBin(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	tempHome := t.TempDir()
 	firstPathDir := filepath.Join(t.TempDir(), "path-bin")
 	if err := os.MkdirAll(firstPathDir, 0o755); err != nil {
 		t.Fatalf("mkdir first PATH dir: %v", err)
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": tempHome,
-			"PATH": installerPath(t, firstPathDir),
+			"PATH": support.InstallerPath(t, firstPathDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -81,13 +60,13 @@ func TestInstallDevHarnessHelpDoesNotMentionGlobalFlag(t *testing.T) {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
-	result := runCommand(
+	repoRoot := support.CopyInstallerFixture(t)
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t),
+			"PATH": support.InstallerPath(t),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -107,13 +86,13 @@ func TestInstallDevHarnessRejectsRemovedGlobalFlag(t *testing.T) {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
-	result := runCommand(
+	repoRoot := support.CopyInstallerFixture(t)
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t),
+			"PATH": support.InstallerPath(t),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -131,18 +110,18 @@ func TestInstallDevHarnessVerifiesPATHResolvedWrapperWhenInstallDirIsAlreadyOnPA
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		t.Fatalf("mkdir install dir: %v", err)
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir),
+			"PATH": support.InstallerPath(t, installDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -163,16 +142,16 @@ func TestInstallDevHarnessWrapperDispatchesToCurrentWorktreeOverStablePathFallba
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	stableDir, _ := newFakeStableHarness(t)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir, stableDir),
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -186,11 +165,11 @@ func TestInstallDevHarnessWrapperDispatchesToCurrentWorktreeOverStablePathFallba
 	support.RequireFileExists(t, wrapperPath)
 
 	_, nestedDir := newFakeWorktree(t)
-	wrapperResult := runCommand(
+	wrapperResult := support.RunCommand(
 		t,
 		nestedDir,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, installDir, stableDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		wrapperPath,
 		"status",
@@ -211,15 +190,15 @@ func TestInstallDevHarnessWrapperRequiresStableHarnessOnPathOutsideWorktree(t *t
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir),
+			"PATH": support.InstallerPath(t, installDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -233,10 +212,10 @@ func TestInstallDevHarnessWrapperRequiresStableHarnessOnPathOutsideWorktree(t *t
 	support.RequireFileExists(t, wrapperPath)
 
 	otherProject := t.TempDir()
-	wrapperResult := runCommand(
+	wrapperResult := support.RunCommand(
 		t,
 		otherProject,
-		envWithOverrides(t, map[string]string{
+		support.EnvWithOverrides(t, map[string]string{
 			"PATH": strings.Join([]string{installDir, "/usr/bin", "/bin", "/usr/sbin", "/sbin"}, string(os.PathListSeparator)),
 		}),
 		wrapperPath,
@@ -256,16 +235,16 @@ func TestInstallDevHarnessWrapperUsesStableHarnessOnPathOutsideWorktree(t *testi
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	stableDir, _ := newFakeStableHarness(t)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir, stableDir),
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -279,11 +258,11 @@ func TestInstallDevHarnessWrapperUsesStableHarnessOnPathOutsideWorktree(t *testi
 	support.RequireFileExists(t, wrapperPath)
 
 	otherProject := t.TempDir()
-	helpResult := runCommand(
+	helpResult := support.RunCommand(
 		t,
 		otherProject,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, installDir, stableDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		wrapperPath,
 		"--help",
@@ -316,18 +295,18 @@ func TestInstallDevHarnessWrapperSkipsOtherManagedWrappersOnPathOutsideWorktree(
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			repoRoot := copyInstallerFixture(t)
+			repoRoot := support.CopyInstallerFixture(t)
 			installDir := filepath.Join(t.TempDir(), "path-bin")
 			managedDir := t.TempDir()
 			stableDir, _ := newFakeStableHarness(t)
-			writeFixtureFile(t, filepath.Join(managedDir, "harness"), tc.script, 0o755)
+			support.WriteFixtureFile(t, filepath.Join(managedDir, "harness"), tc.script, 0o755)
 
-			result := runCommand(
+			result := support.RunCommand(
 				t,
 				repoRoot,
-				installerEnv(t, map[string]string{
+				support.InstallerEnv(t, map[string]string{
 					"HOME": t.TempDir(),
-					"PATH": installerPath(t, installDir, managedDir, stableDir),
+					"PATH": support.InstallerPath(t, installDir, managedDir, stableDir),
 				}),
 				"/bin/bash",
 				filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -339,11 +318,11 @@ func TestInstallDevHarnessWrapperSkipsOtherManagedWrappersOnPathOutsideWorktree(
 
 			wrapperPath := filepath.Join(installDir, "harness")
 			otherProject := t.TempDir()
-			helpResult := runCommand(
+			helpResult := support.RunCommand(
 				t,
 				otherProject,
-				envWithOverrides(t, map[string]string{
-					"PATH": installerPath(t, installDir, managedDir, stableDir),
+				support.EnvWithOverrides(t, map[string]string{
+					"PATH": support.InstallerPath(t, installDir, managedDir, stableDir),
 				}),
 				wrapperPath,
 				"--help",
@@ -365,18 +344,18 @@ func TestInstallDevHarnessWrapperSkipsSymlinkAliasesOnPathOutsideWorktree(t *tes
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	aliasOneDir := t.TempDir()
 	aliasTwoDir := t.TempDir()
 	stableDir, _ := newFakeStableHarness(t)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir, stableDir),
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -395,12 +374,12 @@ func TestInstallDevHarnessWrapperSkipsSymlinkAliasesOnPathOutsideWorktree(t *tes
 	}
 
 	otherProject := t.TempDir()
-	helpResult := runCommandWithTimeout(
+	helpResult := support.RunCommandWithTimeout(
 		t,
 		5*time.Second,
 		otherProject,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, aliasOneDir, aliasTwoDir, installDir, stableDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, aliasOneDir, aliasTwoDir, installDir, stableDir),
 		}),
 		wrapperPath,
 		"--help",
@@ -417,17 +396,17 @@ func TestInstallDevHarnessWrapperSkipsRepoLocalDevBinaryOnPathOutsideWorktree(t 
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	devDir, _ := newFakeDevHarness(t)
 	stableDir, _ := newFakeStableHarness(t)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir, devDir, stableDir),
+			"PATH": support.InstallerPath(t, installDir, devDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -439,11 +418,11 @@ func TestInstallDevHarnessWrapperSkipsRepoLocalDevBinaryOnPathOutsideWorktree(t 
 
 	wrapperPath := filepath.Join(installDir, "harness")
 	otherProject := t.TempDir()
-	helpResult := runCommand(
+	helpResult := support.RunCommand(
 		t,
 		otherProject,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, installDir, devDir, stableDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, installDir, devDir, stableDir),
 		}),
 		wrapperPath,
 		"--help",
@@ -463,16 +442,16 @@ func TestInstallDevHarnessVersionReportsDevModeAndPathInsideWorktree(t *testing.
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	stableDir, _ := newFakeStableHarness(t)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir, stableDir),
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -483,11 +462,11 @@ func TestInstallDevHarnessVersionReportsDevModeAndPathInsideWorktree(t *testing.
 	}
 
 	wrapperPath := filepath.Join(installDir, "harness")
-	versionResult := runCommand(
+	versionResult := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, installDir, stableDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		wrapperPath,
 		"--version",
@@ -496,7 +475,7 @@ func TestInstallDevHarnessVersionReportsDevModeAndPathInsideWorktree(t *testing.
 		t.Fatalf("wrapper version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
 	}
 
-	if mode := requireVersionField(t, versionResult.Stdout, "mode"); mode != "dev" {
+	if mode := support.RequireVersionField(t, versionResult.Stdout, "mode"); mode != "dev" {
 		t.Fatalf("expected dev mode from repo-local worktree binary, got %q\noutput:\n%s", mode, versionResult.Stdout)
 	}
 	versionSeedBytes, err := os.ReadFile(filepath.Join(repoRoot, "VERSION"))
@@ -504,14 +483,14 @@ func TestInstallDevHarnessVersionReportsDevModeAndPathInsideWorktree(t *testing.
 		t.Fatalf("read VERSION: %v", err)
 	}
 	expectedVersion := "v" + strings.TrimSpace(string(versionSeedBytes)) + "-dev"
-	if version := requireVersionField(t, versionResult.Stdout, "version"); version != expectedVersion {
+	if version := support.RequireVersionField(t, versionResult.Stdout, "version"); version != expectedVersion {
 		t.Fatalf("expected dev version %q, got %q\noutput:\n%s", expectedVersion, version, versionResult.Stdout)
 	}
 	expectedPath := filepath.Join(repoRoot, ".local", "bin", "harness")
 	if resolvedPath, err := filepath.EvalSymlinks(expectedPath); err == nil {
 		expectedPath = resolvedPath
 	}
-	if path := requireVersionField(t, versionResult.Stdout, "path"); path != expectedPath {
+	if path := support.RequireVersionField(t, versionResult.Stdout, "path"); path != expectedPath {
 		t.Fatalf("expected repo-local dev path %q, got %q\noutput:\n%s", expectedPath, path, versionResult.Stdout)
 	}
 }
@@ -521,16 +500,16 @@ func TestInstallDevHarnessVersionReportsStableModeAndPathOutsideWorktree(t *test
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	stableDir, _ := newFakeStableHarness(t)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir, stableDir),
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -544,11 +523,11 @@ func TestInstallDevHarnessVersionReportsStableModeAndPathOutsideWorktree(t *test
 	support.RequireFileExists(t, wrapperPath)
 
 	otherProject := t.TempDir()
-	versionResult := runCommand(
+	versionResult := support.RunCommand(
 		t,
 		otherProject,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, installDir, stableDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		wrapperPath,
 		"--version",
@@ -557,10 +536,10 @@ func TestInstallDevHarnessVersionReportsStableModeAndPathOutsideWorktree(t *test
 		t.Fatalf("wrapper version failed with exit %d\nstdout:\n%s\nstderr:\n%s", versionResult.ExitCode, versionResult.Stdout, versionResult.Stderr)
 	}
 
-	if mode := requireVersionField(t, versionResult.Stdout, "mode"); mode != "release" {
+	if mode := support.RequireVersionField(t, versionResult.Stdout, "mode"); mode != "release" {
 		t.Fatalf("expected release mode from stable PATH fallback, got %q\noutput:\n%s", mode, versionResult.Stdout)
 	}
-	if commit := requireVersionField(t, versionResult.Stdout, "commit"); commit != "stable-test-commit" {
+	if commit := support.RequireVersionField(t, versionResult.Stdout, "commit"); commit != "stable-test-commit" {
 		t.Fatalf("expected stable fallback commit %q, got %q\noutput:\n%s", "stable-test-commit", commit, versionResult.Stdout)
 	}
 	if strings.Contains(versionResult.Stdout, `"path"`) {
@@ -573,7 +552,7 @@ func TestInstallDevHarnessReplacesLegacyManagedWrapperWithoutForce(t *testing.T)
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	if err := os.MkdirAll(installDir, 0o755); err != nil {
 		t.Fatalf("mkdir install dir: %v", err)
@@ -623,14 +602,14 @@ fi
 
 exec "${binary_path}" "$@"
 `
-	writeFixtureFile(t, wrapperPath, legacyWrapper, 0o755)
+	support.WriteFixtureFile(t, wrapperPath, legacyWrapper, 0o755)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t),
+			"PATH": support.InstallerPath(t),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -668,7 +647,7 @@ func TestInstallDevHarnessReplacesLegacySymlinkedBinaryWithoutForce(t *testing.T
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			repoRoot := copyInstallerFixture(t)
+			repoRoot := support.CopyInstallerFixture(t)
 			installDir := filepath.Join(t.TempDir(), "path-bin")
 			if err := os.MkdirAll(installDir, 0o755); err != nil {
 				t.Fatalf("mkdir install dir: %v", err)
@@ -684,22 +663,22 @@ func TestInstallDevHarnessReplacesLegacySymlinkedBinaryWithoutForce(t *testing.T
 					t.Fatalf("mkdir legacy dir %s: %v", dir, err)
 				}
 			}
-			writeFixtureFile(t, filepath.Join(legacyRoot, "scripts", "install-dev-harness"), "#!/usr/bin/env bash\n", 0o755)
-			writeFixtureFile(t, filepath.Join(legacyRoot, "cmd", "harness", "main.go"), "package main\n", 0o644)
-			writeFixtureFile(t, filepath.Join(legacyRoot, "go.mod"), tc.moduleLine, 0o644)
-			writeFixtureFile(t, filepath.Join(legacyRoot, ".local", "bin", "harness"), "#!/bin/sh\nexit 0\n", 0o755)
+			support.WriteFixtureFile(t, filepath.Join(legacyRoot, "scripts", "install-dev-harness"), "#!/usr/bin/env bash\n", 0o755)
+			support.WriteFixtureFile(t, filepath.Join(legacyRoot, "cmd", "harness", "main.go"), "package main\n", 0o644)
+			support.WriteFixtureFile(t, filepath.Join(legacyRoot, "go.mod"), tc.moduleLine, 0o644)
+			support.WriteFixtureFile(t, filepath.Join(legacyRoot, ".local", "bin", "harness"), "#!/bin/sh\nexit 0\n", 0o755)
 
 			wrapperPath := filepath.Join(installDir, "harness")
 			if err := os.Symlink(filepath.Join(legacyRoot, ".local", "bin", "harness"), wrapperPath); err != nil {
 				t.Fatalf("create legacy symlink: %v", err)
 			}
 
-			result := runCommand(
+			result := support.RunCommand(
 				t,
 				repoRoot,
-				installerEnv(t, map[string]string{
+				support.InstallerEnv(t, map[string]string{
 					"HOME": t.TempDir(),
-					"PATH": installerPath(t),
+					"PATH": support.InstallerPath(t),
 				}),
 				"/bin/bash",
 				filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -730,16 +709,16 @@ func TestInstallDevHarnessWrapperDoesNotUseStablePathFallbackInsideSourceTreeWit
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	stableDir, _ := newFakeStableHarness(t)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		installerEnv(t, map[string]string{
+		support.InstallerEnv(t, map[string]string{
 			"HOME": t.TempDir(),
-			"PATH": installerPath(t, installDir, stableDir),
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "install-dev-harness"),
@@ -751,11 +730,11 @@ func TestInstallDevHarnessWrapperDoesNotUseStablePathFallbackInsideSourceTreeWit
 
 	_, nestedDir := newFakeWorktreeWithoutLocalBinary(t)
 	wrapperPath := filepath.Join(installDir, "harness")
-	wrapperResult := runCommand(
+	wrapperResult := support.RunCommand(
 		t,
 		nestedDir,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, installDir, stableDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, installDir, stableDir),
 		}),
 		wrapperPath,
 		"status",
@@ -768,80 +747,6 @@ func TestInstallDevHarnessWrapperDoesNotUseStablePathFallbackInsideSourceTreeWit
 	support.RequireContains(t, wrapperResult.Stderr, filepath.Join(".local", "bin", "harness"))
 	if strings.Contains(wrapperResult.CombinedOutput(), "stable fallback harness") {
 		t.Fatalf("expected source-tree invocation to refuse the stable PATH fallback\nstdout:\n%s\nstderr:\n%s", wrapperResult.Stdout, wrapperResult.Stderr)
-	}
-}
-
-func copyInstallerFixture(t *testing.T) string {
-	t.Helper()
-
-	root := t.TempDir()
-	sourceRoot := support.RepoRoot(t)
-	for _, rel := range []string{
-		"VERSION",
-		"go.mod",
-		"go.sum",
-		"assets",
-		"cmd",
-		"internal",
-		"scripts/build-embedded-ui",
-		"scripts/install-dev-harness",
-	} {
-		copyPath(t, filepath.Join(sourceRoot, rel), filepath.Join(root, rel))
-	}
-	for _, rel := range []string{
-		"web/index.html",
-		"web/package.json",
-		"web/pnpm-lock.yaml",
-		"web/tsconfig.json",
-		"web/vite.config.ts",
-		"web/src",
-	} {
-		copyPath(t, filepath.Join(sourceRoot, rel), filepath.Join(root, rel))
-	}
-	_ = os.RemoveAll(filepath.Join(root, "internal", "ui", "generated", "build"))
-	return root
-}
-
-func copyPath(t *testing.T, src, dst string) {
-	t.Helper()
-
-	info, err := os.Stat(src)
-	if err != nil {
-		t.Fatalf("stat %s: %v", src, err)
-	}
-
-	if info.IsDir() {
-		if err := os.MkdirAll(dst, info.Mode().Perm()); err != nil {
-			t.Fatalf("mkdir %s: %v", dst, err)
-		}
-		entries, err := os.ReadDir(src)
-		if err != nil {
-			t.Fatalf("read dir %s: %v", src, err)
-		}
-		for _, entry := range entries {
-			copyPath(t, filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name()))
-		}
-		return
-	}
-
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		t.Fatalf("mkdir parent for %s: %v", dst, err)
-	}
-
-	in, err := os.Open(src)
-	if err != nil {
-		t.Fatalf("open %s: %v", src, err)
-	}
-	defer in.Close()
-
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode().Perm())
-	if err != nil {
-		t.Fatalf("create %s: %v", dst, err)
-	}
-	defer out.Close()
-
-	if _, err := io.Copy(out, in); err != nil {
-		t.Fatalf("copy %s -> %s: %v", src, dst, err)
 	}
 }
 
@@ -860,10 +765,10 @@ func newFakeWorktree(t *testing.T) (string, string) {
 		}
 	}
 
-	writeFixtureFile(t, filepath.Join(root, "scripts", "install-dev-harness"), "#!/usr/bin/env bash\n", 0o755)
-	writeFixtureFile(t, filepath.Join(root, "cmd", "harness", "main.go"), "package main\n", 0o644)
-	writeFixtureFile(t, filepath.Join(root, "go.mod"), "module github.com/catu-ai/easyharness\n", 0o644)
-	writeFixtureFile(
+	support.WriteFixtureFile(t, filepath.Join(root, "scripts", "install-dev-harness"), "#!/usr/bin/env bash\n", 0o755)
+	support.WriteFixtureFile(t, filepath.Join(root, "cmd", "harness", "main.go"), "package main\n", 0o644)
+	support.WriteFixtureFile(t, filepath.Join(root, "go.mod"), "module github.com/catu-ai/easyharness\n", 0o644)
+	support.WriteFixtureFile(
 		t,
 		filepath.Join(root, ".local", "bin", "harness"),
 		"#!/bin/sh\nprintf 'fake worktree harness\\n'\nprintf 'args=%s\\n' \"$*\"\n",
@@ -887,9 +792,9 @@ func newFakeWorktreeWithoutLocalBinary(t *testing.T) (string, string) {
 		}
 	}
 
-	writeFixtureFile(t, filepath.Join(root, "scripts", "install-dev-harness"), "#!/usr/bin/env bash\n", 0o755)
-	writeFixtureFile(t, filepath.Join(root, "cmd", "harness", "main.go"), "package main\n", 0o644)
-	writeFixtureFile(t, filepath.Join(root, "go.mod"), "module github.com/catu-ai/easyharness\n", 0o644)
+	support.WriteFixtureFile(t, filepath.Join(root, "scripts", "install-dev-harness"), "#!/usr/bin/env bash\n", 0o755)
+	support.WriteFixtureFile(t, filepath.Join(root, "cmd", "harness", "main.go"), "package main\n", 0o644)
+	support.WriteFixtureFile(t, filepath.Join(root, "go.mod"), "module github.com/catu-ai/easyharness\n", 0o644)
 
 	return root, filepath.Join(root, "nested", "dir")
 }
@@ -899,7 +804,7 @@ func newFakeStableHarness(t *testing.T) (string, string) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "harness")
-	writeFixtureFile(
+	support.WriteFixtureFile(
 		t,
 		path,
 		`#!/bin/sh
@@ -944,7 +849,7 @@ func newFakeDevHarness(t *testing.T) (string, string) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "harness")
-	writeFixtureFile(
+	support.WriteFixtureFile(
 		t,
 		path,
 		`#!/bin/sh
@@ -966,214 +871,4 @@ esac
 		0o755,
 	)
 	return dir, path
-}
-
-func writeFixtureFile(t *testing.T, path, contents string, mode os.FileMode) {
-	t.Helper()
-	if err := os.WriteFile(path, []byte(contents), mode); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
-}
-
-func envWithOverrides(t *testing.T, overrides map[string]string) []string {
-	t.Helper()
-
-	env := append([]string(nil), os.Environ()...)
-	for key, value := range overrides {
-		prefix := key + "="
-		replaced := false
-		for i, entry := range env {
-			if len(entry) >= len(prefix) && entry[:len(prefix)] == prefix {
-				env[i] = prefix + value
-				replaced = true
-				break
-			}
-		}
-		if !replaced {
-			env = append(env, prefix+value)
-		}
-	}
-	return env
-}
-
-func installerEnv(t *testing.T, overrides map[string]string) []string {
-	t.Helper()
-
-	if overrides == nil {
-		overrides = map[string]string{}
-	}
-	if _, ok := overrides["GOCACHE"]; !ok {
-		overrides["GOCACHE"] = sharedInstallerGoCache(t)
-	}
-	if _, ok := overrides["GOMODCACHE"]; !ok {
-		overrides["GOMODCACHE"] = sharedInstallerGoModCache(t)
-	}
-	if _, ok := overrides["GOFLAGS"]; !ok {
-		overrides["GOFLAGS"] = "-modcacherw"
-	}
-	return envWithOverrides(t, overrides)
-}
-
-func sharedInstallerGoCache(t *testing.T) string {
-	t.Helper()
-	initializeInstallerCaches(t)
-	return installerCacheDirs.goCache
-}
-
-func sharedInstallerGoModCache(t *testing.T) string {
-	t.Helper()
-	initializeInstallerCaches(t)
-	return installerCacheDirs.goModCache
-}
-
-func initializeInstallerCaches(t *testing.T) {
-	t.Helper()
-
-	installerCacheDirs.once.Do(func() {
-		root, err := os.MkdirTemp("", "easyharness-install-smoke-cache-*")
-		if err != nil {
-			installerCacheDirs.err = err
-			return
-		}
-		installerCacheDirs.goCache = filepath.Join(root, "go-build")
-		installerCacheDirs.goModCache = filepath.Join(root, "gomod")
-		for _, dir := range []string{installerCacheDirs.goCache, installerCacheDirs.goModCache} {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				installerCacheDirs.err = err
-				return
-			}
-		}
-	})
-
-	if installerCacheDirs.err != nil {
-		t.Fatalf("initialize shared installer caches: %v", installerCacheDirs.err)
-	}
-}
-
-func installerPath(t *testing.T, extraDirs ...string) string {
-	t.Helper()
-
-	goPath, err := exec.LookPath("go")
-	if err != nil {
-		t.Fatalf("find go on PATH: %v", err)
-	}
-	pnpmPath, err := exec.LookPath("pnpm")
-	if err != nil {
-		t.Fatalf("find pnpm on PATH: %v", err)
-	}
-
-	seen := map[string]bool{}
-	dirs := make([]string, 0, len(extraDirs)+6)
-	addDir := func(dir string) {
-		if dir == "" || seen[dir] {
-			return
-		}
-		seen[dir] = true
-		dirs = append(dirs, dir)
-	}
-
-	for _, dir := range extraDirs {
-		addDir(dir)
-	}
-	addDir(filepath.Dir(goPath))
-	addDir(filepath.Dir(pnpmPath))
-	addDir("/usr/bin")
-	addDir("/bin")
-	addDir("/usr/sbin")
-	addDir("/sbin")
-
-	return strings.Join(dirs, string(os.PathListSeparator))
-}
-
-func releaseSmokePath(t *testing.T, extraToolPaths ...string) string {
-	t.Helper()
-
-	goPath, err := exec.LookPath("go")
-	if err != nil {
-		t.Fatalf("find go on PATH: %v", err)
-	}
-	pnpmPath, err := exec.LookPath("pnpm")
-	if err != nil {
-		t.Fatalf("find pnpm on PATH: %v", err)
-	}
-
-	toolPaths := make([]string, 0, len(extraToolPaths)+2)
-	toolPaths = append(toolPaths, goPath, pnpmPath)
-	toolPaths = append(toolPaths, extraToolPaths...)
-	return releaseSmokePathFromToolPaths(os.Getenv("PATH"), toolPaths...)
-}
-
-func releaseSmokePathFromToolPaths(currentPath string, toolPaths ...string) string {
-	seen := map[string]bool{}
-	dirs := make([]string, 0, len(toolPaths)+len(filepath.SplitList(currentPath))+4)
-	addDir := func(dir string) {
-		if dir == "" || seen[dir] {
-			return
-		}
-		seen[dir] = true
-		dirs = append(dirs, dir)
-	}
-
-	for _, toolPath := range toolPaths {
-		addDir(filepath.Dir(toolPath))
-	}
-	for _, dir := range filepath.SplitList(currentPath) {
-		addDir(dir)
-	}
-	addDir("/usr/bin")
-	addDir("/bin")
-	addDir("/usr/sbin")
-	addDir("/sbin")
-
-	return strings.Join(dirs, string(os.PathListSeparator))
-}
-
-func runCommand(t *testing.T, workdir string, env []string, argv ...string) commandResult {
-	t.Helper()
-
-	return runCommandWithTimeout(t, 0, workdir, env, argv...)
-}
-
-func runCommandWithTimeout(t *testing.T, timeout time.Duration, workdir string, env []string, argv ...string) commandResult {
-	t.Helper()
-
-	var (
-		cmd    *exec.Cmd
-		cancel func()
-	)
-	if timeout > 0 {
-		var ctx context.Context
-		ctx, cancel = context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		cmd = exec.CommandContext(ctx, argv[0], argv[1:]...)
-	} else {
-		cmd = exec.Command(argv[0], argv[1:]...)
-	}
-
-	cmd.Dir = workdir
-	cmd.Env = env
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	result := commandResult{
-		Stdout: stdout.String(),
-		Stderr: stderr.String(),
-	}
-	if err == nil {
-		return result
-	}
-
-	var exitErr *exec.ExitError
-	if !errors.As(err, &exitErr) {
-		if errors.Is(err, context.DeadlineExceeded) {
-			t.Fatalf("run command %v timed out after %s\nstdout:\n%s\nstderr:\n%s", argv, timeout, stdout.String(), stderr.String())
-		}
-		t.Fatalf("run command %v: %v", argv, err)
-	}
-	result.ExitCode = exitErr.ExitCode()
-	return result
 }

--- a/tests/installer/install_dev_harness_test.go
+++ b/tests/installer/install_dev_harness_test.go
@@ -1,4 +1,4 @@
-//go:build slow_smoke
+//go:build installer_smoke
 
 package installer_test
 

--- a/tests/installer/install_dev_harness_test.go
+++ b/tests/installer/install_dev_harness_test.go
@@ -18,6 +18,8 @@ func TestInstallDevHarnessDefaultsToUserLocalBin(t *testing.T) {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
+	t.Parallel()
+
 	repoRoot := support.CopyInstallerFixture(t)
 	tempHome := t.TempDir()
 	firstPathDir := filepath.Join(t.TempDir(), "path-bin")
@@ -60,6 +62,8 @@ func TestInstallDevHarnessHelpDoesNotMentionGlobalFlag(t *testing.T) {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
+	t.Parallel()
+
 	repoRoot := support.CopyInstallerFixture(t)
 	result := support.RunCommand(
 		t,
@@ -86,6 +90,8 @@ func TestInstallDevHarnessRejectsRemovedGlobalFlag(t *testing.T) {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
+	t.Parallel()
+
 	repoRoot := support.CopyInstallerFixture(t)
 	result := support.RunCommand(
 		t,
@@ -109,6 +115,8 @@ func TestInstallDevHarnessVerifiesPATHResolvedWrapperWhenInstallDirIsAlreadyOnPA
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
+
+	t.Parallel()
 
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
@@ -141,6 +149,8 @@ func TestInstallDevHarnessWrapperDispatchesToCurrentWorktreeOverStablePathFallba
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
+
+	t.Parallel()
 
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
@@ -190,6 +200,8 @@ func TestInstallDevHarnessWrapperRequiresStableHarnessOnPathOutsideWorktree(t *t
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
+	t.Parallel()
+
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 
@@ -235,6 +247,8 @@ func TestInstallDevHarnessWrapperUsesStableHarnessOnPathOutsideWorktree(t *testi
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
+	t.Parallel()
+
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	stableDir, _ := newFakeStableHarness(t)
@@ -278,6 +292,8 @@ func TestInstallDevHarnessWrapperSkipsOtherManagedWrappersOnPathOutsideWorktree(
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
+
+	t.Parallel()
 
 	cases := []struct {
 		name   string
@@ -344,6 +360,8 @@ func TestInstallDevHarnessWrapperSkipsSymlinkAliasesOnPathOutsideWorktree(t *tes
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
+	t.Parallel()
+
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	aliasOneDir := t.TempDir()
@@ -396,6 +414,8 @@ func TestInstallDevHarnessWrapperSkipsRepoLocalDevBinaryOnPathOutsideWorktree(t 
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
+	t.Parallel()
+
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	devDir, _ := newFakeDevHarness(t)
@@ -441,6 +461,8 @@ func TestInstallDevHarnessVersionReportsDevModeAndPathInsideWorktree(t *testing.
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
+
+	t.Parallel()
 
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
@@ -500,6 +522,8 @@ func TestInstallDevHarnessVersionReportsStableModeAndPathOutsideWorktree(t *test
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
+	t.Parallel()
+
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
 	stableDir, _ := newFakeStableHarness(t)
@@ -551,6 +575,8 @@ func TestInstallDevHarnessReplacesLegacyManagedWrapperWithoutForce(t *testing.T)
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
+
+	t.Parallel()
 
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")
@@ -631,6 +657,8 @@ func TestInstallDevHarnessReplacesLegacySymlinkedBinaryWithoutForce(t *testing.T
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
 
+	t.Parallel()
+
 	cases := []struct {
 		name       string
 		moduleLine string
@@ -708,6 +736,8 @@ func TestInstallDevHarnessWrapperDoesNotUseStablePathFallbackInsideSourceTreeWit
 	if runtime.GOOS == "windows" {
 		t.Skip("installer smoke tests require a POSIX shell")
 	}
+
+	t.Parallel()
 
 	repoRoot := support.CopyInstallerFixture(t)
 	installDir := filepath.Join(t.TempDir(), "path-bin")

--- a/tests/release/homebrew_formula_test.go
+++ b/tests/release/homebrew_formula_test.go
@@ -1,4 +1,4 @@
-package smoke_test
+package release_test
 
 import (
 	"encoding/json"
@@ -28,11 +28,11 @@ func TestRenderHomebrewFormulaFromChecksums(t *testing.T) {
 		t.Fatalf("write SHA256SUMS: %v", err)
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		workdir,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "render-homebrew-formula"),
@@ -79,11 +79,11 @@ func TestRenderHomebrewFormulaFailsWhenChecksumIsMissing(t *testing.T) {
 		t.Fatalf("write SHA256SUMS: %v", err)
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t),
 		}),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "render-homebrew-formula"),
@@ -104,11 +104,11 @@ func TestUpdateHomebrewTapWarnsWithoutToken(t *testing.T) {
 		t.Fatalf("write formula file: %v", err)
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, map[string]string{
-			"PATH":                           installerPath(t),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH":                           support.InstallerPath(t),
 			"EASYHARNESS_HOMEBREW_TAP_TOKEN": "",
 		}),
 		"/bin/bash",
@@ -154,11 +154,11 @@ func TestUpdateHomebrewTapPushesFromDetachedCheckout(t *testing.T) {
 		t.Fatalf("write formula file: %v", err)
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, map[string]string{
-			"PATH":                           installerPath(t),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH":                           support.InstallerPath(t),
 			"EASYHARNESS_HOMEBREW_TAP_TOKEN": "dummy-token",
 		}),
 		"/bin/bash",
@@ -226,8 +226,8 @@ func TestReleaseWorkflowWiresHomebrewTapPublishing(t *testing.T) {
 	support.RequireContains(t, workflow, "- name: Verify published release namespace\n        env:")
 	support.RequireContains(t, workflow, `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`)
 	support.RequireContains(t, workflow, `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`)
-	support.RequireContains(t, workflow, "run: go test ./tests/smoke -run TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled -count=1")
-	if strings.Contains(workflow, "working-directory: dist/release-source\n        run: go test ./tests/smoke -run TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled -count=1") {
+	support.RequireContains(t, workflow, "run: go test ./tests/release -run TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled -count=1")
+	if strings.Contains(workflow, "working-directory: dist/release-source\n        run: go test ./tests/release -run TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled -count=1") {
 		t.Fatalf("expected namespace verification to run from the root checkout so main-branch smoke fixes apply to release reruns")
 	}
 	support.RequireContains(t, workflow, `scripts/update-homebrew-tap \`)
@@ -244,11 +244,11 @@ func TestReleaseWorkflowWiresHomebrewTapPublishing(t *testing.T) {
 	support.RequireContains(t, workflow, "- name: Set up Go\n        uses: actions/setup-go@v6\n        with:\n          go-version-file: go.mod\n          cache: true\n\n      - name: Set up pnpm\n        uses: pnpm/action-setup@v5\n        with:\n          version: 10.32.1\n          run_install: false")
 	support.RequireContains(t, workflow, `EASYHARNESS_LIVE_GH_REPO: ${{ github.repository }}`)
 	support.RequireContains(t, workflow, `EASYHARNESS_LIVE_GH_TAG: ${{ steps.release-version.outputs.version }}`)
-	support.RequireContains(t, workflow, `go test ./tests/smoke -run TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled -count=1`)
-	requireSubstringOrder(t, workflow, `uses: pnpm/action-setup@v5`, `uses: actions/setup-node@v6`)
-	requireSubstringOrder(t, workflow, "- name: Set up pnpm\n        uses: pnpm/action-setup@v5", `go test ./tests/smoke -run TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled -count=1`)
-	requireSubstringOrder(t, workflow, "working-directory: dist/release-source\n        run: scripts/build-embedded-ui", "working-directory: dist/release-source\n        run: go test ./...")
-	requireSubstringOrder(t, workflow, "working-directory: dist/release-source\n        run: scripts/build-embedded-ui", `run: dist/release-source/scripts/build-release --version "${{ steps.release-version.outputs.version }}" --output-dir dist/release`)
+	support.RequireContains(t, workflow, `go test ./tests/release -run TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled -count=1`)
+	support.RequireSubstringOrder(t, workflow, `uses: pnpm/action-setup@v5`, `uses: actions/setup-node@v6`)
+	support.RequireSubstringOrder(t, workflow, "- name: Set up pnpm\n        uses: pnpm/action-setup@v5", `go test ./tests/release -run TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled -count=1`)
+	support.RequireSubstringOrder(t, workflow, "working-directory: dist/release-source\n        run: scripts/build-embedded-ui", "working-directory: dist/release-source\n        run: go test ./...")
+	support.RequireSubstringOrder(t, workflow, "working-directory: dist/release-source\n        run: scripts/build-embedded-ui", `run: dist/release-source/scripts/build-release --version "${{ steps.release-version.outputs.version }}" --output-dir dist/release`)
 }
 
 func TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled(t *testing.T) {
@@ -273,14 +273,14 @@ func TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled(t *testing.T) {
 	}
 
 	repoRoot := support.RepoRoot(t)
-	env := envWithOverrides(t, map[string]string{
-		"PATH": releaseSmokePath(t, brewPath, ghPath),
+	env := support.EnvWithOverrides(t, map[string]string{
+		"PATH": support.ReleaseSmokePath(t, brewPath, ghPath),
 	})
 	if previousTag == "" {
 		previousTag = resolvePreviousHomebrewReleaseTag(t, repoRoot, env, repo, tag)
 	}
 
-	brewRepoResult := runCommand(t, repoRoot, env, brewPath, "--repository")
+	brewRepoResult := support.RunCommand(t, repoRoot, env, brewPath, "--repository")
 	if brewRepoResult.ExitCode != 0 {
 		t.Fatalf("brew --repository failed with exit %d\nstdout:\n%s\nstderr:\n%s", brewRepoResult.ExitCode, brewRepoResult.Stdout, brewRepoResult.Stderr)
 	}
@@ -305,28 +305,28 @@ func TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled(t *testing.T) {
 		previousChecksumsPath := downloadReleaseChecksums(t, repoRoot, env, repo, previousTag)
 		renderHomebrewFormula(t, repoRoot, env, repo, previousTag, previousChecksumsPath, formulaPath)
 
-		installResult := runCommand(t, repoRoot, env, brewPath, "install", "catu-ai/tap/easyharness")
+		installResult := support.RunCommand(t, repoRoot, env, brewPath, "install", "catu-ai/tap/easyharness")
 		if installResult.ExitCode != 0 {
 			t.Fatalf("brew install catu-ai/tap/easyharness failed with exit %d\nstdout:\n%s\nstderr:\n%s", installResult.ExitCode, installResult.Stdout, installResult.Stderr)
 		}
 		requireInstalledHarnessVersion(t, repoRoot, env, brewPath, previousTag)
 
 		renderHomebrewFormula(t, repoRoot, env, repo, tag, currentChecksumsPath, formulaPath)
-		upgradeResult := runCommand(t, repoRoot, env, brewPath, "upgrade", "catu-ai/tap/easyharness")
+		upgradeResult := support.RunCommand(t, repoRoot, env, brewPath, "upgrade", "catu-ai/tap/easyharness")
 		if upgradeResult.ExitCode != 0 {
 			t.Fatalf("brew upgrade catu-ai/tap/easyharness failed with exit %d\nstdout:\n%s\nstderr:\n%s", upgradeResult.ExitCode, upgradeResult.Stdout, upgradeResult.Stderr)
 		}
 	} else {
 		renderHomebrewFormula(t, repoRoot, env, repo, tag, currentChecksumsPath, formulaPath)
 
-		installResult := runCommand(t, repoRoot, env, brewPath, "install", "catu-ai/tap/easyharness")
+		installResult := support.RunCommand(t, repoRoot, env, brewPath, "install", "catu-ai/tap/easyharness")
 		if installResult.ExitCode != 0 {
 			t.Fatalf("brew install catu-ai/tap/easyharness failed with exit %d\nstdout:\n%s\nstderr:\n%s", installResult.ExitCode, installResult.Stdout, installResult.Stderr)
 		}
 	}
 	requireInstalledHarnessVersion(t, repoRoot, env, brewPath, tag)
 
-	testResult := runCommand(t, repoRoot, env, brewPath, "test", "easyharness")
+	testResult := support.RunCommand(t, repoRoot, env, brewPath, "test", "easyharness")
 	if testResult.ExitCode != 0 {
 		t.Fatalf("brew test easyharness failed with exit %d\nstdout:\n%s\nstderr:\n%s", testResult.ExitCode, testResult.Stdout, testResult.Stderr)
 	}
@@ -336,7 +336,7 @@ func downloadReleaseChecksums(t *testing.T, repoRoot string, env []string, repo,
 	t.Helper()
 
 	downloadDir := filepath.Join(t.TempDir(), "downloads")
-	verifyResult := runCommand(
+	verifyResult := support.RunCommand(
 		t,
 		repoRoot,
 		env,
@@ -356,7 +356,7 @@ func downloadReleaseChecksums(t *testing.T, repoRoot string, env []string, repo,
 func renderHomebrewFormula(t *testing.T, repoRoot string, env []string, repo, tag, checksumsPath, formulaPath string) {
 	t.Helper()
 
-	renderResult := runCommand(
+	renderResult := support.RunCommand(
 		t,
 		repoRoot,
 		env,
@@ -375,7 +375,7 @@ func renderHomebrewFormula(t *testing.T, repoRoot string, env []string, repo, ta
 func requireInstalledHarnessVersion(t *testing.T, repoRoot string, env []string, brewPath string, tag string) {
 	t.Helper()
 
-	prefixResult := runCommand(t, repoRoot, env, brewPath, "--prefix")
+	prefixResult := support.RunCommand(t, repoRoot, env, brewPath, "--prefix")
 	if prefixResult.ExitCode != 0 {
 		t.Fatalf("brew --prefix failed with exit %d\nstdout:\n%s\nstderr:\n%s", prefixResult.ExitCode, prefixResult.Stdout, prefixResult.Stderr)
 	}
@@ -387,10 +387,10 @@ func requireInstalledHarnessVersion(t *testing.T, repoRoot string, env []string,
 	if err != nil {
 		t.Fatalf("run installed harness --version: %v\n%s", err, versionOutput)
 	}
-	if got := requireVersionField(t, string(versionOutput), "version"); got != tag {
+	if got := support.RequireVersionField(t, string(versionOutput), "version"); got != tag {
 		t.Fatalf("expected installed harness version %q, got %q\noutput:\n%s", tag, got, versionOutput)
 	}
-	if got := requireVersionField(t, string(versionOutput), "mode"); got != "release" {
+	if got := support.RequireVersionField(t, string(versionOutput), "mode"); got != "release" {
 		t.Fatalf("expected installed harness mode release, got %q\noutput:\n%s", got, versionOutput)
 	}
 }

--- a/tests/release/homebrew_formula_test.go
+++ b/tests/release/homebrew_formula_test.go
@@ -208,7 +208,7 @@ func TestReleaseWorkflowWiresHomebrewTapPublishing(t *testing.T) {
 	support.RequireContains(t, workflow, `cache-dependency-path: dist/release-source/web/pnpm-lock.yaml`)
 	support.RequireContains(t, workflow, `run: corepack enable`)
 	support.RequireContains(t, workflow, `working-directory: dist/release-source`)
-	support.RequireContains(t, workflow, `run: scripts/build-embedded-ui`)
+	support.RequireContains(t, workflow, `run: scripts/validate`)
 	support.RequireContains(t, workflow, `EASYHARNESS_HOMEBREW_TAP_TOKEN: ""`)
 	support.RequireContains(t, workflow, `if: ${{ env.EASYHARNESS_HOMEBREW_TAP_TOKEN != '' }}`)
 	support.RequireContains(t, workflow, `repository: catu-ai/homebrew-tap`)
@@ -247,8 +247,7 @@ func TestReleaseWorkflowWiresHomebrewTapPublishing(t *testing.T) {
 	support.RequireContains(t, workflow, `go test ./tests/release -run TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled -count=1`)
 	support.RequireSubstringOrder(t, workflow, `uses: pnpm/action-setup@v5`, `uses: actions/setup-node@v6`)
 	support.RequireSubstringOrder(t, workflow, "- name: Set up pnpm\n        uses: pnpm/action-setup@v5", `go test ./tests/release -run TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled -count=1`)
-	support.RequireSubstringOrder(t, workflow, "working-directory: dist/release-source\n        run: scripts/build-embedded-ui", "working-directory: dist/release-source\n        run: go test ./...")
-	support.RequireSubstringOrder(t, workflow, "working-directory: dist/release-source\n        run: scripts/build-embedded-ui", `run: dist/release-source/scripts/build-release --version "${{ steps.release-version.outputs.version }}" --output-dir dist/release`)
+	support.RequireSubstringOrder(t, workflow, "working-directory: dist/release-source\n        run: scripts/validate", `run: dist/release-source/scripts/build-release --version "${{ steps.release-version.outputs.version }}" --output-dir dist/release`)
 }
 
 func TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled(t *testing.T) {

--- a/tests/release/homebrew_formula_test.go
+++ b/tests/release/homebrew_formula_test.go
@@ -291,7 +291,7 @@ func TestVerifyHomebrewTapInstallAgainstGitHubWhenEnabled(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		_ = exec.Command(brewPath, "uninstall", "--force", "easyharness").Run()
+		_ = support.RunCommand(t, repoRoot, env, brewPath, "uninstall", "--force", "easyharness")
 		_ = os.RemoveAll(tapRoot)
 	})
 
@@ -380,17 +380,15 @@ func requireInstalledHarnessVersion(t *testing.T, repoRoot string, env []string,
 		t.Fatalf("brew --prefix failed with exit %d\nstdout:\n%s\nstderr:\n%s", prefixResult.ExitCode, prefixResult.Stdout, prefixResult.Stderr)
 	}
 	binaryPath := filepath.Join(strings.TrimSpace(prefixResult.Stdout), "bin", "harness")
-	versionCmd := exec.Command(binaryPath, "--version")
-	versionCmd.Dir = repoRoot
-	versionCmd.Env = env
-	versionOutput, err := versionCmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("run installed harness --version: %v\n%s", err, versionOutput)
+	versionResult := support.RunCommand(t, repoRoot, env, binaryPath, "--version")
+	if versionResult.ExitCode != 0 {
+		t.Fatalf("run installed harness --version exited with code %d\n%s", versionResult.ExitCode, versionResult.CombinedOutput())
 	}
-	if got := support.RequireVersionField(t, string(versionOutput), "version"); got != tag {
+	versionOutput := versionResult.CombinedOutput()
+	if got := support.RequireVersionField(t, versionOutput, "version"); got != tag {
 		t.Fatalf("expected installed harness version %q, got %q\noutput:\n%s", tag, got, versionOutput)
 	}
-	if got := support.RequireVersionField(t, string(versionOutput), "mode"); got != "release" {
+	if got := support.RequireVersionField(t, versionOutput, "mode"); got != "release" {
 		t.Fatalf("expected installed harness mode release, got %q\noutput:\n%s", got, versionOutput)
 	}
 }
@@ -434,17 +432,14 @@ func listGitHubReleases(t *testing.T, repoRoot string, env []string, repo string
 
 	releases := make([]githubRelease, 0, 100)
 	for page := 1; ; page++ {
-		cmd := exec.Command(ghPath, "api", fmt.Sprintf("repos/%s/releases?per_page=100&page=%d", repo, page))
-		cmd.Dir = repoRoot
-		cmd.Env = env
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("gh api releases page %d failed: %v\n%s", page, err, output)
+		result := support.RunCommand(t, repoRoot, env, ghPath, "api", fmt.Sprintf("repos/%s/releases?per_page=100&page=%d", repo, page))
+		if result.ExitCode != 0 {
+			t.Fatalf("gh api releases page %d exited with code %d\n%s", page, result.ExitCode, result.CombinedOutput())
 		}
 
 		var pageReleases []githubRelease
-		if err := json.Unmarshal(output, &pageReleases); err != nil {
-			t.Fatalf("parse gh release response page %d: %v\n%s", page, err, output)
+		if err := json.Unmarshal([]byte(result.Stdout), &pageReleases); err != nil {
+			t.Fatalf("parse gh release response page %d: %v\n%s", page, err, result.CombinedOutput())
 		}
 		releases = append(releases, pageReleases...)
 		if len(pageReleases) < 100 {
@@ -472,21 +467,17 @@ func releaseSupportsHomebrewFormula(t *testing.T, checksumsPath string, tag stri
 
 func mustRunGit(t *testing.T, workdir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = workdir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v failed: %v\n%s", args, err, output)
+	result := support.RunCommand(t, workdir, nil, append([]string{"git"}, args...)...)
+	if result.ExitCode != 0 {
+		t.Fatalf("git %v exited with code %d\n%s", args, result.ExitCode, result.CombinedOutput())
 	}
 }
 
 func runGitOutput(t *testing.T, workdir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = workdir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v failed: %v\n%s", args, err, output)
+	result := support.RunCommand(t, workdir, nil, append([]string{"git"}, args...)...)
+	if result.ExitCode != 0 {
+		t.Fatalf("git %v exited with code %d\n%s", args, result.ExitCode, result.CombinedOutput())
 	}
-	return string(output)
+	return result.Stdout
 }

--- a/tests/release/release_build_test.go
+++ b/tests/release/release_build_test.go
@@ -104,15 +104,10 @@ func TestBuildReleaseProducesStableArchiveAndVersionedBinary(t *testing.T) {
 }
 
 func TestBuildReleaseHelpUsesStableExampleVersion(t *testing.T) {
-	cmd := exec.Command("scripts/build-release", "--help")
-	cmd.Dir = support.RepoRoot(t)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("build-release --help: %v\n%s", err, output)
-	}
+	result := requireBuildReleaseSuccess(t, support.RepoRoot(t), nil, "--help")
 
-	if !strings.Contains(string(output), "for example v0.0.0") {
-		t.Fatalf("expected stable example version in build-release help, got:\n%s", output)
+	if !strings.Contains(result.CombinedOutput(), "for example v0.0.0") {
+		t.Fatalf("expected stable example version in build-release help, got:\n%s", result.CombinedOutput())
 	}
 }
 
@@ -189,19 +184,16 @@ func TestBuildReleaseRejectsUnsafeOutputDirectory(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := exec.Command(
-				"scripts/build-release",
+			result := runBuildReleaseCommand(t, support.RepoRoot(t), nil,
 				"--version", "v0.1.0-alpha.1",
 				"--output-dir", tc.outputDir,
 				"--platform", runtime.GOOS+"/"+runtime.GOARCH,
 			)
-			cmd.Dir = support.RepoRoot(t)
-			result, err := cmd.CombinedOutput()
-			if err == nil {
+			if result.ExitCode == 0 {
 				t.Fatalf("expected build-release to reject output dir %q", tc.outputDir)
 			}
-			if !strings.Contains(string(result), tc.wantText) {
-				t.Fatalf("expected output for %q to contain %q, got:\n%s", tc.outputDir, tc.wantText, result)
+			if !strings.Contains(result.CombinedOutput(), tc.wantText) {
+				t.Fatalf("expected output for %q to contain %q, got:\n%s", tc.outputDir, tc.wantText, result.CombinedOutput())
 			}
 		})
 	}
@@ -329,19 +321,16 @@ func TestBuildReleaseRejectsSymlinkEscapesFromAllowedOutputRoots(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Remove(symlinkPath) })
 
-	cmd := exec.Command(
-		"scripts/build-release",
+	result := runBuildReleaseCommand(t, repoRoot, nil,
 		"--version", "v0.1.0-alpha.1",
 		"--output-dir", filepath.Join(symlinkPath, "release-out"),
 		"--platform", hostPlatform,
 	)
-	cmd.Dir = repoRoot
-	result, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected build-release to reject symlinked output dir, output:\n%s", result)
+	if result.ExitCode == 0 {
+		t.Fatalf("expected build-release to reject symlinked output dir, output:\n%s", result.CombinedOutput())
 	}
-	if !strings.Contains(string(result), "output directory path must not traverse symlink segments") {
-		t.Fatalf("expected symlink rejection message, got:\n%s", result)
+	if !strings.Contains(result.CombinedOutput(), "output directory path must not traverse symlink segments") {
+		t.Fatalf("expected symlink rejection message, got:\n%s", result.CombinedOutput())
 	}
 	if _, err := os.Stat(sentinelPath); err != nil {
 		t.Fatalf("expected sentinel outside allowed roots to survive rejected build, got: %v", err)
@@ -351,19 +340,16 @@ func TestBuildReleaseRejectsSymlinkEscapesFromAllowedOutputRoots(t *testing.T) {
 func TestBuildReleaseRejectsUnsafeVersion(t *testing.T) {
 	outputDir := newReleaseOutputDir(t, "unsafe-version")
 
-	cmd := exec.Command(
-		"scripts/build-release",
+	result := runBuildReleaseCommand(t, support.RepoRoot(t), nil,
 		"--version", "v0.1.0/../../escape",
 		"--output-dir", outputDir,
 		"--platform", runtime.GOOS+"/"+runtime.GOARCH,
 	)
-	cmd.Dir = support.RepoRoot(t)
-	result, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected build-release to reject unsafe version, output:\n%s", result)
+	if result.ExitCode == 0 {
+		t.Fatalf("expected build-release to reject unsafe version, output:\n%s", result.CombinedOutput())
 	}
-	if !strings.Contains(string(result), "version must use only ASCII letters, digits, dot, underscore, plus, or hyphen") {
-		t.Fatalf("expected unsafe-version rejection message, got:\n%s", result)
+	if !strings.Contains(result.CombinedOutput(), "version must use only ASCII letters, digits, dot, underscore, plus, or hyphen") {
+		t.Fatalf("expected unsafe-version rejection message, got:\n%s", result.CombinedOutput())
 	}
 }
 
@@ -401,20 +387,17 @@ exec %q "$@"
 		t.Fatalf("write fake mkdir: %v", err)
 	}
 
-	cmd := exec.Command(
-		"scripts/build-release",
+	result := runBuildReleaseCommand(t, repoRoot,
+		append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH")),
 		"--version", "v0.1.0-alpha.1",
 		"--output-dir", outputDir,
 		"--platform", hostPlatform,
 	)
-	cmd.Dir = repoRoot
-	cmd.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	result, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected build-release to reject mkdir-time symlink replacement into a different safe-root directory, output:\n%s", result)
+	if result.ExitCode == 0 {
+		t.Fatalf("expected build-release to reject mkdir-time symlink replacement into a different safe-root directory, output:\n%s", result.CombinedOutput())
 	}
-	if !strings.Contains(string(result), "output directory path must stay on the requested directory path during preparation") {
-		t.Fatalf("expected mkdir-race rejection message, got:\n%s", result)
+	if !strings.Contains(result.CombinedOutput(), "output directory path must stay on the requested directory path during preparation") {
+		t.Fatalf("expected mkdir-race rejection message, got:\n%s", result.CombinedOutput())
 	}
 	entries, err := os.ReadDir(redirectedOutputDir)
 	if err != nil {
@@ -460,20 +443,17 @@ exec %q "$@"
 		t.Fatalf("write fake zip: %v", err)
 	}
 
-	cmd := exec.Command(
-		"scripts/build-release",
+	result := runBuildReleaseCommand(t, repoRoot,
+		append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH")),
 		"--version", "v0.1.0-alpha.1",
 		"--output-dir", outputDir,
 		"--platform", hostPlatform,
 	)
-	cmd.Dir = repoRoot
-	cmd.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	result, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected build-release to reject prepared output dir replacement during build, output:\n%s", result)
+	if result.ExitCode == 0 {
+		t.Fatalf("expected build-release to reject prepared output dir replacement during build, output:\n%s", result.CombinedOutput())
 	}
-	if !strings.Contains(string(result), "prepared output directory changed unexpectedly during build") {
-		t.Fatalf("expected output-dir replacement rejection message, got:\n%s", result)
+	if !strings.Contains(result.CombinedOutput(), "prepared output directory changed unexpectedly during build") {
+		t.Fatalf("expected output-dir replacement rejection message, got:\n%s", result.CombinedOutput())
 	}
 	redirectedEntries, err := os.ReadDir(redirectedOutputDir)
 	if err != nil {
@@ -520,18 +500,12 @@ exec %q "$@"
 		t.Fatalf("write fake checksum tool: %v", err)
 	}
 
-	cmd := exec.Command(
-		"scripts/build-release",
+	requireBuildReleaseSuccess(t, support.RepoRoot(t),
+		append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH")),
 		"--version", version,
 		"--output-dir", outputDir,
 		"--platform", hostPlatform,
 	)
-	cmd.Dir = support.RepoRoot(t)
-	cmd.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	result, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("expected build-release to safely replace symlinked output entry during publish, got:\n%s", result)
-	}
 	redirectedEntries, err := os.ReadDir(redirectedOutputDir)
 	if err != nil {
 		t.Fatalf("read redirected output dir: %v", err)
@@ -612,20 +586,17 @@ exec "$real_go" "$@"
 		t.Fatalf("write fake go wrapper: %v", err)
 	}
 
-	cmd := exec.Command(
-		"scripts/build-release",
+	result := runBuildReleaseCommand(t, repoRoot,
+		append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH")),
 		"--version", "v0.1.0-alpha.1",
 		"--output-dir", outputDir,
 		"--platform", hostPlatform,
 	)
-	cmd.Dir = repoRoot
-	cmd.Env = append(os.Environ(), "PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	result, err := cmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected build-release to reject prepared output directory replacement during publish, output:\n%s", result)
+	if result.ExitCode == 0 {
+		t.Fatalf("expected build-release to reject prepared output directory replacement during publish, output:\n%s", result.CombinedOutput())
 	}
-	if !strings.Contains(string(result), "prepared output directory changed unexpectedly during build") {
-		t.Fatalf("expected publish-directory replacement message, got:\n%s", result)
+	if !strings.Contains(result.CombinedOutput(), "prepared output directory changed unexpectedly during build") {
+		t.Fatalf("expected publish-directory replacement message, got:\n%s", result.CombinedOutput())
 	}
 	redirectedEntries, err := os.ReadDir(redirectedOutputDir)
 	if err != nil {
@@ -634,6 +605,29 @@ exec "$real_go" "$@"
 	if len(redirectedEntries) != 0 {
 		t.Fatalf("expected redirected output dir to stay empty, found %d entries", len(redirectedEntries))
 	}
+}
+
+func runBuildReleaseCommand(t *testing.T, repoDir string, env []string, args ...string) support.CommandResult {
+	t.Helper()
+
+	argv := append([]string{"scripts/build-release"}, args...)
+	return support.RunCommand(t, repoDir, env, argv...)
+}
+
+func requireBuildReleaseSuccess(t *testing.T, repoDir string, env []string, args ...string) support.CommandResult {
+	t.Helper()
+
+	return requireCommandSuccess(t, "build release", repoDir, env, append([]string{"scripts/build-release"}, args...)...)
+}
+
+func requireCommandSuccess(t *testing.T, description, workdir string, env []string, argv ...string) support.CommandResult {
+	t.Helper()
+
+	result := support.RunCommand(t, workdir, env, argv...)
+	if result.ExitCode != 0 {
+		t.Fatalf("%s exited with code %d\n%s", description, result.ExitCode, result.CombinedOutput())
+	}
+	return result
 }
 
 func runReleaseBuild(t *testing.T, version, outputDir string) string {
@@ -648,13 +642,8 @@ func runReleaseBuildInDir(t *testing.T, repoDir, version, outputDir string, plat
 	for _, platform := range platforms {
 		args = append(args, "--platform", platform)
 	}
-	cmd := exec.Command("scripts/build-release", args...)
-	cmd.Dir = repoDir
-	result, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("build release: %v\n%s", err, result)
-	}
-	return string(result)
+	result := requireBuildReleaseSuccess(t, repoDir, nil, args...)
+	return result.CombinedOutput()
 }
 
 func runReleaseBuildForPlatforms(t *testing.T, version, outputDir string, platforms ...string) string {
@@ -721,14 +710,8 @@ func verifyArchiveContents(t *testing.T, workspace *support.Workspace, archivePa
 	binaryPath := filepath.Join(extractDir, binaryName)
 	verifyBinaryMetadata(t, binaryPath, version, goos, goarch, expectedCommit)
 	if goos == runtime.GOOS && goarch == runtime.GOARCH {
-		versionCmd := exec.Command(binaryPath, "--version")
-		versionCmd.Dir = extractDir
-		versionOutput, err := versionCmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("run packaged binary --version: %v\n%s", err, versionOutput)
-		}
-
-		output := string(versionOutput)
+		versionResult := requireCommandSuccess(t, "run packaged binary --version", extractDir, nil, binaryPath, "--version")
+		output := versionResult.CombinedOutput()
 		if got := support.RequireVersionField(t, output, "version"); got != version {
 			t.Fatalf("expected packaged version %q, got %q\noutput:\n%s", version, got, output)
 		}
@@ -742,15 +725,9 @@ func verifyArchiveContents(t *testing.T, workspace *support.Workspace, archivePa
 			t.Fatalf("expected packaged release output to omit path, got %q", output)
 		}
 
-		statusCmd := exec.Command(binaryPath, "status")
-		statusCmd.Dir = workspace.Root
-		statusOutput, err := statusCmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("run packaged binary status: %v\n%s", err, statusOutput)
-		}
-
-		if !strings.Contains(string(statusOutput), `"current_node": "idle"`) {
-			t.Fatalf("expected packaged binary status output to report idle workspace, got:\n%s", statusOutput)
+		statusResult := requireCommandSuccess(t, "run packaged binary status", workspace.Root, nil, binaryPath, "status")
+		if !strings.Contains(statusResult.CombinedOutput(), `"current_node": "idle"`) {
+			t.Fatalf("expected packaged binary status output to report idle workspace, got:\n%s", statusResult.CombinedOutput())
 		}
 	}
 }
@@ -758,13 +735,9 @@ func verifyArchiveContents(t *testing.T, workspace *support.Workspace, archivePa
 func gitCommitTimestampUTC(t *testing.T, repoRoot, commit string) time.Time {
 	t.Helper()
 
-	cmd := exec.Command("git", "-C", repoRoot, "show", "-s", "--format=%ct", commit)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git show commit timestamp: %v\n%s", err, output)
-	}
+	result := requireCommandSuccess(t, "git show commit timestamp", repoRoot, nil, "git", "-C", repoRoot, "show", "-s", "--format=%ct", commit)
 
-	secondsText := strings.TrimSpace(string(output))
+	secondsText := strings.TrimSpace(result.CombinedOutput())
 	seconds, err := strconv.ParseInt(secondsText, 10, 64)
 	if err != nil {
 		t.Fatalf("parse commit timestamp %q: %v", secondsText, err)
@@ -928,15 +901,11 @@ func newReleaseBuildCheckout(t *testing.T) string {
 
 	repoRoot := support.RepoRoot(t)
 	checkoutRoot := filepath.Join(t.TempDir(), "checkout")
-	cmd := exec.Command("git", "-C", repoRoot, "worktree", "add", "--detach", checkoutRoot, "HEAD")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git worktree add: %v\n%s", err, output)
-	}
+	requireCommandSuccess(t, "git worktree add", repoRoot, nil, "git", "-C", repoRoot, "worktree", "add", "--detach", checkoutRoot, "HEAD")
 	t.Cleanup(func() {
-		removeCmd := exec.Command("git", "-C", repoRoot, "worktree", "remove", "--force", checkoutRoot)
-		if cleanupOutput, cleanupErr := removeCmd.CombinedOutput(); cleanupErr != nil {
-			t.Errorf("git worktree remove: %v\n%s", cleanupErr, cleanupOutput)
+		result := support.RunCommand(t, repoRoot, nil, "git", "-C", repoRoot, "worktree", "remove", "--force", checkoutRoot)
+		if result.ExitCode != 0 {
+			t.Errorf("git worktree remove exited with code %d\n%s", result.ExitCode, result.CombinedOutput())
 		}
 	})
 

--- a/tests/release/release_build_test.go
+++ b/tests/release/release_build_test.go
@@ -1,4 +1,4 @@
-//go:build slow_smoke
+//go:build release_smoke
 
 package release_test
 

--- a/tests/release/release_build_test.go
+++ b/tests/release/release_build_test.go
@@ -1,4 +1,6 @@
-package smoke_test
+//go:build slow_smoke
+
+package release_test
 
 import (
 	"archive/zip"
@@ -27,7 +29,7 @@ func TestBuildReleaseProducesSupportedAlphaArchivesAndVersionedBinary(t *testing
 	firstOutputDir := newReleaseOutputDir(t, "supported-alpha-a")
 	secondOutputDir := newReleaseOutputDir(t, "supported-alpha-b")
 	version := "v0.1.0-alpha.1"
-	expectedCommit := gitHeadCommit(t, support.RepoRoot(t))
+	expectedCommit := support.GitHeadCommit(t, support.RepoRoot(t))
 	expectedArchiveTime := gitCommitTimestampUTC(t, support.RepoRoot(t), expectedCommit)
 
 	firstResult := runReleaseBuild(t, version, firstOutputDir)
@@ -81,7 +83,7 @@ func TestBuildReleaseProducesStableArchiveAndVersionedBinary(t *testing.T) {
 	}
 
 	version := "v0.0.0"
-	expectedCommit := gitHeadCommit(t, support.RepoRoot(t))
+	expectedCommit := support.GitHeadCommit(t, support.RepoRoot(t))
 	expectedArchiveTime := gitCommitTimestampUTC(t, support.RepoRoot(t), expectedCommit)
 
 	runReleaseBuildForPlatforms(t, version, outputDir, hostPlatform)
@@ -727,13 +729,13 @@ func verifyArchiveContents(t *testing.T, workspace *support.Workspace, archivePa
 		}
 
 		output := string(versionOutput)
-		if got := requireVersionField(t, output, "version"); got != version {
+		if got := support.RequireVersionField(t, output, "version"); got != version {
 			t.Fatalf("expected packaged version %q, got %q\noutput:\n%s", version, got, output)
 		}
-		if got := requireVersionField(t, output, "mode"); got != "release" {
+		if got := support.RequireVersionField(t, output, "mode"); got != "release" {
 			t.Fatalf("expected packaged mode release, got %q\noutput:\n%s", got, output)
 		}
-		if got := requireVersionField(t, output, "commit"); got != expectedCommit {
+		if got := support.RequireVersionField(t, output, "commit"); got != expectedCommit {
 			t.Fatalf("expected packaged commit %q, got %q\noutput:\n%s", expectedCommit, got, output)
 		}
 		if strings.Contains(output, `"path"`) {
@@ -965,7 +967,7 @@ func newReleaseBuildCheckout(t *testing.T) string {
 		"web/src",
 		"internal/ui",
 	} {
-		copyPath(t, filepath.Join(repoRoot, rel), filepath.Join(checkoutRoot, rel))
+		support.CopyPath(t, filepath.Join(repoRoot, rel), filepath.Join(checkoutRoot, rel))
 	}
 	_ = os.RemoveAll(filepath.Join(checkoutRoot, "internal", "ui", "generated", "build"))
 

--- a/tests/release/release_version_file_test.go
+++ b/tests/release/release_version_file_test.go
@@ -1,4 +1,4 @@
-package smoke_test
+package release_test
 
 import (
 	"os"
@@ -12,10 +12,10 @@ import (
 func TestRepositoryVersionFileUsesUnprefixedReleaseVersion(t *testing.T) {
 	repoRoot := support.RepoRoot(t)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, nil),
+		support.EnvWithOverrides(t, nil),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "read-release-version"),
 	)
@@ -44,10 +44,10 @@ func TestRepositoryVersionFileResolvesMatchingReleaseTag(t *testing.T) {
 		t.Fatalf("expected repository VERSION file to contain a release version")
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, nil),
+		support.EnvWithOverrides(t, nil),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "read-release-version"),
 		"--tag",
@@ -69,10 +69,10 @@ func TestReadReleaseVersionOutputsVersionAndTag(t *testing.T) {
 		t.Fatalf("write VERSION file: %v", err)
 	}
 
-	versionResult := runCommand(
+	versionResult := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, nil),
+		support.EnvWithOverrides(t, nil),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "read-release-version"),
 		"--version-file", versionFile,
@@ -84,10 +84,10 @@ func TestReadReleaseVersionOutputsVersionAndTag(t *testing.T) {
 		t.Fatalf("expected raw version output %q, got %q", "0.2.0-alpha.1", got)
 	}
 
-	tagResult := runCommand(
+	tagResult := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, nil),
+		support.EnvWithOverrides(t, nil),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "read-release-version"),
 		"--version-file", versionFile,
@@ -108,10 +108,10 @@ func TestReadReleaseVersionRejectsPrefixedVersionFile(t *testing.T) {
 		t.Fatalf("write VERSION file: %v", err)
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, nil),
+		support.EnvWithOverrides(t, nil),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "read-release-version"),
 		"--version-file", versionFile,
@@ -126,10 +126,10 @@ func TestReadReleaseVersionRejectsMissingVersionFile(t *testing.T) {
 	repoRoot := support.RepoRoot(t)
 	versionFile := filepath.Join(t.TempDir(), "missing-version")
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, nil),
+		support.EnvWithOverrides(t, nil),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "read-release-version"),
 		"--version-file", versionFile,
@@ -147,10 +147,10 @@ func TestReadReleaseVersionRejectsEmptyVersionFile(t *testing.T) {
 		t.Fatalf("write VERSION file: %v", err)
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, nil),
+		support.EnvWithOverrides(t, nil),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "read-release-version"),
 		"--version-file", versionFile,
@@ -168,10 +168,10 @@ func TestReadReleaseVersionRejectsVersionThatCannotFormGitTag(t *testing.T) {
 		t.Fatalf("write VERSION file: %v", err)
 	}
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, nil),
+		support.EnvWithOverrides(t, nil),
 		"/bin/bash",
 		filepath.Join(repoRoot, "scripts", "read-release-version"),
 		"--version-file", versionFile,
@@ -191,8 +191,8 @@ func TestCreateReleaseTagFromVersionSkipsWhenTagAlreadyMatchesCommit(t *testing.
 	mustRunGit(t, cloneDir, "commit", "-m", "Add VERSION")
 	mustRunGit(t, cloneDir, "push", "-u", "origin", "main")
 
-	env := envWithOverrides(t, nil)
-	firstResult := runCommand(
+	env := support.EnvWithOverrides(t, nil)
+	firstResult := support.RunCommand(
 		t,
 		cloneDir,
 		env,
@@ -205,7 +205,7 @@ func TestCreateReleaseTagFromVersionSkipsWhenTagAlreadyMatchesCommit(t *testing.
 	support.RequireContains(t, firstResult.Stdout, "Created and pushed tag v0.2.0")
 
 	headCommit := strings.TrimSpace(runGitOutput(t, cloneDir, "rev-parse", "HEAD"))
-	secondResult := runCommand(
+	secondResult := support.RunCommand(
 		t,
 		cloneDir,
 		env,
@@ -232,8 +232,8 @@ func TestCreateReleaseTagFromVersionFailsWhenTagPointsAtDifferentCommit(t *testi
 	mustRunGit(t, cloneDir, "commit", "-m", "Add VERSION")
 	mustRunGit(t, cloneDir, "push", "-u", "origin", "main")
 
-	env := envWithOverrides(t, nil)
-	firstResult := runCommand(
+	env := support.EnvWithOverrides(t, nil)
+	firstResult := support.RunCommand(
 		t,
 		cloneDir,
 		env,
@@ -251,7 +251,7 @@ func TestCreateReleaseTagFromVersionFailsWhenTagPointsAtDifferentCommit(t *testi
 	mustRunGit(t, cloneDir, "commit", "-m", "Change README")
 	mustRunGit(t, cloneDir, "push", "origin", "main")
 
-	secondResult := runCommand(
+	secondResult := support.RunCommand(
 		t,
 		cloneDir,
 		env,
@@ -311,7 +311,7 @@ func newTaggedReleaseRepo(t *testing.T) (string, string) {
 	mustRunGit(t, tempDir, "clone", remoteDir, cloneDir)
 	mustRunGit(t, cloneDir, "config", "user.name", "Test User")
 	mustRunGit(t, cloneDir, "config", "user.email", "test@example.com")
-	writeFixtureFile(t, filepath.Join(cloneDir, "README.md"), "# repo\n", 0o644)
+	support.WriteFixtureFile(t, filepath.Join(cloneDir, "README.md"), "# repo\n", 0o644)
 	mustRunGit(t, cloneDir, "add", "README.md")
 	mustRunGit(t, cloneDir, "commit", "-m", "Initial commit")
 	mustRunGit(t, cloneDir, "branch", "-M", "main")

--- a/tests/release/verify_release_namespace_test.go
+++ b/tests/release/verify_release_namespace_test.go
@@ -239,16 +239,15 @@ func TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled(t *testing.T) {
 	extractDir := filepath.Join(t.TempDir(), "extract")
 	extractZipAsset(t, filepath.Join(downloadDir, hostAsset), extractDir)
 	binaryPath := filepath.Join(extractDir, strings.TrimSuffix(hostAsset, ".zip"), "harness")
-	versionCmd := exec.Command(binaryPath, "--version")
-	versionCmd.Dir = support.RepoRoot(t)
-	versionOutput, err := versionCmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("run downloaded harness --version: %v\n%s", err, versionOutput)
+	versionResult := support.RunCommand(t, support.RepoRoot(t), nil, binaryPath, "--version")
+	if versionResult.ExitCode != 0 {
+		t.Fatalf("run downloaded harness --version exited with code %d\n%s", versionResult.ExitCode, versionResult.CombinedOutput())
 	}
-	if got := support.RequireVersionField(t, string(versionOutput), "version"); got != tag {
+	versionOutput := versionResult.CombinedOutput()
+	if got := support.RequireVersionField(t, versionOutput, "version"); got != tag {
 		t.Fatalf("expected downloaded harness version %q, got %q\noutput:\n%s", tag, got, versionOutput)
 	}
-	if got := support.RequireVersionField(t, string(versionOutput), "mode"); got != "release" {
+	if got := support.RequireVersionField(t, versionOutput, "mode"); got != "release" {
 		t.Fatalf("expected downloaded harness mode release, got %q\noutput:\n%s", got, versionOutput)
 	}
 }

--- a/tests/release/verify_release_namespace_test.go
+++ b/tests/release/verify_release_namespace_test.go
@@ -1,4 +1,4 @@
-package smoke_test
+package release_test
 
 import (
 	"archive/zip"
@@ -37,11 +37,11 @@ func TestVerifyReleaseNamespaceWithFakeGHDownloadsAndChecksums(t *testing.T) {
 	)
 
 	downloadDir := filepath.Join(t.TempDir(), "downloads")
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		support.RepoRoot(t),
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, fakeGHDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, fakeGHDir),
 		}),
 		"/bin/bash",
 		filepath.Join(support.RepoRoot(t), "scripts", "verify-release-namespace"),
@@ -86,13 +86,13 @@ func TestVerifyReleaseNamespaceMapsGitHubTokenToGHToken(t *testing.T) {
 		},
 	)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		support.RepoRoot(t),
-		envWithOverrides(t, map[string]string{
+		support.EnvWithOverrides(t, map[string]string{
 			"GH_TOKEN":     "",
 			"GITHUB_TOKEN": "fallback-token",
-			"PATH":         installerPath(t, fakeGHDir),
+			"PATH":         support.InstallerPath(t, fakeGHDir),
 		}),
 		"/bin/bash",
 		filepath.Join(support.RepoRoot(t), "scripts", "verify-release-namespace"),
@@ -125,11 +125,11 @@ func TestVerifyReleaseNamespaceFailsWhenAssetIsMissing(t *testing.T) {
 		},
 	)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		support.RepoRoot(t),
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, fakeGHDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, fakeGHDir),
 		}),
 		"/bin/bash",
 		filepath.Join(support.RepoRoot(t), "scripts", "verify-release-namespace"),
@@ -164,11 +164,11 @@ func TestVerifyReleaseNamespaceFailsWhenChecksumDoesNotMatch(t *testing.T) {
 	)
 
 	downloadDir := filepath.Join(t.TempDir(), "downloads")
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		support.RepoRoot(t),
-		envWithOverrides(t, map[string]string{
-			"PATH": installerPath(t, fakeGHDir),
+		support.EnvWithOverrides(t, map[string]string{
+			"PATH": support.InstallerPath(t, fakeGHDir),
 		}),
 		"/bin/bash",
 		filepath.Join(support.RepoRoot(t), "scripts", "verify-release-namespace"),
@@ -202,13 +202,13 @@ func TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled(t *testing.T) {
 	}
 
 	downloadDir := filepath.Join(t.TempDir(), "downloads")
-	var result commandResult
+	var result support.CommandResult
 	for _, asset := range assets {
-		result = runCommand(
+		result = support.RunCommand(
 			t,
 			support.RepoRoot(t),
-			envWithOverrides(t, map[string]string{
-				"PATH": releaseSmokePath(t, ghPath),
+			support.EnvWithOverrides(t, map[string]string{
+				"PATH": support.ReleaseSmokePath(t, ghPath),
 			}),
 			"/bin/bash",
 			filepath.Join(support.RepoRoot(t), "scripts", "verify-release-namespace"),
@@ -245,10 +245,10 @@ func TestVerifyReleaseNamespaceAgainstGitHubWhenEnabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run downloaded harness --version: %v\n%s", err, versionOutput)
 	}
-	if got := requireVersionField(t, string(versionOutput), "version"); got != tag {
+	if got := support.RequireVersionField(t, string(versionOutput), "version"); got != tag {
 		t.Fatalf("expected downloaded harness version %q, got %q\noutput:\n%s", tag, got, versionOutput)
 	}
-	if got := requireVersionField(t, string(versionOutput), "mode"); got != "release" {
+	if got := support.RequireVersionField(t, string(versionOutput), "mode"); got != "release" {
 		t.Fatalf("expected downloaded harness mode release, got %q\noutput:\n%s", got, versionOutput)
 	}
 }
@@ -260,7 +260,7 @@ func TestReleaseSmokePathKeepsSetupGoAheadOfExternalTools(t *testing.T) {
 	brewDir := filepath.Join(t.TempDir(), "homebrew", "bin")
 	originalPath := strings.Join([]string{ghDir, setupGoDir, brewDir}, string(os.PathListSeparator))
 
-	got := releaseSmokePathFromToolPaths(
+	got := support.ReleaseSmokePathFromToolPaths(
 		originalPath,
 		filepath.Join(setupGoDir, "go"),
 		filepath.Join(pnpmDir, "pnpm"),

--- a/tests/smoke/bootstrap_sync_test.go
+++ b/tests/smoke/bootstrap_sync_test.go
@@ -1,7 +1,6 @@
 package smoke_test
 
 import (
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,13 +10,11 @@ import (
 
 func TestSyncBootstrapAssetsCheckPassesForCurrentRepo(t *testing.T) {
 	repoRoot := support.RepoRoot(t)
-	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "sync-bootstrap-assets"), "--check")
-	cmd.Dir = repoRoot
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("sync-bootstrap-assets --check: %v\n%s", err, output)
+	result := support.RunCommand(t, repoRoot, nil, filepath.Join(repoRoot, "scripts", "sync-bootstrap-assets"), "--check")
+	if result.ExitCode != 0 {
+		t.Fatalf("sync-bootstrap-assets --check exited with code %d\n%s", result.ExitCode, result.CombinedOutput())
 	}
-	if !strings.Contains(string(output), "Bootstrap dogfood outputs are in sync with assets/bootstrap.") {
-		t.Fatalf("unexpected check output:\n%s", output)
+	if !strings.Contains(result.CombinedOutput(), "Bootstrap dogfood outputs are in sync with assets/bootstrap.") {
+		t.Fatalf("unexpected check output:\n%s", result.CombinedOutput())
 	}
 }

--- a/tests/smoke/build_embedded_ui_test.go
+++ b/tests/smoke/build_embedded_ui_test.go
@@ -16,14 +16,14 @@ func TestBuildEmbeddedUIScriptFailsWithActionableMessageWhenNodeIsMissingButPnpm
 		t.Skip("embedded UI build smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	fakeBin := newBuildEmbeddedUITestBin(t)
-	writeFixtureFile(t, filepath.Join(fakeBin, "pnpm"), "#!/bin/sh\nprintf 'unexpected pnpm invocation\\n' >&2\nexit 99\n", 0o755)
+	support.WriteFixtureFile(t, filepath.Join(fakeBin, "pnpm"), "#!/bin/sh\nprintf 'unexpected pnpm invocation\\n' >&2\nexit 99\n", 0o755)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, map[string]string{
+		support.EnvWithOverrides(t, map[string]string{
 			"PATH": fakeBin,
 		}),
 		"/bin/bash",
@@ -45,14 +45,14 @@ func TestBuildEmbeddedUIScriptFailsWithActionableMessageWhenPnpmIsMissing(t *tes
 		t.Skip("embedded UI build smoke tests require a POSIX shell")
 	}
 
-	repoRoot := copyInstallerFixture(t)
+	repoRoot := support.CopyInstallerFixture(t)
 	fakeBin := newBuildEmbeddedUITestBin(t)
-	writeFixtureFile(t, filepath.Join(fakeBin, "node"), "#!/bin/sh\nexit 0\n", 0o755)
+	support.WriteFixtureFile(t, filepath.Join(fakeBin, "node"), "#!/bin/sh\nexit 0\n", 0o755)
 
-	result := runCommand(
+	result := support.RunCommand(
 		t,
 		repoRoot,
-		envWithOverrides(t, map[string]string{
+		support.EnvWithOverrides(t, map[string]string{
 			"PATH": fakeBin,
 		}),
 		"/bin/bash",

--- a/tests/smoke/ci_workflow_test.go
+++ b/tests/smoke/ci_workflow_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/catu-ai/easyharness/tests/support"
 )
 
-func TestCIWorkflowBuildsEmbeddedUIBeforeGoTests(t *testing.T) {
+func TestCIWorkflowUsesDevelopmentValidationProfile(t *testing.T) {
 	repoRoot := support.RepoRoot(t)
 
 	workflowData, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", "ci.yml"))
@@ -27,8 +27,45 @@ func TestCIWorkflowBuildsEmbeddedUIBeforeGoTests(t *testing.T) {
 	support.RequireContains(t, workflow, `cache-dependency-path: web/pnpm-lock.yaml`)
 	support.RequireContains(t, workflow, `run: corepack enable`)
 	support.RequireContains(t, workflow, `uses: actions/setup-go@v6`)
-	support.RequireContains(t, workflow, `run: scripts/build-embedded-ui`)
-	support.RequireContains(t, workflow, `run: go test ./...`)
+	support.RequireContains(t, workflow, `run: scripts/validate`)
 	support.RequireSubstringOrder(t, workflow, `uses: pnpm/action-setup@v5`, `uses: actions/setup-node@v6`)
-	support.RequireSubstringOrder(t, workflow, `run: scripts/build-embedded-ui`, `run: go test ./...`)
+}
+
+func TestValidationScriptsDefineDevelopmentAndReleaseProfiles(t *testing.T) {
+	repoRoot := support.RepoRoot(t)
+
+	validatePath := filepath.Join(repoRoot, "scripts", "validate")
+	validateInfo, err := os.Stat(validatePath)
+	if err != nil {
+		t.Fatalf("stat scripts/validate: %v", err)
+	}
+	if validateInfo.Mode()&0o111 == 0 {
+		t.Fatalf("expected scripts/validate to be executable, mode %s", validateInfo.Mode())
+	}
+	validateData, err := os.ReadFile(validatePath)
+	if err != nil {
+		t.Fatalf("read scripts/validate: %v", err)
+	}
+	validate := string(validateData)
+	support.RequireContains(t, validate, "scripts/build-embedded-ui")
+	support.RequireContains(t, validate, "go test ./...")
+
+	validateReleasePath := filepath.Join(repoRoot, "scripts", "validate-release")
+	validateReleaseInfo, err := os.Stat(validateReleasePath)
+	if err != nil {
+		t.Fatalf("stat scripts/validate-release: %v", err)
+	}
+	if validateReleaseInfo.Mode()&0o111 == 0 {
+		t.Fatalf("expected scripts/validate-release to be executable, mode %s", validateReleaseInfo.Mode())
+	}
+	validateReleaseData, err := os.ReadFile(validateReleasePath)
+	if err != nil {
+		t.Fatalf("read scripts/validate-release: %v", err)
+	}
+	validateRelease := string(validateReleaseData)
+	support.RequireContains(t, validateRelease, "scripts/validate")
+	support.RequireContains(t, validateRelease, "go test -tags installer_smoke ./tests/installer -count=1")
+	support.RequireContains(t, validateRelease, "go test -tags release_smoke ./tests/release -count=1")
+	support.RequireSubstringOrder(t, validateRelease, "scripts/validate", "installer_smoke")
+	support.RequireSubstringOrder(t, validateRelease, "installer_smoke", "release_smoke")
 }

--- a/tests/smoke/ci_workflow_test.go
+++ b/tests/smoke/ci_workflow_test.go
@@ -3,7 +3,6 @@ package smoke_test
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/catu-ai/easyharness/tests/support"
@@ -30,22 +29,6 @@ func TestCIWorkflowBuildsEmbeddedUIBeforeGoTests(t *testing.T) {
 	support.RequireContains(t, workflow, `uses: actions/setup-go@v6`)
 	support.RequireContains(t, workflow, `run: scripts/build-embedded-ui`)
 	support.RequireContains(t, workflow, `run: go test ./...`)
-	requireSubstringOrder(t, workflow, `uses: pnpm/action-setup@v5`, `uses: actions/setup-node@v6`)
-	requireSubstringOrder(t, workflow, `run: scripts/build-embedded-ui`, `run: go test ./...`)
-}
-
-func requireSubstringOrder(t *testing.T, haystack, first, second string) {
-	t.Helper()
-
-	firstIndex := strings.Index(haystack, first)
-	if firstIndex < 0 {
-		t.Fatalf("expected %q to appear in content", first)
-	}
-	secondIndex := strings.Index(haystack, second)
-	if secondIndex < 0 {
-		t.Fatalf("expected %q to appear in content", second)
-	}
-	if firstIndex >= secondIndex {
-		t.Fatalf("expected %q to appear before %q", first, second)
-	}
+	support.RequireSubstringOrder(t, workflow, `uses: pnpm/action-setup@v5`, `uses: actions/setup-node@v6`)
+	support.RequireSubstringOrder(t, workflow, `run: scripts/build-embedded-ui`, `run: go test ./...`)
 }

--- a/tests/smoke/ci_workflow_test.go
+++ b/tests/smoke/ci_workflow_test.go
@@ -49,6 +49,7 @@ func TestValidationScriptsDefineDevelopmentAndReleaseProfiles(t *testing.T) {
 	validate := string(validateData)
 	support.RequireContains(t, validate, "scripts/build-embedded-ui")
 	support.RequireContains(t, validate, "go test ./...")
+	support.RequireSubstringOrder(t, validate, `cd "${repo_root}"`, "go test ./...")
 
 	validateReleasePath := filepath.Join(repoRoot, "scripts", "validate-release")
 	validateReleaseInfo, err := os.Stat(validateReleasePath)
@@ -66,6 +67,7 @@ func TestValidationScriptsDefineDevelopmentAndReleaseProfiles(t *testing.T) {
 	support.RequireContains(t, validateRelease, "scripts/validate")
 	support.RequireContains(t, validateRelease, "go test -tags installer_smoke ./tests/installer -count=1")
 	support.RequireContains(t, validateRelease, "go test -tags release_smoke ./tests/release -count=1")
+	support.RequireSubstringOrder(t, validateRelease, `cd "${repo_root}"`, "scripts/validate")
 	support.RequireSubstringOrder(t, validateRelease, "scripts/validate", "installer_smoke")
 	support.RequireSubstringOrder(t, validateRelease, "installer_smoke", "release_smoke")
 }

--- a/tests/smoke/ci_workflow_test.go
+++ b/tests/smoke/ci_workflow_test.go
@@ -69,3 +69,43 @@ func TestValidationScriptsDefineDevelopmentAndReleaseProfiles(t *testing.T) {
 	support.RequireSubstringOrder(t, validateRelease, "scripts/validate", "installer_smoke")
 	support.RequireSubstringOrder(t, validateRelease, "installer_smoke", "release_smoke")
 }
+
+func TestValidationProfileTagsSelectReleaseReadySmokeTests(t *testing.T) {
+	repoRoot := support.RepoRoot(t)
+
+	installerList := support.RunCommand(
+		t,
+		repoRoot,
+		nil,
+		"go",
+		"test",
+		"-tags",
+		"installer_smoke",
+		"-list",
+		"TestInstallDevHarness",
+		"./tests/installer",
+	)
+	if installerList.ExitCode != 0 {
+		t.Fatalf("list installer_smoke tests failed\nstdout:\n%s\nstderr:\n%s", installerList.Stdout, installerList.Stderr)
+	}
+	support.RequireContains(t, installerList.Stdout, "TestInstallDevHarnessDefaultsToUserLocalBin")
+	support.RequireContains(t, installerList.Stdout, "TestInstallDevHarnessWrapperDispatchesToCurrentWorktreeOverStablePathFallback")
+
+	releaseList := support.RunCommand(
+		t,
+		repoRoot,
+		nil,
+		"go",
+		"test",
+		"-tags",
+		"release_smoke",
+		"-list",
+		"TestBuildRelease",
+		"./tests/release",
+	)
+	if releaseList.ExitCode != 0 {
+		t.Fatalf("list release_smoke tests failed\nstdout:\n%s\nstderr:\n%s", releaseList.Stdout, releaseList.Stderr)
+	}
+	support.RequireContains(t, releaseList.Stdout, "TestBuildReleaseProducesSupportedAlphaArchivesAndVersionedBinary")
+	support.RequireContains(t, releaseList.Stdout, "TestBuildReleaseRejectsUnsafeOutputDirectory")
+}

--- a/tests/smoke/contract_sync_test.go
+++ b/tests/smoke/contract_sync_test.go
@@ -1,6 +1,8 @@
 package smoke_test
 
 import (
+	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,14 +14,12 @@ import (
 
 func TestSyncContractArtifactsCheckPassesForCurrentRepo(t *testing.T) {
 	repoRoot := support.RepoRoot(t)
-	cmd := exec.Command(filepath.Join(repoRoot, "scripts", "sync-contract-artifacts"), "--check")
-	cmd.Dir = repoRoot
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("sync-contract-artifacts --check: %v\n%s", err, output)
+	result := support.RunCommand(t, repoRoot, nil, filepath.Join(repoRoot, "scripts", "sync-contract-artifacts"), "--check")
+	if result.ExitCode != 0 {
+		t.Fatalf("sync-contract-artifacts --check exited with code %d\n%s", result.ExitCode, result.CombinedOutput())
 	}
-	if !strings.Contains(string(output), "Contract schemas are in sync.") {
-		t.Fatalf("unexpected check output:\n%s", output)
+	if !strings.Contains(result.CombinedOutput(), "Contract schemas are in sync.") {
+		t.Fatalf("unexpected check output:\n%s", result.CombinedOutput())
 	}
 }
 
@@ -36,31 +36,25 @@ func TestSyncContractArtifactsCheckFailsOnStaleGeneratedFiles(t *testing.T) {
 		t.Fatalf("write stale schema: %v", err)
 	}
 
-	checkCmd := exec.Command(filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"), "--check")
-	checkCmd.Dir = cloneRoot
-	output, err := checkCmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected stale generated file check to fail:\n%s", output)
+	result := support.RunCommand(t, cloneRoot, nil, filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"), "--check")
+	if result.ExitCode == 0 {
+		t.Fatalf("expected stale generated file check to fail:\n%s", result.CombinedOutput())
 	}
-	if !strings.Contains(string(output), "stale generated file") {
-		t.Fatalf("expected stale-file error, got:\n%s", output)
+	if !strings.Contains(result.CombinedOutput(), "stale generated file") {
+		t.Fatalf("expected stale-file error, got:\n%s", result.CombinedOutput())
 	}
 
-	syncCmd := exec.Command(filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"))
-	syncCmd.Dir = cloneRoot
-	output, err = syncCmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("sync-contract-artifacts repair run: %v\n%s", err, output)
+	result = support.RunCommand(t, cloneRoot, nil, filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"))
+	if result.ExitCode != 0 {
+		t.Fatalf("sync-contract-artifacts repair run exited with code %d\n%s", result.ExitCode, result.CombinedOutput())
 	}
 
-	checkCmd = exec.Command(filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"), "--check")
-	checkCmd.Dir = cloneRoot
-	output, err = checkCmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("post-repair sync-contract-artifacts --check: %v\n%s", err, output)
+	result = support.RunCommand(t, cloneRoot, nil, filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"), "--check")
+	if result.ExitCode != 0 {
+		t.Fatalf("post-repair sync-contract-artifacts --check exited with code %d\n%s", result.ExitCode, result.CombinedOutput())
 	}
-	if !strings.Contains(string(output), "Contract schemas are in sync.") {
-		t.Fatalf("unexpected post-repair check output:\n%s", output)
+	if !strings.Contains(result.CombinedOutput(), "Contract schemas are in sync.") {
+		t.Fatalf("unexpected post-repair check output:\n%s", result.CombinedOutput())
 	}
 }
 
@@ -80,31 +74,25 @@ func TestSyncContractArtifactsCheckFailsOnDeprecatedGeneratedDocs(t *testing.T) 
 		t.Fatalf("write stale docs: %v", err)
 	}
 
-	checkCmd := exec.Command(filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"), "--check")
-	checkCmd.Dir = cloneRoot
-	output, err := checkCmd.CombinedOutput()
-	if err == nil {
-		t.Fatalf("expected deprecated generated docs check to fail:\n%s", output)
+	result := support.RunCommand(t, cloneRoot, nil, filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"), "--check")
+	if result.ExitCode == 0 {
+		t.Fatalf("expected deprecated generated docs check to fail:\n%s", result.CombinedOutput())
 	}
-	if !strings.Contains(string(output), "unexpected generated file") {
-		t.Fatalf("expected unexpected-file error, got:\n%s", output)
+	if !strings.Contains(result.CombinedOutput(), "unexpected generated file") {
+		t.Fatalf("expected unexpected-file error, got:\n%s", result.CombinedOutput())
 	}
 
-	syncCmd := exec.Command(filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"))
-	syncCmd.Dir = cloneRoot
-	output, err = syncCmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("sync-contract-artifacts cleanup run: %v\n%s", err, output)
+	result = support.RunCommand(t, cloneRoot, nil, filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"))
+	if result.ExitCode != 0 {
+		t.Fatalf("sync-contract-artifacts cleanup run exited with code %d\n%s", result.ExitCode, result.CombinedOutput())
 	}
 
-	checkCmd = exec.Command(filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"), "--check")
-	checkCmd.Dir = cloneRoot
-	output, err = checkCmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("post-repair sync-contract-artifacts --check: %v\n%s", err, output)
+	result = support.RunCommand(t, cloneRoot, nil, filepath.Join(cloneRoot, "scripts", "sync-contract-artifacts"), "--check")
+	if result.ExitCode != 0 {
+		t.Fatalf("post-repair sync-contract-artifacts --check exited with code %d\n%s", result.ExitCode, result.CombinedOutput())
 	}
-	if !strings.Contains(string(output), "Contract schemas are in sync.") {
-		t.Fatalf("unexpected post-repair check output:\n%s", output)
+	if !strings.Contains(result.CombinedOutput(), "Contract schemas are in sync.") {
+		t.Fatalf("unexpected post-repair check output:\n%s", result.CombinedOutput())
 	}
 
 	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
@@ -114,16 +102,24 @@ func TestSyncContractArtifactsCheckFailsOnDeprecatedGeneratedDocs(t *testing.T) 
 
 func copyCurrentRepo(t *testing.T, src, dst string) {
 	t.Helper()
-	archive := exec.Command("tar", "-cf", "-", "--exclude=.git", "--exclude=.local", ".")
+
+	ctx, cancel := context.WithTimeout(context.Background(), support.DefaultCommandTimeout)
+	defer cancel()
+
+	archive := exec.CommandContext(ctx, "tar", "-cf", "-", "--exclude=.git", "--exclude=.local", ".")
 	archive.Dir = src
-	extract := exec.Command("tar", "-xf", "-", "-C", dst)
+	extract := exec.CommandContext(ctx, "tar", "-xf", "-", "-C", dst)
+
+	var archiveStderr bytes.Buffer
+	var extractStderr bytes.Buffer
+	archive.Stderr = &archiveStderr
+	extract.Stderr = &extractStderr
 
 	pipe, err := archive.StdoutPipe()
 	if err != nil {
 		t.Fatalf("archive stdout pipe: %v", err)
 	}
 	extract.Stdin = pipe
-	extract.Stderr = os.Stderr
 
 	if err := archive.Start(); err != nil {
 		t.Fatalf("start archive: %v", err)
@@ -132,9 +128,15 @@ func copyCurrentRepo(t *testing.T, src, dst string) {
 		t.Fatalf("start extract: %v", err)
 	}
 	if err := archive.Wait(); err != nil {
-		t.Fatalf("archive repo: %v", err)
+		if ctx.Err() == context.DeadlineExceeded {
+			t.Fatalf("archive repo timed out after %s: %v\nstderr:\n%s", support.DefaultCommandTimeout, err, archiveStderr.String())
+		}
+		t.Fatalf("archive repo: %v\nstderr:\n%s", err, archiveStderr.String())
 	}
 	if err := extract.Wait(); err != nil {
-		t.Fatalf("extract repo: %v", err)
+		if ctx.Err() == context.DeadlineExceeded {
+			t.Fatalf("extract repo timed out after %s: %v\nstderr:\n%s", support.DefaultCommandTimeout, err, extractStderr.String())
+		}
+		t.Fatalf("extract repo: %v\nstderr:\n%s", err, extractStderr.String())
 	}
 }

--- a/tests/smoke/contract_sync_test.go
+++ b/tests/smoke/contract_sync_test.go
@@ -106,7 +106,17 @@ func copyCurrentRepo(t *testing.T, src, dst string) {
 	ctx, cancel := context.WithTimeout(context.Background(), support.DefaultCommandTimeout)
 	defer cancel()
 
-	archive := exec.CommandContext(ctx, "tar", "-cf", "-", "--exclude=.git", "--exclude=.local", ".")
+	archive := exec.CommandContext(
+		ctx,
+		"tar",
+		"-cf",
+		"-",
+		"--exclude=.git",
+		"--exclude=.local",
+		"--exclude=web/node_modules",
+		"--exclude=internal/ui/generated/build",
+		".",
+	)
 	archive.Dir = src
 	extract := exec.CommandContext(ctx, "tar", "-xf", "-", "-C", dst)
 

--- a/tests/smoke/release_docs_test.go
+++ b/tests/smoke/release_docs_test.go
@@ -36,7 +36,8 @@ func TestReleaseDocsPresentStableOnboardingSurface(t *testing.T) {
 	support.RequireContains(t, normalizedDevelopment, "stable `harness` installation to already be available on `PATH`")
 	support.RequireContains(t, normalizedDevelopment, "Homebrew install shown in the root")
 	support.RequireContains(t, development, "bundled Playwright wrapper")
-	support.RequireContains(t, development, "scripts/build-embedded-ui")
+	support.RequireContains(t, development, "scripts/validate")
+	support.RequireContains(t, development, "scripts/validate-release")
 	if strings.Contains(development, "--global") {
 		t.Fatalf("expected development doc to avoid retired --global guidance, got:\n%s", development)
 	}
@@ -54,7 +55,7 @@ func TestReleaseDocsPresentStableOnboardingSurface(t *testing.T) {
 	support.RequireContains(t, normalizedReleasing, "`v0.0.0`")
 	support.RequireContains(t, normalizedReleasing, "including prerelease tags")
 	support.RequireContains(t, normalizedReleasing, "default Homebrew formula `easyharness`")
-	support.RequireContains(t, releasing, "scripts/build-embedded-ui")
+	support.RequireContains(t, releasing, "scripts/validate-release")
 	if strings.Contains(strings.ToLower(releasing), "first public alpha") {
 		t.Fatalf("expected releasing doc to avoid first-public-alpha wording, got:\n%s", releasing)
 	}

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -2,9 +2,7 @@ package smoke_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -111,14 +109,14 @@ func TestVersionPrintsJSONBuildInfo(t *testing.T) {
 	result := support.Run(t, workspace.Root, "--version")
 	support.RequireSuccess(t, result)
 	support.RequireNoStderr(t, result)
-	if version := requireVersionField(t, result.Stdout, "version"); version == "" {
+	if version := support.RequireVersionField(t, result.Stdout, "version"); version == "" {
 		t.Fatalf("expected non-empty release version\noutput:\n%s", result.Stdout)
 	}
-	if mode := requireVersionField(t, result.Stdout, "mode"); mode != "release" {
+	if mode := support.RequireVersionField(t, result.Stdout, "mode"); mode != "release" {
 		t.Fatalf("expected release mode, got %q\noutput:\n%s", mode, result.Stdout)
 	}
-	expectedCommit := gitHeadCommit(t, support.RepoRoot(t))
-	if commit := requireVersionField(t, result.Stdout, "commit"); commit != expectedCommit {
+	expectedCommit := support.GitHeadCommit(t, support.RepoRoot(t))
+	if commit := support.RequireVersionField(t, result.Stdout, "commit"); commit != expectedCommit {
 		t.Fatalf("expected release version commit %q, got %q\noutput:\n%s", expectedCommit, commit, result.Stdout)
 	}
 	if strings.Contains(result.Stdout, `"path"`) {
@@ -1094,44 +1092,4 @@ func TestPlanTemplateAndLintRoundTrip(t *testing.T) {
 	if payload.Artifacts.PlanPath != planRelPath {
 		t.Fatalf("expected lint plan path %q, got %#v", planRelPath, payload)
 	}
-}
-
-func requireVersionField(t *testing.T, output, field string) string {
-	t.Helper()
-
-	var payload map[string]any
-	if err := json.Unmarshal([]byte(output), &payload); err != nil {
-		t.Fatalf("expected JSON version output: %v\noutput:\n%s", err, output)
-	}
-	value, ok := payload[field]
-	if !ok {
-		t.Fatalf("expected version field %q in output:\n%s", field, output)
-	}
-	switch typed := value.(type) {
-	case string:
-		if typed == "" {
-			t.Fatalf("expected version field %q to be non-empty\noutput:\n%s", field, output)
-		}
-		return typed
-	case bool:
-		return fmt.Sprintf("%t", typed)
-	default:
-		return fmt.Sprint(typed)
-	}
-}
-
-func gitHeadCommit(t *testing.T, repoRoot string) string {
-	t.Helper()
-
-	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "HEAD")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git rev-parse HEAD: %v\n%s", err, output)
-	}
-
-	commit := strings.TrimSpace(string(output))
-	if commit == "" {
-		t.Fatalf("expected git HEAD commit for %s", repoRoot)
-	}
-	return commit
 }

--- a/tests/support/binary.go
+++ b/tests/support/binary.go
@@ -1,6 +1,9 @@
 package support
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -53,9 +56,7 @@ func BuildBinary(t *testing.T) string {
 		}
 
 		ldflags := fmt.Sprintf("-X %s.BuildCommit=%s -X %s.BuildVersion=%s", versionPackage, commit, versionPackage, version)
-		cmd := exec.Command("go", "build", "-ldflags", ldflags, "-o", buildPath, "./cmd/harness")
-		cmd.Dir = repoRoot()
-		output, err := cmd.CombinedOutput()
+		output, err := runOutputWithTimeout(repoRoot(), "go", "build", "-ldflags", ldflags, "-o", buildPath, "./cmd/harness")
 		if err != nil {
 			buildErr = fmt.Errorf("build harness binary: %w\n%s", err, output)
 		}
@@ -76,7 +77,7 @@ func repoRoot() string {
 }
 
 func repoHeadCommit(root string) (string, error) {
-	output, err := exec.Command("git", "-C", root, "rev-parse", "HEAD").CombinedOutput()
+	output, err := runOutputWithTimeout(root, "git", "-C", root, "rev-parse", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse HEAD: %w\n%s", err, output)
 	}
@@ -98,4 +99,27 @@ func repoReleaseVersion(root string) (string, error) {
 		return "", fmt.Errorf("VERSION file is empty")
 	}
 	return "v" + version, nil
+}
+
+func runOutputWithTimeout(workdir string, argv ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Dir = workdir
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	output := stdout.String() + stderr.String()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return output, fmt.Errorf("run command %v timed out after %s", argv, DefaultCommandTimeout)
+	}
+	if err != nil {
+		return output, fmt.Errorf("run command %v: %w", argv, err)
+	}
+	return output, nil
 }

--- a/tests/support/run.go
+++ b/tests/support/run.go
@@ -2,11 +2,13 @@ package support
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 type RunOptions struct {
@@ -14,6 +16,7 @@ type RunOptions struct {
 	Args    []string
 	Stdin   string
 	Env     []string
+	Timeout time.Duration
 }
 
 type Result struct {
@@ -38,7 +41,14 @@ func Run(t *testing.T, workdir string, args ...string) Result {
 func RunWithOptions(t *testing.T, opts RunOptions) Result {
 	t.Helper()
 
-	cmd := exec.Command(BuildBinary(t), opts.Args...)
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = DefaultCommandTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, BuildBinary(t), opts.Args...)
 	cmd.Dir = opts.Workdir
 	cmd.Env = append(os.Environ(), opts.Env...)
 	cmd.Stdin = strings.NewReader(opts.Stdin)
@@ -58,9 +68,13 @@ func RunWithOptions(t *testing.T, opts RunOptions) Result {
 		return result
 	}
 
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("run harness %v timed out after %s\nstdout:\n%s\nstderr:\n%s", opts.Args, timeout, stdout.String(), stderr.String())
+	}
+
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
-		t.Fatalf("run harness %v: %v", opts.Args, err)
+		t.Fatalf("run harness %v: %v\nstdout:\n%s\nstderr:\n%s", opts.Args, err, stdout.String(), stderr.String())
 	}
 	result.ExitCode = exitErr.ExitCode()
 	return result

--- a/tests/support/smoke.go
+++ b/tests/support/smoke.go
@@ -145,9 +145,6 @@ func InstallerEnv(t *testing.T, overrides map[string]string) []string {
 	if _, ok := overrides["GOCACHE"]; !ok {
 		overrides["GOCACHE"] = sharedInstallerGoCache(t)
 	}
-	if _, ok := overrides["GOMODCACHE"]; !ok {
-		overrides["GOMODCACHE"] = sharedInstallerGoModCache(t)
-	}
 	if _, ok := overrides["GOFLAGS"]; !ok {
 		overrides["GOFLAGS"] = "-modcacherw"
 	}
@@ -293,7 +290,6 @@ func RequireSubstringOrder(t *testing.T, haystack, first, second string) {
 var (
 	installerCacheOnce sync.Once
 	installerGoCache   string
-	installerModCache  string
 	installerCacheErr  error
 )
 
@@ -301,12 +297,6 @@ func sharedInstallerGoCache(t *testing.T) string {
 	t.Helper()
 	InitializeInstallerCaches(t)
 	return installerGoCache
-}
-
-func sharedInstallerGoModCache(t *testing.T) string {
-	t.Helper()
-	InitializeInstallerCaches(t)
-	return installerModCache
 }
 
 func initializeSharedInstallerCaches() {
@@ -317,12 +307,9 @@ func initializeSharedInstallerCaches() {
 			return
 		}
 		installerGoCache = filepath.Join(root, "go-build")
-		installerModCache = filepath.Join(root, "gomod")
-		for _, dir := range []string{installerGoCache, installerModCache} {
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				installerCacheErr = err
-				return
-			}
+		if err := os.MkdirAll(installerGoCache, 0o755); err != nil {
+			installerCacheErr = err
+			return
 		}
 	})
 }

--- a/tests/support/smoke.go
+++ b/tests/support/smoke.go
@@ -21,6 +21,8 @@ type CommandResult struct {
 	ExitCode int
 }
 
+const DefaultCommandTimeout = 5 * time.Minute
+
 func (r CommandResult) CombinedOutput() string {
 	return r.Stdout + r.Stderr
 }
@@ -28,7 +30,7 @@ func (r CommandResult) CombinedOutput() string {
 func RunCommand(t *testing.T, workdir string, env []string, argv ...string) CommandResult {
 	t.Helper()
 
-	return RunCommandWithTimeout(t, 0, workdir, env, argv...)
+	return RunCommandWithTimeout(t, DefaultCommandTimeout, workdir, env, argv...)
 }
 
 func RunCommandWithTimeout(t *testing.T, timeout time.Duration, workdir string, env []string, argv ...string) CommandResult {
@@ -37,9 +39,12 @@ func RunCommandWithTimeout(t *testing.T, timeout time.Duration, workdir string, 
 	var (
 		cmd    *exec.Cmd
 		cancel func()
+		ctx    context.Context
 	)
+	if timeout == 0 {
+		timeout = DefaultCommandTimeout
+	}
 	if timeout > 0 {
-		var ctx context.Context
 		ctx, cancel = context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 		cmd = exec.CommandContext(ctx, argv[0], argv[1:]...)
@@ -62,6 +67,10 @@ func RunCommandWithTimeout(t *testing.T, timeout time.Duration, workdir string, 
 	}
 	if err == nil {
 		return result
+	}
+
+	if ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("run command %v timed out after %s\nstdout:\n%s\nstderr:\n%s", argv, timeout, stdout.String(), stderr.String())
 	}
 
 	var exitErr *exec.ExitError
@@ -156,8 +165,6 @@ func InitializeInstallerCaches(t *testing.T) {
 	if installerCacheErr != nil {
 		t.Fatalf("initialize shared installer caches: %v", installerCacheErr)
 	}
-	t.Setenv("GOCACHE", installerGoCache)
-	t.Setenv("GOMODCACHE", installerModCache)
 }
 
 func InstallerPath(t *testing.T, extraDirs ...string) string {

--- a/tests/support/smoke.go
+++ b/tests/support/smoke.go
@@ -1,0 +1,371 @@
+package support
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type CommandResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+func (r CommandResult) CombinedOutput() string {
+	return r.Stdout + r.Stderr
+}
+
+func RunCommand(t *testing.T, workdir string, env []string, argv ...string) CommandResult {
+	t.Helper()
+
+	return RunCommandWithTimeout(t, 0, workdir, env, argv...)
+}
+
+func RunCommandWithTimeout(t *testing.T, timeout time.Duration, workdir string, env []string, argv ...string) CommandResult {
+	t.Helper()
+
+	var (
+		cmd    *exec.Cmd
+		cancel func()
+	)
+	if timeout > 0 {
+		var ctx context.Context
+		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		cmd = exec.CommandContext(ctx, argv[0], argv[1:]...)
+	} else {
+		cmd = exec.Command(argv[0], argv[1:]...)
+	}
+
+	cmd.Dir = workdir
+	cmd.Env = env
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	result := CommandResult{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+	if err == nil {
+		return result
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		if errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("run command %v timed out after %s\nstdout:\n%s\nstderr:\n%s", argv, timeout, stdout.String(), stderr.String())
+		}
+		t.Fatalf("run command %v: %v", argv, err)
+	}
+	result.ExitCode = exitErr.ExitCode()
+	return result
+}
+
+func CopyInstallerFixture(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	sourceRoot := RepoRoot(t)
+	for _, rel := range []string{
+		"VERSION",
+		"go.mod",
+		"go.sum",
+		"assets",
+		"cmd",
+		"internal",
+		"scripts/build-embedded-ui",
+		"scripts/install-dev-harness",
+	} {
+		CopyPath(t, filepath.Join(sourceRoot, rel), filepath.Join(root, rel))
+	}
+	for _, rel := range []string{
+		"web/index.html",
+		"web/package.json",
+		"web/pnpm-lock.yaml",
+		"web/tsconfig.json",
+		"web/vite.config.ts",
+		"web/src",
+	} {
+		CopyPath(t, filepath.Join(sourceRoot, rel), filepath.Join(root, rel))
+	}
+	_ = os.RemoveAll(filepath.Join(root, "internal", "ui", "generated", "build"))
+	return root
+}
+
+func EnvWithOverrides(t *testing.T, overrides map[string]string) []string {
+	t.Helper()
+
+	env := os.Environ()
+	for key, value := range overrides {
+		prefix := key + "="
+		replaced := false
+		for i, entry := range env {
+			if strings.HasPrefix(entry, prefix) {
+				env[i] = prefix + value
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			env = append(env, prefix+value)
+		}
+	}
+	return env
+}
+
+func InstallerEnv(t *testing.T, overrides map[string]string) []string {
+	t.Helper()
+
+	if overrides == nil {
+		overrides = map[string]string{}
+	}
+	if _, ok := overrides["GOCACHE"]; !ok {
+		overrides["GOCACHE"] = sharedInstallerGoCache(t)
+	}
+	if _, ok := overrides["GOMODCACHE"]; !ok {
+		overrides["GOMODCACHE"] = sharedInstallerGoModCache(t)
+	}
+	if _, ok := overrides["GOFLAGS"]; !ok {
+		overrides["GOFLAGS"] = "-modcacherw"
+	}
+	return EnvWithOverrides(t, overrides)
+}
+
+func InitializeInstallerCaches(t *testing.T) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("install-dev-harness smoke test skipped in short mode")
+	}
+
+	initializeSharedInstallerCaches()
+	if installerCacheErr != nil {
+		t.Fatalf("initialize shared installer caches: %v", installerCacheErr)
+	}
+	t.Setenv("GOCACHE", installerGoCache)
+	t.Setenv("GOMODCACHE", installerModCache)
+}
+
+func InstallerPath(t *testing.T, extraDirs ...string) string {
+	t.Helper()
+	InitializeInstallerCaches(t)
+
+	var dirs []string
+	seen := make(map[string]bool)
+	addDir := func(dir string) {
+		if dir == "" || seen[dir] {
+			return
+		}
+		seen[dir] = true
+		dirs = append(dirs, dir)
+	}
+
+	for _, dir := range extraDirs {
+		addDir(dir)
+	}
+	addDir(filepath.Join(RepoRoot(t), "node_modules", ".bin"))
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		addDir(dir)
+	}
+	addDir("/usr/bin")
+	addDir("/bin")
+	addDir("/usr/sbin")
+	addDir("/sbin")
+
+	return strings.Join(dirs, string(os.PathListSeparator))
+}
+
+func ReleaseSmokePath(t *testing.T, extraToolPaths ...string) string {
+	t.Helper()
+
+	toolPaths := make([]string, 0, len(extraToolPaths)+2)
+	if goPath, err := exec.LookPath("go"); err == nil {
+		toolPaths = append(toolPaths, goPath)
+	} else {
+		t.Fatalf("find go on PATH: %v", err)
+	}
+	if pnpmPath, err := exec.LookPath("pnpm"); err == nil {
+		toolPaths = append(toolPaths, pnpmPath)
+	} else {
+		t.Fatalf("find pnpm on PATH: %v", err)
+	}
+	toolPaths = append(toolPaths, extraToolPaths...)
+
+	return ReleaseSmokePathFromToolPaths(os.Getenv("PATH"), toolPaths...)
+}
+
+func ReleaseSmokePathFromToolPaths(currentPath string, toolPaths ...string) string {
+	var dirs []string
+	seen := make(map[string]bool)
+	addDir := func(dir string) {
+		if dir == "" || seen[dir] {
+			return
+		}
+		seen[dir] = true
+		dirs = append(dirs, dir)
+	}
+
+	for _, toolPath := range toolPaths {
+		addDir(filepath.Dir(toolPath))
+	}
+	addDir(filepath.Join(repoRoot(), "node_modules", ".bin"))
+	for _, dir := range filepath.SplitList(currentPath) {
+		addDir(dir)
+	}
+	addDir("/usr/bin")
+	addDir("/bin")
+	addDir("/usr/sbin")
+	addDir("/sbin")
+
+	return strings.Join(dirs, string(os.PathListSeparator))
+}
+
+func GitHeadCommit(t *testing.T, repoRoot string) string {
+	t.Helper()
+
+	commit, err := repoHeadCommit(repoRoot)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	return commit
+}
+
+func RequireVersionField(t *testing.T, output, field string) string {
+	t.Helper()
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		t.Fatalf("expected JSON version output: %v\noutput:\n%s", err, output)
+	}
+	value, ok := payload[field]
+	if !ok {
+		t.Fatalf("expected version field %q in output:\n%s", field, output)
+	}
+	switch typed := value.(type) {
+	case string:
+		if typed == "" {
+			t.Fatalf("expected version field %q to be non-empty\noutput:\n%s", field, output)
+		}
+		return typed
+	case bool:
+		return fmt.Sprintf("%t", typed)
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func RequireSubstringOrder(t *testing.T, haystack, first, second string) {
+	t.Helper()
+	firstIndex := strings.Index(haystack, first)
+	if firstIndex < 0 {
+		t.Fatalf("expected workflow to contain %q", first)
+	}
+	secondIndex := strings.Index(haystack, second)
+	if secondIndex < 0 {
+		t.Fatalf("expected workflow to contain %q", second)
+	}
+	if firstIndex > secondIndex {
+		t.Fatalf("expected %q to appear before %q", first, second)
+	}
+}
+
+var (
+	installerCacheOnce sync.Once
+	installerGoCache   string
+	installerModCache  string
+	installerCacheErr  error
+)
+
+func sharedInstallerGoCache(t *testing.T) string {
+	t.Helper()
+	InitializeInstallerCaches(t)
+	return installerGoCache
+}
+
+func sharedInstallerGoModCache(t *testing.T) string {
+	t.Helper()
+	InitializeInstallerCaches(t)
+	return installerModCache
+}
+
+func initializeSharedInstallerCaches() {
+	installerCacheOnce.Do(func() {
+		root, err := os.MkdirTemp("", "easyharness-install-smoke-cache-*")
+		if err != nil {
+			installerCacheErr = err
+			return
+		}
+		installerGoCache = filepath.Join(root, "go-build")
+		installerModCache = filepath.Join(root, "gomod")
+		for _, dir := range []string{installerGoCache, installerModCache} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				installerCacheErr = err
+				return
+			}
+		}
+	})
+}
+
+func WriteFixtureFile(t *testing.T, path, contents string, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func CopyPath(t *testing.T, src, dst string) {
+	t.Helper()
+
+	info, err := os.Stat(src)
+	if err != nil {
+		t.Fatalf("stat %s: %v", src, err)
+	}
+
+	if info.IsDir() {
+		if err := os.MkdirAll(dst, info.Mode().Perm()); err != nil {
+			t.Fatalf("mkdir %s: %v", dst, err)
+		}
+		entries, err := os.ReadDir(src)
+		if err != nil {
+			t.Fatalf("read dir %s: %v", src, err)
+		}
+		for _, entry := range entries {
+			CopyPath(t, filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name()))
+		}
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatalf("mkdir parent for %s: %v", dst, err)
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("open %s: %v", src, err)
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode().Perm())
+	if err != nil {
+		t.Fatalf("create %s: %v", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := out.ReadFrom(in); err != nil {
+		t.Fatalf("copy %s to %s: %v", src, dst, err)
+	}
+}

--- a/tests/support/smoke.go
+++ b/tests/support/smoke.go
@@ -111,6 +111,9 @@ func CopyInstallerFixture(t *testing.T) string {
 	} {
 		CopyPath(t, filepath.Join(sourceRoot, rel), filepath.Join(root, rel))
 	}
+	if _, err := os.Stat(filepath.Join(sourceRoot, "web", "node_modules")); err == nil {
+		CopyPath(t, filepath.Join(sourceRoot, "web", "node_modules"), filepath.Join(root, "web", "node_modules"))
+	}
 	_ = os.RemoveAll(filepath.Join(root, "internal", "ui", "generated", "build"))
 	return root
 }
@@ -309,6 +312,10 @@ func initializeSharedInstallerCaches() {
 		installerGoCache = filepath.Join(root, "go-build")
 		if err := os.MkdirAll(installerGoCache, 0o755); err != nil {
 			installerCacheErr = err
+			return
+		}
+		if _, err := runOutputWithTimeout(repoRoot(), "go", "mod", "download"); err != nil {
+			installerCacheErr = fmt.Errorf("warm installer Go module cache: %w", err)
 			return
 		}
 	})

--- a/tests/support/smoke.go
+++ b/tests/support/smoke.go
@@ -111,9 +111,6 @@ func CopyInstallerFixture(t *testing.T) string {
 	} {
 		CopyPath(t, filepath.Join(sourceRoot, rel), filepath.Join(root, rel))
 	}
-	if _, err := os.Stat(filepath.Join(sourceRoot, "web", "node_modules")); err == nil {
-		CopyPath(t, filepath.Join(sourceRoot, "web", "node_modules"), filepath.Join(root, "web", "node_modules"))
-	}
 	_ = os.RemoveAll(filepath.Join(root, "internal", "ui", "generated", "build"))
 	return root
 }

--- a/tests/support/smoke.go
+++ b/tests/support/smoke.go
@@ -151,6 +151,12 @@ func InstallerEnv(t *testing.T, overrides map[string]string) []string {
 	if _, ok := overrides["GOFLAGS"]; !ok {
 		overrides["GOFLAGS"] = "-modcacherw"
 	}
+	if _, ok := overrides["COREPACK_HOME"]; !ok {
+		overrides["COREPACK_HOME"] = sharedInstallerCorepackHome(t)
+	}
+	if _, ok := overrides["NPM_CONFIG_STORE_DIR"]; !ok {
+		overrides["NPM_CONFIG_STORE_DIR"] = sharedInstallerPnpmStore(t)
+	}
 	return EnvWithOverrides(t, overrides)
 }
 
@@ -184,6 +190,7 @@ func InstallerPath(t *testing.T, extraDirs ...string) string {
 	for _, dir := range extraDirs {
 		addDir(dir)
 	}
+	addDir(filepath.Join(RepoRoot(t), "web", "node_modules", ".bin"))
 	addDir(filepath.Join(RepoRoot(t), "node_modules", ".bin"))
 	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
 		addDir(dir)
@@ -291,15 +298,29 @@ func RequireSubstringOrder(t *testing.T, haystack, first, second string) {
 }
 
 var (
-	installerCacheOnce sync.Once
-	installerGoCache   string
-	installerCacheErr  error
+	installerCacheOnce    sync.Once
+	installerGoCache      string
+	installerCorepackHome string
+	installerPnpmStore    string
+	installerCacheErr     error
 )
 
 func sharedInstallerGoCache(t *testing.T) string {
 	t.Helper()
 	InitializeInstallerCaches(t)
 	return installerGoCache
+}
+
+func sharedInstallerCorepackHome(t *testing.T) string {
+	t.Helper()
+	InitializeInstallerCaches(t)
+	return installerCorepackHome
+}
+
+func sharedInstallerPnpmStore(t *testing.T) string {
+	t.Helper()
+	InitializeInstallerCaches(t)
+	return installerPnpmStore
 }
 
 func initializeSharedInstallerCaches() {
@@ -310,7 +331,17 @@ func initializeSharedInstallerCaches() {
 			return
 		}
 		installerGoCache = filepath.Join(root, "go-build")
+		installerCorepackHome = filepath.Join(root, "corepack")
+		installerPnpmStore = filepath.Join(root, "pnpm-store")
 		if err := os.MkdirAll(installerGoCache, 0o755); err != nil {
+			installerCacheErr = err
+			return
+		}
+		if err := os.MkdirAll(installerCorepackHome, 0o755); err != nil {
+			installerCacheErr = err
+			return
+		}
+		if err := os.MkdirAll(installerPnpmStore, 0o755); err != nil {
 			installerCacheErr = err
 			return
 		}
@@ -318,7 +349,45 @@ func initializeSharedInstallerCaches() {
 			installerCacheErr = fmt.Errorf("warm installer Go module cache: %w", err)
 			return
 		}
+		cacheEnv := append(
+			os.Environ(),
+			"CI=true",
+			"COREPACK_HOME="+installerCorepackHome,
+			"NPM_CONFIG_STORE_DIR="+installerPnpmStore,
+		)
+		if _, err := runOutputWithEnvWithTimeout(repoRoot(), cacheEnv, "corepack", "prepare", "pnpm@10.32.1", "--activate"); err != nil {
+			installerCacheErr = fmt.Errorf("warm installer Corepack cache: %w", err)
+			return
+		}
+		if _, err := runOutputWithEnvWithTimeout(repoRoot(), cacheEnv, "pnpm", "--dir", "web", "fetch", "--frozen-lockfile"); err != nil {
+			installerCacheErr = fmt.Errorf("warm installer pnpm store: %w", err)
+			return
+		}
 	})
+}
+
+func runOutputWithEnvWithTimeout(workdir string, env []string, argv ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Dir = workdir
+	cmd.Env = env
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	output := stdout.String() + stderr.String()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return output, fmt.Errorf("run command %v timed out after %s", argv, DefaultCommandTimeout)
+	}
+	if err != nil {
+		return output, fmt.Errorf("run command %v: %w\n%s", argv, err, output)
+	}
+	return output, nil
 }
 
 func WriteFixtureFile(t *testing.T, path, contents string, mode os.FileMode) {

--- a/tests/support/smoke_timeout_test.go
+++ b/tests/support/smoke_timeout_test.go
@@ -1,0 +1,49 @@
+package support
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunCommandWithTimeoutReportsCommandAndOutput(t *testing.T) {
+	switch {
+	case os.Getenv("EASYHARNESS_TIMEOUT_HELPER_SLEEP") == "1":
+		fmt.Println("helper stdout before sleep")
+		fmt.Fprintln(os.Stderr, "helper stderr before sleep")
+		time.Sleep(5 * time.Second)
+		return
+	case os.Getenv("EASYHARNESS_TIMEOUT_HELPER_CALL") == "1":
+		RunCommandWithTimeout(
+			t,
+			50*time.Millisecond,
+			"",
+			append(os.Environ(), "EASYHARNESS_TIMEOUT_HELPER_SLEEP=1"),
+			os.Args[0],
+			"-test.run=TestRunCommandWithTimeoutReportsCommandAndOutput",
+		)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunCommandWithTimeoutReportsCommandAndOutput")
+	cmd.Env = append(os.Environ(), "EASYHARNESS_TIMEOUT_HELPER_CALL=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected helper test process to fail on timeout")
+	}
+
+	text := string(output)
+	for _, fragment := range []string{
+		"timed out after 50ms",
+		"helper stdout before sleep",
+		"helper stderr before sleep",
+		"-test.run=TestRunCommandWithTimeoutReportsCommandAndOutput",
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("expected timeout output to contain %q, got:\n%s", fragment, text)
+		}
+	}
+}

--- a/tests/support/smoke_timeout_test.go
+++ b/tests/support/smoke_timeout_test.go
@@ -16,10 +16,17 @@ func TestRunCommandWithTimeoutReportsCommandAndOutput(t *testing.T) {
 		fmt.Fprintln(os.Stderr, "helper stderr before sleep")
 		time.Sleep(5 * time.Second)
 		return
+	case os.Getenv("EASYHARNESS_TIMEOUT_HELPER_RUN_WITH_OPTIONS") == "1":
+		RunWithOptions(t, RunOptions{
+			Workdir: RepoRoot(t),
+			Args:    []string{"ui", "--port", "0", "--no-open"},
+			Timeout: 500 * time.Millisecond,
+		})
+		return
 	case os.Getenv("EASYHARNESS_TIMEOUT_HELPER_CALL") == "1":
 		RunCommandWithTimeout(
 			t,
-			50*time.Millisecond,
+			500*time.Millisecond,
 			"",
 			append(os.Environ(), "EASYHARNESS_TIMEOUT_HELPER_SLEEP=1"),
 			os.Args[0],
@@ -37,10 +44,35 @@ func TestRunCommandWithTimeoutReportsCommandAndOutput(t *testing.T) {
 
 	text := string(output)
 	for _, fragment := range []string{
-		"timed out after 50ms",
+		"timed out after 500ms",
 		"helper stdout before sleep",
 		"helper stderr before sleep",
 		"-test.run=TestRunCommandWithTimeoutReportsCommandAndOutput",
+	} {
+		if !strings.Contains(text, fragment) {
+			t.Fatalf("expected timeout output to contain %q, got:\n%s", fragment, text)
+		}
+	}
+}
+
+func TestRunWithOptionsReportsTimeout(t *testing.T) {
+	if os.Getenv("EASYHARNESS_TIMEOUT_HELPER_RUN_WITH_OPTIONS") == "1" {
+		TestRunCommandWithTimeoutReportsCommandAndOutput(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunWithOptionsReportsTimeout")
+	cmd.Env = append(os.Environ(), "EASYHARNESS_TIMEOUT_HELPER_RUN_WITH_OPTIONS=1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected helper test process to fail on harness timeout")
+	}
+
+	text := string(output)
+	for _, fragment := range []string{
+		"run harness [ui --port 0 --no-open] timed out after 500ms",
+		"stdout:",
+		"stderr:",
 	} {
 		if !strings.Contains(text, fragment) {
 			t.Fatalf("expected timeout output to contain %q, got:\n%s", fragment, text)


### PR DESCRIPTION
## What Changed

This resolves issue #257 by separating ordinary development validation from release-ready validation as purpose-named profiles.

- `scripts/validate` is the ordinary development profile: build embedded UI assets, then run the default Go suite.
- `scripts/validate-release` is the full release-ready profile: run `scripts/validate`, then run installer smoke and release archive smoke through functional tags.
- The old duration-oriented `slow_smoke` tag is replaced with `installer_smoke` and `release_smoke`.
- CI now calls `scripts/validate`; release docs require `scripts/validate-release` for `VERSION` and release PRs before merge.
- The post-merge Release workflow remains publish validation from the packaged source tree, not a substitute for PR validation.

## Confidence

- `scripts/validate` passed from the repo root and from `docs/` via `../scripts/validate`, proving the entrypoint anchors validation to the repository root.
- `scripts/validate-release` passed end to end after the finalize repair; installer smoke passed in 182.964s and release archive smoke passed in 113.788s.
- Functional tag coverage is guarded by smoke tests that list `installer_smoke` and `release_smoke` tests and assert representative release-ready tests are reachable.
- Installer smoke now shares warmed Corepack/pnpm caches to avoid accidental live pnpm downloads from temporary test homes.
- Step and finalize reviews passed after repairs, ending with `review-019-delta` reporting no findings across correctness, tests, docs-consistency, and risk-scan.

## Handoff

Broader validation taxonomy remains deferred to #258. This PR intentionally keeps the user-facing model to two profiles: ordinary development and full release-ready validation.
