### PR TITLE
[codex] Clarify managed AGENTS block wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Keep easyharness-specific guidance outside the managed markers.
 
 ## Harness Source of Truth
 
-The default harness split for repositories using this bootstrap is:
+Harness resolves these workflow roots from repo config:
 
 - active plan root, resolved with
   `harness repo config get paths.plans.active` and defaulting to
@@ -121,14 +121,16 @@ The default harness split for repositories using this bootstrap is:
   `harness repo config get paths.local_runtime` and defaulting to
   `.local/harness/`: disposable runtime state, review artifacts, evidence
   artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
-- `docs/specs/`: default location for durable harness-facing contracts that
-  the repository chooses to keep as specs; do not assume every repo-local spec
-  is an upstream easyharness product contract
-- `.agents/skills`: agent skill packages; easyharness-managed `harness-*`
-  skills are refreshed by bootstrap, while other repo-owned skills stay
-  outside easyharness ownership
 
-If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
+Other durable repository contracts live wherever repo-owned instructions,
+plans, docs, or code say they live. Do not assume a repository has
+`docs/specs/`, or that any repo-local specs are upstream easyharness product
+contracts.
+
+When bootstrap-installed skills are present, easyharness-managed `harness-*`
+skills are refreshed by bootstrap. Other repo-owned skills stay outside
+easyharness ownership. If a tracked plan conflicts with a repo-local skill, the
+tracked plan wins.
 
 ## Harness Product Help
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,17 +122,15 @@ Harness resolves these workflow roots from repo config:
   `.local/harness/`: disposable runtime state, review artifacts, evidence
   artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
 
-Repository-specific durable contracts may live in `docs/specs/` or anywhere
-else repo-owned instructions, plans, docs, or code say they live. Do not assume
-`docs/specs/` exists, or that any repo-local specs are upstream easyharness
-product contracts.
+Repository-owned guidance may define additional durable contract locations.
+When present, `docs/specs/` is a common place for repository specs and workflow
+contracts; follow repo-owned instructions to interpret what those specs govern.
 
-For Codex, bootstrap installs managed harness workflow skills under
-`.agents/skills` by default unless a different skills target was used. When
-bootstrap-installed skills are present, easyharness-managed `harness-*` skills
-are refreshed by bootstrap. Other repo-owned skills stay outside easyharness
-ownership. If a tracked plan conflicts with a repo-local skill, the tracked
-plan wins.
+For Codex, the default bootstrap skills target is `.agents/skills` unless a
+different target was used. easyharness refreshes managed `harness-*` skills at
+the bootstrap target; other repo-owned skills stay outside easyharness
+ownership. If a tracked plan conflicts with a repo-local skill, the tracked plan
+wins.
 
 ## Harness Product Help
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,15 +122,17 @@ Harness resolves these workflow roots from repo config:
   `.local/harness/`: disposable runtime state, review artifacts, evidence
   artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
 
-Other durable repository contracts live wherever repo-owned instructions,
-plans, docs, or code say they live. Do not assume a repository has
-`docs/specs/`, or that any repo-local specs are upstream easyharness product
-contracts.
+Repository-specific durable contracts may live in `docs/specs/` or anywhere
+else repo-owned instructions, plans, docs, or code say they live. Do not assume
+`docs/specs/` exists, or that any repo-local specs are upstream easyharness
+product contracts.
 
-When bootstrap-installed skills are present, easyharness-managed `harness-*`
-skills are refreshed by bootstrap. Other repo-owned skills stay outside
-easyharness ownership. If a tracked plan conflicts with a repo-local skill, the
-tracked plan wins.
+For Codex, bootstrap installs managed harness workflow skills under
+`.agents/skills` by default unless a different skills target was used. When
+bootstrap-installed skills are present, easyharness-managed `harness-*` skills
+are refreshed by bootstrap. Other repo-owned skills stay outside easyharness
+ownership. If a tracked plan conflicts with a repo-local skill, the tracked
+plan wins.
 
 ## Harness Product Help
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,11 +101,13 @@ Keep easyharness-specific guidance outside the managed markers.
    tracked docs or code before archive.
 5. Evidence beats memory. Use `harness status`, tracked plans, and owned local
    artifacts instead of relying on long-session recall.
-6. Keep tracked docs and code in English.
+6. Keep harness workflow artifacts such as plans, summaries, and review notes
+   in English unless repo-owned instructions explicitly set a different
+   language policy.
 
 ## Harness Source of Truth
 
-The default harness split in this repository is:
+The default harness split for repositories using this bootstrap is:
 
 - active plan root, resolved with
   `harness repo config get paths.plans.active` and defaulting to
@@ -119,8 +121,12 @@ The default harness split in this repository is:
   `harness repo config get paths.local_runtime` and defaulting to
   `.local/harness/`: disposable runtime state, review artifacts, evidence
   artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
-- `docs/specs/`: normative harness contracts
-- `.agents/skills`: repo-local harness workflow skills
+- `docs/specs/`: default location for durable harness-facing contracts that
+  the repository chooses to keep as specs; do not assume every repo-local spec
+  is an upstream easyharness product contract
+- `.agents/skills`: agent skill packages; easyharness-managed `harness-*`
+  skills are refreshed by bootstrap, while other repo-owned skills stay
+  outside easyharness ownership
 
 If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
 
@@ -134,14 +140,15 @@ result back to the human.
 
 ## Harness Workflow
 
-For harness-managed work that is not already clear enough to execute directly:
+For work coordinated through harness that is not already clear enough to
+execute directly:
 
 1. Discovery
 2. Plan
 3. Plan approval
 4. Execute
-4. Archive / publish / await merge approval
-5. Land
+5. Archive / publish / await merge approval
+6. Land
 
 Plan approval is explicit. Writing a plan or hearing the original task request
 does not by itself approve execution. After the plan is shown and the human
@@ -262,7 +269,8 @@ When entering the repository or resuming after compaction:
    candidates may live under the local runtime root resolved by
    `harness repo config get paths.local_runtime`.
    If status reports `idle`, there is no current plan to resume yet.
-4. Most resumed work should continue in `harness-execute`.
+4. If status reports approved or in-progress harness execution, most resumed
+   work should continue in `harness-execute`.
 5. Switch only when `harness status` and the workflow boundary clearly call for
    a different skill:
    - `harness-discovery` when direction is unclear

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -8,11 +8,13 @@
    tracked docs or code before archive.
 5. Evidence beats memory. Use `harness status`, tracked plans, and owned local
    artifacts instead of relying on long-session recall.
