### PR TITLE
Add goal-oriented plan authoring preview

### DIFF
--- a/.agents/skills/harness-plan/SKILL.md
+++ b/.agents/skills/harness-plan/SKILL.md
@@ -30,6 +30,17 @@ Use this skill to create or update the tracked plan that will drive execution.
    - even in lightweight mode, keep the active plan under the active plan root
      resolved by `harness repo config get paths.plans.active` and use the
      field plus archive behavior to distinguish the profile
+   - use `harness plan template --goal-oriented` only when the work is
+     adaptive: the objective and success scorecard are clear, but the path
+     needs hypotheses, probes, checkpoint reports, optional challenge, and
+     final synthesis
+   - treat `workflow_profile: goal_oriented` as a recognized preview workflow
+     profile defined for v0.6.0 authoring; full execution support, structural
+     lint coverage, status next actions, challenge/review guidance,
+     archive/reopen behavior, and public examples are still being completed
+   - when writing a goal-oriented plan, keep checkpoint reports inside
+     adaptive steps instead of creating one harness step per model turn, probe,
+     or checkpoint report
    - if the slice touches normative contract meaning, core runtime state,
      review/archive/evidence semantics, release safety, security-sensitive
      logic, or another non-trivial risk surface, stay on the standard
@@ -76,6 +87,9 @@ Use this skill to create or update the tracked plan that will drive execution.
 8. Run `harness plan lint <plan-path>`.
    - lightweight plans are still tracked active plans, so lint the tracked
      file before execution starts
+   - goal-oriented preview plans are lint-recognized for active-plan authoring,
+     but lint does not yet prove the full goal-oriented structure or lifecycle
+     support
 9. Present the plan for approval before execution starts.
    - the original task request does not count as approval for the newly
      written plan
@@ -100,6 +114,10 @@ The plan is ready when:
   that archive snapshots move under the local runtime root resolved by
   `harness repo config get paths.local_runtime`, and know that archive-time
   breadcrumb guidance remains required
+- when the plan is goal-oriented, a future agent could identify the objective,
+  success scorecard, hypotheses or candidate directions, checkpoint cadence,
+  evidence requirements, challenge triggers, stopping conditions, where
+  checkpoint reports belong, and what final synthesis must contain
 - when the plan is sized `XXL`, the plan or approval handoff makes clear that
   the human explicitly confirmed not splitting it further yet and that obvious
   spillover moved into `Deferred Items` or follow-up issues where appropriate

--- a/assets/bootstrap/skills/harness-plan/SKILL.md
+++ b/assets/bootstrap/skills/harness-plan/SKILL.md
@@ -27,6 +27,17 @@ Use this skill to create or update the tracked plan that will drive execution.
    - even in lightweight mode, keep the active plan under the active plan root
      resolved by `harness repo config get paths.plans.active` and use the
      field plus archive behavior to distinguish the profile
+   - use `harness plan template --goal-oriented` only when the work is
+     adaptive: the objective and success scorecard are clear, but the path
+     needs hypotheses, probes, checkpoint reports, optional challenge, and
+     final synthesis
+   - treat `workflow_profile: goal_oriented` as a recognized preview workflow
+     profile defined for v0.6.0 authoring; full execution support, structural
+     lint coverage, status next actions, challenge/review guidance,
+     archive/reopen behavior, and public examples are still being completed
+   - when writing a goal-oriented plan, keep checkpoint reports inside
+     adaptive steps instead of creating one harness step per model turn, probe,
+     or checkpoint report
    - if the slice touches normative contract meaning, core runtime state,
      review/archive/evidence semantics, release safety, security-sensitive
      logic, or another non-trivial risk surface, stay on the standard
@@ -73,6 +84,9 @@ Use this skill to create or update the tracked plan that will drive execution.
 8. Run `harness plan lint <plan-path>`.
    - lightweight plans are still tracked active plans, so lint the tracked
      file before execution starts
+   - goal-oriented preview plans are lint-recognized for active-plan authoring,
+     but lint does not yet prove the full goal-oriented structure or lifecycle
+     support
 9. Present the plan for approval before execution starts.
    - the original task request does not count as approval for the newly
      written plan
@@ -97,6 +111,10 @@ The plan is ready when:
   that archive snapshots move under the local runtime root resolved by
   `harness repo config get paths.local_runtime`, and know that archive-time
   breadcrumb guidance remains required
+- when the plan is goal-oriented, a future agent could identify the objective,
+  success scorecard, hypotheses or candidate directions, checkpoint cadence,
+  evidence requirements, challenge triggers, stopping conditions, where
+  checkpoint reports belong, and what final synthesis must contain
 - when the plan is sized `XXL`, the plan or approval handoff makes clear that
   the human explicitly confirmed not splitting it further yet and that obvious
   spillover moved into `Deferred Items` or follow-up issues where appropriate

--- a/docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md
+++ b/docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md
@@ -162,7 +162,7 @@ the behavior and documentation changes are implemented and reviewed under Step
 
 ### Step 2: Implement the preview authoring shape
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -235,11 +235,16 @@ remains blocked only in `tests/release` because `corepack` is not on PATH.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+`review-001-delta` requested changes: archive could write lint-invalid
+goal-oriented preview artifacts, the goal-oriented template silently chose
+`size: M`, the plan schema still used a stale reserved-profile heading, and
+lint tests did not exercise the generated goal-oriented template. Repaired all
+findings in commit `d916fe4`. Follow-up `review-002-delta` passed across
+correctness, docs-consistency, tests, and risk-scan with no findings.
 
 ### Step 3: Validate and prepare for review
 
-- Done: [ ]
+- Done: [x]
 
 #### Objective
 
@@ -272,11 +277,21 @@ lightweight behavior changed.
 
 #### Execution Notes
 
-PENDING_STEP_EXECUTION
+Completed final validation for the implementation and review-repair batch.
+Passed: `go test ./internal/plan ./internal/cli ./internal/lifecycle`, `go
+test $(go list ./... | grep -v '/tests/release$')`, `git diff --check`,
+`harness plan template --goal-oriented --size M` targeted text check, generated
+goal-oriented active-plan lint smoke test, and `harness plan lint` for this
+plan. Targeted `rg` checks confirmed the preview boundary, checkpoint-report
+terminology, and sibling issue ownership remain explicit. `go test ./...` was
+also attempted after the repair and remains blocked only in `tests/release`
+because `corepack` is not on PATH.
 
 #### Review Notes
 
-PENDING_STEP_REVIEW
+NO_STEP_REVIEW_NEEDED: Step 3 only recorded validation and closeout evidence
+after Step 2's clean repair review; the complete candidate proceeds to
+finalize review.
 
 ## Validation Strategy
 

--- a/docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md
+++ b/docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md
@@ -72,24 +72,24 @@ the sibling v0.6.0 issues.
 
 ## Acceptance Criteria
 
-- [ ] A controller can draft a credible goal-oriented tracked plan from the
+- [x] A controller can draft a credible goal-oriented tracked plan from the
       template and repository guidance without relying on hidden issue or chat
       context.
-- [ ] The authoring shape includes setup, adaptive exploration, synthesis, and
+- [x] The authoring shape includes setup, adaptive exploration, synthesis, and
       closeout phases and names where tracked checkpoint reports live.
-- [ ] Goal-oriented plans require objective, success scorecard, hypotheses or
+- [x] Goal-oriented plans require objective, success scorecard, hypotheses or
       candidate directions, checkpoint cadence, evidence requirements,
       challenge triggers, stopping conditions, and final synthesis.
-- [ ] The guidance says checkpoint reports live inside goal-oriented steps and
+- [x] The guidance says checkpoint reports live inside goal-oriented steps and
       do not automatically become separate harness workflow steps.
-- [ ] The CLI, docs, or both describe `workflow_profile: goal_oriented` as a
+- [x] The CLI, docs, or both describe `workflow_profile: goal_oriented` as a
       recognized preview workflow profile defined for v0.6.0 authoring, with
       full execution support still being completed.
-- [ ] Existing standard and lightweight template behavior remains unchanged
+- [x] Existing standard and lightweight template behavior remains unchanged
       unless the caller explicitly requests the goal-oriented preview.
-- [ ] Any lint or CLI guard added in this slice is explicitly narrow preview
+- [x] Any lint or CLI guard added in this slice is explicitly narrow preview
       recognition, not full #274 structural lint enforcement.
-- [ ] Deferred sibling issues #272, #273, #274, and #275 remain named as the
+- [x] Deferred sibling issues #272, #273, #274, and #275 remain named as the
       owners for challenge/review guidance, next actions, lint coverage, and
       docs/examples.
 
@@ -325,26 +325,86 @@ finalize review.
 
 ## Validation Summary
 
-PENDING_UNTIL_ARCHIVE
+- `harness plan lint docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md`
+  passed after plan creation, step closeout, review repair, and archive
+  closeout.
+- `go test ./internal/plan ./internal/cli ./internal/lifecycle` passed.
+- `go test $(go list ./... | grep -v '/tests/release$')` passed.
+- `git diff --check` passed.
+- `harness plan template --goal-oriented --size M` targeted text checks passed
+  for profile, preview-boundary, adaptive-step, and checkpoint-report anchors.
+- A generated goal-oriented active-plan smoke test passed
+  `harness plan lint`.
+- Targeted `rg` checks confirmed the preview boundary, checkpoint-report
+  terminology, and sibling issue ownership remain explicit.
+- `go test ./...` was attempted and remains blocked only in `tests/release`
+  because `corepack` is not on PATH.
 
 ## Review Summary
 
