### PR TITLE
Define goal-oriented checkpoint reports

### DIFF
--- a/docs/plans/active/2026-07-05-define-goal-oriented-checkpoint-reports.md
+++ b/docs/plans/active/2026-07-05-define-goal-oriented-checkpoint-reports.md
@@ -1,0 +1,354 @@
+---
+template_version: 0.2.0
+created_at: "2026-07-05T12:31:03+08:00"
+approved_at: "2026-07-05T12:38:10+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/271
+    - https://github.com/catu-ai/easyharness/issues/262
+    - https://github.com/catu-ai/easyharness/pull/279
+size: S
+---
+
+# Define Goal-Oriented Checkpoint Reports
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Define the checkpoint report convention for `workflow_profile:
+goal_oriented` so adaptive work has a durable intermediate record between
+Codex goal turns and harness steps.
+
+The finished contract should make checkpoint reports structured enough for
+future shallow lint/status consumption while preserving enough writing room for
+complex exploration. A checkpoint report should be a structured narrative
+digest, not a fixed bullet-only form, raw transcript, standalone evidence
+report, or formal review gate.
+
+## Scope
+
+### In Scope
+
+- Define what a checkpoint report is and is not.
+- Define the checkpoint report relationship to a harness step, Codex goal turn,
+  local checkpoint draft, step `Execution Notes`, step `Review Notes`,
+  advisory challenge, final synthesis, evidence, and archive summaries.
+- Define the durable storage convention: inline plan-body checkpoint reports as
+  the default reading and review entrypoint, with supplements only for approved
+  curated support material that would bloat the plan body.
+- Define stable shallow structure for future tooling, including a checkpoint
+  section anchor, stable checkpoint IDs, and required labels.
+- Explicitly allow checkpoint label content to use prose, bullets, tables, or
+  short lists as appropriate instead of requiring bullet-only formatting.
+- Define required and optional checkpoint report fields.
+- Define when agents should write a checkpoint report and when they should
+  consider optional challenge.
+- Keep #271 bounded against the neighboring v0.6.0 issues: #270, #272, #273,
+  #274, and #275.
+
+### Out of Scope
+
+- Implementing CLI status, next-action, lint, template, archive, or reopen
+  behavior.
+- Adding automatic checkpoint generation.
+- Adding UI timeline rendering or dashboard behavior.
+- Adding a new hypothesis state machine.
+- Changing review aggregation semantics or creating a formal review gate for
+  every checkpoint.
+- Adding the goal-oriented plan template or user-facing example plan.
+- Requiring every raw experiment log, failed attempt, transcript, or command
+  trace to enter git.
+
+## Acceptance Criteria
+
+- [x] The goal-oriented spec defines checkpoint reports as structured narrative
+  digests for meaningful adaptive work boundaries, not raw logs, transcripts,
+  evidence reports by default, or formal review gates.
+- [x] The spec distinguishes checkpoint reports from harness steps, Codex goal
+  turns, local checkpoint drafts, `Execution Notes`, `Review Notes`, challenge
+  rounds, final synthesis, and archive summaries.
+- [x] The durable storage convention says inline plan-body checkpoint reports
+  are the canonical entrypoint, while supplements are allowed only for approved
+  curated support artifacts that are indexed from the inline report.
+- [x] The checkpoint structure uses stable anchors, IDs, and labels that future
+  tooling may consume shallowly without requiring bullet-only content or
+  judging hypothesis/evidence quality.
+- [x] Required checkpoint labels include trigger, hypotheses or candidate
+  directions, probe or experiment, observed result, scorecard movement,
+  decision or next mutation, residual uncertainty, and evidence pointers.
+- [x] Optional fields cover challenge notes, rejected alternatives, human
+  decision needs, follow-up/deferred items, curated supplement paths, and
+  validation or reproduction notes.
+- [x] The spec describes checkpoint triggers such as plateau, meaningful result,
+  hypothesis pivot, challenge request, before synthesis, or human scope input.
+- [x] The plan-schema or adjacent normative prose is updated only as needed to
+  make the convention discoverable without absorbing #270, #273, #274, or #275
+  implementation work.
+- [x] The slice leaves lint/status/template/docs/examples work explicitly
+  deferred to the existing follow-up issues.
+
+## Deferred Items
+
+- #270 owns goal-oriented template and workflow guidance, including the
+  generated authoring shape.
+- #272 owns evidence-validity review and hypothesis-challenge guidance.
+- #273 owns status and next-action behavior for goal-oriented plans.
+- #274 owns lint enforcement for goal-oriented structure.
+- #275 owns user-facing docs, help text, and examples.
+- #276 owns any UI checkpoint timeline support.
+
+## Work Breakdown
+
+### Step 1: Define the checkpoint report contract
+
+- Done: [x]
+
+#### Objective
+
+Update the goal-oriented workflow spec with a richer checkpoint report
+contract that can stand alone from discovery chat.
+
+#### Details
+
+The contract should preserve the core #269 decisions while sharpening #271's
+artifact shape:
+
+- a checkpoint report is a concise durable digest of a meaningful checkpoint
+  round inside an approved goal-oriented step;
+- it records decision movement, not every action;
+- it is distinct from local checkpoint drafts, which remain disposable runtime
+  working memory unless promoted;
+- it is distinct from step `Execution Notes`, which summarize completed step
+  work after the fact;
+- it is distinct from step `Review Notes`, which record formal review closeout
+  or why step review was not needed;
+- it can summarize optional challenge input, but challenge remains advisory
+  unless an approved plan makes it a gate;
+- it feeds final synthesis and archive summaries, but should not duplicate
+  them once the decision trail has been absorbed.
+
+Specify that checkpoint reports should use stable markdown anchors and labels,
+but the content under each label may be prose, bullets, tables, or short lists.
+The intended phrase is "structured narrative digest": structured enough for
+future shallow tooling, expressive enough for real adaptive exploration.
+
+Required labels should cover:
+
+- `Trigger`
+- `Hypotheses` or `Candidate Directions`
+- `Probe` or `Experiment`
+- `Observed Result`
+- `Scorecard Movement`
+- `Decision / Next Mutation`
+- `Residuals`
+- `Evidence`
+
+Optional labels should cover:
+
+- `Challenge`
+- `Rejected Alternatives`
+- `Human Decision Needed`
+- `Follow-Up / Deferred`
+- `Supplement`
+- `Validation / Reproduction`
+
+#### Expected Files
+
+- `docs/specs/goal-oriented-workflow.md`
+
+#### Validation
+
+- Read the updated spec as a cold future agent and confirm it explains the
+  checkpoint report contract without relying on issue or chat history.
+- Targeted text checks should find the structured narrative digest wording,
+  required labels, optional labels, and relationship boundaries.
+
+#### Execution Notes
+
+Updated `docs/specs/goal-oriented-workflow.md` to define tracked checkpoint
+reports as concise, git-tracked structured narrative digests. The spec now
+uses checkpoint report terminology consistently, names required and optional
+labels, permits prose/bullets/tables/lists inside label content, and clarifies
+that future tooling may consume headings, IDs, and labels shallowly without
+judging hypothesis or evidence quality. TDD was not applicable because this
+step changed normative documentation only.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 2 connects the same checkpoint-report convention
+into the plan schema, so review is more useful after both documentation
+surfaces are aligned.
+
+### Step 2: Connect the convention to plan schema boundaries
+
+- Done: [x]
+
+#### Objective
+
+Update the plan schema or adjacent normative prose only enough to make the
+checkpoint report convention discoverable from the tracked plan contract.
+
+#### Details
+
+The plan schema should remain the general markdown-led plan package contract.
+Do not turn this slice into the full goal-oriented template, lint, or status
+implementation.
+
+The connective wording should clarify:
+
+- inline plan-body checkpoint reports are the default entrypoint for future
+  resume, review, and archive;
+- checkpoint reports may live under a dedicated step-local section such as
+  `#### Checkpoint Reports`, with stable checkpoint IDs such as `CP1` or
+  `S2-CP1`;
+- supplements are acceptable only for approved curated support material, and
+  the inline checkpoint report must carry the actual conclusion plus an index
+  to that support;
+- future lint/status may consume headings, IDs, and labels shallowly, but must
+  not require bullet-only content or evaluate hypothesis/evidence quality.
+
+If another spec needs a narrow cross-reference to avoid ambiguity, keep it as
+a pointer. Leave concrete generated templates, lint fixtures, status outputs,
+help text, and examples to the sibling issues.
+
+#### Expected Files
+
+- `docs/specs/plan-schema.md`
+- `docs/specs/goal-oriented-workflow.md`
+- `docs/specs/cli-contract.md` only if a narrow cross-reference is needed
+- `docs/specs/state-model.md` only if a narrow cross-reference is needed
+
+#### Validation
+
+- Targeted searches for `Checkpoint Reports`, `structured narrative digest`,
+  `goal_oriented`, `supplements`, `lint`, and `status` should show no conflict
+  with the existing #269 support boundary.
+- Confirm #270, #273, #274, and #275 implementation behavior remains deferred.
+
+#### Execution Notes
+
+Updated `docs/specs/plan-schema.md` so the reserved goal-oriented profile
+points to tracked checkpoint reports as the durable intermediate plan-body
+record, normally under `#### Checkpoint Reports` with stable IDs such as `CP1`
+or `S2-CP1`. Also updated the spec index and state model to use the same
+checkpoint report terminology. Kept CLI/status/lint/template behavior
+deferred; TDD was not applicable because this step changed normative
+documentation only.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Step 3 performs integrated validation for the complete
+documentation contract before finalize review.
+
+### Step 3: Validate issue boundaries and archive readiness
+
+- Done: [x]
+
+#### Objective
+
+Confirm the documentation-only checkpoint report slice is internally
+consistent, lintable, and cleanly bounded against the rest of v0.6.0.
+
+#### Details
+
+Validate that #271 does not accidentally absorb neighboring implementation
+work. The final plan and changed specs should say enough for a future
+goal-oriented executor to know:
+
+- when a checkpoint report should be written;
+- how many small attempts should be summarized inside one report instead of
+  split into tiny checkpoints;
+- when a pivot, plateau, meaningful result, challenge request, or pre-synthesis
+  boundary deserves a new checkpoint;
+- when bulky evidence belongs in supplements or another approved artifact;
+- what future tooling may inspect structurally and what remains human/reviewer
+  judgment.
+
+#### Expected Files
+
+- `docs/plans/active/2026-07-05-define-goal-oriented-checkpoint-reports.md`
+- Any docs changed in Steps 1 and 2
+
+#### Validation
+
+- Run `harness plan lint docs/plans/active/2026-07-05-define-goal-oriented-checkpoint-reports.md`.
+- Run `git diff --check`.
+- Run targeted `rg` checks for the accepted vocabulary, labels, storage
+  convention, issue boundaries, and non-goals.
+- Run broader docs or repository validation only if the execution changes
+  warrant it; otherwise record why targeted docs validation is sufficient.
+
+#### Execution Notes
+
+Validated the documentation slice with `harness plan lint`, `git diff
+--check`, targeted `rg` checks for checkpoint-report terminology and issue
+boundaries, and `go test` for all packages except environment-blocked
+`internal/ui` and `tests/release`. Attempted `scripts/validate`, but pnpm
+blocked the embedded UI build because `esbuild` build scripts require local
+approval; the generated approval stub was removed. `go test ./internal/ui`
+fails with the same unbuilt-UI-asset symptom, and `go test ./tests/release`
+fails because `corepack` is unavailable in this environment. TDD was not
+applicable because this step performed validation and plan closeout only.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: Finalize review will cover the integrated documentation
+candidate.
+
+## Validation Strategy
+
+- Lint the active plan before approval.
+- During execution, validate documentation consistency with targeted searches
+  for checkpoint reports, structured narrative digest, required labels,
+  optional labels, supplements, challenge, final synthesis, status, and lint.
+- Run `git diff --check` before archive.
+- Run broader repository validation only if the documentation changes affect
+  generated assets or behavior; otherwise record that this is a documentation
+  contract slice and why targeted validation is enough.
+
+## Risks
+
+- Risk: The convention becomes a rigid form that cannot handle complex
+  exploration.
+  - Mitigation: Require stable anchors and labels, but explicitly allow prose,
+    bullets, tables, and short lists inside label content.
+- Risk: The convention is too loose for future lint/status support.
+  - Mitigation: Define shallow structural anchors, checkpoint IDs, and labels
+    that tooling can detect without judging natural-language quality.
+- Risk: Checkpoint reports turn into raw process logs.
+  - Mitigation: Define reports as decision-movement digests and leave raw logs
+    local, regenerable, external, or summarized into approved artifacts.
+- Risk: #271 absorbs neighboring v0.6.0 work.
+  - Mitigation: Keep template, challenge/review guidance, status, lint, docs,
+    examples, and UI behavior explicitly deferred to their existing issues.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/archived/2026-07-05-define-goal-oriented-checkpoint-reports.md
+++ b/docs/plans/archived/2026-07-05-define-goal-oriented-checkpoint-reports.md
@@ -329,26 +329,90 @@ candidate.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `harness plan lint docs/plans/active/2026-07-05-define-goal-oriented-checkpoint-reports.md`
+  passed after plan creation, step closeout, review repair, and archive
+  closeout.
+- `git diff --check` passed.
+- Targeted `rg` checks passed for checkpoint report terminology, stable
+  required labels, optional labels, storage convention, issue boundaries, and
+  absence of stale `checkpoint digest` wording.
+- `go test $(go list ./... | grep -v '/internal/ui$' | grep -v '/tests/release$')`
+  passed.
+- `scripts/validate` was attempted with bundled Node and pnpm on `PATH`, but
+  pnpm blocked the embedded UI build because `esbuild` build scripts require
+  local approval in this environment.
+- `go test ./internal/ui` reproduced the same unbuilt embedded-UI-asset
+  symptom with `TestNewHandlerFallsBackToIndexForSPAPath` returning 500
+  instead of 200.
+- `go test ./tests/release` was blocked because `corepack` is unavailable in
+  this environment.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Finalize review `review-001-full` requested changes across docs-consistency,
+  agent-ux, and risk-scan. The blocking findings were stale follow-up-boundary
+  wording that still described #271 as future digest work, plus ambiguous
+  required-label aliases.
+- Repaired the findings by making required checkpoint-report label names stable
+  except for the explicitly listed pairs, and by stating that this contract now
+  owns the #271 checkpoint report convention while leaving #270, #272, #273,
+  #274, and #275 as follow-up implementation/documentation slices.
+- Repair review `review-002-delta` passed across docs-consistency, agent-ux,
+  and risk-scan with no findings.
+- Finalize review `review-003-full` passed across docs-consistency, agent-ux,
+  risk-scan, and tests with no blocking or non-blocking findings.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-07-05T12:56:27+08:00
+- Revision: 1
+- PR: NONE
+- Ready: Yes. Acceptance criteria are checked, tracked steps are complete,
+  targeted validation passed, the only broader validation gaps are documented
+  environment blockers, repair review passed, and final full review passed.
+- Merge Handoff: After archive, commit the archive move, push
+  `codex/define-goal-oriented-checkpoint-reports`, open a PR for #271, record
+  publish/CI/sync evidence through harness, and wait for explicit human merge
+  approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Defined tracked checkpoint reports in `docs/specs/goal-oriented-workflow.md`
+  as concise, git-tracked structured narrative digests for meaningful adaptive
+  work boundaries.
+- Replaced stale checkpoint digest terminology in the touched normative specs
+  with checkpoint report terminology.
+- Defined what checkpoint reports are not: raw logs, transcripts, every-command
+  lists, every-small-attempt records, bullet-only forms, formal review gates,
+  or evidence reports by default.
+- Defined the durable storage convention: inline plan-body checkpoint reports
+  are the canonical review/resume entrypoint, with supplements only for
+  approved curated support artifacts indexed from the inline report.
+- Defined stable shallow structure for future tooling: checkpoint report
+  headings, stable IDs such as `CP1` or `S2-CP1`, and required labels.
+- Clarified that label content may use prose, bullets, tables, or short lists,
+  and that future tooling must not require bullet-only content or judge
+  hypothesis/evidence quality.
+- Connected the convention into `docs/specs/plan-schema.md`,
+  `docs/specs/state-model.md`, and `docs/specs/index.md` without implementing
+  template, status, lint, archive, reopen, or UI behavior.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- No CLI status, next-action, lint, template, archive, or reopen behavior was
+  implemented.
+- No automatic checkpoint generation was added.
+- No UI timeline or dashboard behavior was added.
+- No new hypothesis state machine or review aggregation behavior was added.
+- No user-facing help text or example plan was added.
 
 ### Follow-Up Issues
 
