### PR TITLE
Add repo config refresh diff preview

### DIFF
--- a/assets/help/repo/config.md
+++ b/assets/help/repo/config.md
@@ -58,6 +58,12 @@ Before applying the canonical refresh rewrite, inspect it with:
 harness repo config refresh --diff
 ```
 
+After reviewing and accepting the preview, apply it with:
+
+```bash
+harness repo config refresh
+```
+
 `harness repo config refresh` owns the canonical rendered file shape. Valid
 user-authored YAML comments are accepted when the config values remain valid,
 but refresh does not preserve those comments or the original field ordering.

--- a/assets/help/repo/config.md
+++ b/assets/help/repo/config.md
@@ -52,6 +52,18 @@ harness repo config get paths.local_runtime
 harness repo config get paths.review.dimensions
 ```
 
+Before applying the canonical refresh rewrite, inspect it with:
+
+```bash
+harness repo config refresh --diff
+```
+
+`harness repo config refresh` owns the canonical rendered file shape. Valid
+user-authored YAML comments are accepted when the config values remain valid,
+but refresh does not preserve those comments or the original field ordering.
+The canonical renderer preserves supported configured values, normalizes field
+ordering, and still rejects unsupported fields.
+
 If `.harness/config.yaml` is missing, easyharness uses built-in defaults. If
 the file exists but is invalid, commands warn the agent, ignore the whole
 config, and use built-in defaults instead of partially consuming it.

--- a/assets/help/repo/config.md
+++ b/assets/help/repo/config.md
@@ -64,9 +64,11 @@ but refresh does not preserve those comments or the original field ordering.
 The canonical renderer preserves supported configured values, normalizes field
 ordering, and still rejects unsupported fields.
 
-If `.harness/config.yaml` is missing, easyharness uses built-in defaults. If
-the file exists but is invalid, commands warn the agent, ignore the whole
-config, and use built-in defaults instead of partially consuming it.
+If `.harness/config.yaml` is missing, easyharness uses built-in defaults.
+Config-consuming commands warn the agent, ignore an invalid existing config as
+a whole, and use built-in defaults instead of partially consuming it. Refresh
+commands are stricter: `harness repo config refresh` and `harness repo config
+refresh --diff` fail invalid existing configs without overwriting them.
 
 Repo-defined review dimensions are Markdown files directly under the resolved
 `paths.review.dimensions` root, which defaults to:

--- a/docs/plans/active/2026-06-28-repo-config-refresh-diff-preview.md
+++ b/docs/plans/active/2026-06-28-repo-config-refresh-diff-preview.md
@@ -56,22 +56,22 @@ bootstrap JSON result envelope.
 
 ## Acceptance Criteria
 
-- [ ] `harness repo config refresh --diff` leaves `.harness/config.yaml`
+- [x] `harness repo config refresh --diff` leaves `.harness/config.yaml`
       untouched for missing, stale, non-canonical valid, already canonical, and
       invalid existing config cases.
-- [ ] `--diff` prints a unified diff to stdout when refresh would create or
+- [x] `--diff` prints a unified diff to stdout when refresh would create or
       update `.harness/config.yaml`.
-- [ ] `--diff` prints empty stdout and exits successfully when the current file
+- [x] `--diff` prints empty stdout and exits successfully when the current file
       is already canonical.
-- [ ] `--diff` rejects invalid existing config with the same failure semantics
+- [x] `--diff` rejects invalid existing config with the same failure semantics
       as ordinary refresh and does not print a misleading diff.
-- [ ] Ordinary `harness repo config refresh` still rewrites valid config to the
+- [x] Ordinary `harness repo config refresh` still rewrites valid config to the
       canonical render, preserves configured values, emits the existing JSON
       result envelope, and does not include diff text in JSON.
-- [ ] Tests cover a valid config with user-authored comments and non-canonical
+- [x] Tests cover a valid config with user-authored comments and non-canonical
       field order so the expected diff demonstrates comment removal/order
       normalization while preserving configured values.
-- [ ] Docs/spec/help text explain that refresh owns canonical file shape:
+- [x] Docs/spec/help text explain that refresh owns canonical file shape:
       valid comments are accepted on load but not preserved by refresh, field
       ordering is normalized by the renderer, configured values are preserved,
       and unsupported fields remain invalid.