-6. Keep tracked docs and code in English.
+6. Keep harness workflow artifacts such as plans, summaries, and review notes
+   in English unless repo-owned instructions explicitly set a different
+   language policy.
 
 ## Harness Source of Truth
 
-The default harness split in this repository is:
+The default harness split for repositories using this bootstrap is:
 
 - active plan root, resolved with
   `harness repo config get paths.plans.active` and defaulting to
@@ -26,8 +28,12 @@ The default harness split in this repository is:
   `harness repo config get paths.local_runtime` and defaulting to
   `.local/harness/`: disposable runtime state, review artifacts, evidence
   artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
-- `docs/specs/`: normative harness contracts
-- `.agents/skills/`: repo-local harness workflow skills
+- `docs/specs/`: default location for durable harness-facing contracts that
+  the repository chooses to keep as specs; do not assume every repo-local spec
+  is an upstream easyharness product contract
+- `.agents/skills/`: agent skill packages; easyharness-managed `harness-*`
+  skills are refreshed by bootstrap, while other repo-owned skills stay
+  outside easyharness ownership
 
 If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
 
@@ -41,14 +47,15 @@ result back to the human.
 
 ## Harness Workflow
 
-For harness-managed work that is not already clear enough to execute directly:
+For work coordinated through harness that is not already clear enough to
+execute directly:
 
 1. Discovery
 2. Plan
 3. Plan approval
 4. Execute
-4. Archive / publish / await merge approval
-5. Land
+5. Archive / publish / await merge approval
+6. Land
 
 Plan approval is explicit. Writing a plan or hearing the original task request
 does not by itself approve execution. After the plan is shown and the human
@@ -169,7 +176,8 @@ When entering the repository or resuming after compaction:
    candidates may live under the local runtime root resolved by
    `harness repo config get paths.local_runtime`.
    If status reports `idle`, there is no current plan to resume yet.
-4. Most resumed work should continue in `harness-execute`.
+4. If status reports approved or in-progress harness execution, most resumed
+   work should continue in `harness-execute`.
 5. Switch only when `harness status` and the workflow boundary clearly call for
    a different skill:
    - `harness-discovery` when direction is unclear

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -29,15 +29,17 @@ Harness resolves these workflow roots from repo config:
   `.local/harness/`: disposable runtime state, review artifacts, evidence
   artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
 
-Other durable repository contracts live wherever repo-owned instructions,
-plans, docs, or code say they live. Do not assume a repository has
-`docs/specs/`, or that any repo-local specs are upstream easyharness product
-contracts.
+Repository-specific durable contracts may live in `docs/specs/` or anywhere
+else repo-owned instructions, plans, docs, or code say they live. Do not assume
+`docs/specs/` exists, or that any repo-local specs are upstream easyharness
+product contracts.
 
-When bootstrap-installed skills are present, easyharness-managed `harness-*`
-skills are refreshed by bootstrap. Other repo-owned skills stay outside
-easyharness ownership. If a tracked plan conflicts with a repo-local skill, the
-tracked plan wins.
+For Codex, bootstrap installs managed harness workflow skills under
+`.agents/skills/` by default unless a different skills target was used. When
+bootstrap-installed skills are present, easyharness-managed `harness-*` skills
+are refreshed by bootstrap. Other repo-owned skills stay outside easyharness
+ownership. If a tracked plan conflicts with a repo-local skill, the tracked
+plan wins.
 
 ## Harness Product Help
 

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -29,17 +29,15 @@ Harness resolves these workflow roots from repo config:
   `.local/harness/`: disposable runtime state, review artifacts, evidence
   artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
 
-Repository-specific durable contracts may live in `docs/specs/` or anywhere
-else repo-owned instructions, plans, docs, or code say they live. Do not assume
-`docs/specs/` exists, or that any repo-local specs are upstream easyharness
-product contracts.
+Repository-owned guidance may define additional durable contract locations.
+When present, `docs/specs/` is a common place for repository specs and workflow
+contracts; follow repo-owned instructions to interpret what those specs govern.
 
-For Codex, bootstrap installs managed harness workflow skills under
-`.agents/skills/` by default unless a different skills target was used. When
-bootstrap-installed skills are present, easyharness-managed `harness-*` skills
-are refreshed by bootstrap. Other repo-owned skills stay outside easyharness
-ownership. If a tracked plan conflicts with a repo-local skill, the tracked
-plan wins.
+For Codex, the default bootstrap skills target is `.agents/skills/` unless a
+different target was used. easyharness refreshes managed `harness-*` skills at
+the bootstrap target; other repo-owned skills stay outside easyharness
+ownership. If a tracked plan conflicts with a repo-local skill, the tracked plan
+wins.
 
 ## Harness Product Help
 

--- a/assets/bootstrap/agents-managed-block.md
+++ b/assets/bootstrap/agents-managed-block.md
@@ -14,7 +14,7 @@
 
 ## Harness Source of Truth
 
-The default harness split for repositories using this bootstrap is:
+Harness resolves these workflow roots from repo config:
 
 - active plan root, resolved with
   `harness repo config get paths.plans.active` and defaulting to
@@ -28,14 +28,16 @@ The default harness split for repositories using this bootstrap is:
   `harness repo config get paths.local_runtime` and defaulting to
   `.local/harness/`: disposable runtime state, review artifacts, evidence
   artifacts, trajectory, and `plans/archived/` lightweight archived snapshots
-- `docs/specs/`: default location for durable harness-facing contracts that
-  the repository chooses to keep as specs; do not assume every repo-local spec
-  is an upstream easyharness product contract
-- `.agents/skills/`: agent skill packages; easyharness-managed `harness-*`
-  skills are refreshed by bootstrap, while other repo-owned skills stay
-  outside easyharness ownership
 
-If a tracked plan conflicts with a repo-local skill, the tracked plan wins.
+Other durable repository contracts live wherever repo-owned instructions,
+plans, docs, or code say they live. Do not assume a repository has
+`docs/specs/`, or that any repo-local specs are upstream easyharness product
+contracts.
+
+When bootstrap-installed skills are present, easyharness-managed `harness-*`
+skills are refreshed by bootstrap. Other repo-owned skills stay outside
+easyharness ownership. If a tracked plan conflicts with a repo-local skill, the
+tracked plan wins.
 
 ## Harness Product Help
 

--- a/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
@@ -103,6 +103,15 @@ harness execution. Ran `scripts/sync-bootstrap-assets` so the root `AGENTS.md`
 managed block matches the bootstrap source. TDD was not applicable because this
 step is a documentation/prompt wording change.
 