-PENDING_UNTIL_ARCHIVE
+- Step review `review-001-delta` requested changes for three blocking issues
+  and two non-blocking issues: archive could write lint-invalid goal-oriented
+  preview artifacts, the goal-oriented template silently chose `size: M`, docs
+  still had stale reserved-profile wording, and lint coverage did not exercise
+  the generated goal-oriented template.
+- Repaired the findings by preserving the explicit size-placeholder contract,
+  adding generated-template lint coverage, renaming stale heading text,
+  tightening preview lifecycle wording, blocking goal-oriented preview archive
+  before any archived artifact is written, and polishing the explicit-standard
+  lint diagnostic.
+- Repair review `review-002-delta` passed across correctness,
+  docs-consistency, tests, and risk-scan with no findings.
+- Finalize review `review-003-full` passed across correctness, tests, and
+  risk-scan with no findings and one non-blocking docs-consistency finding;
+  the non-blocking lint-diagnostic wording issue was fixed afterward.
 
 ## Archive Summary
 
-PENDING_UNTIL_ARCHIVE
+- PR: NONE
+- Ready: Candidate is ready for publish/CI/sync evidence after archive.
+  Acceptance criteria are checked, tracked steps are complete, focused and
+  broad-minus-release validation passed, final full review passed, and the
+  only blocked broad check is the known missing-`corepack` release-test
+  environment gap.
+- Merge Handoff: Commit the archive move, push
+  `codex/270-goal-oriented-template`, open a PR for #270, record publish, CI,
+  and sync evidence through harness, and wait for explicit human merge
+  approval.
 
 ## Outcome Summary
 
 ### Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Added `harness plan template --goal-oriented`, a goal-oriented authoring
+  preview variant that seeds `workflow_profile: goal_oriented`, setup,
+  adaptive exploration, synthesis, closeout, and step-local checkpoint report
+  anchors.
+- Added `WorkflowProfileGoalOriented` and shallow active-plan lint recognition
+  for the preview profile without adding full structural lint enforcement.
+- Added archive preflight rejection for goal-oriented preview plans so the CLI
+  does not write a lint-invalid archived artifact before archive/reopen support
+  lands.
+- Updated goal-oriented workflow, plan schema, state model, CLI contract, spec
+  index, and harness-plan skill guidance to describe `goal_oriented` as a
+  recognized preview workflow profile for v0.6.0 authoring.
+- Synced the bootstrap-managed harness-plan skill into `.agents/skills/`.
+- Added focused tests for CLI flag behavior, generated template shape, active
+  preview lint, archive preflight rejection, and diagnostic wording.
 
 ### Not Delivered
 
-PENDING_UNTIL_ARCHIVE
+- Full goal-oriented execution support, status next actions, archive/reopen
+  profile preservation, challenge/review guidance, public docs/examples, and
+  UI checkpoint rendering remain out of scope.
+- No hypothesis state machine or separate workflow engine was added.
+- No default standard or lightweight behavior was changed.
+- No full structural lint enforcement for objective, scorecard, hypotheses,
+  checkpoint cadence, checkpoint report quality, or final synthesis was added.
 
 ### Follow-Up Issues
 
-NONE
+- #272: Add evidence-validity review and hypothesis-challenge guidance.
+- #273: Teach next actions for goal-oriented plans.
+- #274: Add full lint coverage for goal-oriented plans.
+- #275: Add docs and examples for goal-oriented workflow.
+- #276: Add UI support for goal-oriented checkpoint timelines.

--- a/docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md
+++ b/docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md
@@ -1,0 +1,323 @@
+---
+template_version: 0.2.0
+created_at: "2026-07-05T18:15:56+08:00"
+approved_at: "2026-07-05T18:26:33+08:00"
+source_type: github_issue
+source_refs:
+    - https://github.com/catu-ai/easyharness/issues/270
+    - https://github.com/catu-ai/easyharness/pull/284
+size: S
+---
+
+# Add Goal-Oriented Plan Authoring Preview
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb any repository-facing normative content into formal tracked locations
+before archive, and record archive-time supplement absorption in Archive
+Summary or Outcome Summary. Lightweight plans should normally avoid
+supplements. -->
+
+## Goal
+
+Add a first-class authoring preview for `workflow_profile: goal_oriented` so
+controllers can draft credible goal-oriented tracked plans from repository
+guidance alone, without implying the full v0.6.0 execution surface has shipped.
+
+The finished slice should make `goal_oriented` recognizable as a defined
+preview workflow profile for v0.6.0 authoring. It should seed or document a
+stable plan shape with objective, scorecard, hypotheses, checkpoint cadence,
+tracked checkpoint reports, evidence requirements, stopping conditions, and
+final synthesis, while leaving full execution support, challenge/review
+guidance, status next actions, structural lint coverage, and public examples to
+the sibling v0.6.0 issues.
+
+## Scope
+
+### In Scope
+
+- Add goal-oriented authoring guidance and, if the existing CLI shape supports
+  it cleanly, a dedicated `harness plan template` variant for the preview
+  profile.
+- Show the stable goal-oriented step shape: setup, adaptive exploration,
+  synthesis, and closeout.
+- Make the generated or documented shape include objective, success scorecard,
+  hypotheses or candidate directions, checkpoint cadence, checkpoint report
+  anchors, evidence requirements, challenge triggers, stopping conditions, and
+  final synthesis.
+- Keep checkpoint reports under goal-oriented steps rather than turning each
+  checkpoint into a separate harness workflow step.
+- Clearly label `workflow_profile: goal_oriented` as a recognized preview
+  workflow profile defined for v0.6.0 authoring while full execution support is
+  still being completed.
+- Add only the narrow CLI or lint recognition needed to avoid misleading users
+  about the authoring preview, without adding full goal-oriented lint
+  enforcement.
+- Update bootstrap-managed agent guidance from `assets/bootstrap/` if the
+  harness-managed skills or managed `AGENTS.md` block need new authoring cues,
+  then sync materialized assets.
+- Add focused tests or validation for the authoring/template behavior and the
+  chosen preview boundary.
+
+### Out of Scope
+
+- Implementing a hypothesis state machine or separate workflow engine.
+- Changing default `standard` or `lightweight` behavior.
+- Adding full goal-oriented execution guidance, status next actions, archive
+  and reopen support, challenge/review protocol, or UI rendering.
+- Adding broad structural lint coverage for goal-oriented plans; #274 owns
+  full lint enforcement.
+- Adding user-facing docs, examples, or tutorials beyond the repo guidance
+  needed for this authoring preview; #275 owns broader docs/examples.
+- Changing review aggregation semantics.
+
+## Acceptance Criteria
+
+- [ ] A controller can draft a credible goal-oriented tracked plan from the
+      template and repository guidance without relying on hidden issue or chat
+      context.
+- [ ] The authoring shape includes setup, adaptive exploration, synthesis, and
+      closeout phases and names where tracked checkpoint reports live.
+- [ ] Goal-oriented plans require objective, success scorecard, hypotheses or
+      candidate directions, checkpoint cadence, evidence requirements,
+      challenge triggers, stopping conditions, and final synthesis.
+- [ ] The guidance says checkpoint reports live inside goal-oriented steps and
+      do not automatically become separate harness workflow steps.
+- [ ] The CLI, docs, or both describe `workflow_profile: goal_oriented` as a
+      recognized preview workflow profile defined for v0.6.0 authoring, with
+      full execution support still being completed.
+- [ ] Existing standard and lightweight template behavior remains unchanged
+      unless the caller explicitly requests the goal-oriented preview.
+- [ ] Any lint or CLI guard added in this slice is explicitly narrow preview
+      recognition, not full #274 structural lint enforcement.
+- [ ] Deferred sibling issues #272, #273, #274, and #275 remain named as the
+      owners for challenge/review guidance, next actions, lint coverage, and
+      docs/examples.
+
+## Deferred Items
+
+- #272 owns evidence-validity review and hypothesis-challenge guidance.
+- #273 owns status and next-action behavior for goal-oriented plans.
+- #274 owns full lint coverage for goal-oriented structure.
+- #275 owns user-facing docs, help text, and examples.
+- #276 owns any UI checkpoint timeline support.
+
+## Work Breakdown
+
+### Step 1: Align the authoring contract
+
+- Done: [x]
+
+#### Objective
+
+Decide the narrow implementation shape for the goal-oriented authoring preview
+and align the normative wording before touching behavior.
+
+#### Details
+
+Read the current goal-oriented workflow spec, plan schema, state model, plan
+template code, template CLI help, lint path/profile checks, and the archived
+#271 checkpoint-report plan together.
+
+Use that context to choose the smallest durable change that makes
+`goal_oriented` authorable without pretending it is fully deliverable. The
+likely target is a preview authoring template plus narrow profile recognition.
+If inspection shows that making generated goal-oriented plans lint-valid would
+absorb #274 or imply full archive/reopen support, stop and keep the generated
+shape documented as preview-only instead.
+
+#### Expected Files
+
+- `docs/specs/goal-oriented-workflow.md`
+- `docs/specs/plan-schema.md`
+- `internal/plan/template.go`
+- `internal/plan/lint.go`
+- `internal/cli/app.go`
+- `assets/templates/plan-template.md`
+- `assets/bootstrap/skills/harness-plan/SKILL.md`
+
+#### Validation
+
+- The selected implementation path is written into this plan's execution notes
+  with an explicit boundary for #272, #273, #274, and #275.
+- Targeted searches show no wording that claims full goal-oriented execution,
+  status, archive, reopen, challenge/review, or lint support has shipped.
+
+#### Execution Notes
+
+Selected a narrow #270 implementation path: add `harness plan template
+--goal-oriented` as a recognized preview authoring variant, seed
+`workflow_profile: goal_oriented` plus the required goal-oriented plan
+concepts, and add shallow active-plan lint recognition so generated preview
+plans can lint from a valid active-plan path. Full structural lint coverage,
+status next actions, challenge/review guidance, archive/reopen profile
+preservation, docs/examples, and UI behavior remain deferred to #272, #273,
+#274, #275, and #276. Targeted searches found no remaining stale wording that
+describes `goal_oriented` as not lint-valid or not yet templated.
+
+#### Review Notes
+
+NO_STEP_REVIEW_NEEDED: This step recorded the contract decision and boundary;
+the behavior and documentation changes are implemented and reviewed under Step
+2 and final validation.
+
+### Step 2: Implement the preview authoring shape
+
+- Done: [ ]
+
+#### Objective
+
+Add the goal-oriented preview template or equivalent authoring guidance, plus
+focused recognition tests, while preserving existing standard and lightweight
+behavior.
+
+#### Details
+
+The goal-oriented shape should seed stable phase boundaries rather than a
+linear list of every future probe:
+
+- setup and scorecard framing;
+- adaptive exploration with checkpoint reports under the step body;
+- synthesis of accepted conclusions, rejected hypotheses, residuals, evidence,
+  and follow-up;
+- closeout/validation/archive readiness.
+
+The preview should include anchors or headings that future lint/status work can
+consume shallowly, but this slice must not implement full structural linting.
+If the implementation touches bootstrap-managed skills or the managed root
+`AGENTS.md` block, edit `assets/bootstrap/` first and run
+`scripts/sync-bootstrap-assets`.
+
+#### Expected Files
+
+- `internal/plan/template.go`
+- `internal/cli/app.go`
+- `internal/cli/app_test.go`
+- `assets/templates/plan-template.md`
+- `docs/specs/goal-oriented-workflow.md`
+- `docs/specs/plan-schema.md`
+- `assets/bootstrap/skills/harness-plan/SKILL.md`
+- `.agents/skills/harness-plan/SKILL.md`
+
+#### Validation
+
+- Add or update focused tests proving standard and lightweight templates keep
+  their existing shape.
+- Add focused tests for any new goal-oriented template flag, rendering path, or
+  narrow lint/profile guard.
+- Run `scripts/sync-bootstrap-assets` if bootstrap assets change.
+
+#### Execution Notes
+
+Implemented the goal-oriented authoring preview. Added
+`WorkflowProfileGoalOriented`, `harness plan template --goal-oriented`, a
+three-step preview template shape, a `#### Checkpoint Reports` step subsection
+anchor, and shallow active-plan lint recognition for
+`workflow_profile: goal_oriented`. Archived goal-oriented plans still fail lint
+with preview-boundary wording because archive/reopen profile preservation is
+out of scope. Updated the goal-oriented workflow, plan schema, state model,
+CLI contract, spec index, and harness-plan skill guidance from
+`assets/bootstrap/`, then synced materialized `.agents/skills/` output.
+Validation so far: `go test ./internal/plan ./internal/cli`, generated
+template text check for preview/checkpoint anchors, and generated active-plan
+lint smoke test all passed.
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+### Step 3: Validate and prepare for review
+
+- Done: [ ]
+
+#### Objective
+
+Confirm the #270 slice is internally consistent, tested, and PR-ready without
+expanding into the rest of the v0.6.0 goal-oriented capability.
+
+#### Details
+
+Validate that the candidate can generate or document a credible goal-oriented
+plan, that it uses checkpoint report terminology from #271/PR #284, and that
+it clearly describes the preview boundary. Check that no default standard or
+lightweight behavior changed.
+
+#### Expected Files
+
+- `docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md`
+- Any files changed in Steps 1 and 2
+
+#### Validation
+
+- Run `harness plan lint docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md`.
+- Run focused Go tests for plan template and CLI behavior.
+- Run `git diff --check`.
+- Run targeted `rg` checks for `goal_oriented`, `recognized preview workflow
+  profile`, `checkpoint reports`, `full execution support`, and sibling issue
+  boundaries.
+- Run broader validation only if the final change touches shared behavior
+  beyond the template/profile-recognition surface; record any environment
+  blockers exactly.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+## Validation Strategy
+
+- Lint this active plan before approval and again before archive.
+- Use focused unit tests for CLI/template/profile behavior because this slice
+  is primarily an authoring/template change.
+- Use targeted text checks to confirm the preview boundary and sibling issue
+  ownership remain explicit.
+- Run `git diff --check`.
+- If bootstrap assets change, run `scripts/sync-bootstrap-assets` and inspect
+  the materialized diff.
+- Run broader Go or repository validation if implementation affects shared
+  plan loading, lint, status, archive, or reopen behavior; otherwise keep
+  validation focused and explain why.
+
+## Risks
+
+- Risk: The template makes users think the full goal-oriented workflow has
+  shipped.
+  - Mitigation: Label the profile as a recognized preview workflow profile and
+    explicitly state that full execution support is still being completed.
+- Risk: A narrow lint or CLI change accidentally absorbs #274.
+  - Mitigation: Limit this slice to profile/template recognition and avoid
+    structural quality checks for scorecards, hypotheses, checkpoints, or
+    synthesis.
+- Risk: The new authoring path regresses standard or lightweight defaults.
+  - Mitigation: Add focused regression tests for the existing template modes.
+- Risk: The plan shape encourages one harness step per checkpoint.
+  - Mitigation: Seed checkpoint reports inside adaptive steps and repeat that
+    checkpoint reports do not automatically become separate workflow steps.
+
+## Validation Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Review Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Archive Summary
+
+PENDING_UNTIL_ARCHIVE
+
+## Outcome Summary
+
+### Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Not Delivered
+
+PENDING_UNTIL_ARCHIVE
+
+### Follow-Up Issues
+
+NONE

