### PR TITLE
[codex] Fix Plan reader scroll intent

### DIFF
--- a/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
+++ b/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
@@ -235,7 +235,8 @@ regression test.
 
 Both findings were fixed by adding the root/default-root regression test and
 checking off the satisfied acceptance criteria. Follow-up review remains
-pending.
+complete: `review-003-delta` passed with `tests` and `agent-ux` reviewer slots
+and zero findings.
 
 ## Archive Summary
 

--- a/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
+++ b/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
@@ -1,0 +1,219 @@
+---
+template_version: 0.2.0
+created_at: "2026-06-26T16:18:10+08:00"
+approved_at: "2026-06-26T16:19:15+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/261
+size: S
+---
+
+# Plan Reader Refresh Scroll Intent
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Fix the Plan workspace reader so live refreshes do not replay the last selected
+heading as an ongoing scroll command. Manual scrolling inside the right-hand
+Plan reader should stay under user control across refreshed Plan payloads when
+the selected Plan node has not changed.
+
+Keep the useful parts of warm Plan state: the explorer may continue to show the
+remembered selected node, and clicking a Plan heading in the explorer should
+still navigate the reader to that heading once at the time of selection.
+
+## Scope
+
+### In Scope
+
+- Split Plan reader heading anchor assignment from imperative reader
+  navigation in `PlanWorkspace`.
+- Ensure selecting a document root, heading, supplement directory, or
+  supplement file still updates the inspector and explorer state correctly.
+- Add regression coverage for refreshed Plan document payloads preserving
+  manual reader scroll when the selected node is unchanged.
+- Keep or update the existing Plan UI smoke coverage that verifies an explicit
+  heading click scrolls the reader to the selected heading.
+
+### Out of Scope
+
+- Changing the live refresh cadence or `useLiveResource` polling behavior.
+- Reworking Plan explorer selection semantics beyond the scroll intent bug.
+- Adding browser hash navigation or deep-link support for individual headings.
+- Compatibility shims for obsolete Plan UI state shapes.
+
+## Acceptance Criteria
+
+- [ ] A Plan heading selection scrolls the reader to that heading once.
+- [ ] A subsequent live refresh or equivalent rerender with a fresh
+      `document`/markdown payload does not snap the reader back to the selected
+      heading after the user has manually scrolled away.
+- [ ] Selecting the document root may still take the reader to the top as an
+      explicit navigation action, but refreshes do not repeatedly force that
+      top position.
+- [ ] Supplement file/directory selection remains functional and does not
+      trigger markdown reader scroll restoration.
+- [ ] Automated coverage fails on the old repeated-scroll behavior and passes
+      with the new scroll intent boundary.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Separate Scroll Intent From Render Refresh
+
+- Done: [ ]
+
+#### Objective
+
+Update `PlanWorkspace` so rendered heading IDs are maintained whenever markdown
+content changes, while `scrollTop` changes only for an explicit Plan node
+navigation request.
+
+#### Details
+
+The current effect in `web/src/pages.tsx` both assigns heading IDs and scrolls
+to `selectedHeading` or top. Because the effect depends on refreshed
+`document`/`documentHTML` data, each live Plan poll can rerun the scroll logic
+even when the selected node is unchanged.
+
+Prefer a small local state/ref boundary in `PlanWorkspace`: record a navigation
+intent when `selectPlanNode` handles an explicit user selection, then consume
+that intent after render to perform the one-time scroll. Keep anchor assignment
+as its own render-following effect so refreshed markdown still receives stable
+heading IDs.
+
+The implementation should preserve the clean target shape rather than adding
+compatibility layers. Avoid changes to `useLiveResource` unless execution shows
+the bug cannot be fixed at the Plan workspace boundary.
+
+#### Expected Files
+
+- `web/src/pages.tsx`
+- `web/src/types.ts` if a state type change is truly needed
+
+#### Validation
+
+- Existing Plan explorer interactions continue to render the right selected
+  title/detail.
+- Explicit heading and root selections still produce exactly one expected
+  reader scroll.
+- No refresh-driven effect path directly sets `scrollTop` merely because the
+  Plan payload object changed.
+
+#### Execution Notes
+
+Implemented the scroll intent boundary in `PlanWorkspace`: heading ID
+assignment now follows markdown render refreshes, while `scrollTop` changes
+only when `selectPlanNode` records an explicit navigation request. Added a
+local request version so repeat-clicking the same selected node can still issue
+a fresh one-time scroll. The implementation stayed inside `web/src/pages.tsx`
+and did not require `PlanWorkspaceState` or `useLiveResource` changes.
+
+Validation run:
+
+- `pnpm --dir web test -- main.test.tsx` first failed on the new regression
+  test with the old behavior (`scrollTop` changed from 111 to 513 after
+  rerender), then passed after the fix.
+- `pnpm --dir web test`
+- `pnpm --dir web check`
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Add Regression Coverage And Verify
+
+- Done: [ ]
+
+#### Objective
+
+Add focused coverage for the refresh/rerender scroll regression and run the
+relevant frontend validation.
+
+#### Details
+
+Prefer a Vitest/jsdom component test around `PlanWorkspace` or the existing App
+state tests. The test should select a heading, confirm the initial navigation
+intent, manually move the reader scroll position away from that heading, then
+rerender with an equivalent-but-new Plan document payload. The assertion should
+prove the manual scroll position is preserved unless a new selection is made.
+
+Keep the existing Playwright smoke heading-navigation check intact. Extend the
+smoke only if component coverage cannot reliably model the refresh behavior or
+if execution changes the browser-only scroll path.
+
+#### Expected Files
+
+- `web/src/main.test.tsx` or `web/src/pages.test.tsx`
+- `scripts/ui-playwright-plan-smoke` only if a browser-level check is needed
+
+#### Validation
+
+- Run the relevant frontend unit test command, such as `pnpm --dir web test`
+  or a narrower Vitest invocation if supported by the repo.
+- Run `pnpm --dir web check`.
+- Run `scripts/ui-playwright-plan-smoke` if the smoke script is updated or if
+  execution needs browser-level confidence for the scroll behavior.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Focus first on deterministic component coverage for the state/ref boundary:
+  explicit selection should scroll once, refreshed equivalent Plan data should
+  not scroll again.
+- Use TypeScript checking to catch state/type regressions.
+- Preserve existing Plan smoke coverage for real browser heading navigation;
+  expand it only when needed to cover behavior that jsdom cannot represent.
+
+## Risks
+
+- Risk: The fix could stop legitimate first-time heading navigation after a
+  user clicks the explorer.
+  - Mitigation: Keep the existing smoke assertion that heading clicks move the
+    reader near the selected heading, and add a focused unit assertion for the
+    one-time navigation request.
+- Risk: A component test may not faithfully model browser scroll layout.
+  - Mitigation: Test the intent boundary in Vitest and use the existing
+    Playwright smoke path for real layout confidence when execution warrants
+    it.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
+++ b/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
@@ -49,16 +49,16 @@ still navigate the reader to that heading once at the time of selection.
 
 ## Acceptance Criteria
 