+Revision 2 addressed PR feedback that the managed block must not assume user
+repositories have `docs/specs/`, `.agents/skills/`, or any other non-configured
+repo path. The source-of-truth section now lists only roots resolved through
+`harness repo config get ...`; durable repository contracts are described as
+living wherever repo-owned instructions, plans, docs, or code say they live,
+and bootstrap-installed skills are described conditionally. Ran
+`scripts/sync-bootstrap-assets` again so the root `AGENTS.md` managed block
+matches the repaired bootstrap source.
+
 #### Review Notes
 
 `review-001-delta` passed with 0 blocking and 0 non-blocking findings across
@@ -177,15 +186,18 @@ review.
 ## Validation Summary
 
 - `scripts/sync-bootstrap-assets` refreshed the materialized root `AGENTS.md`
-  managed block from `assets/bootstrap/agents-managed-block.md`.
+  managed block from `assets/bootstrap/agents-managed-block.md`, including the
+  revision 2 repair.
 - `go test ./internal/bootstrapsync ./internal/install ./internal/status`
-  passed before finalize and again during archive prep.
+  passed before finalize, during archive prep, and after the revision 2 repair.
 - `harness repo init --dry-run` reports bootstrap assets are already up to
   date after reinstalling the dev harness binary with the updated embedded
-  bootstrap asset.
+  bootstrap asset for both the original wording change and the revision 2
+  repair.
 - `harness plan lint docs/plans/active/2026-07-05-clarify-managed-block-wording.md`
   passed after the plan was written, after step notes were updated, and during
-  archive prep.
+  revision 2 repair.
+- `git diff --check` passed after the revision 2 repair.
 
 ## Review Summary
 
@@ -196,17 +208,21 @@ review.
 - Reviewers confirmed the managed block source, materialized root `AGENTS.md`,
   issue triage record, validation coverage, and plan notes align with the
   approved wording cleanup.
+- Revision 2 repaired PR feedback that the managed block still assumed
+  non-configured repo paths. Fresh finalize review is required before archive.
 
 ## Archive Summary
 
 - Archived At: 2026-07-05T08:32:34+08:00
 - Revision: 1
-- PR: Pending post-archive publish.
-- Ready: Yes. The managed block wording cleanup is implemented, synced,
-validated, and passed step and finalize review with no findings.
-- Merge Handoff: After archive, commit and push the archive move, open a PR with
-a readable merge memo, record publish evidence, refresh CI/sync evidence, and
-wait for explicit human merge approval.
+- Reopened At: revision 2, after PR feedback on non-configured repo path
+  assumptions.
+- PR: https://github.com/catu-ai/easyharness/pull/281
+- Ready: Not yet. Revision 2 repair is implemented and validated, but it still
+  needs fresh finalize review and archive.
+- Merge Handoff: After fresh finalize review and archive, commit and push the
+  archive move, update PR #281, refresh CI/sync evidence, and wait for explicit
+  human merge approval.
 
 ## Outcome Summary
 
@@ -215,6 +231,10 @@ wait for explicit human merge approval.
 - Clarified the managed block source so downstream repositories do not read
   `docs/specs/` as an unconditional upstream easyharness product-contract
   location.
+- Repaired revision 2 feedback by removing `docs/specs/`, `.agents/skills/`,
+  and other non-configured repo paths from the managed block's default split.
+  The block now lists only harness roots resolved through repo config, and
+  describes repo-owned contracts and bootstrap-installed skills conditionally.
 - Narrowed the managed block language policy from all tracked docs and code to
   harness workflow artifacts unless repo-owned instructions say otherwise.
 - Fixed the raw workflow numbering and rephrased the workflow as work

--- a/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
@@ -120,6 +120,12 @@ Codex bootstrap skills target unless a different target was used. Updated the
 install regression test to require that conditional/default guidance while
 still rejecting the old unconditional path bullets.
 
+`review-004-delta` found one blocking tests finding: the regression test kept
+the new default `.agents/skills` cue but no longer explicitly protected the
+`When bootstrap-installed skills are present` conditional. Added that assertion
+so the test covers both the default discovery cue and the conditional ownership
+guard.
+
 #### Review Notes
 
 `review-001-delta` passed with 0 blocking and 0 non-blocking findings across
@@ -210,6 +216,8 @@ UPDATE_REQUIRED_AFTER_REOPEN
 - `git diff --check` passed after the revision 2 repair.
 - Revision 3 reran the same focused validation after restoring conditional
   discovery cues for `docs/specs/` and `.agents/skills/`.
+- After the `review-004-delta` tests finding, focused validation was rerun with
+  the restored bootstrap-installed-skills conditional assertion.
 
 ## Review Summary
 
@@ -229,6 +237,9 @@ UPDATE_REQUIRED_AFTER_REOPEN
 - Revision 3 repaired follow-up PR feedback that the managed block should still
   mention conventional/default surfaces so agents can discover them. Fresh
   finalize review is required before archive.
+- `review-004-delta` requested one blocking tests fix for the install
+  regression coverage. The assertion was restored; fresh delta review is
+  required before archive.
 
 ## Archive Summary
 