-NONE
+- #270: Add the goal-oriented plan template and workflow guidance.
+- #272: Add evidence-validity and hypothesis-challenge guidance.
+- #273: Teach next actions for goal-oriented plans.
+- #274: Add lint coverage for goal-oriented plans.
+- #275: Add docs and examples for goal-oriented workflow.
+- #276: Add UI support for goal-oriented checkpoint timelines.

--- a/docs/specs/goal-oriented-workflow.md
+++ b/docs/specs/goal-oriented-workflow.md
@@ -195,14 +195,15 @@ artifact from that report. Supplements share the same approval boundary as the
 plan package; they are not free-form scratch space.
 
 Checkpoint report structure is a shallow parseable contract, not a prose
-straitjacket. Required labels should be stable enough for future lint/status
+straitjacket. Required label names are stable enough for future lint/status
 support to find them, but the content under a label may be prose, bullets,
 tables, or short lists according to what the checkpoint needs to explain.
 Future tooling may inspect headings, IDs, and labels; it must not require
 bullet-only content or judge whether a hypothesis, probe, evidence argument, or
 next mutation is good.
 
-A tracked checkpoint report must include these labels or clear equivalents:
+A tracked checkpoint report must include these labels. The only interchangeable
+required label names are the pairs shown explicitly below:
 
 - `Trigger`
 - `Hypotheses` or `Candidate Directions`