-- [ ] A Plan heading selection scrolls the reader to that heading once.
-- [ ] A subsequent live refresh or equivalent rerender with a fresh
+- [x] A Plan heading selection scrolls the reader to that heading once.
+- [x] A subsequent live refresh or equivalent rerender with a fresh
       `document`/markdown payload does not snap the reader back to the selected
       heading after the user has manually scrolled away.
-- [ ] Selecting the document root may still take the reader to the top as an
+- [x] Selecting the document root may still take the reader to the top as an
       explicit navigation action, but refreshes do not repeatedly force that
       top position.
-- [ ] Supplement file/directory selection remains functional and does not
+- [x] Supplement file/directory selection remains functional and does not
       trigger markdown reader scroll restoration.
-- [ ] Automated coverage fails on the old repeated-scroll behavior and passes
+- [x] Automated coverage fails on the old repeated-scroll behavior and passes
       with the new scroll intent boundary.
 
 ## Deferred Items
@@ -176,6 +176,11 @@ equivalent fresh `PlanDocument` object. With the old implementation this test
 failed because rerender replayed the selected-heading scroll and changed
 `scrollTop` from 111 to 513; after the Step 1 fix it passes.
 
+After finalize review, added a second focused regression for the document-root
+path: default root selection preserves manual reader `scrollTop` across an
+equivalent fresh `PlanDocument` rerender, while an explicit root click still
+scrolls the reader back to top once.
+
 Validation run:
 
 - `pnpm --dir web test -- main.test.tsx`