--- a/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
@@ -1,0 +1,186 @@
+---
+template_version: 0.2.0
+created_at: "2026-07-05T08:22:30+08:00"
+approved_at: "2026-07-05T08:23:10+08:00"
+source_type: issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/280
+size: XS
+---
+
+# Clarify Managed Block Wording
+
+## Goal
+
+Clarify the easyharness-managed `AGENTS.md` block so downstream repositories
+can distinguish harness workflow guidance from repository-owned product or
+operational documentation. The generated block should still stay compact and
+agent-facing, but it should avoid implying that every downstream `docs/specs/`
+tree is owned by easyharness or that easyharness controls all tracked
+repository documentation and code language.
+
+## Scope
+
+### In Scope
+
+- Update the managed block source in `assets/bootstrap/agents-managed-block.md`.
+- Sync the materialized managed block in the root `AGENTS.md`.
+- Keep the workflow list numbering coherent in the raw managed prompt.
+- Clarify that the harness workflow applies to work coordinated through
+  harness, not only work on easyharness itself.
+- Clarify the relationship between easyharness-managed skills and repo-owned
+  local skills.
+- Triage GitHub issue #280 with the appropriate type/state labels and
+  rationale comment.
+
+### Out of Scope
+
+- Adding new `.harness/config.yaml` fields.
+- Creating a new long-form help topic for managed instruction customization.
+- Changing harness command behavior, state transitions, review semantics, or
+  bootstrap install mechanics.
+- Rewriting the managed skill pack beyond sync output caused by the managed
+  block source change.
+
+## Acceptance Criteria
+
+- [ ] The managed block no longer presents `docs/specs/` as an unconditional
+      downstream easyharness product-contract location.
+- [ ] The managed block no longer broadly requires all tracked docs and code in
+      downstream repositories to be English unless repo-owned instructions add
+      that rule outside the managed block.
+- [ ] The managed workflow list has coherent numbering in raw markdown.
+- [ ] The managed block wording distinguishes easyharness-managed workflow
+      skills from repo-owned local skills.
+- [ ] `scripts/sync-bootstrap-assets` has refreshed materialized output after
+      the bootstrap source edit.
+- [ ] Focused validation passes for bootstrap sync/install/status behavior.
+- [ ] Issue #280 is triaged with a short rationale comment.
+
+## Deferred Items
+
+- Consider a future `harness help repo instructions` topic only if more
+  downstream customization examples show that a compact managed block pointer
+  is not enough.
+
+## Work Breakdown
+
+### Step 1: Tighten the managed block source
+
+- Done: [ ]
+
+#### Objective
+
+Revise the managed block source to remove downstream ambiguity while keeping
+the always-loaded prompt compact.
+
+#### Details
+
+Keep the change targeted to wording. Do not introduce a compatibility layer,
+new config shape, or additional bootstrap command behavior. Preserve the
+existing source-of-truth model: edit `assets/bootstrap/`, then sync generated
+outputs.
+
+#### Expected Files
+
+- `assets/bootstrap/agents-managed-block.md`
+- `AGENTS.md`
+
+#### Validation
+
+- Run `scripts/sync-bootstrap-assets`.
+- Inspect the diff for source/materialized consistency and no unrelated managed
+  skill churn.
+
+#### Execution Notes
+
+Updated `assets/bootstrap/agents-managed-block.md` to narrow the language
+policy to harness workflow artifacts, clarify the default `docs/specs/`
+meaning, distinguish easyharness-managed `harness-*` skills from repo-owned
+skills, rephrase the workflow as work coordinated through harness, fix the raw
+workflow numbering, and narrow resumed-work guidance to approved or in-progress
+harness execution. Ran `scripts/sync-bootstrap-assets` so the root `AGENTS.md`
+managed block matches the bootstrap source. TDD was not applicable because this
+step is a documentation/prompt wording change.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 2: Validate and triage the issue
+
+- Done: [ ]
+
+#### Objective
+
+Validate the managed block change and record the issue triage decision on
+GitHub.
+
+#### Details
+
+Use the repo-local issue triage rules. The issue should receive the appropriate
+GitHub type label and open backlog state or milestone; leave a concise
+rationale comment explaining the decision.
+
+#### Expected Files
+
+- `docs/plans/active/2026-07-05-clarify-managed-block-wording.md`
+
+#### Validation
+
+- Run focused Go tests for bootstrap sync/install/status behavior.
+- Run `harness repo init --dry-run` to confirm managed outputs are current.
+- Run `harness plan lint` on this plan.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Use bootstrap sync as the source/materialized-output check.
+- Use focused Go tests covering bootstrap sync, install, and status drift
+  behavior.
+- Use `harness repo init --dry-run` as an end-to-end check that the running
+  binary sees managed assets as current.
+- Use harness review orchestration for step closeout and finalize review.
+
+## Risks
+
+- Risk: The managed block becomes too vague and stops giving downstream agents
+  enough useful defaults.
+  - Mitigation: Keep resolved harness roots and command pointers explicit while
+    narrowing only the misleading ownership language.
+- Risk: Sync output accidentally changes unrelated managed skills.
+  - Mitigation: Review the diff after `scripts/sync-bootstrap-assets` and keep
+    the source edit limited to `agents-managed-block.md`.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
@@ -112,6 +112,14 @@ and bootstrap-installed skills are described conditionally. Ran
 `scripts/sync-bootstrap-assets` again so the root `AGENTS.md` managed block
 matches the repaired bootstrap source.
 
+Revision 3 addressed follow-up PR feedback that omitting the conventional
+locations entirely left agents without a discovery cue. The managed block now
+names `docs/specs/` as one possible repo-owned contract location while still
+saying not to assume it exists, and names `.agents/skills/` as the default
+Codex bootstrap skills target unless a different target was used. Updated the
+install regression test to require that conditional/default guidance while
+still rejecting the old unconditional path bullets.
+
 #### Review Notes
 
 `review-001-delta` passed with 0 blocking and 0 non-blocking findings across
@@ -185,6 +193,8 @@ review.
 
 ## Validation Summary
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - `scripts/sync-bootstrap-assets` refreshed the materialized root `AGENTS.md`
   managed block from `assets/bootstrap/agents-managed-block.md`, including the
   revision 2 repair.
@@ -198,8 +208,12 @@ review.
   passed after the plan was written, after step notes were updated, and during
   revision 2 repair.
 - `git diff --check` passed after the revision 2 repair.
+- Revision 3 reran the same focused validation after restoring conditional
+  discovery cues for `docs/specs/` and `.agents/skills/`.
 
 ## Review Summary
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Step closeout review `review-001-delta` passed with 0 blocking and 0
   non-blocking findings across `docs-consistency` and `agent-ux`.
@@ -212,23 +226,31 @@ review.
   non-configured repo paths. Finalize repair review `review-003-delta` passed
   with 0 blocking and 0 non-blocking findings across `docs-consistency`,
   `agent-ux`, and `tests`.
+- Revision 3 repaired follow-up PR feedback that the managed block should still
+  mention conventional/default surfaces so agents can discover them. Fresh
+  finalize review is required before archive.
 
 ## Archive Summary
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Archived At: 2026-07-05T09:17:07+08:00
 - Revision: 2
 - Reopened At: revision 2, after PR feedback on non-configured repo path
   assumptions.
+- Reopened At: revision 3, after follow-up PR feedback that the conditional
+  guidance still needs to mention the conventional/default locations.
 - PR: https://github.com/catu-ai/easyharness/pull/281
-- Ready: Yes. Revision 2 removes non-configured repo path assumptions from the
-  managed block, syncs the materialized output, updates regression coverage,
-  validates cleanly, and passed finalize repair review with no findings.
-- Merge Handoff: After archive, commit and push the archive move, update PR
-  #281, refresh CI/sync evidence, and wait for explicit human merge approval.
+- Ready: Not yet. Revision 3 is implemented and ready for validation/review.
+- Merge Handoff: After validation, fresh finalize review, and archive, commit
+  and push the archive move, update PR #281, refresh CI/sync evidence, and wait
+  for explicit human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - Clarified the managed block source so downstream repositories do not read
   `docs/specs/` as an unconditional upstream easyharness product-contract