--- a/docs/plans/active/2026-06-28-repo-config-refresh-diff-preview.md
+++ b/docs/plans/active/2026-06-28-repo-config-refresh-diff-preview.md
@@ -1,0 +1,240 @@
+---
+template_version: 0.2.0
+created_at: "2026-06-28T23:27:48+08:00"
+approved_at: "2026-06-28T23:28:57+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/247
+size: S
+---
+
+# Add repo config refresh diff preview
+
+## Goal
+
+Add a focused preview mode for `harness repo config refresh` so users can
+inspect the canonical rewrite before applying it. The preview command should
+show the same file change ordinary refresh would make, but it must not write
+`.harness/config.yaml`.
+
+Keep the command shape aligned with the existing repo config surface:
+ordinary `harness repo config refresh` remains the JSON-emitting mutation
+command, while `harness repo config refresh --diff` is a plain-text preview
+mode that prints a unified diff to stdout and never embeds diff text inside the
+bootstrap JSON result envelope.
+
+## Scope
+
+### In Scope
+
+- Add `harness repo config refresh --diff`.
+- Make `--diff` compute the canonical refresh result for missing, stale, or
+  non-canonical valid config files without applying the planned write.
+- Print a readable unified diff to stdout when refresh would change
+  `.harness/config.yaml`.
+- Print empty stdout and exit successfully when the file already matches the
+  current canonical render.
+- Reject invalid existing config through the same validation rules ordinary
+  refresh uses, without overwriting the file.
+- Preserve ordinary `harness repo config refresh` JSON output and write
+  behavior.
+- Document the canonical text contract for comments, field ordering, and
+  configured value preservation.
+- Add focused CLI, service or helper, and smoke coverage for the diff mode and
+  canonical text behavior.
+
+### Out of Scope
+
+- Adding `harness repo config refresh --dry-run`.
+- Adding a new `harness repo config diff` subcommand.
+- Preserving user-authored YAML comments or original field ordering during
+  refresh.
+- Introducing YAML AST round-trip editing.
+- Changing repo config schema, path-root semantics, or unsupported-field
+  validation.
+- Changing the bootstrap JSON result schema to carry diff content.
+
+## Acceptance Criteria
+
+- [ ] `harness repo config refresh --diff` leaves `.harness/config.yaml`
+      untouched for missing, stale, non-canonical valid, already canonical, and
+      invalid existing config cases.
+- [ ] `--diff` prints a unified diff to stdout when refresh would create or
+      update `.harness/config.yaml`.
+- [ ] `--diff` prints empty stdout and exits successfully when the current file
+      is already canonical.
+- [ ] `--diff` rejects invalid existing config with the same failure semantics
+      as ordinary refresh and does not print a misleading diff.
+- [ ] Ordinary `harness repo config refresh` still rewrites valid config to the
+      canonical render, preserves configured values, emits the existing JSON
+      result envelope, and does not include diff text in JSON.
+- [ ] Tests cover a valid config with user-authored comments and non-canonical
+      field order so the expected diff demonstrates comment removal/order
+      normalization while preserving configured values.
+- [ ] Docs/spec/help text explain that refresh owns canonical file shape:
+      valid comments are accepted on load but not preserved by refresh, field
+      ordering is normalized by the renderer, configured values are preserved,
+      and unsupported fields remain invalid.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Define the refresh diff contract
+
+- Done: [x]
+
+#### Objective
+
+Update the repo config command contract and user-facing help to describe
+`harness repo config refresh --diff` and the canonical text behavior.
+
+#### Details
+
+The contract should present `--diff` as a preview mode for the existing
+refresh operation, not as a generic dry-run facility and not as a new bootstrap
+JSON envelope variant. Keep `repo config get/list` as existing plain-text
+exceptions, and document this new plain-text preview mode narrowly so future
+agents do not route diff text into `contracts.BootstrapResult`.
+
+The canonical text documentation should say:
+
+- refresh owns the canonical rendered file shape
+- valid YAML comments are accepted by load when the values remain valid
+- refresh does not preserve user-authored comments
+- refresh normalizes field ordering through the canonical renderer
+- configured values are preserved
+- unsupported fields remain invalid
+
+#### Expected Files
+
+- `docs/specs/bootstrap-install.md`
+- `docs/specs/repo-config.md`
+- `docs/specs/cli-contract.md`
+- `assets/help/repo/config.md`
+- `internal/cli/app.go`
+- `internal/cli/app_test.go`
+
+#### Validation
+
+- `go test ./internal/cli -run 'TestRepoConfigRefreshHelp|TestHelpRepoConfig'`
+- Confirm help text mentions `--diff` without implying `--dry-run` support.
+- Confirm the written contract makes ordinary refresh JSON output and diff
+  preview stdout mutually clear.
+
+#### Execution Notes
+
+Added CLI help coverage for `harness repo config refresh --diff`, updated
+refresh command help to advertise `--diff` without `--dry-run`, and documented
+the plain-text preview/canonical text contract in bootstrap, CLI, repo config,
+and help-topic docs. Validation: `go test ./internal/cli -run
+'TestRepoConfigRefreshHelp|TestHelpRepoConfig'`; reran
+`scripts/install-dev-harness` after changing Go CLI code.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 1 only establishes the documented command
+contract and help text; Step 2 will receive implementation-focused review
+after the behavior and tests exist.
+
+### Step 2: Implement preview output and regression coverage
+
+- Done: [ ]
+
+#### Objective
+
+Implement `harness repo config refresh --diff` using the same canonical render
+and validation rules as ordinary refresh, while leaving ordinary refresh
+behavior unchanged.
+
+#### Details
+
+The implementation should keep the existing `install.Service.RefreshConfig`
+JSON path stable for ordinary refresh. A focused helper may expose the planned
+repo config refresh content to the CLI or service layer, but the public
+bootstrap result contract should not gain a diff field.
+
+Unified diff output should compare the current target path with the canonical
+refresh content. For a missing config, the diff should make clear that
+`.harness/config.yaml` would be created with canonical content. For an already
+canonical config, stdout should be empty. For invalid existing config, return
+the ordinary refresh-style failure and leave the file untouched.
+
+#### Expected Files
+
+- `internal/cli/app.go`
+- `internal/install/service.go`
+- `internal/install/service_test.go`
+- `internal/cli/app_test.go`
+- `tests/smoke/smoke_test.go`
+- `internal/repoconfig/config_test.go`
+
+#### Validation
+
+- `go test ./internal/repoconfig`
+- `go test ./internal/install`
+- `go test ./internal/cli -run 'TestRepoConfigRefresh'`
+- `go test ./tests/smoke -run TestRepoConfigRefresh`
+- `git diff --check`
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Use focused package tests for canonical rendering, refresh planning, CLI
+  stdout/stderr/exit behavior, and write/no-write guarantees.
+- Use smoke coverage to verify the built CLI behavior matches the direct CLI
+  tests for `refresh --diff`.
+- Use `git diff --check` for whitespace and patch hygiene.
+- After changing Go CLI code, rerun `scripts/install-dev-harness` before
+  relying on the direct `harness` binary for any post-change harness command.
+
+## Risks
+
+- Risk: The diff mode could accidentally change the bootstrap JSON contract by
+  adding diff text to `BootstrapResult` or routing preview output through the
+  JSON writer.
+  - Mitigation: Keep `--diff` as an explicit CLI output branch and test that
+    ordinary refresh still emits JSON without diff content.
+- Risk: The diff preview could drift from the actual refresh write behavior.
+  - Mitigation: Compute preview content from the same canonical render and
+    validation path used by refresh, then test preview-vs-refresh equivalence
+    on representative configs.
+- Risk: Missing-file diff output may be hard to read or inconsistent with
+  users' `git diff` expectations.
+  - Mitigation: Use conventional unified diff headers and add a smoke test for
+    creation preview output.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-06-28-repo-config-refresh-diff-preview.md
+++ b/docs/plans/active/2026-06-28-repo-config-refresh-diff-preview.md
@@ -141,7 +141,7 @@ after the behavior and tests exist.
 
 ### Step 2: Implement preview output and regression coverage
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -196,7 +196,9 @@ output and no-write behavior.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+Step-closeout review `review-001-delta` passed with 0 findings. Reviewer
+slots: `correctness` and `tests`; both submitted clean results and the
+aggregate decision was `pass`.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-06-28-repo-config-refresh-diff-preview.md
+++ b/docs/plans/active/2026-06-28-repo-config-refresh-diff-preview.md
@@ -181,7 +181,18 @@ the ordinary refresh-style failure and leave the file untouched.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Added `install.Service.PlanConfigRefreshDiff` plus internal unified-file diff
+rendering for repo config refresh previews. Wired `harness repo config refresh
+--diff` to print plain diff text without writing files, while ordinary refresh
+continues to emit the existing bootstrap JSON result and apply changes. Added
+install, CLI, and smoke tests for missing config creation preview,
+commented/out-of-order valid config normalization, canonical no-op empty
+stdout, invalid config failure/no-write behavior, and ordinary refresh JSON
+preservation. Validation: `go test ./internal/repoconfig`; `go test
+./internal/install`; `go test ./internal/cli -run 'TestRepoConfigRefresh'`;
+`go test ./tests/smoke -run TestRepoConfigRefresh`; `git diff --check`;
+`scripts/install-dev-harness`; manual repo-local binary preview confirmed diff
+output and no-write behavior.
 
 #### Review Notes
 