@@ -344,12 +345,11 @@ plan package or another approved durable artifact before archive.
 
 ## Follow-Up Boundaries
 
-This contract intentionally leaves implementation details to the v0.6.0
+This contract now owns the #271 checkpoint report convention. It intentionally
+leaves the remaining goal-oriented implementation details to the v0.6.0
 follow-up issues:
 
 - #270 adds the goal-oriented plan template and workflow guidance
-- #271 defines richer checkpoint report conventions and storage details if
-  tracked plan digests are not enough
 - #272 adds evidence-validity and hypothesis-challenge guidance
 - #273 teaches status and next-action behavior for goal-oriented plans
 - #274 adds lint coverage for goal-oriented plans, including when

--- a/docs/specs/goal-oriented-workflow.md
+++ b/docs/specs/goal-oriented-workflow.md
@@ -39,7 +39,7 @@ adding a known CLI flag, fixing an already-localized bug, updating narrow docs,
 or applying a known template change.
 
 Do not use `goal_oriented` as a heavier name for ordinary standard work. If
-the work does not need hypotheses, probes, checkpoint digests, or final
+the work does not need hypotheses, probes, checkpoint reports, or final
 synthesis, the ordinary standard workflow is clearer.
 
 ## Workflow Profile Semantics
@@ -61,7 +61,7 @@ The profile preserves these core harness boundaries:
 
 Goal-oriented execution adds a disciplined layer inside approved steps: the
 controller runs bounded checkpoint rounds, records concise tracked checkpoint