--- a/docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md
+++ b/docs/plans/active/2026-07-05-add-goal-oriented-plan-authoring-preview.md
@@ -221,6 +221,18 @@ Validation so far: `go test ./internal/plan ./internal/cli`, generated
 template text check for preview/checkpoint anchors, and generated active-plan
 lint smoke test all passed.
 
+Repair after `review-001-delta`: preserved the explicit size-placeholder
+contract for goal-oriented templates unless `--size` is supplied, added a
+generated-template lint test, renamed stale reserved-profile wording, tightened
+goal-oriented docs so lifecycle support is described as target behavior rather
+than available preview behavior, and added archive preflight rejection for
+goal-oriented preview plans so archive does not write a lint-invalid artifact.
+Repair validation passed for `go test ./internal/plan ./internal/cli
+./internal/lifecycle`, generated `--goal-oriented --size M` template text and
+lint smoke checks, `harness plan lint` on this plan, `git diff --check`, and
+`go test $(go list ./... | grep -v '/tests/release$')`. `go test ./...`
+remains blocked only in `tests/release` because `corepack` is not on PATH.
+
 #### Review Notes
 
 PENDING_STEP_REVIEW

--- a/docs/plans/archived/2026-07-05-add-goal-oriented-plan-authoring-preview.md
+++ b/docs/plans/archived/2026-07-05-add-goal-oriented-plan-authoring-preview.md
@@ -360,6 +360,8 @@ finalize review.
 
 ## Archive Summary
 
+- Archived At: 2026-07-05T19:05:17+08:00
+- Revision: 1
 - PR: NONE
 - Ready: Candidate is ready for publish/CI/sync evidence after archive.
   Acceptance criteria are checked, tracked steps are complete, focused and

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -453,12 +453,14 @@ Contract:
   lightweight template with explicit `size: XXS`
 - in standard mode, preserve current behavior when `workflow_profile` is
   omitted
-- goal-oriented authoring support belongs to the goal-oriented template slice;
-  when added, it should seed `workflow_profile: goal_oriented` and the
-  required concepts from [Goal-Oriented Workflow](./goal-oriented-workflow.md)
-  without changing ordinary standard or lightweight authoring; until that
-  implementation lands, `workflow_profile: goal_oriented` is a reserved
-  contract value rather than a lint-valid template output
+- goal-oriented authoring support is exposed through `--goal-oriented`; it
+  seeds `workflow_profile: goal_oriented` and the required authoring concepts
+  from [Goal-Oriented Workflow](./goal-oriented-workflow.md) without changing
+  ordinary standard or lightweight authoring
+- `workflow_profile: goal_oriented` is a recognized preview workflow profile
+  for active-plan authoring; full execution support, archive/reopen behavior,
+  status next actions, challenge/review guidance, docs/examples, and
+  structural lint coverage remain follow-up work
 
 The template asset belongs to the harness version, not to the user's tracked
 plan history. Upgrading the harness may upgrade the generated template for new

--- a/docs/specs/goal-oriented-workflow.md
+++ b/docs/specs/goal-oriented-workflow.md
@@ -10,9 +10,12 @@ are explicit, but the path to the result must adapt through hypotheses,
 probes, checkpoint rounds, optional challenge, and synthesis.
 
 `goal_oriented` is a profile on top of the existing harness workflow. It does
-not create a separate workflow engine. Goal-oriented plans still use explicit
-human approval, stable plan steps, formal step-closeout and finalize review,
-archive, evidence, and the canonical node state model.
+not create a separate workflow engine. The completed v0.6.0 profile is
+designed to use explicit human approval, stable plan steps, formal
+step-closeout and finalize review, archive, evidence, and the canonical node
+state model. In the current authoring preview, agents can draft and lint active
+tracked goal-oriented plans, but must not rely on full lifecycle support until
+the follow-up implementation slices land.
 
 `goal_oriented` is a recognized preview workflow profile for v0.6.0 authoring.
 `harness plan template --goal-oriented` can seed the goal-oriented plan shape,