@@ -218,7 +223,19 @@ PENDING_UNTIL_ARCHIVE
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+`review-001-delta` passed with zero findings for the implementation and first
+regression test.
+
+`review-002-full` requested changes for two archive-readiness gaps:
+
+- the document-root/default-root refresh replay path lacked explicit
+  regression coverage
+- the top-level acceptance criteria were still unchecked despite completed
+  steps and validation
+
+Both findings were fixed by adding the root/default-root regression test and
+checking off the satisfied acceptance criteria. Follow-up review remains
+pending.
 
 ## Archive Summary
 

--- a/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
+++ b/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
@@ -69,7 +69,7 @@ still navigate the reader to that heading once at the time of selection.
 
 ### Step 1: Separate Scroll Intent From Render Refresh
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -127,11 +127,15 @@ Validation run:
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` passed on 2026-06-26 with `correctness` and `tests`
+reviewer slots. Both reviewers submitted valid results through
+`harness review submit`, both reported no findings, and
+`harness review aggregate --round review-001-delta` passed with zero blocking
+or non-blocking findings.
 
 ### Step 2: Add Regression Coverage And Verify
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -165,11 +169,27 @@ if execution changes the browser-only scroll path.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added a focused Vitest regression in `web/src/main.test.tsx` that mounts
+`PlanWorkspace`, clicks the `Scope` heading, verifies the explicit navigation
+scroll, manually changes reader `scrollTop`, then rerenders with an
+equivalent fresh `PlanDocument` object. With the old implementation this test
+failed because rerender replayed the selected-heading scroll and changed
+`scrollTop` from 111 to 513; after the Step 1 fix it passes.
+
+Validation run:
+
+- `pnpm --dir web test -- main.test.tsx`
+- `pnpm --dir web test`
+- `pnpm --dir web check`
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 2 was the regression coverage half of the same
+tightly coupled Step 1 implementation slice already reviewed in
+`review-001-delta`. The `tests` reviewer specifically reviewed whether the new
+regression proves the refreshed-document scroll replay risk and reported no
+findings, so a separate second step review would duplicate that accepted
+closeout.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
+++ b/docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md
@@ -219,7 +219,18 @@ closeout.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+Validation completed successfully:
+
+- `pnpm --dir web test -- main.test.tsx`
+- `pnpm --dir web test`
+- `pnpm --dir web check`
+- `harness plan lint docs/plans/active/2026-06-26-plan-reader-refresh-scroll-intent.md`
+
+The focused frontend regression first failed against the old selected-heading
+scroll replay behavior, then passed after the PlanWorkspace scroll-intent fix.
+Follow-up root/default-root coverage also passed, proving refreshed equivalent
+Plan document data no longer forces the reader back to top while explicit root
+selection still navigates to top once.
 
 ## Review Summary
 
@@ -238,19 +249,32 @@ checking off the satisfied acceptance criteria. Follow-up review remains
 complete: `review-003-delta` passed with `tests` and `agent-ux` reviewer slots
 and zero findings.
 
+Final archive review `review-004-full` passed with `correctness`, `tests`, and
+`agent-ux` reviewer slots and zero findings.
+
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: Pending post-archive publish.
+- Ready: Yes, after archive and publish/CI/sync evidence are recorded.
+- Merge Handoff: Use the PR body to summarize the scroll-intent behavior fix,
+  selected-heading and document-root regression coverage, and the clean review
+  history.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Split Plan reader anchor assignment from one-time scroll navigation intent in
+  `PlanWorkspace`.
+- Preserved manual reader scrolling across refreshed equivalent Plan document
+  payloads for both selected heading and document-root/default-root states.
+- Preserved explicit heading and root navigation as one-time scroll actions.
+- Added Vitest regression coverage for selected-heading and document-root
+  refresh replay behavior.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+None.
 
 ### Follow-Up Issues
 

--- a/docs/plans/archived/2026-06-26-plan-reader-refresh-scroll-intent.md
+++ b/docs/plans/archived/2026-06-26-plan-reader-refresh-scroll-intent.md
@@ -254,6 +254,8 @@ Final archive review `review-004-full` passed with `correctness`, `tests`, and
 
 ## Archive Summary
 
+- Archived At: 2026-06-26T16:36:16+08:00
+- Revision: 1
 - PR: Pending post-archive publish.
 - Ready: Yes, after archive and publish/CI/sync evidence are recorded.
 - Merge Handoff: Use the PR body to summarize the scroll-intent behavior fix,

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -472,6 +472,30 @@ describe("workbench page state continuity", () => {
     await waitFor(() => expect(reader.scrollTop).toBe(111));
   });
 
+  test("keeps manual Plan reader scroll at the document root until root is selected again", async () => {
+    if (!planResult.document) throw new Error("missing plan document fixture");
+    const { rerender } = render(<PlanDocumentHarness planDocument={planResult.document} />);
+
+    await waitFor(() => expect(activePlanTreeText()).toBe("Warm Plan"));
+    const reader = document.querySelector(".plan-reader") as HTMLElement | null;
+    if (!reader) throw new Error("missing plan reader fixture element");
+
+    reader.scrollTop = 222;
+    rerender(
+      <PlanDocumentHarness
+        planDocument={{
+          ...planResult.document,
+          headings: planResult.document.headings.map((heading) => ({ ...heading })),
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(reader.scrollTop).toBe(222));
+
+    clickPlanTreeLabel("Warm Plan");
+    await waitFor(() => expect(reader.scrollTop).toBe(0));
+  });
+
   test("keeps supplements-only Plan child selection warm across tab switches", async () => {
     currentPlanResult = supplementsOnlyPlanResult;
     window.history.pushState({}, "", "/workspace/wk_alpha/plan");

--- a/web/src/main.test.tsx
+++ b/web/src/main.test.tsx
@@ -6,6 +6,7 @@ import { App } from "./main";
 import { PlanWorkspace, ReviewWorkspace, TimelineWorkspace } from "./pages";
 import type {
   DashboardResult,
+  PlanDocument,
   PlanResult,
   PlanWorkspaceState,
   ReviewResult,
@@ -299,6 +300,22 @@ function PlanStateHarness() {
   );
 }
 
+function PlanDocumentHarness(props: { planDocument: PlanDocument }) {
+  const [state, setState] = useState<PlanWorkspaceState>({ selectedNodeId: null, expandedNodeIds: null });
+  return (
+    <PlanWorkspace
+      loading={false}
+      error={null}
+      summary={planResult.summary}
+      document={props.planDocument}
+      supplements={null}
+      warnings={[]}
+      state={state}
+      onStateChange={setState}
+    />
+  );
+}
+
 function TimelineStateHarness() {
   const [mounted, setMounted] = useState(true);
   const [state, setState] = useState<TimelineWorkspaceState>({ selectedEventId: null, selectedTab: "event" });
@@ -425,6 +442,34 @@ describe("workbench page state continuity", () => {
       document: planResult.document ? { ...planResult.document, title: "Refreshed Plan", markdown: "# Refreshed Plan" } : null,
     });
     await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Refreshed Plan"));
+  });
+
+  test("keeps manual Plan reader scroll when refreshed document data keeps the same selection", async () => {
+    if (!planResult.document) throw new Error("missing plan document fixture");
+    const { rerender } = render(<PlanDocumentHarness planDocument={planResult.document} />);
+
+    await waitFor(() => expect(document.querySelector(".plan-tree-text")?.textContent).toBe("Warm Plan"));
+    const reader = document.querySelector(".plan-reader") as HTMLElement | null;
+    const scope = document.querySelector("#scope") as HTMLElement | null;
+    if (!reader || !scope) throw new Error("missing plan reader fixture elements");
+
+    reader.getBoundingClientRect = () => ({ left: 0, right: 640, width: 640, top: 100, bottom: 700, height: 600, x: 0, y: 100, toJSON: () => ({}) });
+    scope.getBoundingClientRect = () => ({ left: 0, right: 640, width: 640, top: 520, bottom: 548, height: 28, x: 0, y: 520, toJSON: () => ({}) });
+
+    clickPlanTreeLabel("Scope");
+    await waitFor(() => expect(reader.scrollTop).toBeGreaterThan(300));
+
+    reader.scrollTop = 111;
+    rerender(
+      <PlanDocumentHarness
+        planDocument={{
+          ...planResult.document,
+          headings: planResult.document.headings.map((heading) => ({ ...heading })),
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(reader.scrollTop).toBe(111));
   });
 
   test("keeps supplements-only Plan child selection warm across tab switches", async () => {

--- a/web/src/pages.tsx
+++ b/web/src/pages.tsx
@@ -476,6 +476,8 @@ export function PlanWorkspace(props: {
   const { loading, error, summary, document, supplements, warnings, state, onStateChange } = props;
   const documentRootId = document ? `document:${document.path}` : "document";
   const readerRef = useRef<HTMLDivElement | null>(null);
+  const pendingScrollNodeIdRef = useRef<string | null>(null);
+  const [scrollRequestVersion, setScrollRequestVersion] = useState(0);
 
   const flattenedHeadings = useMemo(() => flattenPlanHeadings(document?.headings ?? []), [document?.headings]);
   const documentHTML = useMemo(() => (document ? markdownRenderer.render(document.markdown) : ""), [document]);
@@ -543,8 +545,23 @@ export function PlanWorkspace(props: {
         element.id = heading.anchor;
       }
     });
+  }, [document, documentHTML, flattenedHeadings, selectedFile]);
 
+  useEffect(() => {
+    const pendingScrollNodeId = pendingScrollNodeIdRef.current;
+    if (!pendingScrollNodeId || pendingScrollNodeId !== selectedNodeId) return;
+    pendingScrollNodeIdRef.current = null;
+    if (!document || selectedFile) return;
+    const root = readerRef.current;
+    if (!root) return;
+
+    if (pendingScrollNodeId === documentRootId) {
+      const scrollContainer = findNearestScrollableAncestor(root) || root;
+      scrollContainer.scrollTop = 0;
+      return;
+    }
     if (selectedHeading) {
+      const headingElements = Array.from(root.querySelectorAll("h1, h2, h3, h4, h5, h6"));
       const target = headingElements.find((element) => element.id === selectedHeading.anchor) as HTMLElement | undefined;
       if (target) {
         const scrollContainer = findNearestScrollableAncestor(target) || findNearestScrollableAncestor(root) || root;
@@ -554,9 +571,7 @@ export function PlanWorkspace(props: {
         return;
       }
     }
-    const scrollContainer = findNearestScrollableAncestor(root) || root;
-    scrollContainer.scrollTop = 0;
-  }, [document, documentHTML, flattenedHeadings, selectedFile, selectedHeading]);
+  }, [document, documentRootId, scrollRequestVersion, selectedFile, selectedHeading, selectedNodeId]);
 
   const toggleNode = (id: string) => {
     setExpandedNodeIds((current) => {
@@ -574,6 +589,8 @@ export function PlanWorkspace(props: {
     if (opts?.toggle) {
       toggleNode(id);
     }
+    pendingScrollNodeIdRef.current = id;
+    setScrollRequestVersion((current) => current + 1);
     setSelectedNodeId(id);
   };
 


### PR DESCRIPTION
## What Changed

Fixes #261 by separating Plan reader heading anchor assignment from one-time scroll navigation intent. Live Plan refreshes can still update rendered heading IDs, but they no longer replay the last selected heading or document-root selection as a repeated `scrollTop` command after the user manually scrolls the reader.

Explicit explorer navigation still works: selecting a heading scrolls to that heading once, and selecting the Plan document root scrolls to the top once. Supplement file and directory selections remain outside markdown reader scroll restoration.

## Confidence

- Added focused Vitest coverage for selected-heading refresh preservation after manual reader scroll.
- Added focused Vitest coverage for document-root/default-root refresh preservation and explicit root-click top navigation.
- Ran `pnpm --dir web test -- main.test.tsx`, `pnpm --dir web test`, and `pnpm --dir web check` successfully.
- Harness reviews completed cleanly after repair: `review-003-delta` passed the targeted repair review, and `review-004-full` passed final correctness, tests, and agent-UX review with zero findings.
- Archived plan: `docs/plans/archived/2026-06-26-plan-reader-refresh-scroll-intent.md`.

## Handoff

Draft PR pending remote CI/sync evidence refresh. No deferred follow-up issues are recorded in the archived plan.