-digests when the work reaches meaningful decision points, optionally requests
+reports when the work reaches meaningful decision points, optionally requests
 challenge when hypotheses or evidence need stress testing, and writes a final
 synthesis before closeout.
 
@@ -84,7 +84,7 @@ agent can resume without hidden chat context:
     signal, scorecard comparison, and next decision
 - `checkpoint cadence or budget`
   - the expected checkpoint rhythm for adaptive steps, such as "write 2-4
-    checkpoint digests for the main exploration step"
+    checkpoint reports for the main exploration step"
   - a cadence is guidance for keeping the work bounded, not a global hard
     minimum or maximum
   - follow-up template and lint work must give this cadence a stable
@@ -109,7 +109,7 @@ Future lint and status support must not rely on unstructured prose guessing.
 The implementation slices that make `workflow_profile: goal_oriented`
 lint-valid must choose stable parseable anchors for the fields status and lint
 need, especially the success scorecard, checkpoint cadence, tracked
-checkpoint digest index, and final synthesis. Prefer plan-body structure for
+checkpoint report index, and final synthesis. Prefer plan-body structure for
 goal-oriented working concepts; reserve frontmatter for durable command-level
 metadata such as profile selection unless a field truly affects command
 resolution.
@@ -122,14 +122,14 @@ or accounting unit. A checkpoint round is the goal-oriented layer between them.
 Do not make one harness step per model turn the default shape. A single
 adaptive step may contain several model continuations, probes, observations,
 and pivots. Durable learning from that work belongs in tracked checkpoint