@@ -46,9 +49,10 @@ synthesis, the ordinary standard workflow is clearer.
 ## Workflow Profile Semantics
 
 `workflow_profile: goal_oriented` means the active plan is a standard tracked
-plan with an adaptive execution contract. It is not a lightweight shortcut.
+plan with an adaptive authoring contract. It is not a lightweight shortcut.
 
-The profile preserves these core harness boundaries:
+The completed profile preserves these core harness boundaries once full
+execution support lands:
 
 - human approval still approves the tracked plan package
 - plan steps still represent stable approved phase boundaries
@@ -60,11 +64,14 @@ The profile preserves these core harness boundaries:
 - `current_node` still comes from the canonical state model, not from plan
   prose or checkpoint markdown
 
-Goal-oriented execution adds a disciplined layer inside approved steps: the
-controller runs bounded checkpoint rounds, records concise tracked checkpoint
-reports when the work reaches meaningful decision points, optionally requests
-challenge when hypotheses or evidence need stress testing, and writes a final
-synthesis before closeout.
+The current authoring preview seeds these concepts so future work can be
+planned credibly, while archive/reopen behavior, status next actions,
+challenge/review guidance, and full structural lint remain follow-up work.
+Goal-oriented execution will add a disciplined layer inside approved steps:
+the controller runs bounded checkpoint rounds, records concise tracked
+checkpoint reports when the work reaches meaningful decision points,
+optionally requests challenge when hypotheses or evidence need stress testing,
+and writes a final synthesis before closeout.
 
 ## Plan Requirements
 

--- a/docs/specs/goal-oriented-workflow.md
+++ b/docs/specs/goal-oriented-workflow.md
@@ -14,12 +14,13 @@ not create a separate workflow engine. Goal-oriented plans still use explicit
 human approval, stable plan steps, formal step-closeout and finalize review,
 archive, evidence, and the canonical node state model.
 
-This document defines the product contract before the supporting CLI surfaces
-are implemented. Until the follow-up implementation slices add authoring,
-lint, status, archive, and reopen support, agents must not assume that a
-tracked plan containing `workflow_profile: goal_oriented` will pass
-`harness plan lint` or that archive/reopen will preserve goal-oriented profile
-identity automatically.
+`goal_oriented` is a recognized preview workflow profile for v0.6.0 authoring.
+`harness plan template --goal-oriented` can seed the goal-oriented plan shape,
+and `harness plan lint` recognizes active tracked plans that declare
+`workflow_profile: goal_oriented` with shallow preview validation. Full
+execution support is still being completed: follow-up implementation slices own
+status next actions, challenge/review guidance, structural lint coverage,
+archive/reopen profile preservation, docs/examples, and UI rendering.
 
 ## When To Use It
 
@@ -87,9 +88,8 @@ agent can resume without hidden chat context:
     checkpoint reports for the main exploration step"
   - a cadence is guidance for keeping the work bounded, not a global hard
     minimum or maximum
-  - follow-up template and lint work must give this cadence a stable
-    parseable anchor, such as a dedicated heading, bounded metadata block, or
-    another explicit structure
+  - the preview template gives this cadence a stable authoring anchor, and
+    follow-up lint/status work may tighten the parseable contract as needed
 - `challenge triggers`
   - when advisory challenge should be considered or is required by the plan
 - `evidence requirements`
@@ -101,18 +101,17 @@ agent can resume without hidden chat context:
   - the closeout explanation of accepted conclusions, rejected hypotheses,
     residual uncertainty, evidence, and follow-up work
 
-The plan may express these concepts in dedicated sections, step details, or a
-goal-oriented template once that template exists. The contract requires the
-meaning, not a particular heading set in this first slice.
+The plan may express these concepts in dedicated sections, step details, or
+the goal-oriented template shape. The preview template uses stable authoring
+anchors, but the full structural lint contract remains follow-up work.
 
 Future lint and status support must not rely on unstructured prose guessing.
-The implementation slices that make `workflow_profile: goal_oriented`
-lint-valid must choose stable parseable anchors for the fields status and lint
-need, especially the success scorecard, checkpoint cadence, tracked
-checkpoint report index, and final synthesis. Prefer plan-body structure for
-goal-oriented working concepts; reserve frontmatter for durable command-level
-metadata such as profile selection unless a field truly affects command
-resolution.
+Those implementation slices may consume stable parseable anchors for the
+fields status and lint need, especially the success scorecard, checkpoint
+cadence, tracked checkpoint report index, and final synthesis. Prefer
+plan-body structure for goal-oriented working concepts; reserve frontmatter for
+durable command-level metadata such as profile selection unless a field truly
+affects command resolution.
 
 ## Steps, Checkpoint Rounds, And Model Turns
 
@@ -308,11 +307,13 @@ substitute for explicit plan lint or formal review.
 
 `harness plan lint` remains the explicit validation surface for tracked plans.
 
-Goal-oriented lint coverage belongs in a follow-up implementation slice. That
-coverage may check structural requirements such as objective, success
-scorecard, checkpoint cadence, tracked checkpoint report anchors, and final
-synthesis presence. It should avoid judging whether a hypothesis is good or
-whether evidence is persuasive; those are review and challenge concerns.
+Current goal-oriented lint support is intentionally shallow preview
+recognition for active tracked plans. Full coverage belongs in a follow-up
+implementation slice. That coverage may check structural requirements such as
+objective, success scorecard, checkpoint cadence, tracked checkpoint report
+anchors, and final synthesis presence. It should avoid judging whether a
+hypothesis is good or whether evidence is persuasive; those are review and
+challenge concerns.
 
 Status may point the controller toward lint when tracked checkpoint reports or
 final synthesis change, but status should not silently run or replace full
@@ -349,11 +350,12 @@ This contract now owns the #271 checkpoint report convention. It intentionally
 leaves the remaining goal-oriented implementation details to the v0.6.0
 follow-up issues:
 
-- #270 adds the goal-oriented plan template and workflow guidance
+- #270 adds the goal-oriented plan template and authoring-preview workflow
+  guidance
 - #272 adds evidence-validity and hypothesis-challenge guidance
 - #273 teaches status and next-action behavior for goal-oriented plans
-- #274 adds lint coverage for goal-oriented plans, including when
-  `workflow_profile: goal_oriented` becomes a lint-valid active-plan value
+- #274 adds full structural lint coverage for goal-oriented plans beyond the
+  shallow active-plan preview recognition
 - #275 adds user-facing docs, help text, and examples
 
 The implementation slices must also define how archive and reopen preserve the

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -6,13 +6,13 @@
 - [State Transitions](./state-transitions.md): exhaustive enumeration of every
   allowed v0.2 `current_node` transition, including command-driven milestones
   and derived progression rules.
-- [Plan Schema](./plan-schema.md): shared plan contract for tracked `standard`
-  and `lightweight` plans, their markdown-led package layout, and local state
-  expectations.
+- [Plan Schema](./plan-schema.md): shared plan contract for tracked `standard`,
+  `lightweight`, and goal-oriented authoring-preview plans, their
+  markdown-led package layout, and local state expectations.
 - [Goal-Oriented Workflow](./goal-oriented-workflow.md): normative
-  reserved `workflow_profile: goal_oriented` contract for adaptive work with
-  explicit objectives, scorecards, checkpoint reports, optional challenge,
-  evidence, and final synthesis.
+  `workflow_profile: goal_oriented` authoring-preview contract for adaptive
+  work with explicit objectives, scorecards, checkpoint reports, optional
+  challenge, evidence, and final synthesis.
 - [Bootstrap Install](./bootstrap-install.md): normative bootstrap resource
   model for `harness repo init`, `harness repo skills ...`,
   `harness repo instructions ...`, and `harness repo config ...`, including

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -4,21 +4,23 @@
 
 This document defines the normative v0.2 plan contract for `easyharness`.
 
-In v0.2, standard and lightweight plans share one markdown schema, but the
-durable planning unit is a markdown-led plan package rather than a lone file.
-Active plans for both currently implemented profiles live in tracked markdown
-under the active plan root resolved by
+In v0.2, standard, lightweight, and the goal-oriented authoring preview share
+one markdown schema, but the durable planning unit is a markdown-led plan
+package rather than a lone file. Active plans for currently recognized
+profiles live in tracked markdown under the active plan root resolved by
 `harness repo config get paths.plans.active`, which defaults to
 `docs/plans/active/`, and may carry approval-scoped companion material under a
 matching `supplements/<plan-stem>/` directory. Lightweight diverges only at
 archive time, when the archived snapshot moves into command-owned local
-storage. The reserved goal-oriented profile contract is defined separately in
-[Goal-Oriented Workflow](./goal-oriented-workflow.md); authoring, lint,
-archive, and reopen support for `workflow_profile: goal_oriented` belongs to
-the follow-up implementation slices. Runtime lifecycle, milestone timestamps,
-review rounds, evidence history, and resolved node state live in the local
-runtime root resolved by `harness repo config get paths.local_runtime`, which
-defaults to `.local/harness/`.
+storage. The goal-oriented profile contract is defined separately in
+[Goal-Oriented Workflow](./goal-oriented-workflow.md); authoring template and
+active-plan preview lint recognition exist, while full structural lint,
+archive, reopen, status, challenge/review, docs/examples, and UI support
+belongs to follow-up implementation slices. Runtime lifecycle, milestone
+timestamps, review rounds, evidence history, and resolved node state live in
+the local runtime root resolved by
+`harness repo config get paths.local_runtime`, which defaults to
+`.local/harness/`.
 Agents and scripts that need concrete resolved roots should query them with
 `harness repo config get paths.plans.active`,
 `harness repo config get paths.plans.archived`, and