@@ -237,6 +259,10 @@ review.
   and other non-configured repo paths from the managed block's default split.
   The block now lists only harness roots resolved through repo config, and
   describes repo-owned contracts and bootstrap-installed skills conditionally.
+- Repaired revision 3 feedback by restoring explicit conditional discovery cues:
+  `docs/specs/` is named as one possible repo-owned contract location, and
+  `.agents/skills/` is named as the default Codex bootstrap skills target unless
+  a different target was used.
 - Narrowed the managed block language policy from all tracked docs and code to
   harness workflow artifacts unless repo-owned instructions say otherwise.
 - Fixed the raw workflow numbering and rephrased the workflow as work
@@ -249,11 +275,15 @@ review.
 
 ### Not Delivered
 
+UPDATE_REQUIRED_AFTER_REOPEN
+
 - No new repo config field or managed-instructions help topic was added.
 - No command behavior, state transition, review, archive, evidence, or
   bootstrap install mechanics changed.
 
 ### Follow-Up Issues
+
+UPDATE_REQUIRED_AFTER_REOPEN
 
 - No GitHub follow-up issue created. The deferred help-topic idea remains
   conditional: consider a future `harness help repo instructions` topic only if

--- a/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
@@ -44,18 +44,18 @@ repository documentation and code language.
 
 ## Acceptance Criteria
 
-- [ ] The managed block no longer presents `docs/specs/` as an unconditional
+- [x] The managed block no longer presents `docs/specs/` as an unconditional
       downstream easyharness product-contract location.
-- [ ] The managed block no longer broadly requires all tracked docs and code in
+- [x] The managed block no longer broadly requires all tracked docs and code in
       downstream repositories to be English unless repo-owned instructions add
       that rule outside the managed block.
-- [ ] The managed workflow list has coherent numbering in raw markdown.
-- [ ] The managed block wording distinguishes easyharness-managed workflow
+- [x] The managed workflow list has coherent numbering in raw markdown.
+- [x] The managed block wording distinguishes easyharness-managed workflow
       skills from repo-owned local skills.
-- [ ] `scripts/sync-bootstrap-assets` has refreshed materialized output after
+- [x] `scripts/sync-bootstrap-assets` has refreshed materialized output after
       the bootstrap source edit.
-- [ ] Focused validation passes for bootstrap sync/install/status behavior.
-- [ ] Issue #280 is triaged with a short rationale comment.
+- [x] Focused validation passes for bootstrap sync/install/status behavior.
+- [x] Issue #280 is triaged with a short rationale comment.
 
 ## Deferred Items
 