-digests or final synthesis, not in a growing list of tiny plan steps.
+reports or final synthesis, not in a growing list of tiny plan steps.
 
 Use stable steps for boundaries that need approval, review, and archive
 visibility. Use checkpoint rounds for meaningful intermediate learning inside
 those steps.
 
 Before an adaptive step closes, the plan must contain at least one tracked
-checkpoint digest or equivalent final synthesis explaining the adaptive work
+checkpoint report or equivalent final synthesis explaining the adaptive work
 that happened in the step. A step that performs no adaptive work should not use
 goal-oriented ceremony just to satisfy the profile.
 
@@ -149,31 +149,36 @@ Checkpoint drafts may contain transient details such as:
 
 Checkpoint drafts are local and disposable by default. They do not enter git,
 archive, or review unless their content is promoted into a tracked checkpoint
-digest, an approved supplement, a formal evidence artifact, or another
+report, an approved supplement, a formal evidence artifact, or another
 approved deliverable.
 
-## Tracked Checkpoint Digests
+## Tracked Checkpoint Reports
 
-A tracked checkpoint digest is a concise, git-tracked summary of a meaningful
-checkpoint round. It records the hypotheses or directions considered, observed
-signal, scorecard movement, decision, residual uncertainty, and evidence
-pointers needed for future resume, review, and archive.
+A tracked checkpoint report is a concise, git-tracked structured narrative
+digest of a meaningful checkpoint round. It records the hypotheses or
+candidate directions considered, probe or experiment, observed result,
+scorecard movement, decision or next mutation, residual uncertainty, and
+evidence pointers needed for future resume, review, and archive.
 