@@ -82,11 +84,12 @@ contracts.
 
 The source-of-truth split is:
 
-- this schema document defines the shared markdown plan contract for standard
-  and lightweight profiles
-- [Goal-Oriented Workflow](./goal-oriented-workflow.md) defines the reserved
-  adaptive semantics for `workflow_profile: goal_oriented`, with authoring,
-  lint, archive, and reopen support left to follow-up implementation slices
+- this schema document defines the shared markdown plan contract for standard,
+  lightweight, and goal-oriented authoring-preview profiles
+- [Goal-Oriented Workflow](./goal-oriented-workflow.md) defines the recognized
+  preview authoring semantics for `workflow_profile: goal_oriented`, with full
+  structural lint, archive, reopen, status, challenge/review, docs/examples,
+  and UI support left to follow-up implementation slices
 - [the packaged plan template asset](../../assets/templates/plan-template.md)
   is the canonical authoring example shipped by harness
 - `harness plan template` is a convenience wrapper around the packaged asset
@@ -239,21 +242,21 @@ approved_at: 2026-03-17T10:30:00+08:00
     including any matching `supplements/<plan-stem>/` directory
 - `workflow_profile`
   - optional explicit workflow selector
-  - supported value is `lightweight`
+  - supported active-plan values are `lightweight` and `goal_oriented`
   - omitted means `standard`
   - `standard` must not be written explicitly; omitting the field preserves
     the current standard behavior
   - tracked plans under the active plan root resolved by
     `harness repo config get paths.plans.active` may set this field only to
-    `lightweight`
+    `lightweight` or the `goal_oriented` authoring preview
   - tracked plans under the archived plan root resolved by
     `harness repo config get paths.plans.archived` must omit this field
   - local archived plans under the lightweight archived snapshot root must set
     it to `lightweight`
-  - `workflow_profile: goal_oriented` is reserved by
-    [Goal-Oriented Workflow](./goal-oriented-workflow.md), but is not a
-    currently lint-valid plan frontmatter value until the goal-oriented
-    authoring and lint implementation slices land
+  - `workflow_profile: goal_oriented` is recognized by
+    [Goal-Oriented Workflow](./goal-oriented-workflow.md) for active-plan
+    authoring preview only; archive/reopen profile preservation and full
+    structural lint coverage belong to follow-up implementation work
 
 ## Lightweight Eligibility
 
@@ -301,12 +304,11 @@ v0.2 plans must not carry these top-level runtime fields:
 - `updated_at`
 
 Path placement plus optional `workflow_profile: lightweight` answer whether a
-plan is standard or lightweight and whether it is active or archived. The
-reserved `workflow_profile: goal_oriented` contract is documented in
-[Goal-Oriented Workflow](./goal-oriented-workflow.md), but its concrete
-frontmatter, lint, archive, and reopen behavior belongs to follow-up
-implementation work. Runtime milestones and revision history belong in
-command-owned artifacts, not plan frontmatter.
+plan is standard or lightweight and whether it is active or archived.
+`workflow_profile: goal_oriented` is a recognized preview workflow profile for
+active-plan authoring. Its full structural lint, archive, and reopen behavior
+belongs to follow-up implementation work. Runtime milestones and revision
+history belong in command-owned artifacts, not plan frontmatter.
 
 ## Required Sections
 
@@ -383,6 +385,7 @@ Every step must also contain:
 Optional step section:
 
 - `#### Step Acceptance Criteria`
+- `#### Checkpoint Reports`
 
 Rules:
 
@@ -395,6 +398,9 @@ Rules:
   step is too small or low risk to justify a separate step-closeout review
 - if `Step Acceptance Criteria` exists, every entry must be a markdown checkbox
 - archived plans require all step-local acceptance checkboxes to be checked
+- `Checkpoint Reports` is intended for goal-oriented adaptive steps and may
+  carry tracked checkpoint report headings such as `##### CP1 - ...`; it is a
+  preview authoring anchor, not full structural lint enforcement
 - when discovery detail is too bulky for `Details`, move that material into the
   matching `supplements/<plan-stem>/` package directory rather than burying it
   only in chat history
@@ -510,11 +516,12 @@ When there is any doubt, escalate to the standard tracked-plan workflow.
 success scorecard are explicit, but the path must proceed through hypotheses,
 probes, checkpoint rounds, optional challenge, and final synthesis.
 
-This value is a reserved profile contract, not a currently lint-valid plan
-frontmatter value. Goal-oriented authoring, lint, archive, status, and reopen
-support belongs to the v0.6.0 follow-up implementation slices. Until that
-support lands, plan authors should not expect a tracked plan containing
-`workflow_profile: goal_oriented` to pass `harness plan lint`.
+This value is a recognized preview workflow profile for active-plan authoring.
+`harness plan template --goal-oriented` can seed the plan shape, and
+`harness plan lint` recognizes active tracked plans that declare
+`workflow_profile: goal_oriented` with shallow preview validation. Full
+structural lint, archive, status, and reopen support belongs to the v0.6.0
+follow-up implementation slices.
 
 The target profile uses standard tracked plan packages for path and archive
 purposes. It does not create a separate local active path, local archive path,
@@ -555,7 +562,8 @@ An active plan must satisfy all of these:
 - the required frontmatter fields are present
 - any optional `workflow_profile` field is compatible with the path:
   - omitted means `standard`
-  - explicit `workflow_profile` is allowed only for `lightweight`
+  - explicit `workflow_profile` is allowed only for `lightweight` or the
+    `goal_oriented` authoring preview
 - every step uses a `Done` marker
 - archive-only summary sections may still contain the documented active-plan
   placeholders
@@ -567,7 +575,7 @@ An active plan must satisfy all of these:
   supported but should be exceptional rather than the default way to carry plan
   detail
 - future goal-oriented implementation work must update these rules before
-  `workflow_profile: goal_oriented` becomes a lint-valid active-plan value
+  full structural lint or execution support is treated as complete
 
 ## Archived Plan Rules
 
@@ -683,6 +691,8 @@ Mode-specific rules:
     resolved by `harness repo config get paths.local_runtime`
 - plan markdown stored under a `supplements/` subtree
 - plans whose path and `workflow_profile` disagree
+- archived plans that declare the `goal_oriented` authoring preview before
+  archive/reopen profile preservation is implemented
 - supplements paths that are present but are not directories
 - archived plans with unchecked acceptance criteria, incomplete steps, or
   unchecked step-local acceptance criteria

--- a/docs/specs/plan-schema.md
+++ b/docs/specs/plan-schema.md
@@ -510,7 +510,7 @@ it as durable tracked history.
 
 When there is any doubt, escalate to the standard tracked-plan workflow.
 
-## Reserved Goal-Oriented Profile
+## Goal-Oriented Authoring Preview
 
 `workflow_profile: goal_oriented` is for adaptive work where the objective and
 success scorecard are explicit, but the path must proceed through hypotheses,

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -98,13 +98,14 @@ schema and the same active-plan root resolved by
 `harness repo config get paths.plans.active`, but its archived snapshot moves
 under the local runtime root resolved by
 `harness repo config get paths.local_runtime` so the workflow can stay
-lightweight for narrow low-risk changes. The reserved goal-oriented profile is
-specified as using the same canonical node tree while adding adaptive plan
-semantics for checkpoint reports, challenge, evidence, and synthesis, but its
-frontmatter, lint, archive, status, and reopen support belongs to follow-up
-implementation work. Runtime trajectory, milestone timestamps, and
-external-fact capture also belong in the resolved local runtime root. There is
-no separate local active lightweight plan path in this model.
+lightweight for narrow low-risk changes. The goal-oriented profile is
+recognized for active-plan authoring preview and uses the same canonical node
+tree while adding adaptive plan semantics for checkpoint reports, challenge,
+evidence, and synthesis. Full structural lint, archive, status, and reopen
+support belongs to follow-up implementation work. Runtime trajectory,
+milestone timestamps, and external-fact capture also belong in the resolved
+local runtime root. There is no separate local active lightweight plan path in
+this model.
 
 ### Explicit Command Boundaries
 
@@ -266,10 +267,10 @@ The exact transition matrix is normative in
 
 Workflow profiles do not add a second node tree. Lightweight reuses the same
 canonical nodes while changing where the archived snapshot lives and what