--- a/docs/plans/archived/2026-06-28-repo-config-refresh-diff-preview.md
+++ b/docs/plans/archived/2026-06-28-repo-config-refresh-diff-preview.md
@@ -228,25 +228,68 @@ aggregate decision was `pass`.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `go test ./internal/repoconfig`
+- `go test ./internal/install`
+- `go test ./internal/cli -run 'TestRepoConfigRefresh'`
+- `go test ./tests/smoke -run TestRepoConfigRefresh`
+- `go test ./internal/cli -run 'TestRepoConfigRefreshHelp|TestHelpRepoConfig'`
+- `go test ./...`
+- `git diff --check`
+- `scripts/install-dev-harness`
+- Manual repo-local binary checks confirmed `harness repo config refresh
+  --diff` prints unified diff output for planned changes and leaves
+  `.harness/config.yaml` untouched, including invalid/planning-error paths.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step review `review-001-delta` passed with 0 findings for the implementation
+  and tests slice.
+- Finalize review found and drove repairs for invalid-config help wording,
+  ordinary refresh JSON regression coverage, apply-after-preview docs wording,
+  preview planning errors accidentally falling back through mutating refresh,
+  unchecked acceptance criteria, and preview error mode reporting.
+- Focused repair review `review-011-delta` passed with 0 findings after
+  preview-planning errors were modeled as `dry_run`/no-write results.
+- Final full archive-candidate review `review-012-full` passed with 0
+  findings across `correctness`, `tests`, `docs-consistency`, and `agent-ux`.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-06-29T00:17:33+08:00
+- Revision: 1
+- PR: Pending post-archive publish from branch
+  `codex/repo-config-refresh-diff-preview`.
+- Ready: Yes. Acceptance criteria are checked, local validation passed,
+  `review-012-full` passed with 0 findings, and the candidate is ready to
+  archive before publish/CI/sync evidence.
+- Merge Handoff: After archive, commit the tracked plan move and summary
+  updates, push the branch, open the PR for issue #247, record publish evidence
+  with the PR URL, refresh CI/sync evidence, and stop at wait-for-merge
+  approval once `harness status` reaches `execution/finalize/await_merge`.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added `harness repo config refresh --diff` as a non-writing plain-text
+  unified diff preview for the existing refresh operation.
+- Reused the canonical refresh render and validation rules so previews match
+  ordinary refresh writes while preserving the ordinary refresh JSON result
+  envelope.
+- Covered missing, stale/non-canonical valid, already canonical, invalid, and
+  preview-planning-error paths, including tests that protect ordinary refresh
+  JSON from diff content.
+- Updated specs and help text to explain the command shape, canonical comment
+  removal, field-order normalization, configured value preservation, invalid
+  unsupported-field behavior, and the apply command after preview.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No `harness repo config refresh --dry-run` alias.
+- No separate `harness repo config diff` command.
+- No YAML AST round-trip editing or preservation of user-authored comments and
+  original field ordering during refresh.
+- No repo config schema or path-root semantic changes.
 
 ### Follow-Up Issues
 

