### PR TITLE
Define goal-oriented workflow contract

### DIFF
--- a/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
+++ b/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
@@ -342,6 +342,8 @@ define profile identity preservation explicitly. Follow-up review
   #270-#275 remain the implementation follow-up surface.
 - `scripts/validate` passed, including UI build, Go package tests, and e2e,
   release, resilience, smoke, and support test packages.
+- After reopen revision 2, `harness plan lint`, `git diff --check`, and
+  targeted `rg` checks passed for the PR feedback repair.
 
 ## Review Summary
 
@@ -353,16 +355,21 @@ define profile identity preservation explicitly. Follow-up review
   lint, status, archive, and reopen support.
 - Finalize review `review-003-full` passed with no blocking or non-blocking
   findings.
+- Reopened in `finalize-fix` mode for PR feedback about parseable
+  goal-oriented fields and overly broad supplement guidance. The repair
+  requires future template/lint/status work to choose stable parseable anchors,
+  prefers plan-body structure over frontmatter for working concepts, and
+  discourages tracked supplements for bulky raw data.
 
 ## Archive Summary
 
 - Archived At: 2026-06-30T22:47:13+08:00
-- Revision: 1
+- Revision: 2
 - PR: Pending post-archive publish from branch
   `codex/define-goal-oriented-workflow-contract`.
 - Ready: Yes. Acceptance criteria are checked, validation passed,
-  step-closeout review passed after repair, and finalize review passed with no
-  findings.
+  step-closeout review passed after repair, finalize review passed with no
+  findings, and PR feedback repair validation passed.
 - Merge Handoff: After archive, push the branch, open a PR for issue #269,
   record publish/CI/sync evidence through harness, and wait for explicit human
   merge approval.
@@ -381,6 +388,10 @@ define profile identity preservation explicitly. Follow-up review
   lint boundaries, final synthesis, review, archive, and follow-up boundaries.
 - Clarified that `goal_oriented` is reserved until follow-up implementation
   slices add authoring, lint, status, archive, and reopen support.
+- Clarified that future status/lint support needs stable parseable anchors
+  rather than prose guessing, while checkpoint digests should remain
+  self-contained in the plan body and supplements should not become the default
+  home for bulky raw data.
 
 ### Not Delivered
 

--- a/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
+++ b/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
@@ -297,7 +297,12 @@ found beyond the plan lint and repository validation script.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+Review `review-001-delta` requested changes: the first draft made
+`workflow_profile: goal_oriented` read like a currently lint-valid active-plan
+value, and left archive/reopen profile identity handling implicit. Fixed by
+framing `goal_oriented` as a reserved contract until the follow-up authoring,
+lint, status, archive, and reopen slices land, and by requiring those slices to
+define profile identity preservation explicitly.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
+++ b/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
@@ -360,6 +360,12 @@ define profile identity preservation explicitly. Follow-up review
   requires future template/lint/status work to choose stable parseable anchors,
   prefers plan-body structure over frontmatter for working concepts, and
   discourages tracked supplements for bulky raw data.
+- Finalize review `review-004-full` requested a handoff wording repair because
+  the reopened plan still said to open a PR even though PR #279 already
+  existed.
+- Handoff repair review `review-005-delta` passed with no findings after the
+  Archive Summary was updated to direct the next controller to update PR #279
+  and refresh evidence.
 
 ## Archive Summary
 
@@ -369,8 +375,8 @@ define profile identity preservation explicitly. Follow-up review
   `codex/define-goal-oriented-workflow-contract`; update it after the
   revision 2 archive commit.
 - Ready: Yes. Acceptance criteria are checked, validation passed,
-  step-closeout review passed after repair, finalize review passed with no
-  findings, and PR feedback repair validation passed.
+  step-closeout review passed after repair, finalize review passed after
+  handoff repair, and PR feedback repair validation passed.
 - Merge Handoff: After archive, push the branch to update PR #279, refresh
   publish/CI/sync evidence through harness for the repaired candidate, and wait
   for explicit human merge approval.