@@ -67,7 +67,7 @@ repository documentation and code language.
 
 ### Step 1: Tighten the managed block source
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -105,11 +105,15 @@ step is a documentation/prompt wording change.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` passed with 0 blocking and 0 non-blocking findings across
+`docs-consistency` and `agent-ux`. Reviewer submissions confirmed the source
+and materialized managed block align with plan intent, the wording reduces the
+downstream ownership ambiguity, and the `.agents/skills/` source versus
+rendered `.agents/skills` display difference is expected rendering behavior.
 
 ### Step 2: Validate and triage the issue
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -134,11 +138,22 @@ rationale comment explaining the decision.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Ran focused validation:
+`go test ./internal/bootstrapsync ./internal/install ./internal/status`,
+`harness repo init --dry-run`, and
+`harness plan lint docs/plans/active/2026-07-05-clarify-managed-block-wording.md`.
+Reinstalled the dev harness binary with `scripts/install-dev-harness` after the
+embedded bootstrap asset changed, then reran `harness repo init --dry-run` to
+confirm the installed binary reports managed assets as current. Triaged
+GitHub issue #280 with `documentation` and `state/accepted`, and left a
+rationale comment explaining the documentation scope and why no new config
+field or concrete milestone is needed yet.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 2 only recorded validation evidence and GitHub issue
+triage after the managed block wording change had already passed step-closeout
+review.
 
 ## Validation Strategy
 
@@ -153,10 +168,10 @@ PENDING_STEP_REVIEW
 
 - Risk: The managed block becomes too vague and stops giving downstream agents
   enough useful defaults.
-  - Mitigation: Keep resolved harness roots and command pointers explicit while
+  - Mitigation: Kept resolved harness roots and command pointers explicit while
     narrowing only the misleading ownership language.
 - Risk: Sync output accidentally changes unrelated managed skills.
-  - Mitigation: Review the diff after `scripts/sync-bootstrap-assets` and keep
+  - Mitigation: Reviewed the diff after `scripts/sync-bootstrap-assets` and kept
     the source edit limited to `agents-managed-block.md`.
 
 ## Validation Summary

--- a/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/active/2026-07-05-clarify-managed-block-wording.md
@@ -126,6 +126,14 @@ the new default `.agents/skills` cue but no longer explicitly protected the
 so the test covers both the default discovery cue and the conditional ownership
 guard.
 
+Revision 4 addressed follow-up PR feedback that the revision 3 wording sounded
+too defensive. The managed block now uses positive discovery language:
+`docs/specs/` is named as a common repo-owned specs/workflow-contract location
+when present, `.agents/skills/` is named as the default Codex bootstrap skills
+target unless customized, and the old "Do not assume" wording is removed.
+Updated the install regression test to protect that tone while still rejecting
+the old unconditional path bullets.
+
 #### Review Notes
 
 `review-001-delta` passed with 0 blocking and 0 non-blocking findings across
@@ -201,10 +209,10 @@ review.
 
 - `scripts/sync-bootstrap-assets` refreshed the materialized root `AGENTS.md`
   managed block from `assets/bootstrap/agents-managed-block.md`, including the
-  revision 2 and revision 3 repairs.
+  revision 2, revision 3, and revision 4 repairs.
 - `go test ./internal/bootstrapsync ./internal/install ./internal/status`
   passed before finalize, during archive prep, after the revision 2 repair, and
-  after the revision 3 review-finding fix.
+  after the revision 3 and revision 4 repair work.
 - `harness repo init --dry-run` reports bootstrap assets are already up to
   date after reinstalling the dev harness binary with the updated embedded
   bootstrap asset for the original wording change and later repairs.
@@ -216,6 +224,8 @@ review.
   discovery cues for `docs/specs/` and `.agents/skills/`.
 - After the `review-004-delta` tests finding, focused validation was rerun with
   the restored bootstrap-installed-skills conditional assertion.
+- Revision 4 reran focused validation after replacing defensive wording with
+  positive discovery cues.
 
 ## Review Summary
 
@@ -236,6 +246,8 @@ review.
   regression coverage. The assertion was restored.
 - `review-005-delta` passed with 0 blocking and 0 non-blocking findings for the
   restored test assertion.
+- Revision 4 repaired follow-up PR feedback that the managed block sounded too
+  defensive. Fresh finalize review is required before archive.
 
 ## Archive Summary
 
@@ -245,12 +257,14 @@ review.
   assumptions.
 - Reopened At: revision 3, after follow-up PR feedback that the conditional
   guidance still needs to mention the conventional/default locations.
+- Reopened At: revision 4, after follow-up PR feedback that the discovery
+  wording should be positive rather than defensive.
 - PR: https://github.com/catu-ai/easyharness/pull/281
-- Ready: Yes. Revision 3 restores conditional discovery cues for conventional
-  locations, keeps non-assumption guardrails, validates cleanly, and passed the
-  follow-up tests review.
-- Merge Handoff: After archive, commit and push the archive move, update PR
-  #281, refresh CI/sync evidence, and wait for explicit human merge approval.
+- Ready: Not yet. Revision 4 is implemented and validated, but still needs
+  fresh finalize review and archive.
+- Merge Handoff: After fresh review and archive, commit and push the archive
+  move, update PR #281, refresh CI/sync evidence, and wait for explicit human
+  merge approval.
 
 ## Outcome Summary
 
@@ -267,6 +281,9 @@ review.
   `docs/specs/` is named as one possible repo-owned contract location, and
   `.agents/skills/` is named as the default Codex bootstrap skills target unless
   a different target was used.
+- Repaired revision 4 feedback by replacing defensive "do not assume" wording
+  with positive discovery guidance for common repo-owned specs and Codex
+  bootstrap skill locations.
 - Narrowed the managed block language policy from all tracked docs and code to
   harness workflow artifacts unless repo-owned instructions say otherwise.
 - Fixed the raw workflow numbering and rephrased the workflow as work

--- a/docs/plans/archived/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/archived/2026-07-05-clarify-managed-block-wording.md
@@ -247,12 +247,14 @@ review.
 - `review-005-delta` passed with 0 blocking and 0 non-blocking findings for the
   restored test assertion.
 - Revision 4 repaired follow-up PR feedback that the managed block sounded too
-  defensive. Fresh finalize review is required before archive.
+  defensive. Finalize repair review `review-006-delta` passed with 0 blocking
+  and 0 non-blocking findings across `docs-consistency`, `agent-ux`, and
+  `tests`.
 
 ## Archive Summary
 
-- Archived At: 2026-07-05T09:31:22+08:00
-- Revision: 3
+- Archived At: 2026-07-05T09:41:51+08:00
+- Revision: 4
 - Reopened At: revision 2, after PR feedback on non-configured repo path
   assumptions.
 - Reopened At: revision 3, after follow-up PR feedback that the conditional
@@ -260,11 +262,10 @@ review.
 - Reopened At: revision 4, after follow-up PR feedback that the discovery
   wording should be positive rather than defensive.
 - PR: https://github.com/catu-ai/easyharness/pull/281
-- Ready: Not yet. Revision 4 is implemented and validated, but still needs
-  fresh finalize review and archive.
-- Merge Handoff: After fresh review and archive, commit and push the archive
-  move, update PR #281, refresh CI/sync evidence, and wait for explicit human
-  merge approval.
+- Ready: Yes. Revision 4 is implemented, validated, reviewed, and ready for
+  publish/sync evidence refresh.
+- Merge Handoff: Commit and push the archive move, update PR #281, refresh
+  CI/sync evidence, and wait for explicit human merge approval.
 
 ## Outcome Summary
 

--- a/docs/plans/archived/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/archived/2026-07-05-clarify-managed-block-wording.md
@@ -176,26 +176,64 @@ review.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `scripts/sync-bootstrap-assets` refreshed the materialized root `AGENTS.md`
+  managed block from `assets/bootstrap/agents-managed-block.md`.
+- `go test ./internal/bootstrapsync ./internal/install ./internal/status`
+  passed before finalize and again during archive prep.
+- `harness repo init --dry-run` reports bootstrap assets are already up to
+  date after reinstalling the dev harness binary with the updated embedded
+  bootstrap asset.
+- `harness plan lint docs/plans/active/2026-07-05-clarify-managed-block-wording.md`
+  passed after the plan was written, after step notes were updated, and during
+  archive prep.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step closeout review `review-001-delta` passed with 0 blocking and 0
+  non-blocking findings across `docs-consistency` and `agent-ux`.
+- Finalize review `review-002-full` passed with 0 blocking and 0 non-blocking
+  findings across `docs-consistency`, `agent-ux`, and `tests`.
+- Reviewers confirmed the managed block source, materialized root `AGENTS.md`,
+  issue triage record, validation coverage, and plan notes align with the
+  approved wording cleanup.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-07-05T08:32:34+08:00
+- Revision: 1
+- PR: Pending post-archive publish.
+- Ready: Yes. The managed block wording cleanup is implemented, synced,
+validated, and passed step and finalize review with no findings.
+- Merge Handoff: After archive, commit and push the archive move, open a PR with
+a readable merge memo, record publish evidence, refresh CI/sync evidence, and
+wait for explicit human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Clarified the managed block source so downstream repositories do not read
+  `docs/specs/` as an unconditional upstream easyharness product-contract
+  location.
+- Narrowed the managed block language policy from all tracked docs and code to
+  harness workflow artifacts unless repo-owned instructions say otherwise.
+- Fixed the raw workflow numbering and rephrased the workflow as work
+  coordinated through harness.
+- Clarified that easyharness-managed `harness-*` skills are bootstrap-owned
+  while other repo-owned skills stay outside easyharness ownership.
+- Synced the root `AGENTS.md` managed block from the bootstrap source.
+- Triaged issue #280 with `documentation` and `state/accepted`, plus a
+  rationale comment.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No new repo config field or managed-instructions help topic was added.
+- No command behavior, state transition, review, archive, evidence, or
+  bootstrap install mechanics changed.
 
 ### Follow-Up Issues
 
-NONE
+- No GitHub follow-up issue created. The deferred help-topic idea remains
+  conditional: consider a future `harness help repo instructions` topic only if
+  more downstream customization examples show that compact managed-block
+  wording is not enough.

--- a/docs/plans/archived/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/archived/2026-07-05-clarify-managed-block-wording.md
@@ -199,29 +199,25 @@ review.
 
 ## Validation Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 - `scripts/sync-bootstrap-assets` refreshed the materialized root `AGENTS.md`
   managed block from `assets/bootstrap/agents-managed-block.md`, including the
-  revision 2 repair.
+  revision 2 and revision 3 repairs.
 - `go test ./internal/bootstrapsync ./internal/install ./internal/status`
-  passed before finalize, during archive prep, and after the revision 2 repair.
+  passed before finalize, during archive prep, after the revision 2 repair, and
+  after the revision 3 review-finding fix.
 - `harness repo init --dry-run` reports bootstrap assets are already up to
   date after reinstalling the dev harness binary with the updated embedded
-  bootstrap asset for both the original wording change and the revision 2
-  repair.
+  bootstrap asset for the original wording change and later repairs.
 - `harness plan lint docs/plans/active/2026-07-05-clarify-managed-block-wording.md`
   passed after the plan was written, after step notes were updated, and during
-  revision 2 repair.
-- `git diff --check` passed after the revision 2 repair.
+  the repair rounds.
+- `git diff --check` passed after the repair rounds.
 - Revision 3 reran the same focused validation after restoring conditional
   discovery cues for `docs/specs/` and `.agents/skills/`.
 - After the `review-004-delta` tests finding, focused validation was rerun with
   the restored bootstrap-installed-skills conditional assertion.
 
 ## Review Summary
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Step closeout review `review-001-delta` passed with 0 blocking and 0
   non-blocking findings across `docs-consistency` and `agent-ux`.
@@ -235,33 +231,30 @@ UPDATE_REQUIRED_AFTER_REOPEN
   with 0 blocking and 0 non-blocking findings across `docs-consistency`,
   `agent-ux`, and `tests`.
 - Revision 3 repaired follow-up PR feedback that the managed block should still
-  mention conventional/default surfaces so agents can discover them. Fresh
-  finalize review is required before archive.
+  mention conventional/default surfaces so agents can discover them.
 - `review-004-delta` requested one blocking tests fix for the install
-  regression coverage. The assertion was restored; fresh delta review is
-  required before archive.
+  regression coverage. The assertion was restored.
+- `review-005-delta` passed with 0 blocking and 0 non-blocking findings for the
+  restored test assertion.
 
 ## Archive Summary
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
-- Archived At: 2026-07-05T09:17:07+08:00
-- Revision: 2
+- Archived At: 2026-07-05T09:31:22+08:00
+- Revision: 3
 - Reopened At: revision 2, after PR feedback on non-configured repo path
   assumptions.
 - Reopened At: revision 3, after follow-up PR feedback that the conditional
   guidance still needs to mention the conventional/default locations.
 - PR: https://github.com/catu-ai/easyharness/pull/281
-- Ready: Not yet. Revision 3 is implemented and ready for validation/review.
-- Merge Handoff: After validation, fresh finalize review, and archive, commit
-  and push the archive move, update PR #281, refresh CI/sync evidence, and wait
-  for explicit human merge approval.
+- Ready: Yes. Revision 3 restores conditional discovery cues for conventional
+  locations, keeps non-assumption guardrails, validates cleanly, and passed the
+  follow-up tests review.
+- Merge Handoff: After archive, commit and push the archive move, update PR
+  #281, refresh CI/sync evidence, and wait for explicit human merge approval.
 
 ## Outcome Summary
 
 ### Delivered
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - Clarified the managed block source so downstream repositories do not read
   `docs/specs/` as an unconditional upstream easyharness product-contract
@@ -286,15 +279,11 @@ UPDATE_REQUIRED_AFTER_REOPEN
 
 ### Not Delivered
 
-UPDATE_REQUIRED_AFTER_REOPEN
-
 - No new repo config field or managed-instructions help topic was added.
 - No command behavior, state transition, review, archive, evidence, or
   bootstrap install mechanics changed.
 
 ### Follow-Up Issues
-
-UPDATE_REQUIRED_AFTER_REOPEN
 
 - No GitHub follow-up issue created. The deferred help-topic idea remains
   conditional: consider a future `harness help repo instructions` topic only if

--- a/docs/plans/archived/2026-07-05-clarify-managed-block-wording.md
+++ b/docs/plans/archived/2026-07-05-clarify-managed-block-wording.md
@@ -209,20 +209,22 @@ review.
   issue triage record, validation coverage, and plan notes align with the
   approved wording cleanup.
 - Revision 2 repaired PR feedback that the managed block still assumed
-  non-configured repo paths. Fresh finalize review is required before archive.
+  non-configured repo paths. Finalize repair review `review-003-delta` passed
+  with 0 blocking and 0 non-blocking findings across `docs-consistency`,
+  `agent-ux`, and `tests`.
 
 ## Archive Summary
 
-- Archived At: 2026-07-05T08:32:34+08:00
-- Revision: 1
+- Archived At: 2026-07-05T09:17:07+08:00
+- Revision: 2
 - Reopened At: revision 2, after PR feedback on non-configured repo path
   assumptions.
 - PR: https://github.com/catu-ai/easyharness/pull/281
-- Ready: Not yet. Revision 2 repair is implemented and validated, but it still
-  needs fresh finalize review and archive.
-- Merge Handoff: After fresh finalize review and archive, commit and push the
-  archive move, update PR #281, refresh CI/sync evidence, and wait for explicit
-  human merge approval.
+- Ready: Yes. Revision 2 removes non-configured repo path assumptions from the
+  managed block, syncs the materialized output, updates regression coverage,
+  validates cleanly, and passed finalize repair review with no findings.
+- Merge Handoff: After archive, commit and push the archive move, update PR
+  #281, refresh CI/sync evidence, and wait for explicit human merge approval.
 
 ## Outcome Summary
 

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -40,8 +40,14 @@ func TestInitCreatesManagedInstructionsAndSkills(t *testing.T) {
 	if !strings.Contains(agentsBody, `<!-- easyharness:begin version="v9.9.9" -->`) {
 		t.Fatalf("expected versioned managed marker, got:\n%s", agentsBody)
 	}
-	if !strings.Contains(agentsBody, ".agents/skills") {
-		t.Fatalf("expected default repo skills path in managed block, got:\n%s", agentsBody)
+	if !strings.Contains(agentsBody, "Harness resolves these workflow roots from repo config") {
+		t.Fatalf("expected repo-config root guidance in managed block, got:\n%s", agentsBody)
+	}
+	if strings.Contains(agentsBody, "- `docs/specs/`:") || strings.Contains(agentsBody, ".agents/skills") {
+		t.Fatalf("managed block should not assume non-configured repo paths, got:\n%s", agentsBody)
+	}
+	if !strings.Contains(agentsBody, "When bootstrap-installed skills are present") {
+		t.Fatalf("expected conditional bootstrap skill guidance in managed block, got:\n%s", agentsBody)
 	}
 
 	skillData, err := os.ReadFile(filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md"))

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -53,6 +53,10 @@ func TestInitCreatesManagedInstructionsAndSkills(t *testing.T) {
 	if !strings.Contains(agentsBody, "`.agents/skills` by default unless a different skills target was used") {
 		t.Fatalf("expected conditional default skills target guidance in managed block, got:\n%s", agentsBody)
 	}
+	if !strings.Contains(agentsBody, "When") ||
+		!strings.Contains(agentsBody, "bootstrap-installed skills are present") {
+		t.Fatalf("expected bootstrap-installed skills conditional in managed block, got:\n%s", agentsBody)
+	}
 
 	skillData, err := os.ReadFile(filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md"))
 	if err != nil {

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -43,11 +43,15 @@ func TestInitCreatesManagedInstructionsAndSkills(t *testing.T) {
 	if !strings.Contains(agentsBody, "Harness resolves these workflow roots from repo config") {
 		t.Fatalf("expected repo-config root guidance in managed block, got:\n%s", agentsBody)
 	}
-	if strings.Contains(agentsBody, "- `docs/specs/`:") || strings.Contains(agentsBody, ".agents/skills") {
+	if strings.Contains(agentsBody, "- `docs/specs/`:") || strings.Contains(agentsBody, "- `.agents/skills") {
 		t.Fatalf("managed block should not assume non-configured repo paths, got:\n%s", agentsBody)
 	}