--- a/docs/specs/bootstrap-install.md
+++ b/docs/specs/bootstrap-install.md
@@ -145,7 +145,12 @@ Contract:
   file shape
 - fail without overwriting when the existing config is invalid
 - return the existing repo resource JSON result shape
-- do not support `--dry-run` in the initial command shape
+- support `--diff` as a plain-text preview mode that prints the unified diff
+  refresh would apply without writing `.harness/config.yaml`
+- print empty stdout and exit successfully for `--diff` when the existing
+  config already matches the current canonical file shape
+- do not embed `--diff` output in the repo resource JSON result shape
+- do not support `--dry-run`
 - leave explicit validation commands such as `harness repo config lint` to
   future work
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -349,6 +349,8 @@ Recommended next action:
 
 - for bootstrap commands that support `--dry-run`, rerun without `--dry-run`
   to apply a previewed bootstrap change
+- after reviewing `harness repo config refresh --diff`, rerun
+  `harness repo config refresh` to apply the previewed canonical config rewrite
 - open the target instructions file or skills directory to review the installed
   contract
 

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -339,6 +339,11 @@ Contract:
   `harness repo config get <key>` prints one resolved scalar value, while
   `harness repo config list [prefix]` prints resolved `key=value` leaf entries
   in deterministic order
+- `harness repo config refresh --diff` is a narrow plain-text preview
+  exception for the refresh mutation command: it prints the unified diff that
+  refresh would apply, prints empty stdout when the file is already canonical,
+  and does not write `.harness/config.yaml` or embed diff text in the bootstrap
+  JSON result envelope
 
 Recommended next action:
 

--- a/docs/specs/repo-config.md
+++ b/docs/specs/repo-config.md
@@ -150,6 +150,20 @@ content, rewrites valid existing config into the current canonical file shape,
 preserves custom path-root values, and fails without overwriting when the
 existing config is invalid.
 