-A tracked checkpoint digest is not:
+A tracked checkpoint report is not:
 
 - a raw log
 - a transcript
 - a list of every command
+- a record of every small attempt
+- a bullet-only form
 - a formal review gate
 - the canonical evidence report unless the plan explicitly designates it as
   such
 
-Tracked checkpoint digests should normally live in the plan body under a
-`Checkpoint Digests` section when they are concise enough to keep the plan
-readable. Use one subsection per digest so a single checkpoint can compare
-several hypotheses without turning the plan into a nested bullet log.
+Tracked checkpoint reports should normally live in the plan body under a
+`Checkpoint Reports` section. For step-local reports, use a dedicated
+`#### Checkpoint Reports` subsection inside the adaptive step. Use one
+subsection per report with a stable checkpoint ID, such as `CP1`, `CP2`, or
+`S2-CP1`, so a single checkpoint can compare several hypotheses without
+turning the plan into a nested bullet log or a series of tiny pseudo-steps.
 
-Tracked checkpoint digests should be self-contained enough that a future agent
+Tracked checkpoint reports should be self-contained enough that a future agent
 can understand the decision trail from the plan body. Do not push essential
 checkpoint meaning into a separate file merely to keep the plan short.
 
@@ -185,24 +190,45 @@ regenerable, external, or be summarized into a smaller approved deliverable
 unless the user objective explicitly requires committing them.
 
 When a small durable support artifact is approved for the tracked plan package,
-keep a concise digest or index in the plan body. Supplements share the same
-approval boundary as the plan package; they are not free-form scratch space.
+keep the actual checkpoint report in the plan body and index the support
+artifact from that report. Supplements share the same approval boundary as the
+plan package; they are not free-form scratch space.
 
-A useful digest should answer, at summary level:
+Checkpoint report structure is a shallow parseable contract, not a prose
+straitjacket. Required labels should be stable enough for future lint/status
+support to find them, but the content under a label may be prose, bullets,
+tables, or short lists according to what the checkpoint needs to explain.
+Future tooling may inspect headings, IDs, and labels; it must not require
+bullet-only content or judge whether a hypothesis, probe, evidence argument, or
+next mutation is good.
 
-- why this checkpoint exists
-- which hypothesis, hypotheses, or candidate directions were tested or
-  reconsidered
-- what signal the probe produced
-- how that signal moved the scorecard or decision space
-- whether the controller should continue probing, pivot, request challenge,
-  synthesize, close the step, or stop for human scope input
-- what residual uncertainty remains
-- which durable evidence or deliverable supports the decision
+A tracked checkpoint report must include these labels or clear equivalents:
 