--- a/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
+++ b/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
@@ -1,0 +1,353 @@
+---
+template_version: 0.2.0
+created_at: "2026-06-30T22:20:58+08:00"
+approved_at: "2026-06-30T22:23:25+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/269
+    - https://github.com/catu-ai/easyharness/issues/262
+size: M
+---
+
+# Define Goal-Oriented Workflow Contract
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Define the normative `workflow_profile: goal_oriented` contract before
+template, lint, status, review guidance, UI, or example work depends on it.
+
+The finished contract should describe how goal-oriented work keeps harness's
+existing approval, step, review, archive, and evidence boundaries while giving
+agents a disciplined way to run adaptive work through hypotheses, probes,
+checkpoint rounds, optional challenge, and final synthesis.
+
+## Scope
+
+### In Scope
+
+- Add a normative goal-oriented workflow spec under `docs/specs/`.
+- Define when to use `workflow_profile: goal_oriented` and when to keep the
+  ordinary standard workflow.
+- Define the vocabulary and boundaries for stable plan steps, local checkpoint
+  drafts, tracked checkpoint digests, optional challenge rounds, formal
+  reviews, evidence, and final synthesis.
+- Specify that checkpoint drafts may live under the local runtime root as
+  disposable working memory, while tracked checkpoint digests are concise
+  decision-quality summaries in the tracked plan package.
+- Define that tracked checkpoint digests should be self-contained enough for
+  resume and review, but must not become raw command logs or duplicate a final
+  report.
+- Define checkpoint cadence and status guidance at the contract level:
+  goal-oriented plans should declare a checkpoint cadence or budget, and
+  future status guidance may present a short list of general next actions such
+  as continue another bounded checkpoint round, synthesize, request challenge,
+  or close the step.
+- Clarify that `harness status` may later do advisory structural checks for
+  goal-oriented plans, but checkpoint markdown must not derive or mutate
+  `current_node`.
+- Clarify that `harness plan lint` remains the explicit validation gate; status
+  may surface guidance but must not silently become full lint.
+- Clarify that standalone evidence reports or decision reports are deliverables
+  only when the user objective and approved plan scope call for them.
+- Update the spec index and plan-schema prose so the new contract is
+  discoverable and does not conflict with existing `workflow_profile`
+  semantics.
+
+### Out of Scope
+
+- Implementing CLI behavior, `harness status` next-action logic, or
+  `harness plan lint` enforcement.
+- Adding the goal-oriented plan template or generated authoring shape.
+- Defining the full checkpoint report storage convention beyond the tracked
+  digest contract needed for this slice.
+- Adding new review aggregation behavior or making challenge a formal review
+  gate.
+- Adding UI timeline support.
+- Requiring every goal-oriented plan to produce a standalone evidence report.
+- Requiring every goal-oriented plan to run at least one challenge round.
+- Requiring every checkpoint draft, raw transcript, failed attempt, or command
+  trace to enter git or archive.
+
+## Acceptance Criteria
+
+- [x] A normative spec defines `workflow_profile: goal_oriented` as a profile
+  on top of the existing harness workflow, not a separate workflow engine.
+- [x] The contract explains appropriate and inappropriate use cases for
+  `goal_oriented`.
+- [x] The contract distinguishes `step`, checkpoint draft, tracked checkpoint
+  digest, `challenge`, formal `review`, evidence, and final synthesis.
+- [x] The contract defines required plan concepts: objective, success
+  scorecard, hypotheses or candidate directions, probe/checkpoint loop,
+  checkpoint cadence, challenge triggers, evidence requirements, stopping
+  conditions, and final synthesis.
+- [x] The contract states that local checkpoint drafts are disposable working
+  memory under the local runtime root unless their content is promoted into a
+  tracked digest or approved deliverable.
+- [x] The contract states that tracked checkpoint digests live in the tracked
+  plan package, preferably in the plan body when concise, and record
+  decision-quality summaries rather than raw logs.
+- [x] The contract explains that status guidance for goal-oriented plans should
+  be advisory and general, and must not derive `current_node` from checkpoint
+  markdown.
+- [x] The contract explains that lint remains an explicit validation surface,
+  while status may later surface lightweight structural guidance.
+- [x] The contract preserves existing human approval, formal review, archive,
+  and evidence boundaries.
+- [x] The contract explicitly rejects one harness step per model turn as the
+  default shape.
+- [x] Follow-up implementation surfaces are clearly left to the existing
+  v0.6.0 issues: #270, #271, #272, #273, #274, and #275.
+
+## Deferred Items
+
+- #270 will add the goal-oriented plan template and workflow guidance.
+- #271 will define richer checkpoint report conventions and storage details if
+  more than tracked plan digests are needed.
+- #272 will add evidence-validity and hypothesis-challenge guidance.
+- #273 will implement status/next-action behavior for goal-oriented plans.
+- #274 will add lint coverage for goal-oriented plans.
+- #275 will add user-facing docs, help, and examples.
+
+## Work Breakdown
+
+### Step 1: Write the normative contract
+
+- Done: [x]
+
+#### Objective
+
+Add a self-contained `docs/specs/goal-oriented-workflow.md` document that
+defines the profile's semantics and boundaries.
+
+#### Details
+
+The spec should make the following settled discovery decisions durable:
+
+- `goal_oriented` is a workflow profile layered on the existing harness
+  workflow, not a new engine.
+- Steps stay stable approved phase boundaries; checkpoint rounds live inside
+  those steps and do not map one-to-one with model turns.
+- Agents may keep messy checkpoint drafts under the local runtime root as
+  disposable working memory.
+- A tracked checkpoint digest is a concise, git-tracked summary of a meaningful
+  checkpoint round. It records the hypotheses or directions considered,
+  observed signal, scorecard movement, decision, residual uncertainty, and
+  evidence pointers needed for future resume, review, and archive. It is not a
+  raw log, not a formal review gate, and not the canonical evidence report
+  unless the plan explicitly designates it as such.
+- Tracked checkpoint digests should normally live in the plan body under a
+  `Checkpoint Digests` section when concise enough to keep the plan readable.
+  Supplements are acceptable only when the digest or related durable material
+  would bloat the plan.
+- Each goal-oriented plan should declare checkpoint cadence or budget instead
+  of relying on a global hard minimum or maximum. Before an adaptive step
+  closes, at least one tracked checkpoint digest or equivalent final synthesis
+  must explain the adaptive work.
+- Challenge is optional unless the approved plan declares a required challenge
+  boundary. It should be triggered by agent judgment, human direction, or plan
+  criteria such as high uncertainty, competing hypotheses, weak evidence, or a
+  risky synthesis.
+- Evidence/report artifacts are created according to the user objective and
+  approved scope. The profile requires conclusions to be supported by evidence;
+  it does not require every plan to create a standalone evidence report.
+- Future status guidance may surface a general action list at checkpoint-round
+  boundaries, such as continue another bounded checkpoint round, synthesize if
+  the scorecard is decisive, request challenge if uncertainty remains, or close
+  the step if synthesis and evidence are ready.
+- Checkpoint digests may inform status guidance, but must not derive, mutate,
+  or override `current_node`.
+- Lint remains the explicit validation gate. Status may later surface advisory
+  structural checks, but must not silently run or replace full plan lint.
+
+#### Expected Files
+
+- `docs/specs/goal-oriented-workflow.md`
+
+#### Validation
+
+- The new spec can be read without issue or chat history and answers the
+  vocabulary, checkpoint, challenge, evidence, lint, status, and archive
+  boundary questions above.
+- No CLI behavior, tests, templates, or schema files are changed in this step
+  unless needed only for documentation linkage.
+
+#### Execution Notes
+
+Added `docs/specs/goal-oriented-workflow.md` as the normative profile
+contract. The spec defines use cases, profile semantics, required plan
+concepts, stable steps versus checkpoint rounds, local checkpoint drafts,
+tracked checkpoint digests, optional challenge, evidence/report ownership,
+status guidance, lint boundaries, review/archive behavior, and follow-up issue
+boundaries. This is documentation-only, so TDD was not applicable.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 will immediately connect the new contract into
+the existing specs, so review is more useful after the normative document and
+cross-references are both in place.
+
+### Step 2: Connect the contract to existing specs
+
+- Done: [x]
+
+#### Objective
+
+Update existing normative indexes and workflow-profile prose so the new
+goal-oriented contract is discoverable and does not contradict the existing
+`lightweight` profile contract.
+
+#### Details
+
+The plan-schema prose currently documents `workflow_profile` as supporting only
+`lightweight`. Update that surface carefully so:
+
+- omitted `workflow_profile` still means ordinary standard workflow;
+- `lightweight` keeps its existing low-risk `XXS` meaning and archive behavior;
+- `goal_oriented` is described as a standard tracked-plan profile for adaptive
+  work, not a lightweight shortcut;
+- active tracked plans may use `workflow_profile: goal_oriented` once the
+  implementation slices land;
+- archived tracked plans should preserve the durable goal-oriented digests and
+  synthesis in the plan package, while local drafts remain disposable.
+
+Avoid over-updating CLI, lint, or status contracts in this slice. If a document
+needs a cross-reference to prevent ambiguity, keep it as a contract pointer and
+leave behavior implementation to the follow-up issues.
+
+#### Expected Files
+
+- `docs/specs/index.md`
+- `docs/specs/plan-schema.md`
+- `docs/specs/cli-contract.md` only if a narrow cross-reference is needed to
+  keep status/lint boundaries understandable
+
+#### Validation
+
+- `rg "workflow_profile|goal_oriented|lightweight"` shows no obvious conflict
+  where docs say only `lightweight` can ever be supported.
+- The updated docs still make clear that this issue does not implement CLI
+  status, lint, template, or UI behavior.
+
+#### Execution Notes
+
+Updated `docs/specs/index.md`, `docs/specs/plan-schema.md`,
+`docs/specs/state-model.md`, and `docs/specs/cli-contract.md` so the new
+contract is discoverable and does not conflict with existing profile, archive,
+status, lint, or `current_node` boundaries. The changes keep implementation
+details for template, status, lint, and review guidance in the existing
+follow-up issues. This is documentation-only, so TDD was not applicable.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 3 performs the integrated boundary and validation
+pass for the complete contract/documentation slice before final review.
+
+### Step 3: Validate issue boundaries and archive readiness
+
+- Done: [x]
+
+#### Objective
+
+Confirm the plan's delivered contract is internally consistent, lintable, and
+clearly scoped against the existing v0.6.0 follow-up issues.
+
+#### Details
+
+Check that #269 remains a contract-first slice. The final plan and spec should
+not accidentally absorb #270-#275 implementation details. Any unavoidable
+spillover or open question should be recorded as a deferred item tied to the
+existing issue that owns it.
+
+The validation should also confirm the spec says enough for a future
+goal-oriented plan author to know:
+
+- when to use the profile;
+- how checkpoint drafts differ from tracked checkpoint digests;
+- where challenge fits;
+- what status may advise without becoming a state machine;
+- when lint remains the explicit validation surface;
+- when evidence/report artifacts are deliverables versus support material.
+
+#### Expected Files
+
+- `docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md`
+- Any files changed in Steps 1 and 2
+
+#### Validation
+
+- Run `harness plan lint docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md`.
+- Run targeted text checks for the settled vocabulary and follow-up issue
+  boundaries.
+- Run the repository's relevant documentation or test validation only if the
+  touched docs have an existing automated check.
+
+#### Execution Notes
+
+Validated the contract-first boundary with targeted searches for
+`goal_oriented`, `workflow_profile`, checkpoint, challenge, `current_node`,
+status, lint, and #270-#275 references. Ran `harness plan lint`, `git diff
+--check`, and `scripts/validate`; all passed. No separate docs-only checker was
+found beyond the plan lint and repository validation script.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Lint the active plan before approval.
+- During execution, validate documentation consistency with targeted searches
+  for `goal_oriented`, `workflow_profile`, `checkpoint`, `challenge`,
+  `current_node`, `status`, and `lint`.
+- Run any existing docs/spec validation commands discovered during execution.
+  If there is no dedicated docs check, record that explicitly in the validation
+  summary.
+
+## Risks
+
+- Risk: The contract accidentally creates a second workflow engine.
+  - Mitigation: State repeatedly that `goal_oriented` uses existing approval,
+    step, formal review, archive, and evidence boundaries.
+- Risk: Checkpoints become process logs that duplicate final evidence or report
+  artifacts.
+  - Mitigation: Define local drafts as disposable and tracked digests as
+    concise decision-quality summaries; define evidence/report artifacts by
+    user objective and approved scope.
+- Risk: Status or lint semantics become over-specified before implementation.
+  - Mitigation: Define only contract-level boundaries and leave concrete
+    behavior to #273 and #274.
+- Risk: Challenge becomes mandatory ceremony.
+  - Mitigation: Define challenge as optional unless a plan declares it
+    required, with clear triggers for when agents should consider it.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
+++ b/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
@@ -302,7 +302,8 @@ Review `review-001-delta` requested changes: the first draft made
 value, and left archive/reopen profile identity handling implicit. Fixed by
 framing `goal_oriented` as a reserved contract until the follow-up authoring,
 lint, status, archive, and reopen slices land, and by requiring those slices to
-define profile identity preservation explicitly.
+define profile identity preservation explicitly. Follow-up review
+`review-002-delta` passed with no blocking or non-blocking findings.
 
 ## Validation Strategy
 
@@ -333,11 +334,23 @@ define profile identity preservation explicitly.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `harness plan lint docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md`
+  passed.
+- `git diff --check` passed.
+- Targeted `rg` checks confirmed the specs describe `goal_oriented` as a
+  reserved contract instead of a currently lint-valid profile value, and that
+  #270-#275 remain the implementation follow-up surface.
+- `scripts/validate` passed, including UI build, Go package tests, and e2e,
+  release, resilience, smoke, and support test packages.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step-closeout review `review-001-delta` requested changes for two related
+  contract risks: the first draft made `goal_oriented` look currently
+  lint-valid, and archive/reopen profile identity handling was implicit.
+- Repair review `review-002-delta` passed with no findings after the contract
+  was reframed as reserved until follow-up implementation slices add authoring,
+  lint, status, archive, and reopen support.
 
 ## Archive Summary
 

--- a/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
+++ b/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
@@ -351,21 +351,48 @@ define profile identity preservation explicitly. Follow-up review
 - Repair review `review-002-delta` passed with no findings after the contract
   was reframed as reserved until follow-up implementation slices add authoring,
   lint, status, archive, and reopen support.
+- Finalize review `review-003-full` passed with no blocking or non-blocking
+  findings.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: Pending post-archive publish from branch
+  `codex/define-goal-oriented-workflow-contract`.
+- Ready: Yes. Acceptance criteria are checked, validation passed,
+  step-closeout review passed after repair, and finalize review passed with no
+  findings.
+- Merge Handoff: After archive, push the branch, open a PR for issue #269,
+  record publish/CI/sync evidence through harness, and wait for explicit human
+  merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added `docs/specs/goal-oriented-workflow.md` as the normative reserved
+  `workflow_profile: goal_oriented` contract.
+- Updated the spec index, plan schema, state model, and CLI contract to point
+  to the goal-oriented contract while preserving current standard/lightweight
+  implementation behavior.
+- Defined checkpoint drafts, tracked checkpoint digests, checkpoint cadence,
+  optional challenge, evidence/report ownership, advisory status guidance,
+  lint boundaries, final synthesis, review, archive, and follow-up boundaries.
+- Clarified that `goal_oriented` is reserved until follow-up implementation
+  slices add authoring, lint, status, archive, and reopen support.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- CLI authoring, lint, status, archive, reopen, review-dimension, help, and
+  example behavior for `goal_oriented`; those remain assigned to existing
+  follow-up issues.
 
 ### Follow-Up Issues
 
-NONE
+- #270: Add the goal-oriented plan template and workflow guidance.
+- #271: Define richer checkpoint report conventions and storage details if
+  tracked plan digests are not enough.
+- #272: Add evidence-validity and hypothesis-challenge guidance.
+- #273: Teach status and next-action behavior for goal-oriented plans.
+- #274: Add lint coverage for goal-oriented plans, including when
+  `workflow_profile: goal_oriented` becomes lint-valid.
+- #275: Add user-facing docs, help text, and examples.

--- a/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
+++ b/docs/plans/active/2026-06-30-define-goal-oriented-workflow-contract.md
@@ -365,14 +365,15 @@ define profile identity preservation explicitly. Follow-up review
 
 - Archived At: 2026-06-30T22:47:13+08:00
 - Revision: 2
-- PR: Pending post-archive publish from branch
-  `codex/define-goal-oriented-workflow-contract`.
+- PR: Existing PR https://github.com/catu-ai/easyharness/pull/279 on branch
+  `codex/define-goal-oriented-workflow-contract`; update it after the
+  revision 2 archive commit.
 - Ready: Yes. Acceptance criteria are checked, validation passed,
   step-closeout review passed after repair, finalize review passed with no
   findings, and PR feedback repair validation passed.
-- Merge Handoff: After archive, push the branch, open a PR for issue #269,
-  record publish/CI/sync evidence through harness, and wait for explicit human
-  merge approval.
+- Merge Handoff: After archive, push the branch to update PR #279, refresh
+  publish/CI/sync evidence through harness for the repaired candidate, and wait
+  for explicit human merge approval.
 
 ## Outcome Summary
 

--- a/docs/plans/archived/2026-06-30-define-goal-oriented-workflow-contract.md
+++ b/docs/plans/archived/2026-06-30-define-goal-oriented-workflow-contract.md
@@ -369,7 +369,7 @@ define profile identity preservation explicitly. Follow-up review
 
 ## Archive Summary
 
-- Archived At: 2026-06-30T22:47:13+08:00
+- Archived At: 2026-06-30T23:26:43+08:00
 - Revision: 2
 - PR: Existing PR https://github.com/catu-ai/easyharness/pull/279 on branch
   `codex/define-goal-oriented-workflow-contract`; update it after the

--- a/docs/plans/archived/2026-06-30-define-goal-oriented-workflow-contract.md
+++ b/docs/plans/archived/2026-06-30-define-goal-oriented-workflow-contract.md
@@ -356,6 +356,8 @@ define profile identity preservation explicitly. Follow-up review
 
 ## Archive Summary
 
+- Archived At: 2026-06-30T22:47:13+08:00
+- Revision: 1
 - PR: Pending post-archive publish from branch
   `codex/define-goal-oriented-workflow-contract`.
 - Ready: Yes. Acceptance criteria are checked, validation passed,

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -456,7 +456,9 @@ Contract:
 - goal-oriented authoring support belongs to the goal-oriented template slice;
   when added, it should seed `workflow_profile: goal_oriented` and the
   required concepts from [Goal-Oriented Workflow](./goal-oriented-workflow.md)
-  without changing ordinary standard or lightweight authoring
+  without changing ordinary standard or lightweight authoring; until that
+  implementation lands, `workflow_profile: goal_oriented` is a reserved
+  contract value rather than a lint-valid template output
 
 The template asset belongs to the harness version, not to the user's tracked
 plan history. Upgrading the harness may upgrade the generated template for new
@@ -518,7 +520,7 @@ understand what is happening now and what to do next.
 Contract:
 
 - detect the current plan artifact, whether it is a tracked active plan, a
-  tracked standard or goal-oriented archive, or a lightweight local archive
+  tracked standard archive, or a lightweight local archive
 - before resolving the status snapshot for a current plan, briefly wait for an
   actively held state mutation lock to settle; if the lock remains held beyond
   the bounded wait, return a clear local-mutation-in-progress result
@@ -588,7 +590,8 @@ Contract:
   may surface advisory checkpoint-round next actions from
   [Goal-Oriented Workflow](./goal-oriented-workflow.md), but status must not
   infer or mutate `state.current_node` from checkpoint markdown and must not
-  silently replace `harness plan lint`
+  silently replace `harness plan lint`; concrete status support belongs to the
+  goal-oriented status implementation slice
 - return recommended next actions for both "continue work" and "wait/observe"
   situations
 - if an already completed earlier step is missing review-complete closeout,
@@ -1083,8 +1086,7 @@ Contract:
 - move the plan from its active path to its archived path:
   - active plan root resolved by `harness repo config get paths.plans.active`
     -> archived plan root resolved by
-    `harness repo config get paths.plans.archived` for `standard` and
-    `goal_oriented`
+    `harness repo config get paths.plans.archived` for `standard`
   - active plan root resolved by `harness repo config get paths.plans.active`
     -> lightweight archived snapshot root under the local runtime root resolved
     by `harness repo config get paths.local_runtime` for `lightweight`
@@ -1100,8 +1102,8 @@ Contract:
   post-archive handoff node, concise `facts`, transition artifacts, and
   actionable `next_actions`
 - return next actions that explicitly include the profile-appropriate handoff:
-  commit and push the archive move for `standard` and `goal_oriented`, or
-  update the repo-visible breadcrumb for `lightweight`
+  commit and push the archive move for `standard`, or update the repo-visible
+  breadcrumb for `lightweight`
 
 Important note:
 
@@ -1129,8 +1131,8 @@ Important note:
 Recommended next action:
 
 - create or verify durable follow-up notes for deferred work
-- commit and push the archived plan for `standard` or `goal_oriented`, or
-  update the repo-visible breadcrumb for `lightweight`
+- commit and push the archived plan for `standard`, or update the repo-visible
+  breadcrumb for `lightweight`
 - wait for post-archive CI or human merge approval once publish, CI, and sync
   evidence move the candidate into `execution/finalize/await_merge`
 - reopen with `harness reopen --mode finalize-fix` for narrow repair or

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -453,6 +453,10 @@ Contract:
   lightweight template with explicit `size: XXS`
 - in standard mode, preserve current behavior when `workflow_profile` is
   omitted
+- goal-oriented authoring support belongs to the goal-oriented template slice;
+  when added, it should seed `workflow_profile: goal_oriented` and the
+  required concepts from [Goal-Oriented Workflow](./goal-oriented-workflow.md)
+  without changing ordinary standard or lightweight authoring
 
 The template asset belongs to the harness version, not to the user's tracked
 plan history. Upgrading the harness may upgrade the generated template for new
@@ -514,7 +518,7 @@ understand what is happening now and what to do next.
 Contract:
 
 - detect the current plan artifact, whether it is a tracked active plan, a
-  tracked standard archive, or a lightweight local archive
+  tracked standard or goal-oriented archive, or a lightweight local archive
 - before resolving the status snapshot for a current plan, briefly wait for an
   actively held state mutation lock to settle; if the lock remains held beyond
   the bounded wait, return a clear local-mutation-in-progress result
@@ -580,6 +584,11 @@ Contract:
   leave the agreed repo-visible breadcrumb, such as a readable PR body merge
   memo explaining what changed, why the branch is mergeable, and why the
   lightweight path was used
+- when the current plan uses the goal-oriented profile, future status guidance
+  may surface advisory checkpoint-round next actions from
+  [Goal-Oriented Workflow](./goal-oriented-workflow.md), but status must not
+  infer or mutate `state.current_node` from checkpoint markdown and must not
+  silently replace `harness plan lint`
 - return recommended next actions for both "continue work" and "wait/observe"
   situations
 - if an already completed earlier step is missing review-complete closeout,
@@ -1074,7 +1083,8 @@ Contract:
 - move the plan from its active path to its archived path:
   - active plan root resolved by `harness repo config get paths.plans.active`
     -> archived plan root resolved by
-    `harness repo config get paths.plans.archived` for `standard`
+    `harness repo config get paths.plans.archived` for `standard` and
+    `goal_oriented`
   - active plan root resolved by `harness repo config get paths.plans.active`
     -> lightweight archived snapshot root under the local runtime root resolved
     by `harness repo config get paths.local_runtime` for `lightweight`
@@ -1090,13 +1100,13 @@ Contract:
   post-archive handoff node, concise `facts`, transition artifacts, and
   actionable `next_actions`
 - return next actions that explicitly include the profile-appropriate handoff:
-  commit and push the archive move for `standard`, or update the repo-visible
-  breadcrumb for `lightweight`
+  commit and push the archive move for `standard` and `goal_oriented`, or
+  update the repo-visible breadcrumb for `lightweight`
 
 Important note:
 
-- `harness archive` changes tracked files locally for both profiles because the
-  active tracked plan is removed from the active plan root resolved by
+- `harness archive` changes tracked files locally for every profile because
+  the active tracked plan is removed from the active plan root resolved by
   `harness repo config get paths.plans.active`
 - the controller agent should commit and push the archive change before
   treating the candidate as truly waiting for merge approval
@@ -1119,8 +1129,8 @@ Important note:
 Recommended next action:
 
 - create or verify durable follow-up notes for deferred work
-- commit and push the archived plan for `standard`, or update the repo-visible
-  breadcrumb for `lightweight`
+- commit and push the archived plan for `standard` or `goal_oriented`, or
+  update the repo-visible breadcrumb for `lightweight`
 - wait for post-archive CI or human merge approval once publish, CI, and sync
   evidence move the candidate into `execution/finalize/await_merge`
 - reopen with `harness reopen --mode finalize-fix` for narrow repair or

--- a/docs/specs/goal-oriented-workflow.md
+++ b/docs/specs/goal-oriented-workflow.md
@@ -87,6 +87,9 @@ agent can resume without hidden chat context:
     checkpoint digests for the main exploration step"
   - a cadence is guidance for keeping the work bounded, not a global hard
     minimum or maximum
+  - follow-up template and lint work must give this cadence a stable
+    parseable anchor, such as a dedicated heading, bounded metadata block, or
+    another explicit structure
 - `challenge triggers`
   - when advisory challenge should be considered or is required by the plan
 - `evidence requirements`
@@ -101,6 +104,15 @@ agent can resume without hidden chat context:
 The plan may express these concepts in dedicated sections, step details, or a
 goal-oriented template once that template exists. The contract requires the
 meaning, not a particular heading set in this first slice.
+
+Future lint and status support must not rely on unstructured prose guessing.
+The implementation slices that make `workflow_profile: goal_oriented`
+lint-valid must choose stable parseable anchors for the fields status and lint
+need, especially the success scorecard, checkpoint cadence, tracked
+checkpoint digest index, and final synthesis. Prefer plan-body structure for
+goal-oriented working concepts; reserve frontmatter for durable command-level
+metadata such as profile selection unless a field truly affects command
+resolution.
 
 ## Steps, Checkpoint Rounds, And Model Turns
 
@@ -161,11 +173,20 @@ Tracked checkpoint digests should normally live in the plan body under a
 readable. Use one subsection per digest so a single checkpoint can compare
 several hypotheses without turning the plan into a nested bullet log.
 
-When a digest or durable supporting material would bloat the plan, put the
-larger material in the matching tracked plan package under
-`supplements/<plan-stem>/` and keep a concise digest or index in the plan body.
-Supplements share the same approval boundary as the plan package; they are not
-free-form scratch space.
+Tracked checkpoint digests should be self-contained enough that a future agent
+can understand the decision trail from the plan body. Do not push essential
+checkpoint meaning into a separate file merely to keep the plan short.
+
+Supplements are allowed only for curated durable material that the approved
+plan deliberately keeps with the plan package. Do not use tracked supplements
+as the default home for bulky raw experiment data, JSON/CSV dumps, transcripts,
+or command logs. Large or messy probe artifacts should stay local,
+regenerable, external, or be summarized into a smaller approved deliverable
+unless the user objective explicitly requires committing them.
+
+When a small durable support artifact is approved for the tracked plan package,
+keep a concise digest or index in the plan body. Supplements share the same
+approval boundary as the plan package; they are not free-form scratch space.
 
 A useful digest should answer, at summary level:
 

--- a/docs/specs/goal-oriented-workflow.md
+++ b/docs/specs/goal-oriented-workflow.md
@@ -1,0 +1,302 @@
+# Goal-Oriented Workflow
+
+## Purpose
+
+This document defines the normative `goal_oriented` workflow profile for
+`easyharness`.
+
+Use `workflow_profile: goal_oriented` when the objective and success scorecard
+are explicit, but the path to the result must adapt through hypotheses,
+probes, checkpoint rounds, optional challenge, and synthesis.
+
+`goal_oriented` is a profile on top of the existing harness workflow. It does
+not create a separate workflow engine. Goal-oriented plans still use explicit
+human approval, stable plan steps, formal step-closeout and finalize review,
+archive, evidence, and the canonical node state model.
+
+## When To Use It
+
+Use `goal_oriented` for work where the plan can name the desired outcome but
+cannot honestly predeclare the exact execution path. Typical examples include:
+
+- performance or reliability investigation with a measurable target
+- design exploration where several plausible contracts need comparison
+- root-cause analysis when the bug or failure mode is not yet isolated
+- benchmark, evaluation, or selection work where evidence decides the path
+- research-like product work that must converge on a durable decision or
+  artifact
+
+Keep the ordinary standard workflow when the task is delivery-oriented and the
+path is already clear enough to plan as implementation steps. Examples include
+adding a known CLI flag, fixing an already-localized bug, updating narrow docs,
+or applying a known template change.
+
+Do not use `goal_oriented` as a heavier name for ordinary standard work. If
+the work does not need hypotheses, probes, checkpoint digests, or final
+synthesis, the ordinary standard workflow is clearer.
+
+## Workflow Profile Semantics
+
+`workflow_profile: goal_oriented` means the active plan is a standard tracked
+plan with an adaptive execution contract. It is not a lightweight shortcut.
+
+The profile preserves these core harness boundaries:
+
+- human approval still approves the tracked plan package
+- plan steps still represent stable approved phase boundaries
+- `harness execute start` still begins execution
+- formal step-closeout and finalize reviews remain hard gates
+- archive still preserves the durable outcome summary and review history
+- command-owned runtime state still lives under the local runtime root resolved
+  by `harness repo config get paths.local_runtime`
+- `current_node` still comes from the canonical state model, not from plan
+  prose or checkpoint markdown
+
+Goal-oriented execution adds a disciplined layer inside approved steps: the
+controller runs bounded checkpoint rounds, records concise tracked checkpoint
+digests when the work reaches meaningful decision points, optionally requests
+challenge when hypotheses or evidence need stress testing, and writes a final
+synthesis before closeout.
+
+## Plan Requirements
+
+A goal-oriented plan must define these concepts clearly enough that a future
+agent can resume without hidden chat context:
+
+- `objective`
+  - the concrete result to achieve or question to answer
+  - not merely "explore" or "investigate"
+- `success scorecard`
+  - the criteria, metrics, observations, or decision rules used to decide
+    whether the work improved, failed, stopped, or completed
+- `hypotheses or candidate directions`
+  - the current explanations, approaches, or options that the checkpoint loop
+    may test or revise
+- `probe/checkpoint loop`
+  - how the controller should move from hypothesis to bounded probe, observed
+    signal, scorecard comparison, and next decision
+- `checkpoint cadence or budget`
+  - the expected checkpoint rhythm for adaptive steps, such as "write 2-4
+    checkpoint digests for the main exploration step"
+  - a cadence is guidance for keeping the work bounded, not a global hard
+    minimum or maximum
+- `challenge triggers`
+  - when advisory challenge should be considered or is required by the plan
+- `evidence requirements`
+  - what kind of durable support is needed for the plan's conclusions
+- `stopping conditions`
+  - when the controller should stop probing and synthesize, close the step,
+    defer remaining uncertainty, or ask the human about scope
+- `final synthesis`
+  - the closeout explanation of accepted conclusions, rejected hypotheses,
+    residual uncertainty, evidence, and follow-up work
+
+The plan may express these concepts in dedicated sections, step details, or a
+goal-oriented template once that template exists. The contract requires the
+meaning, not a particular heading set in this first slice.
+
+## Steps, Checkpoint Rounds, And Model Turns
+
+A harness step is a durable approved phase boundary. A model turn is a runtime
+or accounting unit. A checkpoint round is the goal-oriented layer between them.
+
+Do not make one harness step per model turn the default shape. A single
+adaptive step may contain several model continuations, probes, observations,
+and pivots. Durable learning from that work belongs in tracked checkpoint
+digests or final synthesis, not in a growing list of tiny plan steps.
+
+Use stable steps for boundaries that need approval, review, and archive
+visibility. Use checkpoint rounds for meaningful intermediate learning inside
+those steps.
+
+Before an adaptive step closes, the plan must contain at least one tracked
+checkpoint digest or equivalent final synthesis explaining the adaptive work
+that happened in the step. A step that performs no adaptive work should not use
+goal-oriented ceremony just to satisfy the profile.
+
+## Checkpoint Drafts
+
+A checkpoint draft is execution working memory. It may live under the local
+runtime root and may be messy enough to help the controller resume after
+context compaction.
+
+Checkpoint drafts may contain transient details such as:
+
+- raw observations not yet curated
+- failed probes that may or may not matter
+- command summaries
+- temporary hypothesis notes
+- reminders about what to test next
+
+Checkpoint drafts are local and disposable by default. They do not enter git,
+archive, or review unless their content is promoted into a tracked checkpoint
+digest, an approved supplement, a formal evidence artifact, or another
+approved deliverable.
+
+## Tracked Checkpoint Digests
+
+A tracked checkpoint digest is a concise, git-tracked summary of a meaningful
+checkpoint round. It records the hypotheses or directions considered, observed
+signal, scorecard movement, decision, residual uncertainty, and evidence
+pointers needed for future resume, review, and archive.
+
+A tracked checkpoint digest is not:
+
+- a raw log
+- a transcript
+- a list of every command
+- a formal review gate
+- the canonical evidence report unless the plan explicitly designates it as
+  such
+
+Tracked checkpoint digests should normally live in the plan body under a
+`Checkpoint Digests` section when they are concise enough to keep the plan
+readable. Use one subsection per digest so a single checkpoint can compare
+several hypotheses without turning the plan into a nested bullet log.
+
+When a digest or durable supporting material would bloat the plan, put the
+larger material in the matching tracked plan package under
+`supplements/<plan-stem>/` and keep a concise digest or index in the plan body.
+Supplements share the same approval boundary as the plan package; they are not
+free-form scratch space.
+
+A useful digest should answer, at summary level:
+
+- why this checkpoint exists
+- which hypothesis, hypotheses, or candidate directions were tested or
+  reconsidered
+- what signal the probe produced
+- how that signal moved the scorecard or decision space
+- whether the controller should continue probing, pivot, request challenge,
+  synthesize, close the step, or stop for human scope input
+- what residual uncertainty remains
+- which durable evidence or deliverable supports the decision
+
+The digest should explain decision movement, not activity. Do not preserve raw
+terminal output, every failed attempt, or already-absorbed report detail merely
+because it existed during execution.
+
+## Challenge
+
+Challenge is optional advisory intervention during goal-oriented work. It is
+used to stress-test hypotheses, identify missing probes, notice evidence gaps,
+or broaden candidate directions before the controller commits to a synthesis
+or pivot.
+
+Challenge is not formal review unless an approved plan explicitly creates a
+formal gate. Challenge output is input to the controller, not an automatic
+state transition.
+
+Consider challenge when:
+
+- several plausible hypotheses remain and the current probes cannot distinguish
+  them
+- evidence is too weak for the conclusion the controller is about to write
+- the scorecard has plateaued and the controller is considering a major pivot
+- the synthesis is high-risk enough that alternative explanations should be
+  tested first
+- the human or approved plan declares a required challenge boundary
+
+Do not require every goal-oriented plan to run at least one challenge round.
+When evidence is decisive and the plan did not require challenge, the
+controller may synthesize and proceed to formal review without challenge.
+
+If challenge changes the work materially, record the result in a new tracked
+checkpoint digest. If it only sharpens an existing decision, a short challenge
+summary inside the relevant digest is enough.
+
+## Evidence And Reports
+
+Goal-oriented work must support final conclusions with evidence, but the
+profile does not require every plan to create a standalone evidence report.
+
+The approved plan decides whether an evidence report, decision report, spec,
+code change, configuration change, documentation change, benchmark artifact,
+or other file is the deliverable. Use the user's objective and plan scope to
+choose the durable artifact.
+
+When the deliverable is an evidence or decision report, checkpoint digests
+should point to it or summarize key pivots without duplicating the report.
+When the deliverable is code, docs, configuration, or another artifact,
+checkpoint digests and ordinary validation evidence may be sufficient for
+review and archive.
+
+Archive should preserve conclusions, evidence, rejected hypotheses, residuals,
+and follow-up items that still matter after synthesis. It should not preserve
+duplicate process notes when those notes have been absorbed into a deliverable
+or final synthesis.
+
+## Status Guidance
+
+Future `harness status` support for goal-oriented plans may provide advisory
+structure checks and general next-action guidance. It must not become a hidden
+full lint pass, and it must not infer or mutate `current_node` from checkpoint
+markdown.
+
+At checkpoint-round boundaries, status guidance may present a short list of
+general next actions, such as:
+
+- continue with another bounded checkpoint round
+- synthesize if the scorecard is decisive
+- request challenge if uncertainty or competing hypotheses remain
+- close the step if synthesis and evidence are ready
+
+The controller remains responsible for deciding which action fits the current
+evidence. The CLI should not attempt to judge hypothesis quality from prose.
+
+Status may later warn about shallow structural gaps, such as no checkpoint
+cadence, zero tracked checkpoint digests in an adaptive step, or missing
+digest anchors. Those warnings are navigation guidance. They are not a
+substitute for explicit plan lint or formal review.
+
+## Lint Boundary
+
+`harness plan lint` remains the explicit validation surface for tracked plans.
+
+Goal-oriented lint coverage belongs in a follow-up implementation slice. That
+coverage may check structural requirements such as objective, success
+scorecard, checkpoint cadence, tracked checkpoint digest anchors, and final
+synthesis presence. It should avoid judging whether a hypothesis is good or
+whether evidence is persuasive; those are review and challenge concerns.
+
+Status may point the controller toward lint when tracked checkpoint digests or
+final synthesis change, but status should not silently run or replace full
+lint.
+
+## Review And Archive
+
+Formal step-closeout and finalize reviews remain hard gates. Challenge does
+not replace formal review, and checkpoint digests do not create new review
+states.
+
+Review for goal-oriented work should focus on whether the final synthesis is
+supported by the scorecard, tracked checkpoint digests, durable evidence,
+rejected hypotheses, residual uncertainty, and follow-up handling. The exact
+review dimensions and challenge guidance belong to follow-up implementation
+work.
+
+At archive, the tracked plan package should preserve the durable decision
+trail:
+
+- final synthesis
+- accepted conclusions
+- rejected hypotheses or candidate directions
+- residual uncertainty
+- curated evidence or deliverable pointers
+- follow-up issues for deferred work
+
+Local checkpoint drafts remain disposable unless promoted into the tracked
+plan package or another approved durable artifact before archive.
+
+## Follow-Up Boundaries
+
+This contract intentionally leaves implementation details to the v0.6.0
+follow-up issues:
+
+- #270 adds the goal-oriented plan template and workflow guidance
+- #271 defines richer checkpoint report conventions and storage details if
+  tracked plan digests are not enough
+- #272 adds evidence-validity and hypothesis-challenge guidance
+- #273 teaches status and next-action behavior for goal-oriented plans
+- #274 adds lint coverage for goal-oriented plans
+- #275 adds user-facing docs, help text, and examples

--- a/docs/specs/goal-oriented-workflow.md
+++ b/docs/specs/goal-oriented-workflow.md
@@ -14,6 +14,13 @@ not create a separate workflow engine. Goal-oriented plans still use explicit
 human approval, stable plan steps, formal step-closeout and finalize review,
 archive, evidence, and the canonical node state model.
 
+This document defines the product contract before the supporting CLI surfaces
+are implemented. Until the follow-up implementation slices add authoring,
+lint, status, archive, and reopen support, agents must not assume that a
+tracked plan containing `workflow_profile: goal_oriented` will pass
+`harness plan lint` or that archive/reopen will preserve goal-oriented profile
+identity automatically.
+
 ## When To Use It
 
 Use `goal_oriented` for work where the plan can name the desired outcome but
@@ -298,5 +305,10 @@ follow-up issues:
   tracked plan digests are not enough
 - #272 adds evidence-validity and hypothesis-challenge guidance
 - #273 teaches status and next-action behavior for goal-oriented plans
-- #274 adds lint coverage for goal-oriented plans
+- #274 adds lint coverage for goal-oriented plans, including when
+  `workflow_profile: goal_oriented` becomes a lint-valid active-plan value
 - #275 adds user-facing docs, help text, and examples
+
+The implementation slices must also define how archive and reopen preserve the
+goal-oriented profile identity without relying on hidden chat memory or
+contradicting tracked archived-plan frontmatter rules.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -6,9 +6,13 @@
 - [State Transitions](./state-transitions.md): exhaustive enumeration of every
   allowed v0.2 `current_node` transition, including command-driven milestones
   and derived progression rules.
-- [Plan Schema](./plan-schema.md): shared plan contract for tracked `standard`
-  and `lightweight` plans, their markdown-led package layout, and local state
-  expectations.
+- [Plan Schema](./plan-schema.md): shared plan contract for tracked
+  `standard`, `lightweight`, and `goal_oriented` plans, their markdown-led
+  package layout, and local state expectations.
+- [Goal-Oriented Workflow](./goal-oriented-workflow.md): normative
+  `workflow_profile: goal_oriented` contract for adaptive work with explicit
+  objectives, scorecards, checkpoint digests, optional challenge, evidence,
+  and final synthesis.
 - [Bootstrap Install](./bootstrap-install.md): normative bootstrap resource
   model for `harness repo init`, `harness repo skills ...`,
   `harness repo instructions ...`, and `harness repo config ...`, including

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -6,13 +6,13 @@
 - [State Transitions](./state-transitions.md): exhaustive enumeration of every
   allowed v0.2 `current_node` transition, including command-driven milestones
   and derived progression rules.
-- [Plan Schema](./plan-schema.md): shared plan contract for tracked
-  `standard`, `lightweight`, and `goal_oriented` plans, their markdown-led
-  package layout, and local state expectations.
+- [Plan Schema](./plan-schema.md): shared plan contract for tracked `standard`
+  and `lightweight` plans, their markdown-led package layout, and local state
+  expectations.
 - [Goal-Oriented Workflow](./goal-oriented-workflow.md): normative
-  `workflow_profile: goal_oriented` contract for adaptive work with explicit
-  objectives, scorecards, checkpoint digests, optional challenge, evidence,
-  and final synthesis.
+  reserved `workflow_profile: goal_oriented` contract for adaptive work with
+  explicit objectives, scorecards, checkpoint digests, optional challenge,
+  evidence, and final synthesis.
 - [Bootstrap Install](./bootstrap-install.md): normative bootstrap resource
   model for `harness repo init`, `harness repo skills ...`,
   `harness repo instructions ...`, and `harness repo config ...`, including

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -4,21 +4,21 @@
 
 This document defines the normative v0.2 plan contract for `easyharness`.
 
-In v0.2, standard, lightweight, and goal-oriented plans share one markdown
-schema, but the durable planning unit is a markdown-led plan package rather
-than a lone file. Active plans for all profiles live in tracked markdown under
-the active plan root resolved by
+In v0.2, standard and lightweight plans share one markdown schema, but the
+durable planning unit is a markdown-led plan package rather than a lone file.
+Active plans for both currently implemented profiles live in tracked markdown
+under the active plan root resolved by
 `harness repo config get paths.plans.active`, which defaults to
 `docs/plans/active/`, and may carry approval-scoped companion material under a
 matching `supplements/<plan-stem>/` directory. Lightweight diverges only at
 archive time, when the archived snapshot moves into command-owned local
-storage. Goal-oriented plans stay on the ordinary tracked archive path and add
-adaptive planning semantics defined by
-[Goal-Oriented Workflow](./goal-oriented-workflow.md). Runtime lifecycle,
-milestone timestamps, review rounds, evidence history, and resolved node state
-live in the local runtime root resolved by
-`harness repo config get paths.local_runtime`, which defaults to
-`.local/harness/`.
+storage. The reserved goal-oriented profile contract is defined separately in
+[Goal-Oriented Workflow](./goal-oriented-workflow.md); authoring, lint,
+archive, and reopen support for `workflow_profile: goal_oriented` belongs to
+the follow-up implementation slices. Runtime lifecycle, milestone timestamps,
+review rounds, evidence history, and resolved node state live in the local
+runtime root resolved by `harness repo config get paths.local_runtime`, which
+defaults to `.local/harness/`.
 Agents and scripts that need concrete resolved roots should query them with
 `harness repo config get paths.plans.active`,
 `harness repo config get paths.plans.archived`, and
@@ -46,9 +46,9 @@ resolved by `harness repo config get paths.local_runtime`, defaulting to:
 - `.local/harness/plans/archived/<plan-stem>.md`
 - `.local/harness/plans/archived/supplements/<plan-stem>/`
 
-There is no local active lightweight plan path in v0.2. All active plans,
-including `standard`, `lightweight`, and `goal_oriented`, live under the active
-plan root resolved by `harness repo config get paths.plans.active`.
+There is no local active lightweight plan path in v0.2. Both `standard` and
+`lightweight` active plans live under the active plan root resolved by
+`harness repo config get paths.plans.active`.
 
 The markdown file remains the canonical plan path for status resolution,
 current-plan pointers, and most command artifacts. When a matching
@@ -82,10 +82,11 @@ contracts.
 
 The source-of-truth split is:
 
-- this schema document defines the shared markdown plan contract for standard,
-  lightweight, and goal-oriented profiles
-- [Goal-Oriented Workflow](./goal-oriented-workflow.md) defines the additional
-  adaptive semantics for `workflow_profile: goal_oriented`
+- this schema document defines the shared markdown plan contract for standard
+  and lightweight profiles
+- [Goal-Oriented Workflow](./goal-oriented-workflow.md) defines the reserved
+  adaptive semantics for `workflow_profile: goal_oriented`, with authoring,
+  lint, archive, and reopen support left to follow-up implementation slices
 - [the packaged plan template asset](../../assets/templates/plan-template.md)
   is the canonical authoring example shipped by harness
 - `harness plan template` is a convenience wrapper around the packaged asset
@@ -238,19 +239,21 @@ approved_at: 2026-03-17T10:30:00+08:00
     including any matching `supplements/<plan-stem>/` directory
 - `workflow_profile`
   - optional explicit workflow selector
-  - supported values are `lightweight` and `goal_oriented`
+  - supported value is `lightweight`
   - omitted means `standard`
   - `standard` must not be written explicitly; omitting the field preserves
     the current standard behavior
   - tracked plans under the active plan root resolved by
-    `harness repo config get paths.plans.active` may set this field to
-    `lightweight` or `goal_oriented`
+    `harness repo config get paths.plans.active` may set this field only to
+    `lightweight`
   - tracked plans under the archived plan root resolved by
     `harness repo config get paths.plans.archived` must omit this field
   - local archived plans under the lightweight archived snapshot root must set
     it to `lightweight`
-  - `goal_oriented` plans use the ordinary tracked archive path and must omit
-    this field after archive like other tracked archived plans
+  - `workflow_profile: goal_oriented` is reserved by
+    [Goal-Oriented Workflow](./goal-oriented-workflow.md), but is not a
+    currently lint-valid plan frontmatter value until the goal-oriented
+    authoring and lint implementation slices land
 
 ## Lightweight Eligibility
 
@@ -298,11 +301,12 @@ v0.2 plans must not carry these top-level runtime fields:
 - `updated_at`
 
 Path placement plus optional `workflow_profile: lightweight` answer whether a
-plan uses the lightweight archive profile and whether it is active or
-archived. `workflow_profile: goal_oriented` answers whether an active tracked
-plan uses the adaptive contract defined by
-[Goal-Oriented Workflow](./goal-oriented-workflow.md). Runtime milestones and
-revision history belong in command-owned artifacts, not plan frontmatter.
+plan is standard or lightweight and whether it is active or archived. The
+reserved `workflow_profile: goal_oriented` contract is documented in
+[Goal-Oriented Workflow](./goal-oriented-workflow.md), but its concrete
+frontmatter, lint, archive, and reopen behavior belongs to follow-up
+implementation work. Runtime milestones and revision history belong in
+command-owned artifacts, not plan frontmatter.
 
 ## Required Sections
 
@@ -500,16 +504,22 @@ it as durable tracked history.
 
 When there is any doubt, escalate to the standard tracked-plan workflow.
 
-## Goal-Oriented Profile
+## Reserved Goal-Oriented Profile
 
 `workflow_profile: goal_oriented` is for adaptive work where the objective and
 success scorecard are explicit, but the path must proceed through hypotheses,
 probes, checkpoint rounds, optional challenge, and final synthesis.
 
-Goal-oriented plans are standard tracked plan packages for path and archive
-purposes. The profile does not create a separate local active path, local
-archive path, node tree, review gate, or workflow engine. It adds the
-additional planning and execution semantics defined in
+This value is a reserved profile contract, not a currently lint-valid plan
+frontmatter value. Goal-oriented authoring, lint, archive, status, and reopen
+support belongs to the v0.6.0 follow-up implementation slices. Until that
+support lands, plan authors should not expect a tracked plan containing
+`workflow_profile: goal_oriented` to pass `harness plan lint`.
+
+The target profile uses standard tracked plan packages for path and archive
+purposes. It does not create a separate local active path, local archive path,
+node tree, review gate, or workflow engine. It adds the additional planning and
+execution semantics defined in
 [Goal-Oriented Workflow](./goal-oriented-workflow.md).
 
 The plan body or tracked plan package should carry the durable goal-oriented
@@ -531,8 +541,7 @@ An active plan must satisfy all of these:
 - the required frontmatter fields are present
 - any optional `workflow_profile` field is compatible with the path:
   - omitted means `standard`
-  - explicit `workflow_profile` is allowed for `lightweight` or
-    `goal_oriented`
+  - explicit `workflow_profile` is allowed only for `lightweight`
 - every step uses a `Done` marker
 - archive-only summary sections may still contain the documented active-plan
   placeholders
@@ -543,9 +552,8 @@ An active plan must satisfy all of these:
 - when the active plan uses `workflow_profile: lightweight`, supplements are
   supported but should be exceptional rather than the default way to carry plan
   detail
-- when the active plan uses `workflow_profile: goal_oriented`, the plan package
-  should carry the durable checkpoint digests, synthesis, and evidence pointers
-  required by the goal-oriented contract
+- future goal-oriented implementation work must update these rules before
+  `workflow_profile: goal_oriented` becomes a lint-valid active-plan value
 
 ## Archived Plan Rules
 
@@ -559,10 +567,9 @@ An archived plan must satisfy all of these:
 - any optional `workflow_profile` field is compatible with the path:
   - tracked archived plans must omit `workflow_profile`
   - local archived plans require `workflow_profile: lightweight`
-- tracked archived goal-oriented plans therefore omit `workflow_profile` in
-  frontmatter like other tracked archives, while preserving the durable
-  checkpoint digests, synthesis, and evidence pointers in the archived plan
-  package
+- future goal-oriented implementation work must define how archive and reopen
+  preserve goal-oriented profile identity without violating tracked archived
+  plan frontmatter rules
 - every acceptance criterion is checked
 - the markdown plan does not live inside an archived `supplements/` subtree
 - every step is `Done: [x]`
@@ -616,7 +623,6 @@ active:
   - archived plan root resolved by
     `harness repo config get paths.plans.archived` -> active plan root
     resolved by `harness repo config get paths.plans.active` for `standard`
-    and `goal_oriented`
   - lightweight archived snapshot root -> active plan root resolved by
     `harness repo config get paths.plans.active` for `lightweight`
 - move the matching `supplements/<plan-stem>/` directory with the markdown

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -4,16 +4,20 @@
 
 This document defines the normative v0.2 plan contract for `easyharness`.
 
-In v0.2, standard and lightweight plans share one markdown schema, but the
-durable planning unit is a markdown-led plan package rather than a lone file.
-Active plans for both profiles live in tracked markdown under the active plan
-root resolved by `harness repo config get paths.plans.active`, which defaults
-to `docs/plans/active/`, and may carry approval-scoped companion material
-under a matching `supplements/<plan-stem>/` directory. Lightweight diverges
-only at archive time, when the archived snapshot moves into command-owned
-local storage. Runtime lifecycle, milestone timestamps, review rounds,
-evidence history, and resolved node state live in the local runtime root
-resolved by `harness repo config get paths.local_runtime`, which defaults to
+In v0.2, standard, lightweight, and goal-oriented plans share one markdown
+schema, but the durable planning unit is a markdown-led plan package rather
+than a lone file. Active plans for all profiles live in tracked markdown under
+the active plan root resolved by
+`harness repo config get paths.plans.active`, which defaults to
+`docs/plans/active/`, and may carry approval-scoped companion material under a
+matching `supplements/<plan-stem>/` directory. Lightweight diverges only at
+archive time, when the archived snapshot moves into command-owned local
+storage. Goal-oriented plans stay on the ordinary tracked archive path and add
+adaptive planning semantics defined by
+[Goal-Oriented Workflow](./goal-oriented-workflow.md). Runtime lifecycle,
+milestone timestamps, review rounds, evidence history, and resolved node state
+live in the local runtime root resolved by
+`harness repo config get paths.local_runtime`, which defaults to
 `.local/harness/`.
 Agents and scripts that need concrete resolved roots should query them with
 `harness repo config get paths.plans.active`,
@@ -42,9 +46,9 @@ resolved by `harness repo config get paths.local_runtime`, defaulting to:
 - `.local/harness/plans/archived/<plan-stem>.md`
 - `.local/harness/plans/archived/supplements/<plan-stem>/`
 
-There is no local active lightweight plan path in v0.2. Both `standard` and
-`lightweight` active plans live under the active plan root resolved by
-`harness repo config get paths.plans.active`.
+There is no local active lightweight plan path in v0.2. All active plans,
+including `standard`, `lightweight`, and `goal_oriented`, live under the active
+plan root resolved by `harness repo config get paths.plans.active`.
 
 The markdown file remains the canonical plan path for status resolution,
 current-plan pointers, and most command artifacts. When a matching
@@ -78,8 +82,10 @@ contracts.
 
 The source-of-truth split is:
 
-- this schema document defines the shared plan contract for standard and
-  lightweight profiles
+- this schema document defines the shared markdown plan contract for standard,
+  lightweight, and goal-oriented profiles
+- [Goal-Oriented Workflow](./goal-oriented-workflow.md) defines the additional
+  adaptive semantics for `workflow_profile: goal_oriented`
 - [the packaged plan template asset](../../assets/templates/plan-template.md)
   is the canonical authoring example shipped by harness
 - `harness plan template` is a convenience wrapper around the packaged asset
@@ -232,17 +238,19 @@ approved_at: 2026-03-17T10:30:00+08:00
     including any matching `supplements/<plan-stem>/` directory
 - `workflow_profile`
   - optional explicit workflow selector
-  - supported value is `lightweight`
+  - supported values are `lightweight` and `goal_oriented`
   - omitted means `standard`
   - `standard` must not be written explicitly; omitting the field preserves
     the current standard behavior
   - tracked plans under the active plan root resolved by
-    `harness repo config get paths.plans.active` may set this field only to
-    `lightweight`
+    `harness repo config get paths.plans.active` may set this field to
+    `lightweight` or `goal_oriented`
   - tracked plans under the archived plan root resolved by
     `harness repo config get paths.plans.archived` must omit this field
   - local archived plans under the lightweight archived snapshot root must set
     it to `lightweight`
+  - `goal_oriented` plans use the ordinary tracked archive path and must omit
+    this field after archive like other tracked archived plans
 
 ## Lightweight Eligibility
 
@@ -290,9 +298,11 @@ v0.2 plans must not carry these top-level runtime fields:
 - `updated_at`
 
 Path placement plus optional `workflow_profile: lightweight` answer whether a
-plan is standard or lightweight and whether it is active or archived. Runtime
-milestones and revision history belong in command-owned artifacts, not plan
-frontmatter.
+plan uses the lightweight archive profile and whether it is active or
+archived. `workflow_profile: goal_oriented` answers whether an active tracked
+plan uses the adaptive contract defined by
+[Goal-Oriented Workflow](./goal-oriented-workflow.md). Runtime milestones and
+revision history belong in command-owned artifacts, not plan frontmatter.
 
 ## Required Sections
 
@@ -388,7 +398,7 @@ Rules:
 ## Placeholder Policy
 
 These exact active-plan placeholders are allowed in active tracked plans for
-both profiles:
+all workflow profiles:
 
 - `Execution Notes`: `PENDING_STEP_EXECUTION`
 - `Review Notes`: `PENDING_STEP_REVIEW`
@@ -490,6 +500,26 @@ it as durable tracked history.
 
 When there is any doubt, escalate to the standard tracked-plan workflow.
 
+## Goal-Oriented Profile
+
+`workflow_profile: goal_oriented` is for adaptive work where the objective and
+success scorecard are explicit, but the path must proceed through hypotheses,
+probes, checkpoint rounds, optional challenge, and final synthesis.
+
+Goal-oriented plans are standard tracked plan packages for path and archive
+purposes. The profile does not create a separate local active path, local
+archive path, node tree, review gate, or workflow engine. It adds the
+additional planning and execution semantics defined in
+[Goal-Oriented Workflow](./goal-oriented-workflow.md).
+
+The plan body or tracked plan package should carry the durable goal-oriented
+record required by that contract, including objective, success scorecard,
+checkpoint cadence, tracked checkpoint digests or equivalent synthesis,
+challenge triggers, evidence requirements, stopping conditions, and final
+synthesis. Local checkpoint drafts remain disposable runtime working memory
+unless their content is promoted into the tracked plan package or another
+approved deliverable.
+
 ## Active Plan Rules
 
 An active plan must satisfy all of these:
@@ -501,7 +531,8 @@ An active plan must satisfy all of these:
 - the required frontmatter fields are present
 - any optional `workflow_profile` field is compatible with the path:
   - omitted means `standard`
-  - explicit `workflow_profile` is allowed only for `lightweight`
+  - explicit `workflow_profile` is allowed for `lightweight` or
+    `goal_oriented`
 - every step uses a `Done` marker
 - archive-only summary sections may still contain the documented active-plan
   placeholders
@@ -512,6 +543,9 @@ An active plan must satisfy all of these:
 - when the active plan uses `workflow_profile: lightweight`, supplements are
   supported but should be exceptional rather than the default way to carry plan
   detail
+- when the active plan uses `workflow_profile: goal_oriented`, the plan package
+  should carry the durable checkpoint digests, synthesis, and evidence pointers
+  required by the goal-oriented contract
 
 ## Archived Plan Rules
 
@@ -525,6 +559,10 @@ An archived plan must satisfy all of these:
 - any optional `workflow_profile` field is compatible with the path:
   - tracked archived plans must omit `workflow_profile`
   - local archived plans require `workflow_profile: lightweight`
+- tracked archived goal-oriented plans therefore omit `workflow_profile` in
+  frontmatter like other tracked archives, while preserving the durable
+  checkpoint digests, synthesis, and evidence pointers in the archived plan
+  package
 - every acceptance criterion is checked
 - the markdown plan does not live inside an archived `supplements/` subtree
 - every step is `Done: [x]`
@@ -578,6 +616,7 @@ active:
   - archived plan root resolved by
     `harness repo config get paths.plans.archived` -> active plan root
     resolved by `harness repo config get paths.plans.active` for `standard`
+    and `goal_oriented`
   - lightweight archived snapshot root -> active plan root resolved by
     `harness repo config get paths.plans.active` for `lightweight`
 - move the matching `supplements/<plan-stem>/` directory with the markdown

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -93,15 +93,17 @@ resolving the snapshot.
 ### Durable Plan, Disposable Runtime
 
 Tracked active plans remain the durable source of scope, step closeout, and
-archive summaries for both profiles. Lightweight work uses the same schema and
-the same active-plan root resolved by
+archive summaries for all workflow profiles. Lightweight work uses the same
+schema and the same active-plan root resolved by
 `harness repo config get paths.plans.active`, but its archived snapshot moves
 under the local runtime root resolved by
 `harness repo config get paths.local_runtime` so the workflow can stay
-lightweight for narrow low-risk changes. Runtime trajectory, milestone
-timestamps, and external-fact capture also belong in the resolved local
-runtime root. There is no separate local active lightweight plan path in this
-model.
+lightweight for narrow low-risk changes. Goal-oriented work uses the same
+tracked active and tracked archived plan roots as ordinary standard work while
+adding adaptive plan semantics for checkpoint digests, challenge, evidence,
+and synthesis. Runtime trajectory, milestone timestamps, and external-fact
+capture also belong in the resolved local runtime root. There is no separate
+local active path for either lightweight or goal-oriented work in this model.
 
 ### Explicit Command Boundaries
 
@@ -139,13 +141,14 @@ root
 - step-local `Review Notes`
 - archive-time summaries and outcome notes
 
-For active work in both profiles, this plan artifact is a tracked file under
-the active plan root resolved by
+For active work in all workflow profiles, this plan artifact is a tracked file
+under the active plan root resolved by
 `harness repo config get paths.plans.active`, which defaults to
-`docs/plans/active/`. Standard archives stay tracked under the archived plan
-root resolved by `harness repo config get paths.plans.archived`, which
-defaults to `docs/plans/archived/`. Lightweight archived snapshots move under
-the local runtime root resolved by
+`docs/plans/active/`. Standard and goal-oriented archives stay tracked under
+the archived plan root resolved by
+`harness repo config get paths.plans.archived`, which defaults to
+`docs/plans/archived/`. Lightweight archived snapshots move under the local
+runtime root resolved by
 `harness repo config get paths.local_runtime`, defaulting to
 `.local/harness/plans/archived/` for the snapshot directory.
 Agents and scripts should resolve these roots with
@@ -210,7 +213,7 @@ Resolution rules:
 `harness status` resolves `current_node` from:
 
 - the current plan content
-- the plan path and optional `workflow_profile: lightweight`
+- the plan path and any optional `workflow_profile`
 - whether execution-start has been recorded
 - the first unfinished step from the current plan
 - review artifacts for the current step or the finalize gate
@@ -261,9 +264,12 @@ silently queue behind each other.
 The exact transition matrix is normative in
 [State Transitions](./state-transitions.md).
 
-The lightweight profile does not add a second node tree. It reuses the same
+Workflow profiles do not add a second node tree. Lightweight reuses the same
 canonical nodes while changing where the archived snapshot lives and what
-closeout guidance `harness status` should emphasize.
+closeout guidance `harness status` should emphasize. Goal-oriented also
+reuses the same canonical nodes; checkpoint digests and challenge notes may
+inform guidance, but they must not derive, mutate, or override
+`current_node`.
 
 ## Node Semantics
 
@@ -274,7 +280,7 @@ No current work is in flight. This is the normal post-land resting state.
 ### `plan`
 
 A current tracked active plan exists, but execution has not started. Plan
-edits, approval, and step refinement happen here for both profiles.
+edits, approval, and step refinement happen here for all workflow profiles.
 
 ### `execution/step-<n>/implement`
 

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -98,12 +98,13 @@ schema and the same active-plan root resolved by
 `harness repo config get paths.plans.active`, but its archived snapshot moves
 under the local runtime root resolved by
 `harness repo config get paths.local_runtime` so the workflow can stay
-lightweight for narrow low-risk changes. Goal-oriented work uses the same
-tracked active and tracked archived plan roots as ordinary standard work while
-adding adaptive plan semantics for checkpoint digests, challenge, evidence,
-and synthesis. Runtime trajectory, milestone timestamps, and external-fact
-capture also belong in the resolved local runtime root. There is no separate
-local active path for either lightweight or goal-oriented work in this model.
+lightweight for narrow low-risk changes. The reserved goal-oriented profile is
+specified as using the same canonical node tree while adding adaptive plan
+semantics for checkpoint digests, challenge, evidence, and synthesis, but its
+frontmatter, lint, archive, status, and reopen support belongs to follow-up
+implementation work. Runtime trajectory, milestone timestamps, and
+external-fact capture also belong in the resolved local runtime root. There is
+no separate local active lightweight plan path in this model.
 
 ### Explicit Command Boundaries
 
@@ -141,14 +142,13 @@ root
 - step-local `Review Notes`
 - archive-time summaries and outcome notes
 
-For active work in all workflow profiles, this plan artifact is a tracked file
-under the active plan root resolved by
+For active work in the currently implemented workflow profiles, this plan
+artifact is a tracked file under the active plan root resolved by
 `harness repo config get paths.plans.active`, which defaults to
-`docs/plans/active/`. Standard and goal-oriented archives stay tracked under
-the archived plan root resolved by
-`harness repo config get paths.plans.archived`, which defaults to
-`docs/plans/archived/`. Lightweight archived snapshots move under the local
-runtime root resolved by
+`docs/plans/active/`. Standard archives stay tracked under the archived plan
+root resolved by `harness repo config get paths.plans.archived`, which
+defaults to `docs/plans/archived/`. Lightweight archived snapshots move under
+the local runtime root resolved by
 `harness repo config get paths.local_runtime`, defaulting to
 `.local/harness/plans/archived/` for the snapshot directory.
 Agents and scripts should resolve these roots with
@@ -266,10 +266,10 @@ The exact transition matrix is normative in
 
 Workflow profiles do not add a second node tree. Lightweight reuses the same
 canonical nodes while changing where the archived snapshot lives and what
-closeout guidance `harness status` should emphasize. Goal-oriented also
-reuses the same canonical nodes; checkpoint digests and challenge notes may
-inform guidance, but they must not derive, mutate, or override
-`current_node`.
+closeout guidance `harness status` should emphasize. The reserved
+goal-oriented profile is specified to reuse the same canonical nodes once
+implemented; checkpoint digests and challenge notes may inform guidance, but
+they must not derive, mutate, or override `current_node`.
 
 ## Node Semantics
 
@@ -280,7 +280,8 @@ No current work is in flight. This is the normal post-land resting state.
 ### `plan`
 
 A current tracked active plan exists, but execution has not started. Plan
-edits, approval, and step refinement happen here for all workflow profiles.
+edits, approval, and step refinement happen here for all implemented workflow
+profiles.
 
 ### `execution/step-<n>/implement`
 


### PR DESCRIPTION
## What Changed

Defines the reserved `workflow_profile: goal_oriented` contract for adaptive harness work where the objective and scorecard are explicit but the path evolves through hypotheses, probes, checkpoint rounds, optional challenge, and synthesis.

The new spec separates local checkpoint drafts from tracked checkpoint digests, keeps challenge advisory unless a plan requires it, and clarifies that evidence reports are deliverables only when the user objective and approved scope call for them. Cross-references in the plan schema, state model, CLI contract, and spec index make the contract discoverable while preserving current standard/lightweight behavior.

## Confidence

- The contract is intentionally reserved until follow-up slices add authoring, lint, status, archive, and reopen support, so current `harness plan lint` behavior is not contradicted.
- Step-closeout review caught and repaired the first draft's support-boundary ambiguity; repair review passed with no findings.
- Finalize review passed across docs-consistency, agent-ux, and risk-scan dimensions with no findings.
- `harness plan lint`, `git diff --check`, and `scripts/validate` passed.

## Handoff

Follow-up implementation remains with #270, #271, #272, #273, #274, and #275. This PR closes #269 once merged.