-	if !strings.Contains(agentsBody, "When bootstrap-installed skills are present") {
-		t.Fatalf("expected conditional bootstrap skill guidance in managed block, got:\n%s", agentsBody)
+	if !strings.Contains(agentsBody, "may live in `docs/specs/` or anywhere") ||
+		!strings.Contains(agentsBody, "else repo-owned instructions") {
+		t.Fatalf("expected optional repo contract location guidance in managed block, got:\n%s", agentsBody)
+	}
+	if !strings.Contains(agentsBody, "`.agents/skills` by default unless a different skills target was used") {
+		t.Fatalf("expected conditional default skills target guidance in managed block, got:\n%s", agentsBody)
 	}
 
 	skillData, err := os.ReadFile(filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md"))

--- a/internal/install/service_test.go
+++ b/internal/install/service_test.go
@@ -46,16 +46,17 @@ func TestInitCreatesManagedInstructionsAndSkills(t *testing.T) {
 	if strings.Contains(agentsBody, "- `docs/specs/`:") || strings.Contains(agentsBody, "- `.agents/skills") {
 		t.Fatalf("managed block should not assume non-configured repo paths, got:\n%s", agentsBody)
 	}
-	if !strings.Contains(agentsBody, "may live in `docs/specs/` or anywhere") ||
-		!strings.Contains(agentsBody, "else repo-owned instructions") {
-		t.Fatalf("expected optional repo contract location guidance in managed block, got:\n%s", agentsBody)
+	if strings.Contains(agentsBody, "Do not assume") {
+		t.Fatalf("managed block should avoid defensive non-assumption wording, got:\n%s", agentsBody)
 	}
-	if !strings.Contains(agentsBody, "`.agents/skills` by default unless a different skills target was used") {
-		t.Fatalf("expected conditional default skills target guidance in managed block, got:\n%s", agentsBody)
+	if !strings.Contains(agentsBody, "When present, `docs/specs/` is a common place") {
+		t.Fatalf("expected positive repo contract location guidance in managed block, got:\n%s", agentsBody)
 	}
-	if !strings.Contains(agentsBody, "When") ||
-		!strings.Contains(agentsBody, "bootstrap-installed skills are present") {
-		t.Fatalf("expected bootstrap-installed skills conditional in managed block, got:\n%s", agentsBody)
+	if !strings.Contains(agentsBody, "default bootstrap skills target is `.agents/skills` unless") {
+		t.Fatalf("expected default skills target guidance in managed block, got:\n%s", agentsBody)
+	}
+	if !strings.Contains(agentsBody, "easyharness refreshes managed `harness-*` skills") {
+		t.Fatalf("expected managed skill refresh guidance in managed block, got:\n%s", agentsBody)
 	}
 
 	skillData, err := os.ReadFile(filepath.Join(root, ".agents/skills/harness-discovery/SKILL.md"))


### PR DESCRIPTION
## What Changed

Clarifies the easyharness-managed `AGENTS.md` block so downstream repositories can tell the difference between harness workflow guidance and repo-owned product or operational docs.

The managed block now narrows the English-language guidance to harness workflow artifacts, lists only repo-configured harness roots in the default source-of-truth split, and gives positive discovery cues for repo-owned durable contracts and Codex bootstrap skills: `docs/specs/` is described as a common repo-owned specs/workflow-contract location when present, and `.agents/skills/` is described as the default Codex bootstrap skills target unless a different target was used. It also keeps the easyharness-managed `harness-*` skill ownership boundary clear, fixes the raw workflow numbering, and frames the workflow as work coordinated through harness.

Closes #280.

## Confidence

- Bootstrap source and materialized output were kept in sync with `scripts/sync-bootstrap-assets`.
- Focused validation passed after the latest repair: `scripts/install-dev-harness`, `go test ./internal/bootstrapsync ./internal/install ./internal/status`, `harness repo init --dry-run`, `harness plan lint`, and `git diff --check`.
- Install regression coverage now rejects the old unconditional path bullets and the defensive `Do not assume` wording while requiring the positive `docs/specs/`, `.agents/skills`, and managed `harness-*` cues.
- Final repair review `review-006-delta` passed with no findings across docs consistency, agent UX, and tests.
- Issue #280 was triaged as `documentation` + `state/accepted` with a rationale comment.

## Handoff

No command behavior, state transition, review/archive/evidence logic, or repo config schema changed. The deferred help-topic idea is intentionally not opened as a follow-up issue yet; revisit only if more downstream examples show compact managed-block wording is not enough.