-The digest should explain decision movement, not activity. Do not preserve raw
-terminal output, every failed attempt, or already-absorbed report detail merely
-because it existed during execution.
+- `Trigger`
+- `Hypotheses` or `Candidate Directions`
+- `Probe` or `Experiment`
+- `Observed Result`
+- `Scorecard Movement`
+- `Decision / Next Mutation`
+- `Residuals`
+- `Evidence`
+
+A tracked checkpoint report may include these labels when useful:
+
+- `Challenge`
+- `Rejected Alternatives`
+- `Human Decision Needed`
+- `Follow-Up / Deferred`
+- `Supplement`
+- `Validation / Reproduction`
+
+The report should explain decision movement, not activity. Many small attempts
+that do not independently change the decision space should be summarized inside
+one report, for example under `Probe`, `Observed Result`, or an optional
+attempts summary. A meaningful pivot, plateau, challenge request, scorecard
+movement, pre-synthesis boundary, or human-scope decision is usually a better
+reason to write a new checkpoint report than the mere fact that another model
+turn or command happened.
 
 ## Challenge
 
@@ -230,8 +256,8 @@ When evidence is decisive and the plan did not require challenge, the
 controller may synthesize and proceed to formal review without challenge.
 
 If challenge changes the work materially, record the result in a new tracked
-checkpoint digest. If it only sharpens an existing decision, a short challenge
-summary inside the relevant digest is enough.
+checkpoint report. If it only sharpens an existing decision, a short challenge
+summary inside the relevant report is enough.
 
 ## Evidence And Reports
 
@@ -243,10 +269,10 @@ code change, configuration change, documentation change, benchmark artifact,
 or other file is the deliverable. Use the user's objective and plan scope to
 choose the durable artifact.
 
-When the deliverable is an evidence or decision report, checkpoint digests
+When the deliverable is an evidence or decision report, checkpoint reports
 should point to it or summarize key pivots without duplicating the report.
 When the deliverable is code, docs, configuration, or another artifact,
-checkpoint digests and ordinary validation evidence may be sufficient for
+checkpoint reports and ordinary validation evidence may be sufficient for
 review and archive.
 
 Archive should preserve conclusions, evidence, rejected hypotheses, residuals,
@@ -273,8 +299,8 @@ The controller remains responsible for deciding which action fits the current
 evidence. The CLI should not attempt to judge hypothesis quality from prose.
 
 Status may later warn about shallow structural gaps, such as no checkpoint
-cadence, zero tracked checkpoint digests in an adaptive step, or missing
-digest anchors. Those warnings are navigation guidance. They are not a
+cadence, zero tracked checkpoint reports in an adaptive step, or missing
+report anchors. Those warnings are navigation guidance. They are not a
 substitute for explicit plan lint or formal review.
 
 ## Lint Boundary
@@ -283,22 +309,22 @@ substitute for explicit plan lint or formal review.
 
 Goal-oriented lint coverage belongs in a follow-up implementation slice. That
 coverage may check structural requirements such as objective, success
-scorecard, checkpoint cadence, tracked checkpoint digest anchors, and final
+scorecard, checkpoint cadence, tracked checkpoint report anchors, and final
 synthesis presence. It should avoid judging whether a hypothesis is good or
 whether evidence is persuasive; those are review and challenge concerns.
 
-Status may point the controller toward lint when tracked checkpoint digests or
+Status may point the controller toward lint when tracked checkpoint reports or
 final synthesis change, but status should not silently run or replace full
 lint.
 
 ## Review And Archive
 
 Formal step-closeout and finalize reviews remain hard gates. Challenge does
-not replace formal review, and checkpoint digests do not create new review
+not replace formal review, and checkpoint reports do not create new review
 states.
 
 Review for goal-oriented work should focus on whether the final synthesis is
-supported by the scorecard, tracked checkpoint digests, durable evidence,
+supported by the scorecard, tracked checkpoint reports, durable evidence,
 rejected hypotheses, residual uncertainty, and follow-up handling. The exact
 review dimensions and challenge guidance belong to follow-up implementation
 work.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -11,7 +11,7 @@
   expectations.
 - [Goal-Oriented Workflow](./goal-oriented-workflow.md): normative
   reserved `workflow_profile: goal_oriented` contract for adaptive work with