-closeout guidance `harness status` should emphasize. The reserved
-goal-oriented profile is specified to reuse the same canonical nodes once
-implemented; checkpoint reports and challenge notes may inform guidance, but
-they must not derive, mutate, or override `current_node`.
+closeout guidance `harness status` should emphasize. The goal-oriented
+authoring preview reuses the same canonical nodes; checkpoint reports and
+challenge notes may inform guidance, but they must not derive, mutate, or
+override `current_node`.
 
 ## Node Semantics
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -883,6 +883,7 @@ func (a *App) runPlanTemplate(args []string) int {
 	title := fs.String("title", "", "Seed the H1 title.")
 	output := fs.String("output", "", "Write the rendered template to this file instead of stdout.")
 	lightweight := fs.Bool("lightweight", false, "Render the lightweight variant and seed workflow_profile: lightweight.")
+	goalOriented := fs.Bool("goal-oriented", false, "Render the goal-oriented authoring preview variant and seed workflow_profile: goal_oriented.")
 	dateValue := fs.String("date", "", "Seed timestamps using this YYYY-MM-DD date with the current local time-of-day.")
 	timestampValue := fs.String("timestamp", "", "Seed timestamps using this RFC3339 timestamp.")
 	sourceType := fs.String("source-type", "direct_request", "Seed the frontmatter source_type field.")
@@ -906,6 +907,10 @@ func (a *App) runPlanTemplate(args []string) int {
 		fmt.Fprintln(a.Stderr, "harness plan template does not accept positional arguments")
 		return 2
 	}
+	if *lightweight && *goalOriented {
+		fmt.Fprintln(a.Stderr, "choose only one workflow profile template flag")
+		return 2
+	}
 
 	ts, err := a.resolveTimestamp(*timestampValue, *dateValue)
 	if err != nil {
@@ -922,6 +927,9 @@ func (a *App) runPlanTemplate(args []string) int {
 		WorkflowProfile: func() string {
 			if *lightweight {
 				return plan.WorkflowProfileLightweight
+			}
+			if *goalOriented {
+				return plan.WorkflowProfileGoalOriented
 			}
 			return ""
 		}(),

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -295,6 +295,50 @@ func TestPlanTemplateLightweightRejectsNonXXSSize(t *testing.T) {
 	}
 }
 
+func TestPlanTemplateGoalOrientedFlagSeedsPreviewVariant(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{"plan", "template", "--title", "Goal Plan", "--goal-oriented"})
+	if exitCode != 0 {
+		t.Fatalf("expected goal-oriented template success, got %d: %s", exitCode, stderr.String())
+	}
+	for _, want := range []string{
+		"workflow_profile: goal_oriented",
+		"recognized preview workflow profile",
+		"full execution support is still being completed",
+		"### Step 2: Run adaptive exploration",
+		"#### Checkpoint Reports",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("goal-oriented template missing %q\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestPlanTemplateRejectsConflictingWorkflowProfileFlags(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+
+	exitCode := app.Run([]string{
+		"plan", "template",
+		"--title", "Conflicting Plan",
+		"--lightweight",
+		"--goal-oriented",
+	})
+	if exitCode != 2 {
+		t.Fatalf("expected conflicting profile flags to fail with exit code 2, got %d: %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "choose only one workflow profile template flag") {
+		t.Fatalf("expected profile conflict error, got %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout on error, got %q", stdout.String())
+	}
+}
+
 func TestRootHelpMentionsVersionFlag(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -306,6 +306,7 @@ func TestPlanTemplateGoalOrientedFlagSeedsPreviewVariant(t *testing.T) {
 	}
 	for _, want := range []string{
 		"workflow_profile: goal_oriented",
+		"size: REPLACE_WITH_PLAN_SIZE",
 		"recognized preview workflow profile",
 		"full execution support is still being completed",
 		"### Step 2: Run adaptive exploration",

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -1108,6 +1108,12 @@ func restoreStateSnapshot(workdir, planStem string, originalState *runstate.Stat
 
 func EvaluateArchiveReadiness(workdir, planStem string, doc *plan.Document, state *runstate.State) []CommandError {
 	issues := make([]CommandError, 0)
+	if doc.WorkflowProfile() == plan.WorkflowProfileGoalOriented {
+		issues = append(issues, CommandError{
+			Path:    "frontmatter.workflow_profile",
+			Message: "goal_oriented is a recognized preview workflow profile for active-plan authoring; archive support is still being completed",
+		})
+	}
 	for _, issue := range doc.ArchiveReadinessIssues() {
 		issues = append(issues, CommandError{Path: issue.Path, Message: issue.Message})
 	}

--- a/internal/lifecycle/service_test.go
+++ b/internal/lifecycle/service_test.go
@@ -509,6 +509,48 @@ func TestArchivePreflightFailureLeavesPlanAndPointersUntouched(t *testing.T) {
 	}
 }
 
+func TestArchiveRejectsGoalOrientedPreviewBeforeWritingArchive(t *testing.T) {
+	root := t.TempDir()
+	activeRelPath := "docs/plans/active/2026-03-18-goal-oriented.md"
+	activePath := filepath.Join(root, activeRelPath)
+	content := strings.Replace(buildActiveArchiveCandidate(t), "source_refs: []", "source_refs: []\nworkflow_profile: goal_oriented", 1)
+	writeFile(t, activePath, content)
+	if _, err := runstate.SaveCurrentPlan(root, activeRelPath); err != nil {
+		t.Fatalf("save current plan: %v", err)
+	}
+	if _, err := runstate.SaveState(root, "2026-03-18-goal-oriented", &runstate.State{
+		ExecutionStartedAt: "2026-03-18T01:55:00Z",
+		ActiveReviewRound: &runstate.ReviewRound{
+			RoundID:    "review-001-full",
+			Kind:       "full",
+			Revision:   1,
+			Aggregated: true,
+			Decision:   "pass",
+		},
+	}); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	result := lifecycle.Service{Workdir: root}.Archive()
+	if result.OK {
+		t.Fatalf("expected archive failure, got %#v", result)
+	}
+	assertErrorPath(t, result.Errors, "frontmatter.workflow_profile")
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("expected active plan to remain after failed archive, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs/plans/archived/2026-03-18-goal-oriented.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected no archived goal-oriented plan to be written, got %v", err)
+	}
+	current, err := runstate.LoadCurrentPlan(root)
+	if err != nil {
+		t.Fatalf("load current plan: %v", err)
+	}
+	if current == nil || current.PlanPath != activeRelPath {
+		t.Fatalf("expected current plan pointer to remain on active plan, got %#v", current)
+	}
+}
+
 func TestArchiveRollsBackWhenCurrentPlanWriteFails(t *testing.T) {
 	root := t.TempDir()
 	activeRelPath := "docs/plans/active/2026-03-18-archive-smoke.md"

--- a/internal/plan/lint.go
+++ b/internal/plan/lint.go
@@ -546,7 +546,7 @@ func validatePathRules(ctx *lintContext) []LintIssue {
 	pathProfile := inferWorkflowProfileFromPath(ctx.path)
 	declaredProfile := strings.TrimSpace(ctx.frontmatter.WorkflowProfile)
 	if declaredProfile == WorkflowProfileStandard {
-		issues = append(issues, LintIssue{Path: "frontmatter.workflow_profile", Message: "omit workflow_profile for standard plans; only lightweight plans should declare it"})
+		issues = append(issues, LintIssue{Path: "frontmatter.workflow_profile", Message: "omit workflow_profile for standard plans; only lightweight plans or the goal_oriented authoring preview should declare it"})
 	}
 	switch pathProfile {
 	case WorkflowProfileStandard:

--- a/internal/plan/lint.go
+++ b/internal/plan/lint.go
@@ -52,8 +52,9 @@ var (
 		"Step Acceptance Criteria": 2,
 		"Expected Files":           3,
 		"Validation":               4,
-		"Execution Notes":          5,
-		"Review Notes":             6,
+		"Checkpoint Reports":       5,
+		"Execution Notes":          6,
+		"Review Notes":             7,
 	}
 	allowedStepStatuses = []string{"pending", "in_progress", "completed", "blocked"}
 )
@@ -281,10 +282,10 @@ func validateFrontmatter(ctx *lintContext) []LintIssue {
 	}
 	if rawProfile, ok := ctx.rawFrontmatter["workflow_profile"]; ok {
 		value, ok := rawProfile.(string)
-		if !ok || (strings.TrimSpace(value) != WorkflowProfileStandard && strings.TrimSpace(value) != WorkflowProfileLightweight) {
+		if !ok || !isSupportedWorkflowProfile(strings.TrimSpace(value)) {
 			issues = append(issues, LintIssue{
 				Path:    "frontmatter.workflow_profile",
-				Message: "must be standard or lightweight when provided",
+				Message: "must be standard, lightweight, or goal_oriented when provided",
 			})
 		}
 	}
@@ -549,20 +550,32 @@ func validatePathRules(ctx *lintContext) []LintIssue {
 	}
 	switch pathProfile {
 	case WorkflowProfileStandard:
-		if declaredProfile == WorkflowProfileLightweight {
+		switch declaredProfile {
+		case WorkflowProfileLightweight:
 			issues = append(issues, LintIssue{Path: "frontmatter.workflow_profile", Message: "standard archived paths must omit workflow_profile"})
+		case WorkflowProfileGoalOriented:
+			issues = append(issues, LintIssue{Path: "frontmatter.workflow_profile", Message: "goal_oriented is a recognized preview workflow profile for active-plan authoring; archive support is still being completed"})
 		}
 	case WorkflowProfileLightweight:
 		if declaredProfile != WorkflowProfileLightweight {
 			issues = append(issues, LintIssue{Path: "frontmatter.workflow_profile", Message: "lightweight archived paths require workflow_profile: lightweight"})
 		}
 	default:
-		if ctx.pathKind == "active" && declaredProfile != "" && declaredProfile != WorkflowProfileLightweight {
-			issues = append(issues, LintIssue{Path: "frontmatter.workflow_profile", Message: "tracked active plans must omit workflow_profile unless they explicitly use lightweight"})
+		if ctx.pathKind == "active" && declaredProfile != "" && declaredProfile != WorkflowProfileLightweight && declaredProfile != WorkflowProfileGoalOriented {
+			issues = append(issues, LintIssue{Path: "frontmatter.workflow_profile", Message: "tracked active plans must omit workflow_profile unless they explicitly use lightweight or the goal_oriented authoring preview"})
 		}
 	}
 	issues = append(issues, validateSupplementsRules(ctx)...)
 	return issues
+}
+
+func isSupportedWorkflowProfile(value string) bool {
+	switch value {
+	case WorkflowProfileStandard, WorkflowProfileLightweight, WorkflowProfileGoalOriented:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateSupplementsRules(ctx *lintContext) []LintIssue {

--- a/internal/plan/lint_test.go
+++ b/internal/plan/lint_test.go
@@ -541,6 +541,23 @@ func TestLintFileRejectsUnsupportedWorkflowProfile(t *testing.T) {
 	assertHasError(t, result, "frontmatter.workflow_profile")
 }
 
+func TestLintFileRejectsExplicitStandardWithGoalOrientedDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "docs/plans/active/2026-03-17-standard-profile.md")
+	content := mustRenderTemplate(t, "Explicit Standard Plan")
+	content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: standard", 1)
+	writeFile(t, path, content)
+
+	result := plan.LintFile(path)
+	if result.OK {
+		t.Fatalf("expected explicit standard profile lint failure, got %#v", result)
+	}
+	assertHasError(t, result, "frontmatter.workflow_profile")
+	if !strings.Contains(result.Errors[0].Message, "goal_oriented authoring preview") {
+		t.Fatalf("expected diagnostic to mention goal_oriented authoring preview, got %#v", result.Errors)
+	}
+}
+
 func TestLintFileRejectsInvalidStepHeading(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "docs/plans/active/2026-03-17-easyharness-cli-and-plan-foundations.md")

--- a/internal/plan/lint_test.go
+++ b/internal/plan/lint_test.go
@@ -429,6 +429,19 @@ func TestLintFileAcceptsTrackedActiveLightweightPlan(t *testing.T) {
 	}
 }
 
+func TestLintFileAcceptsTrackedActiveGoalOrientedPreviewPlan(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "docs/plans/active/2026-03-17-goal-oriented-plan.md")
+	content := mustRenderTemplate(t, "Goal-Oriented Preview Plan")
+	content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: goal_oriented", 1)
+	writeFile(t, path, content)
+
+	result := plan.LintFile(path)
+	if !result.OK {
+		t.Fatalf("expected tracked goal-oriented preview lint success, got %#v", result)
+	}
+}
+
 func TestLintFileAcceptsArchivedLightweightLocalPlan(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".local/harness/plans/archived/2026-03-17-lightweight-plan.md")
@@ -477,6 +490,20 @@ func TestLintFileRejectsLightweightActivePlanUnderLocalPath(t *testing.T) {
 		t.Fatalf("expected lint failure, got %#v", result)
 	}
 	assertHasError(t, result, "path")
+}
+
+func TestLintFileRejectsArchivedGoalOrientedPreviewPlan(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "docs/plans/archived/2026-03-17-goal-oriented-plan.md")
+	content := makeArchiveReady(checkAllBoxes(mustRenderTemplate(t, "Archived Goal-Oriented Plan")))
+	content = strings.Replace(content, "source_refs: []", "source_refs: []\nworkflow_profile: goal_oriented", 1)
+	writeFile(t, path, content)
+
+	result := plan.LintFile(path)
+	if result.OK {
+		t.Fatalf("expected archived goal-oriented preview lint failure, got %#v", result)
+	}
+	assertHasError(t, result, "frontmatter.workflow_profile")
 }
 
 func TestLintFileRejectsUnsupportedWorkflowProfile(t *testing.T) {

--- a/internal/plan/lint_test.go
+++ b/internal/plan/lint_test.go
@@ -442,6 +442,27 @@ func TestLintFileAcceptsTrackedActiveGoalOrientedPreviewPlan(t *testing.T) {
 	}
 }
 
+func TestLintFileAcceptsGeneratedGoalOrientedPreviewPlan(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "docs/plans/active/2026-03-17-goal-oriented-plan.md")
+	content, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title:           "Generated Goal-Oriented Preview Plan",
+		Timestamp:       time.Date(2026, 3, 17, 14, 0, 0, 0, time.FixedZone("CST", 8*60*60)),
+		SourceType:      "direct_request",
+		Size:            "M",
+		WorkflowProfile: plan.WorkflowProfileGoalOriented,
+	})
+	if err != nil {
+		t.Fatalf("render goal-oriented template: %v", err)
+	}
+	writeFile(t, path, content)
+
+	result := plan.LintFile(path)
+	if !result.OK {
+		t.Fatalf("expected generated goal-oriented preview lint success, got %#v", result)
+	}
+}
+
 func TestLintFileAcceptsArchivedLightweightLocalPlan(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".local/harness/plans/archived/2026-03-17-lightweight-plan.md")

--- a/internal/plan/profile.go
+++ b/internal/plan/profile.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	WorkflowProfileStandard    = "standard"
-	WorkflowProfileLightweight = "lightweight"
-	SupplementsDirName         = "supplements"
+	WorkflowProfileStandard     = "standard"
+	WorkflowProfileLightweight  = "lightweight"
+	WorkflowProfileGoalOriented = "goal_oriented"
+	SupplementsDirName          = "supplements"
 )
 
 func normalizeWorkflowProfile(value string) string {
@@ -21,6 +22,8 @@ func normalizeWorkflowProfile(value string) string {
 		return WorkflowProfileStandard
 	case WorkflowProfileLightweight:
 		return WorkflowProfileLightweight
+	case WorkflowProfileGoalOriented:
+		return WorkflowProfileGoalOriented
 	default:
 		return strings.TrimSpace(value)
 	}

--- a/internal/plan/template.go
+++ b/internal/plan/template.go
@@ -47,8 +47,8 @@ func RenderTemplate(opts TemplateOptions) (string, error) {
 	}
 	size := opts.Size
 	workflowProfile := normalizeWorkflowProfile(opts.WorkflowProfile)
-	if workflowProfile != WorkflowProfileStandard && workflowProfile != WorkflowProfileLightweight {
-		return "", fmt.Errorf("workflow profile must be %q or %q", WorkflowProfileStandard, WorkflowProfileLightweight)
+	if workflowProfile != WorkflowProfileStandard && workflowProfile != WorkflowProfileLightweight && workflowProfile != WorkflowProfileGoalOriented {
+		return "", fmt.Errorf("workflow profile must be %q, %q, or %q", WorkflowProfileStandard, WorkflowProfileLightweight, WorkflowProfileGoalOriented)
 	}
 	if workflowProfile == WorkflowProfileLightweight {
 		if size == "" {
@@ -57,6 +57,9 @@ func RenderTemplate(opts TemplateOptions) (string, error) {
 		if size != PlanSizeXXS {
 			return "", fmt.Errorf("lightweight templates must use size %q", PlanSizeXXS)
 		}
+	}
+	if workflowProfile == WorkflowProfileGoalOriented && size == "" {
+		size = PlanSizeM
 	}
 	if size == "" {
 		size = placeholderPlanSize
@@ -91,6 +94,134 @@ func RenderTemplate(opts TemplateOptions) (string, error) {
 			}
 		}
 	}
+	if workflowProfile == WorkflowProfileGoalOriented {
+		rendered = renderGoalOrientedTemplate(rendered, size)
+	}
 
 	return rendered, nil
 }
+
+func renderGoalOrientedTemplate(rendered string, size string) string {
+	rendered = strings.Replace(rendered, "size: "+size, "size: "+size+"\nworkflow_profile: goal_oriented", 1)
+	rendered = strings.Replace(rendered, "Describe the intended outcome in one or two short paragraphs.", goalOrientedGoal, 1)
+	rendered = strings.Replace(rendered, "### In Scope\n\n- Item", "### In Scope\n\n- Define the objective, scorecard, hypotheses or candidate directions, checkpoint cadence, evidence requirements, challenge triggers, stopping conditions, and final synthesis.\n- Keep tracked checkpoint reports inside the adaptive step instead of turning each checkpoint into a separate harness workflow step.\n- Treat this as a recognized preview workflow profile for v0.6.0 authoring; full execution support is still being completed.", 1)
+	rendered = strings.Replace(rendered, "### Out of Scope\n\n- Item", "### Out of Scope\n\n- Full status next-action support, archive/reopen profile preservation, challenge/review protocol, UI rendering, and structural lint enforcement.\n- A hypothesis state machine or separate workflow engine.\n- Changes to default standard or lightweight behavior.", 1)
+	rendered = strings.Replace(rendered, "- [ ] Criterion 1\n- [ ] Criterion 2", goalOrientedAcceptanceCriteria, 1)
+	rendered = strings.Replace(rendered, "- None.", "- Full execution support remains in the v0.6.0 follow-up implementation slices for challenge/review guidance, status next actions, structural lint coverage, docs/examples, archive/reopen behavior, and UI rendering.", 1)
+	rendered = strings.Replace(rendered, "### Step 1: Replace with first step title", "### Step 1: Frame objective and scorecard", 1)
+	rendered = strings.Replace(rendered, "Describe the concrete outcome for this step.", "Define the adaptive objective, success scorecard, initial hypotheses or candidate directions, evidence requirements, challenge triggers, checkpoint cadence, and stopping conditions.", 1)
+	rendered = strings.Replace(rendered, "Describe the step-specific details, tradeoffs, or constraints that do not fit\nin the one-line objective. Write `NONE` if the objective is already enough.", goalOrientedStepOneDetails, 1)
+	rendered = strings.Replace(rendered, "- `path/to/file`", "- The tracked plan body or approved plan package artifacts that define the objective, scorecard, and evidence surfaces.", 1)
+	rendered = strings.Replace(rendered, "- Describe how the agent will know this step is complete.\n- Mention the automated tests that should be added or updated if this step\n  changes behavior.", "- The objective, scorecard, hypotheses or candidate directions, checkpoint cadence, challenge triggers, evidence requirements, and stopping conditions are explicit enough for a future agent to resume without hidden chat context.", 1)
+	rendered = strings.Replace(rendered, "### Step 2: Replace with second step title", "### Step 2: Run adaptive exploration", 1)
+	rendered = strings.Replace(rendered, "Describe the concrete outcome for this step.", "Run bounded probes against the scorecard and write tracked checkpoint reports when the decision space changes meaningfully.", 1)
+	rendered = strings.Replace(rendered, "Describe the step-specific details, tradeoffs, or constraints that do not fit\nin the one-line objective. Write `NONE` if the objective is already enough.", goalOrientedStepTwoDetails, 1)
+	rendered = strings.Replace(rendered, "- `path/to/file`", "- The tracked plan body, especially the step-local `#### Checkpoint Reports` section.\n- Approved durable support artifacts only when the plan explicitly needs them.", 1)
+	rendered = strings.Replace(rendered, "- Describe how the agent will know this step is complete.\n- Mention the automated tests that should be added or updated if this step\n  changes behavior.", "- Checkpoint reports explain decision movement against the scorecard, including evidence pointers and residual uncertainty.\n- The controller can decide whether to continue probing, request challenge, synthesize, or ask the human about scope.", 1)
+	rendered = strings.Replace(rendered, "- The controller can decide whether to continue probing, request challenge, synthesize, or ask the human about scope.\n\n#### Execution Notes", "- The controller can decide whether to continue probing, request challenge, synthesize, or ask the human about scope.\n"+goalOrientedCheckpointReports+"#### Execution Notes", 1)
+	rendered = strings.Replace(rendered, "\n## Validation Strategy", goalOrientedStepThree+"\n## Validation Strategy", 1)
+	rendered = strings.Replace(rendered, "- Describe the validation approach for the whole plan.", "- Validate conclusions against the success scorecard, tracked checkpoint reports, durable evidence, and final synthesis.\n- Run focused automated or manual validation that matches the objective; record evidence pointers rather than raw logs.\n- Before archive, ensure accepted conclusions, rejected hypotheses, residual uncertainty, and follow-up issues are reflected in the final synthesis and outcome summaries.", 1)
+	rendered = strings.Replace(rendered, "- Risk: Describe the main risk.\n  - Mitigation: Describe how the work reduces or contains it.", goalOrientedRisks, 1)
+	return rendered
+}
+
+const goalOrientedGoal = `Describe the concrete objective or question to answer, the success scorecard that decides whether the work is complete, and why the path must adapt through hypotheses, probes, checkpoint reports, and final synthesis.
+
+` + "`workflow_profile: goal_oriented`" + ` is a recognized preview workflow profile defined for v0.6.0 authoring; full execution support is still being completed. Use it when the objective is clear but the execution path cannot honestly be reduced to a fixed linear checklist.`
+
+const goalOrientedAcceptanceCriteria = `- [ ] The objective and success scorecard are explicit enough to guide adaptive work.
+- [ ] Initial hypotheses or candidate directions are named, along with the evidence needed to compare them.
+- [ ] Checkpoint cadence, challenge triggers, stopping conditions, and final synthesis expectations are defined.
+- [ ] Tracked checkpoint reports live under adaptive steps and do not automatically become separate harness workflow steps.`
+
+const goalOrientedStepOneDetails = `Capture the goal-oriented authoring contract before probing starts:
+
+- Objective:
+- Success Scorecard:
+- Hypotheses / Candidate Directions:
+- Checkpoint Cadence:
+- Challenge Triggers:
+- Evidence Requirements:
+- Stopping Conditions:
+
+Keep this step focused on framing. Do not use it as a hidden execution log.`
+
+const goalOrientedStepTwoDetails = `Run the probe/checkpoint loop inside this adaptive step:
+
+1. Pick the next bounded hypothesis, candidate direction, or comparison.
+2. Run the smallest useful probe or experiment.
+3. Compare observed signal with the success scorecard.
+4. Write a tracked checkpoint report when the decision space changes.
+5. Decide whether to continue, pivot, request challenge, synthesize, or ask the human about scope.
+
+Checkpoint reports stay inside adaptive steps. Do not create one harness step per model turn, probe, or checkpoint report.`
+
+const goalOrientedCheckpointReports = `
+#### Checkpoint Reports
+
+##### CP1 - Replace with checkpoint title
+
+Trigger:
+
+Hypotheses:
+
+Probe:
+
+Observed Result:
+
+Scorecard Movement:
+
+Decision / Next Mutation:
+
+Residuals:
+
+Evidence:
+
+`
+
+const goalOrientedStepThree = `
+### Step 3: Synthesize and close out
+
+- Done: [ ]
+
+#### Objective
+
+Write the final synthesis and prepare ordinary validation, review, archive, and follow-up handoff.
+
+#### Details
+
+Final Synthesis:
+
+- Accepted Conclusions:
+- Rejected Hypotheses / Candidate Directions:
+- Residual Uncertainty:
+- Evidence:
+- Follow-Up / Deferred:
+
+The synthesis should absorb durable learning from checkpoint reports without duplicating raw process logs.
+
+#### Expected Files
+
+- The tracked plan body or the approved deliverable named by the plan.
+
+#### Validation
+
+- The final synthesis is supported by the success scorecard, checkpoint reports, and durable evidence.
+- Follow-up issues or deferred items are explicit when uncertainty remains out of scope.
+
+#### Execution Notes
+
+PENDING_STEP_EXECUTION
+
+#### Review Notes
+
+PENDING_STEP_REVIEW
+
+`
+
+const goalOrientedRisks = `- Risk: Adaptive work drifts into unbounded exploration.
+  - Mitigation: Use the scorecard, checkpoint cadence, and stopping conditions to decide when to synthesize, defer, or ask the human about scope.
+- Risk: Checkpoint reports become raw logs.
+  - Mitigation: Record decision movement, evidence pointers, and residuals; keep raw drafts local or summarize them into approved artifacts.
+- Risk: The preview profile is mistaken for complete execution support.
+  - Mitigation: Treat this as a recognized preview workflow profile for authoring while full execution support is still being completed.`

--- a/internal/plan/template.go
+++ b/internal/plan/template.go
@@ -58,9 +58,6 @@ func RenderTemplate(opts TemplateOptions) (string, error) {
 			return "", fmt.Errorf("lightweight templates must use size %q", PlanSizeXXS)
 		}
 	}
-	if workflowProfile == WorkflowProfileGoalOriented && size == "" {
-		size = PlanSizeM
-	}
 	if size == "" {
 		size = placeholderPlanSize
 	}

--- a/internal/plan/template_test.go
+++ b/internal/plan/template_test.go
@@ -108,6 +108,36 @@ func TestRenderTemplateLightweightSeedsWorkflowProfileAndSingleStep(t *testing.T
 	}
 }
 
+func TestRenderTemplateGoalOrientedSeedsPreviewAuthoringShape(t *testing.T) {
+	rendered, err := plan.RenderTemplate(plan.TemplateOptions{
+		Title:           "Goal-Oriented Plan",
+		WorkflowProfile: plan.WorkflowProfileGoalOriented,
+	})
+	if err != nil {
+		t.Fatalf("RenderTemplate returned error: %v", err)
+	}
+	for _, want := range []string{
+		"workflow_profile: goal_oriented",
+		"recognized preview workflow profile",
+		"full execution support is still being completed",
+		"### Step 1: Frame objective and scorecard",
+		"### Step 2: Run adaptive exploration",
+		"### Step 3: Synthesize and close out",
+		"#### Checkpoint Reports",
+		"##### CP1 - Replace with checkpoint title",
+		"Scorecard Movement:",
+		"Checkpoint reports stay inside adaptive steps",
+		"Final Synthesis:",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered goal-oriented template missing %q\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "### Step 4:") {
+		t.Fatalf("expected goal-oriented template to use three stable steps\n%s", rendered)
+	}
+}
+
 func TestRenderTemplateRejectsLightweightNonXXSSize(t *testing.T) {
 	_, err := plan.RenderTemplate(plan.TemplateOptions{
 		Title:           "Bad Lightweight Plan",


### PR DESCRIPTION
## What Changed

Adds a goal-oriented authoring preview for `workflow_profile: goal_oriented` without claiming the full v0.6.0 lifecycle has shipped.

The PR adds `harness plan template --goal-oriented`, seeds a stable adaptive plan shape with objective/scorecard framing, checkpoint reports under adaptive steps, synthesis, closeout, and preview-boundary wording. Active plan lint now recognizes the preview profile shallowly, while archive preflight rejects goal-oriented preview plans before writing an invalid archived artifact.

Specs and the harness-plan skill now describe `goal_oriented` as a recognized preview workflow profile for authoring. Full execution support, status next actions, challenge/review guidance, structural lint coverage, docs/examples, archive/reopen preservation, and UI rendering remain follow-up work.

Closes #270.

## Confidence

- Focused template, CLI, lint, and lifecycle tests cover `--goal-oriented`, profile flag conflicts, generated-template linting, archive preflight rejection, and diagnostic wording.
- `scripts/sync-bootstrap-assets` was run so `.agents/skills/harness-plan` matches the bootstrap source update.
- Step review found lifecycle-boundary and size-contract issues; repairs passed `review-002-delta` with no findings.
- Finalize review `review-003-full` passed; its one minor stale-diagnostic finding was fixed afterward.
- `go test ./internal/plan ./internal/cli ./internal/lifecycle`, `go test $(go list ./... | grep -v '/tests/release$')`, `git diff --check`, and goal-oriented template/lint smoke checks passed.

## Handoff

`go test ./...` was attempted but remains blocked in `tests/release` because `corepack` is not on PATH in this environment. The broad suite excluding `tests/release` passes.