+Refresh owns the canonical rendered text shape. The loader accepts
+user-authored YAML comments and field ordering when the underlying v1 values
+remain valid, but refresh does not preserve those comments or the original
+field order. The canonical renderer normalizes field ordering and
+default-equivalent fields while preserving supported configured values.
+Unsupported fields remain invalid instead of being preserved or copied through.
+
+`harness repo config refresh --diff` previews the same canonical rewrite
+without writing `.harness/config.yaml`. It prints a unified diff to stdout
+when refresh would create or update the file, prints empty stdout and exits
+successfully when the file is already canonical, and uses the same invalid
+config failure behavior as ordinary refresh. The diff preview is plain text; it
+does not extend or wrap the bootstrap JSON result envelope.
+
 ## Repo Config Queries
 
 `harness repo config get <key>` is the focused command for reading one resolved

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -702,7 +702,7 @@ func (a *App) runRepoConfigRefresh(args []string) int {
 		service := install.Service{Workdir: workdir}
 		diffText, errs := service.PlanConfigRefreshDiff()
 		if len(errs) > 0 {
-			return a.writeJSONResult(service.RefreshConfig(install.Options{}))
+			return a.writeJSONResult(service.RefreshConfigPreviewError(errs))
 		}
 		fmt.Fprint(a.Stdout, diffText)
 		return 0

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -675,10 +675,13 @@ func (a *App) runRepoConfigInit(args []string) int {
 func (a *App) runRepoConfigRefresh(args []string) int {
 	fs := flag.NewFlagSet("harness repo config refresh", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
+	diff := fs.Bool("diff", false, "Print the unified diff refresh would apply without writing files.")
 	fs.Usage = func() {
-		fmt.Fprintln(a.Stderr, "Usage: harness repo config refresh")
+		fmt.Fprintln(a.Stderr, "Usage: harness repo config refresh [--diff]")
 		fmt.Fprintln(a.Stderr)
 		fmt.Fprintln(a.Stderr, "Create or refresh .harness/config.yaml to the current canonical shape.")
+		fmt.Fprintln(a.Stderr)
+		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -695,6 +698,7 @@ func (a *App) runRepoConfigRefresh(args []string) int {
 		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
 		return 1
 	}
+	_ = diff
 	result := install.Service{Workdir: workdir}.RefreshConfig(install.Options{})
 	return a.writeJSONResult(result)
 }

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -698,7 +698,15 @@ func (a *App) runRepoConfigRefresh(args []string) int {
 		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
 		return 1
 	}
-	_ = diff
+	if *diff {
+		service := install.Service{Workdir: workdir}
+		diffText, errs := service.PlanConfigRefreshDiff()
+		if len(errs) > 0 {
+			return a.writeJSONResult(service.RefreshConfig(install.Options{}))
+		}
+		fmt.Fprint(a.Stdout, diffText)
+		return 0
+	}
 	result := install.Service{Workdir: workdir}.RefreshConfig(install.Options{})
 	return a.writeJSONResult(result)
 }

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -833,7 +833,7 @@ func TestRepoConfigRefreshDiffPlanningErrorDoesNotFallbackToApply(t *testing.T) 
 	if ok, _ := payload["ok"].(bool); ok {
 		t.Fatalf("expected config refresh --diff failure, got %#v", payload)
 	}
-	if mode, _ := payload["mode"].(string); mode != "apply" {
+	if mode, _ := payload["mode"].(string); mode != "dry_run" {
 		t.Fatalf("expected existing error envelope mode, got %#v", payload)
 	}
 	data, err := os.ReadFile(obstruction)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -408,6 +408,7 @@ func TestHelpRepoConfigPrintsAgentGuide(t *testing.T) {
 		"version: 1",
 		"harness repo config get paths.plans.active",
 		"harness repo config list",
+		"harness repo config refresh --diff",
 		".harness/review/dimensions",
 		"humans describe the outcome",
 	} {
@@ -1001,6 +1002,18 @@ func TestRepoConfigRefreshHelpExitsZero(t *testing.T) {
 	exitCode := app.Run([]string{"repo", "config", "refresh", "--help"})
 	if exitCode != 0 {
 		t.Fatalf("expected help exit code 0, got %d", exitCode)
+	}
+	for _, want := range []string{
+		"Usage: harness repo config refresh",
+		"--diff",
+		"unified diff",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("expected config refresh help to contain %q, got %q", want, stderr.String())
+		}
+	}
+	if strings.Contains(stderr.String(), "--dry-run") {
+		t.Fatalf("expected config refresh help not to advertise --dry-run, got %q", stderr.String())
 	}
 	if !strings.Contains(stderr.String(), "Usage: harness repo config refresh") {
 		t.Fatalf("expected config refresh help text, got %q", stderr.String())

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -657,6 +657,14 @@ func TestRepoConfigRefreshCommandUpdatesOldDefaultConfig(t *testing.T) {
 	if payload["command"] != "repo config refresh" || payload["operation"] != "refresh" {
 		t.Fatalf("unexpected payload: %#v", payload)
 	}
+	if _, ok := payload["diff"]; ok {
+		t.Fatalf("ordinary refresh JSON must not include diff field: %#v", payload)
+	}
+	for _, forbidden := range []string{"--- a/.harness/config.yaml", "+++ b/.harness/config.yaml", "@@ -"} {
+		if strings.Contains(stdout.String(), forbidden) {
+			t.Fatalf("ordinary refresh JSON must not include diff marker %q:\n%s", forbidden, stdout.String())
+		}
+	}
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read repo config: %v", err)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -808,6 +808,43 @@ func TestRepoConfigRefreshDiffRejectsInvalidConfigWithoutOverwrite(t *testing.T)
 	}
 }
 
+func TestRepoConfigRefreshDiffPlanningErrorDoesNotFallbackToApply(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	obstruction := filepath.Join(root, ".harness")
+	if err := os.WriteFile(obstruction, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("write obstructing .harness file: %v", err)
+	}
+
+	exitCode := app.Run([]string{"repo", "config", "refresh", "--diff"})
+	if exitCode != 1 {
+		t.Fatalf("expected config refresh --diff exit code 1, got %d", exitCode)
+	}
+	if strings.Contains(stdout.String(), "--- /dev/null") || strings.Contains(stdout.String(), "+++ b/.harness/config.yaml") {
+		t.Fatalf("expected no diff for planning error, got:\n%s", stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON config error output: %v\n%s", err, stdout.String())
+	}
+	if ok, _ := payload["ok"].(bool); ok {
+		t.Fatalf("expected config refresh --diff failure, got %#v", payload)
+	}
+	if mode, _ := payload["mode"].(string); mode != "apply" {
+		t.Fatalf("expected existing error envelope mode, got %#v", payload)
+	}
+	data, err := os.ReadFile(obstruction)
+	if err != nil {
+		t.Fatalf("read obstruction: %v", err)
+	}
+	if string(data) != "not a directory" {
+		t.Fatalf("expected preview error not to mutate obstruction, got:\n%s", data)
+	}
+}
+
 func TestRepoConfigRefreshCommandRejectsInvalidConfig(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -666,6 +666,140 @@ func TestRepoConfigRefreshCommandUpdatesOldDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestRepoConfigRefreshDiffPrintsUnifiedDiffWithoutWriting(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	configPath := filepath.Join(root, ".harness/config.yaml")
+	original := `# local note
+paths:
+  local_runtime: tmp/harness-runtime
+  plans:
+    archived: workflow/plans/done
+    active: workflow/plans/open
+version: 1
+`
+	writeCLIRepoConfig(t, root, original)
+
+	exitCode := app.Run([]string{"repo", "config", "refresh", "--diff"})
+	if exitCode != 0 {
+		t.Fatalf("repo config refresh --diff failed with %d: %s", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr for diff preview, got %q", stderr.String())
+	}
+	if json.Valid(stdout.Bytes()) {
+		t.Fatalf("expected plain diff output, got JSON: %s", stdout.String())
+	}
+	for _, want := range []string{
+		"--- a/.harness/config.yaml",
+		"+++ b/.harness/config.yaml",
+		"-# local note",
+		"+    active: workflow/plans/open",
+		"+    archived: workflow/plans/done",
+		"+  local_runtime: tmp/harness-runtime",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected diff to contain %q, got:\n%s", want, stdout.String())
+		}
+	}
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read repo config: %v", err)
+	}
+	if string(configData) != original {
+		t.Fatalf("expected diff preview to leave config untouched, got:\n%s", configData)
+	}
+}
+
+func TestRepoConfigRefreshDiffCreatesMissingConfigWithoutWriting(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	configPath := filepath.Join(root, ".harness/config.yaml")
+
+	exitCode := app.Run([]string{"repo", "config", "refresh", "--diff"})
+	if exitCode != 0 {
+		t.Fatalf("repo config refresh --diff failed with %d: %s", exitCode, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr for diff preview, got %q", stderr.String())
+	}
+	for _, want := range []string{
+		"--- /dev/null",
+		"+++ b/.harness/config.yaml",
+		"+version: 1",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected diff to contain %q, got:\n%s", want, stdout.String())
+		}
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("expected diff preview to leave config absent, got err=%v", err)
+	}
+}
+
+func TestRepoConfigRefreshDiffNoopsWithEmptyStdout(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	writeCLIRepoConfig(t, root, repoconfig.DefaultContent)
+
+	exitCode := app.Run([]string{"repo", "config", "refresh", "--diff"})
+	if exitCode != 0 {
+		t.Fatalf("repo config refresh --diff failed with %d: %s", exitCode, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout for no-op diff, got %q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected no stderr for no-op diff, got %q", stderr.String())
+	}
+}
+
+func TestRepoConfigRefreshDiffRejectsInvalidConfigWithoutOverwrite(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	root := t.TempDir()
+	app.Getwd = func() (string, error) { return root, nil }
+	configPath := filepath.Join(root, ".harness/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("version: 2\n"), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+
+	exitCode := app.Run([]string{"repo", "config", "refresh", "--diff"})
+	if exitCode != 1 {
+		t.Fatalf("expected config refresh --diff exit code 1, got %d", exitCode)
+	}
+	if strings.Contains(stdout.String(), "--- a/.harness/config.yaml") || strings.Contains(stdout.String(), "+++ b/.harness/config.yaml") {
+		t.Fatalf("expected no diff for invalid config, got:\n%s", stdout.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("expected JSON config error output: %v\n%s", err, stdout.String())
+	}
+	if ok, _ := payload["ok"].(bool); ok {
+		t.Fatalf("expected config refresh --diff failure, got %#v", payload)
+	}
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read repo config: %v", err)
+	}
+	if string(configData) != "version: 2\n" {
+		t.Fatalf("expected invalid config to remain untouched, got:\n%s", configData)
+	}
+}
+
 func TestRepoConfigRefreshCommandRejectsInvalidConfig(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -156,6 +156,32 @@ func (s Service) RefreshConfig(opts Options) Result {
 	return s.successResult("repo config refresh", ResourceConfig, OperationRefresh, scope, agent, opts.DryRun, writes)
 }
 
+func (s Service) PlanConfigRefreshDiff() (string, []CommandError) {
+	writes, errs := s.planRepoConfigRefresh()
+	if len(errs) > 0 {
+		return "", errs
+	}
+	if len(writes) == 0 || writes[0].kind == ActionNoop {
+		return "", nil
+	}
+	write := writes[0]
+	switch write.kind {
+	case ActionCreate:
+		return renderUnifiedFileDiff(pathLabel(s.Workdir, write.path), nil, false, write.content), nil
+	case ActionUpdate:
+		current, err := os.ReadFile(write.path)
+		if err != nil {
+			return "", []CommandError{{
+				Path:    pathLabel(s.Workdir, write.path),
+				Message: fmt.Sprintf("read repo config target: %v", err),
+			}}
+		}
+		return renderUnifiedFileDiff(pathLabel(s.Workdir, write.path), current, true, write.content), nil
+	default:
+		return "", nil
+	}
+}
+
 func (s Service) runSkillCommand(command, operation string, opts Options) Result {
 	scope := normalizeScope(opts.Scope)
 	if scope == "" {
@@ -910,6 +936,55 @@ func pathLabel(workdir, path string) string {
 		return filepath.ToSlash(rel)
 	}
 	return filepath.Clean(path)
+}
+
+func renderUnifiedFileDiff(path string, oldContent []byte, oldExists bool, newContent []byte) string {
+	if oldExists && string(oldContent) == string(newContent) {
+		return ""
+	}
+	oldLines := splitDiffLines(string(oldContent))
+	newLines := splitDiffLines(string(newContent))
+	var b strings.Builder
+	if oldExists {
+		fmt.Fprintf(&b, "--- a/%s\n", path)
+	} else {
+		b.WriteString("--- /dev/null\n")
+	}
+	fmt.Fprintf(&b, "+++ b/%s\n", path)
+	fmt.Fprintf(&b, "@@ -%s +%s @@\n", unifiedRange(len(oldLines), oldExists), unifiedRange(len(newLines), true))
+	for _, line := range oldLines {
+		writeDiffLine(&b, '-', line)
+	}
+	for _, line := range newLines {
+		writeDiffLine(&b, '+', line)
+	}
+	return b.String()
+}
+
+func splitDiffLines(content string) []string {
+	if content == "" {
+		return nil
+	}
+	lines := strings.SplitAfter(content, "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+func unifiedRange(lineCount int, exists bool) string {
+	if !exists || lineCount == 0 {
+		return "0,0"
+	}
+	return fmt.Sprintf("1,%d", lineCount)
+}
+
+func writeDiffLine(b *strings.Builder, prefix byte, line string) {
+	b.WriteByte(prefix)
+	b.WriteString(line)
+	if !strings.HasSuffix(line, "\n") {
+		b.WriteByte('\n')
+	}
 }
 
 func repoConfigWarningsForWorkdir(workdir string, warnings []string) []string {

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -182,6 +182,10 @@ func (s Service) PlanConfigRefreshDiff() (string, []CommandError) {
 	}
 }
 
+func (s Service) RefreshConfigPreviewError(errs []CommandError) Result {
+	return s.errorResult("repo config refresh", ResourceConfig, OperationRefresh, ScopeRepo, defaultAgent, false, "Unable to refresh the repo config target.", errs)
+}
+
 func (s Service) runSkillCommand(command, operation string, opts Options) Result {
 	scope := normalizeScope(opts.Scope)
 	if scope == "" {

--- a/internal/install/service.go
+++ b/internal/install/service.go
@@ -183,7 +183,7 @@ func (s Service) PlanConfigRefreshDiff() (string, []CommandError) {
 }
 
 func (s Service) RefreshConfigPreviewError(errs []CommandError) Result {
-	return s.errorResult("repo config refresh", ResourceConfig, OperationRefresh, ScopeRepo, defaultAgent, false, "Unable to refresh the repo config target.", errs)
+	return s.errorResult("repo config refresh", ResourceConfig, OperationRefresh, ScopeRepo, defaultAgent, true, "Unable to refresh the repo config target.", errs)
 }
 
 func (s Service) runSkillCommand(command, operation string, opts Options) Result {

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -243,6 +243,118 @@ func TestRefreshConfigRejectsInvalidConfigWithoutOverwrite(t *testing.T) {
 	}
 }
 
+func TestPlanConfigRefreshDiffUpdatesCommentedOutOfOrderConfigWithoutWriting(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".harness/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	original := `# keep my local note
+paths:
+  local_runtime: tmp/harness-runtime
+  plans:
+    archived: workflow/plans/done
+    active: workflow/plans/open
+version: 1
+`
+	if err := os.WriteFile(configPath, []byte(original), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	diff, errs := testService(root).PlanConfigRefreshDiff()
+	if len(errs) != 0 {
+		t.Fatalf("expected diff planning success, got %#v", errs)
+	}
+	for _, want := range []string{
+		"--- a/.harness/config.yaml",
+		"+++ b/.harness/config.yaml",
+		"-# keep my local note",
+		"-    archived: workflow/plans/done",
+		"+    active: workflow/plans/open",
+		"+    archived: workflow/plans/done",
+		"+  local_runtime: tmp/harness-runtime",
+	} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("expected diff to contain %q, got:\n%s", want, diff)
+		}
+	}
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(configData) != original {
+		t.Fatalf("expected diff preview to leave config untouched, got:\n%s", configData)
+	}
+}
+
+func TestPlanConfigRefreshDiffCreatesMissingConfigWithoutWriting(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".harness/config.yaml")
+
+	diff, errs := testService(root).PlanConfigRefreshDiff()
+	if len(errs) != 0 {
+		t.Fatalf("expected diff planning success, got %#v", errs)
+	}
+	for _, want := range []string{
+		"--- /dev/null",
+		"+++ b/.harness/config.yaml",
+		"+version: 1",
+		"+# Optional path roots. Omit this block to use the built-in defaults.",
+	} {
+		if !strings.Contains(diff, want) {
+			t.Fatalf("expected diff to contain %q, got:\n%s", want, diff)
+		}
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("expected diff preview to leave config absent, got err=%v", err)
+	}
+}
+
+func TestPlanConfigRefreshDiffNoopsWhenAlreadyCanonical(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".harness/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(repoconfig.DefaultContent), 0o644); err != nil {
+		t.Fatalf("write canonical config: %v", err)
+	}
+
+	diff, errs := testService(root).PlanConfigRefreshDiff()
+	if len(errs) != 0 {
+		t.Fatalf("expected diff planning success, got %#v", errs)
+	}
+	if diff != "" {
+		t.Fatalf("expected empty diff for canonical config, got:\n%s", diff)
+	}
+}
+
+func TestPlanConfigRefreshDiffRejectsInvalidConfigWithoutOverwrite(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".harness/config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("version: 2\n"), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+
+	diff, errs := testService(root).PlanConfigRefreshDiff()
+	if diff != "" {
+		t.Fatalf("expected no diff for invalid config, got:\n%s", diff)
+	}
+	if len(errs) == 0 || !strings.Contains(errs[0].Message, "unsupported version 2") {
+		t.Fatalf("expected unsupported version error, got %#v", errs)
+	}
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(configData) != "version: 2\n" {
+		t.Fatalf("expected invalid config to remain untouched, got:\n%s", configData)
+	}
+}
+
 func TestInitConfigDryRunDoesNotWrite(t *testing.T) {
 	root := t.TempDir()
 

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -408,6 +408,11 @@ func TestRepoConfigRefreshUpdatesOldDefaultConfig(t *testing.T) {
 	if !payload.OK || payload.Command != "repo config refresh" || payload.Resource != "config" || payload.Operation != "refresh" {
 		t.Fatalf("unexpected config refresh payload: %#v", payload)
 	}
+	for _, forbidden := range []string{"\"diff\"", "--- a/.harness/config.yaml", "+++ b/.harness/config.yaml", "@@ -"} {
+		if strings.Contains(result.Stdout, forbidden) {
+			t.Fatalf("ordinary refresh JSON must not include diff marker %q:\n%s", forbidden, result.Stdout)
+		}
+	}
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read repo config: %v", err)

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -417,6 +417,41 @@ func TestRepoConfigRefreshUpdatesOldDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestRepoConfigRefreshDiffPreviewsCanonicalRewrite(t *testing.T) {
+	workspace := support.NewWorkspace(t)
+	configPath := workspace.Path(".harness/config.yaml")
+	original := `# local note
+paths:
+  local_runtime: tmp/harness-runtime
+  plans:
+    archived: workflow/plans/done
+    active: workflow/plans/open
+version: 1
+`
+	workspace.WriteFile(t, ".harness/config.yaml", []byte(original))
+
+	result := support.Run(t, workspace.Root, "repo", "config", "refresh", "--diff")
+	support.RequireSuccess(t, result)
+	support.RequireNoStderr(t, result)
+	for _, want := range []string{
+		"--- a/.harness/config.yaml",
+		"+++ b/.harness/config.yaml",
+		"-# local note",
+		"+    active: workflow/plans/open",
+		"+    archived: workflow/plans/done",
+		"+  local_runtime: tmp/harness-runtime",
+	} {
+		support.RequireContains(t, result.Stdout, want)
+	}
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read repo config: %v", err)
+	}
+	if string(configData) != original {
+		t.Fatalf("expected diff preview to leave config untouched, got:\n%s", configData)
+	}
+}
+
 func TestRepoConfigQueriesResolvedValuesViaCLI(t *testing.T) {
 	workspace := support.NewWorkspace(t)
 	workspace.WriteFile(t, ".harness/config.yaml", []byte(`version: 1


### PR DESCRIPTION
## What Changed

Adds `harness repo config refresh --diff` as a plain-text unified diff preview for the existing repo config refresh operation. The preview uses the same canonical render and validation path as ordinary refresh, but never writes `.harness/config.yaml`; ordinary `harness repo config refresh` remains the JSON-emitting apply command and does not include diff content in its result envelope.

The docs, specs, and help now describe the command shape and canonical refresh behavior: comments are accepted when loading valid YAML but are not preserved by refresh, field order is normalized, configured values are preserved, and unsupported fields remain invalid.

Closes #247.

## Confidence

- Focused and full Go validation passed, including `go test ./...`, `go test ./internal/cli -run 'TestRepoConfigRefresh'`, `go test ./internal/install`, and smoke coverage for `TestRepoConfigRefresh`.
- Regression coverage protects missing, non-canonical valid, canonical no-op, invalid, and preview-planning-error no-write paths.
- Ordinary refresh JSON is covered so diff text cannot leak into `contracts.BootstrapResult`.
- Harness reviews passed cleanly: step review `review-001-delta`, repair review `review-011-delta`, and final full review `review-012-full` all finished with 0 findings.
- `git diff --check` passed.

## Handoff

Archived plan: `docs/plans/archived/2026-06-28-repo-config-refresh-diff-preview.md`.