-  explicit objectives, scorecards, checkpoint digests, optional challenge,
+  explicit objectives, scorecards, checkpoint reports, optional challenge,
   evidence, and final synthesis.
 - [Bootstrap Install](./bootstrap-install.md): normative bootstrap resource
   model for `harness repo init`, `harness repo skills ...`,

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -524,11 +524,25 @@ execution semantics defined in
 
 The plan body or tracked plan package should carry the durable goal-oriented
 record required by that contract, including objective, success scorecard,
-checkpoint cadence, tracked checkpoint digests or equivalent synthesis,
+checkpoint cadence, tracked checkpoint reports or equivalent synthesis,
 challenge triggers, evidence requirements, stopping conditions, and final
 synthesis. Local checkpoint drafts remain disposable runtime working memory
 unless their content is promoted into the tracked plan package or another
 approved deliverable.
+
+Tracked checkpoint reports are the goal-oriented plan body's durable
+intermediate record for meaningful adaptive work boundaries. They should be
+discoverable from the markdown plan, normally through a dedicated section such
+as `#### Checkpoint Reports` inside an adaptive step, and each report should
+use a stable checkpoint ID such as `CP1` or `S2-CP1`. The report itself remains
+the review and resume entrypoint even when it indexes approved curated support
+material under the matching `supplements/<plan-stem>/` directory.
+
+Future goal-oriented lint and status support may consume checkpoint report
+headings, IDs, and labels shallowly. That future tooling must not require
+bullet-only report content, treat supplements as the canonical report body, or
+judge whether a hypothesis, probe, evidence argument, or next mutation is
+persuasive.
 
 ## Active Plan Rules
 

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -100,7 +100,7 @@ under the local runtime root resolved by
 `harness repo config get paths.local_runtime` so the workflow can stay
 lightweight for narrow low-risk changes. The reserved goal-oriented profile is
 specified as using the same canonical node tree while adding adaptive plan
-semantics for checkpoint digests, challenge, evidence, and synthesis, but its
+semantics for checkpoint reports, challenge, evidence, and synthesis, but its
 frontmatter, lint, archive, status, and reopen support belongs to follow-up
 implementation work. Runtime trajectory, milestone timestamps, and
 external-fact capture also belong in the resolved local runtime root. There is
@@ -268,7 +268,7 @@ Workflow profiles do not add a second node tree. Lightweight reuses the same
 canonical nodes while changing where the archived snapshot lives and what
 closeout guidance `harness status` should emphasize. The reserved
 goal-oriented profile is specified to reuse the same canonical nodes once
-implemented; checkpoint digests and challenge notes may inform guidance, but
+implemented; checkpoint reports and challenge notes may inform guidance, but
 they must not derive, mutate, or override `current_node`.
 
 ## Node Semantics


### PR DESCRIPTION
## What Changed

Defines the #271 checkpoint report convention for `workflow_profile: goal_oriented` work.

Checkpoint reports are now described as tracked, structured narrative digests for meaningful adaptive work boundaries. The contract gives future tooling shallow anchors to consume, such as headings, stable checkpoint IDs, and required labels, while explicitly allowing prose, bullets, tables, and short lists inside label content.

The PR also updates the plan schema, state model, and spec index to use checkpoint report terminology and keeps the remaining v0.6.0 implementation work scoped to #270, #272, #273, #274, #275, and #276.

Closes #271.

## Confidence

- `harness plan lint docs/plans/active/2026-07-05-define-goal-oriented-checkpoint-reports.md` passed before archive.
- `git diff --check` passed.
- Targeted `rg` checks passed for checkpoint report terminology, label constraints, storage convention, and stale digest wording.
- `go test $(go list ./... | grep -v '/internal/ui$' | grep -v '/tests/release$')` passed.
- `scripts/validate` is blocked in this environment by pnpm build approval for `esbuild`; `internal/ui` reproduces the unbuilt embedded-UI asset symptom, and `tests/release` is blocked by missing `corepack`.
- Finalize review passed after repair: `review-003-full` had no findings.

## Handoff

After PR checks report, refresh harness CI/sync evidence and wait for explicit human merge approval.
