### PR TITLE
Recover review rounds after rewritten ancestry

### DIFF
--- a/.agents/skills/harness-execute/references/review-orchestration.md
+++ b/.agents/skills/harness-execute/references/review-orchestration.md
@@ -14,7 +14,12 @@ harness review start
 
 The first round establishes full whole-candidate coverage. After a blocking
 review and a narrow committed repair, `review start` infers the linked delta
-from current coverage and unresolved findings. Use
+from current coverage and unresolved findings. If rewritten ancestry makes the
+clean covered tip no longer an ancestor of the current candidate, `review
+start` automatically establishes a new full root before it creates any round.
+When unresolved findings remain, restore ancestry or explicitly choose a full
+replacement; Harness fails before creating a round rather than silently
+discarding those obligations. Use
 `harness review start --full` only when the repair changes design, scope, or
 risk enough to invalidate the prior full judgment.
 
@@ -45,3 +50,9 @@ A clean linked delta extends the full root without another full review.
 Non-blocking findings do not require repair. Archive remains blocked when
 findings are unresolved, candidate changes are uncovered, or the reviewed git
 boundary moved.
+
+If an unfinished round genuinely cannot be completed, do not edit local
+runtime state. Run `harness review abort --round <round-id>`. The command marks
+the historical round aborted, preserves its artifacts and existing finalize
+coverage, clears only the active pointer, and allows a replacement `review
+start` to select a valid delta or full boundary.

--- a/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
+++ b/assets/bootstrap/skills/harness-execute/references/review-orchestration.md
@@ -14,7 +14,12 @@ harness review start
 
 The first round establishes full whole-candidate coverage. After a blocking
 review and a narrow committed repair, `review start` infers the linked delta
-from current coverage and unresolved findings. Use
+from current coverage and unresolved findings. If rewritten ancestry makes the
+clean covered tip no longer an ancestor of the current candidate, `review
+start` automatically establishes a new full root before it creates any round.
+When unresolved findings remain, restore ancestry or explicitly choose a full
+replacement; Harness fails before creating a round rather than silently
+discarding those obligations. Use
 `harness review start --full` only when the repair changes design, scope, or
 risk enough to invalidate the prior full judgment.
 
@@ -45,3 +50,9 @@ A clean linked delta extends the full root without another full review.
 Non-blocking findings do not require repair. Archive remains blocked when
 findings are unresolved, candidate changes are uncovered, or the reviewed git
 boundary moved.
+
+If an unfinished round genuinely cannot be completed, do not edit local
+runtime state. Run `harness review abort --round <round-id>`. The command marks
+the historical round aborted, preserves its artifacts and existing finalize
+coverage, clears only the active pointer, and allows a replacement `review
+start` to select a valid delta or full boundary.

--- a/assets/help/review.md
+++ b/assets/help/review.md
@@ -31,6 +31,20 @@ not covered and block archive.
 
 If review finds a narrow issue, commit the repair and run
 `harness review start` again. Harness infers a linked delta that resolves the
-finding and extends coverage. Use `harness review start --full` only when the
-repair materially changes candidate design, scope, or risk and therefore
-invalidates the earlier full root.
+finding and extends coverage. If rewritten Git ancestry means the covered tip
+is no longer an ancestor of the candidate, Harness automatically starts a new
+full root instead of creating an unusable delta when the covered tip is clean.
+If unresolved findings remain, automatic reset fails before round creation;
+restore ancestry or explicitly use `harness review start --full` when a new
+whole-candidate review should supersede them. Explicit full is also appropriate
+when the repair materially changes candidate design, scope, or risk.
+
+If an unfinished round cannot be completed, preserve it as aborted and clear
+the active pointer through the supported recovery command:
+
+```bash
+harness review abort --round <round-id>
+```
+
+Abort never changes completed coverage or deletes round artifacts. Afterward,
+run `harness review start`; Harness will infer a valid delta or full boundary.

--- a/docs/plans/active/2026-07-15-review-round-ancestry-recovery.md
+++ b/docs/plans/active/2026-07-15-review-round-ancestry-recovery.md
@@ -1,0 +1,122 @@
+---
+template_version: 0.3.0
+created_at: "2026-07-15T10:30:00+08:00"
+approved_at: "2026-07-15T09:11:19+08:00"
+source_type: direct_request
+source_refs:
+    - Codex task 019f606f-3398-7840-a444-f7445512e958
+size: S
+---
+
+# Recover Review Rounds After Rewritten Ancestry
+
+## Goal
+
+Prevent finalize review from entering an unrecoverable linked-delta round after
+a rebase or other history rewrite breaks the reviewed ancestry chain. Make the
+ordinary command choose a valid full-review boundary before creating artifacts,
+and provide a supported way to abandon an unfinished review round without
+editing local harness state by hand.
+
+### Decisions and Constraints
+
+- Preserve linked delta review when the prior reviewed head is an ancestor of
+  the current committed candidate.
+- When prior coverage cannot be extended because ancestry was rewritten,
+  ordinary review start automatically chooses a full review instead of creating
+  a doomed delta or requiring the controller to diagnose Git topology.
+- Add an explicit review-abort operation for the active, unaggregated round.
+  Preserve its artifacts and record the abort; clear only the control-plane
+  blockage needed to start a replacement round.
+- Completed review decisions remain immutable and cannot be aborted.
+- Keep RC3 base-aware publish/sync coverage behavior unchanged: an equivalent,
+  non-overlapping base sync still preserves review, while overlapping upstream
+  edits still require a synchronized-candidate review.
+
+## Scope
+
+### In Scope
+
+- Review-kind inference and preflight validation for rewritten Git ancestry.
+- A command-owned recovery path for an active unaggregated review round.
+- Status, help, state/artifact contracts, and tests needed to make the new
+  behavior discoverable and replayable.
+- Bootstrap-managed skill guidance where the workflow instructions need to
+  mention the recovery behavior.
+
+### Out of Scope
+
+- Weakening candidate cleanliness, fixed-HEAD, or continuous-coverage checks.
+- Preserving linked-delta identity across rewritten commits by patch similarity.
+- Changing base-aware publish/sync overlap policy or merge/land behavior.
+- Migrating old runtime state or supporting legacy command shapes.
+
+## Acceptance Criteria
+
+- [x] Starting finalize review after a history rewrite that makes the prior
+      reviewed head non-ancestral creates a full review boundary before any
+      impossible delta round becomes active.
+- [x] A normal narrow repair whose current head descends from the prior reviewed
+      head still creates and completes a linked delta with existing finding and
+      revision semantics intact.
+- [ ] An active unaggregated review round can be explicitly aborted through the
+      CLI; its artifacts and abort fact remain inspectable, and a replacement
+      full or inferred review can start without manual state edits.
+- [ ] Aborting a completed, non-active, or mismatched round fails safely without
+      changing finalize coverage or the active round.
+- [ ] Status/help and managed workflow guidance lead an agent from an invalid or
+      abandoned round to the supported next action without suggesting local
+      state surgery.
+- [ ] Unit and built-binary E2E coverage reproduces the rebase deadlock, proves
+      the repaired transition, and keeps existing review, publish/sync, and
+      archive behavior green.
+
+## Review Focus
+
+- Confirm the automatic full-review fallback cannot silently discard valid
+  unresolved finding obligations or weaken whole-candidate coverage.
+- Check that abort is atomic across state, round metadata, timeline output, and
+  failure rollback, and that it never mutates an aggregated decision.
+- Verify the rebase test genuinely rewrites ancestry rather than merely adding
+  an upstream merge ancestor.
+- Ensure RC3 base-aware non-overlap preservation and overlap rejection remain
+  distinct from review-round ancestry recovery.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Select a valid review boundary before round creation
+
+- Done: [x]
+- Outcome: Finalize review inference distinguishes extendable ancestry from rewritten history and creates either a linked delta or a full review that can establish valid coverage.
+- Covers: Acceptance criteria 1, 2, and 6.
+- Check: Exercise narrow-repair and rewritten-ancestry cases through service and built-binary workflow tests.
+
+### Step 2: Add supported unfinished-round recovery
+
+- Done: [ ]
+- Outcome: Agents can abort an active unaggregated round through a documented command and immediately follow status guidance into a valid replacement review, with artifacts and prior coverage preserved.
+- Covers: Acceptance criteria 3, 4, 5, and 6.
+- Check: Cover successful abort, invalid targets, rollback behavior, status/help output, schemas, and managed bootstrap synchronization.
+
+## Validation Strategy
+
+- Run focused review service, runstate, CLI, status, contract, and E2E tests for
+  both ancestry inference and abort transitions.
+- Run bootstrap and generated-contract synchronization checks after changing
+  managed guidance or command schemas.
+- Reinstall the development harness after Go CLI changes, then run the full Go
+  and built-binary E2E suites plus `scripts/validate-release`.
+- Complete one independent integrated finalize review against the fixed final
+  candidate before archive and publish.
+
+## Closeout
+
+- Validation: PENDING_UNTIL_ARCHIVE
+- Review: PENDING_UNTIL_ARCHIVE
+- Delivered: PENDING_UNTIL_ARCHIVE
+- Not Delivered: PENDING_UNTIL_ARCHIVE
+- Follow-Up Issues: NONE

--- a/docs/plans/active/2026-07-15-review-round-ancestry-recovery.md
+++ b/docs/plans/active/2026-07-15-review-round-ancestry-recovery.md
@@ -59,15 +59,15 @@ editing local harness state by hand.
 - [x] A normal narrow repair whose current head descends from the prior reviewed
       head still creates and completes a linked delta with existing finding and
       revision semantics intact.
-- [ ] An active unaggregated review round can be explicitly aborted through the
+- [x] An active unaggregated review round can be explicitly aborted through the
       CLI; its artifacts and abort fact remain inspectable, and a replacement
       full or inferred review can start without manual state edits.
-- [ ] Aborting a completed, non-active, or mismatched round fails safely without
+- [x] Aborting a completed, non-active, or mismatched round fails safely without
       changing finalize coverage or the active round.
-- [ ] Status/help and managed workflow guidance lead an agent from an invalid or
+- [x] Status/help and managed workflow guidance lead an agent from an invalid or
       abandoned round to the supported next action without suggesting local
       state surgery.
-- [ ] Unit and built-binary E2E coverage reproduces the rebase deadlock, proves
+- [x] Unit and built-binary E2E coverage reproduces the rebase deadlock, proves
       the repaired transition, and keeps existing review, publish/sync, and
       archive behavior green.
 
@@ -97,7 +97,7 @@ editing local harness state by hand.
 
 ### Step 2: Add supported unfinished-round recovery
 
-- Done: [ ]
+- Done: [x]
 - Outcome: Agents can abort an active unaggregated round through a documented command and immediately follow status guidance into a valid replacement review, with artifacts and prior coverage preserved.
 - Covers: Acceptance criteria 3, 4, 5, and 6.
 - Check: Cover successful abort, invalid targets, rollback behavior, status/help output, schemas, and managed bootstrap synchronization.

--- a/docs/plans/archived/2026-07-15-review-round-ancestry-recovery.md
+++ b/docs/plans/archived/2026-07-15-review-round-ancestry-recovery.md
@@ -115,8 +115,21 @@ editing local harness state by hand.
 
 ## Closeout
 
-- Validation: PENDING_UNTIL_ARCHIVE
-- Review: PENDING_UNTIL_ARCHIVE
-- Delivered: PENDING_UNTIL_ARCHIVE
-- Not Delivered: PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-07-15T09:46:51+08:00
+- Revision: 1
+- Validation: `scripts/validate-release` passed on the final candidate,
+  including the complete Go suite, built-binary E2E, installer and release
+  smoke tests, UI build, and schema/bootstrap synchronization checks.
+- Review: `review-001-full` passed at
+  `50f47a6fb7989ffdd7b83390b415cd6ba2c1a8f8` with no blocking or non-blocking
+  findings; the independent reviewer also reran release, race, and targeted
+  rebase/abort validation.
+- Delivered: Review start now rejects impossible deltas before artifact
+  creation, automatically establishes a full root after clean rewritten
+  ancestry, preserves unresolved-finding obligations, and provides atomic
+  `review abort` recovery with historical UI/timeline visibility and agent
+  guidance.
+- Not Delivered: Patch-similarity ancestry bridging, legacy runtime-state
+  migration, and changes to RC3 publish/sync overlap policy remain outside the
+  approved scope.
 - Follow-Up Issues: NONE

--- a/docs/specs/cli-contract.md
+++ b/docs/specs/cli-contract.md
@@ -48,6 +48,7 @@ The current command surface is:
 - `harness ui`
 - `harness review start [--full]`
 - `harness review submit --round <round-id> --by <reviewer> [--input <path>]`
+- `harness review abort --round <round-id>`
 - `harness archive`
 - `harness reopen --mode <finalize-fix|new-step>`
 - `harness land --pr <url> [--commit <sha>]`
@@ -640,7 +641,11 @@ Contract:
 - default to `full` when establishing finalize coverage; during finalize
   repair, infer a linked `delta` only when the current coverage tip, repair
   revision, reviewed-head ancestry, and targeted finding IDs identify one
-  unambiguous narrow repair
+  unambiguous narrow repair; if a clean covered tip is not an ancestor of the
+  captured candidate, establish a new full root before creating round artifacts
+- when rewritten ancestry coexists with unresolved findings, fail before round
+  creation rather than silently discard them; require restored ancestry for a
+  linked delta or an explicit `--full` whole-candidate replacement
 - fail safely instead of inventing a delta when that link cannot be inferred;
   `--full` explicitly establishes a replacement full root after a material
   design, scope, or risk change
@@ -703,6 +708,31 @@ There is no separate aggregate command. A valid integrated submission is the
 single authoritative review decision for the round and immediately completes
 its decision and coverage update.
 
+### `harness review abort --round <round-id>`
+
+Purpose:
+
+- recover from an active unfinished review round that cannot be completed
+  without directly editing command-owned runtime state
+
+Contract:
+
+- require the exact active round ID and reject missing, mismatched, historical,
+  or completed rounds
+- operate only on an unaggregated round with no completed decision artifact
+- preserve the manifest, submission skeleton, and round directory as
+  historical evidence
+- mark the round's reviewer assignment `aborted` with a timestamp, clear only
+  `active_review_round`, and preserve `finalize_coverage` unchanged
+- record the abort in the plan timeline and roll back ledger and state together
+  if any part of the transaction fails
+- return `harness review start` as the next action; replacement start chooses a
+  linked delta only when ancestry and repair references remain valid, otherwise
+  it establishes a full root
+
+Abort is not a way to erase or override a completed review decision. Completed
+rounds and their coverage remain immutable.
+
 ## Review Sequencing
 
 Every standard candidate requires an independent whole-candidate finalize
@@ -714,6 +744,11 @@ A narrow review-driven, CI, or conflict repair extends that root through an
 automatically linked `delta` that verifies the targeted findings and related
 regressions. A repair that materially changes candidate design, scope, or risk
 uses `review start --full` and establishes a replacement root.
+
+An unfinished round that cannot be completed uses `review abort`, remains
+visible as aborted history, and contributes no coverage. The next `review
+start` selects its boundary from the last completed coverage, not from the
+aborted round.
 
 Archive readiness requires a continuous coverage chain rooted in a full round,
 no unresolved blocking findings, no active round, and coverage of the current

--- a/docs/specs/state-model.md
+++ b/docs/specs/state-model.md
@@ -231,7 +231,9 @@ inputs that do not already live in a more specific artifact:
 - `land`
 
 `active_review_round` is the mutable pointer for the round that is currently in
-flight or most recently completed. It is not, by itself, the
+flight or most recently completed. An explicit `review abort` clears an
+unfinished pointer while preserving that round's artifacts as aborted history.
+It is not, by itself, the
 archive verdict. `finalize_coverage` is a compact command-validated cache of a
 durable coverage chain: the full root round, current tip round, covered Git
 head, revision, and unresolved blocking count. Round manifests, the sole
@@ -240,6 +242,11 @@ of truth, so archive must validate that chain rather than trusting the cache
 alone. Reopen preserves the prior coverage tip
 so a narrow later revision can extend it with a linked delta; a new full review
 may replace the root when broader work invalidates the earlier judgment.
+Rewritten ancestry is detected before round creation. When a clean existing
+coverage tip is no longer an ancestor of the candidate, automatic inference
+starts a new full root rather than creating a delta that cannot aggregate. If
+the old tip has unresolved findings, inference fails before creating a round;
+only restored ancestry or an explicit full replacement may proceed.
 
 The mutation surfaces around those runtime artifacts stay split on purpose:
 

--- a/docs/specs/state-transitions.md
+++ b/docs/specs/state-transitions.md
@@ -28,13 +28,19 @@ complete finalize candidate.
 | --- | --- | --- | --- |
 | `execution/finalize/review` | `execution/finalize/fix` | `harness review submit` | The integrated reviewer reports blocking findings or a conservative failure. |
 | `execution/finalize/review` | `execution/finalize/archive` | `harness review submit` or derived status | A clean full root, optionally extended by clean linked deltas, covers current candidate HEAD. |
+| `execution/finalize/review` | `execution/finalize/review` | `harness review abort` | The exact active unfinished round is preserved as aborted history and its active pointer is cleared; completed coverage is unchanged. |
 | `execution/finalize/fix` | `execution/finalize/review` | `harness review start` | A committed repair starts an inferred linked delta, or `--full` explicitly resets materially invalidated coverage. |
 | `execution/finalize/fix` | `execution/step-<m>/implement` | Plan edit after `reopen --mode new-step` | The first new unfinished step is added. |
 
 `review start` is finalize-only. The first round is full. When prior coverage
 and unresolved findings exist, the ordinary next round is an inferred linked
-delta; another full root is reserved for a material design, scope, or risk
-change. The sole reviewer submission verifies the captured HEAD and completes
+delta. Rewritten ancestry over clean coverage automatically establishes another
+full root before a round is created. Rewritten ancestry with unresolved
+findings fails safely until ancestry is restored or a human explicitly requests
+a replacement full root. A human may also request a full root for a material
+design, scope, or risk change. An unfinished round may be explicitly aborted without
+deleting its history or changing prior coverage. The sole reviewer submission
+verifies the captured HEAD and completes
 the decision and coverage transaction without a controller aggregate action.
 
 ## Archive, Publish, and Land

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -165,6 +165,8 @@ func (a *App) runReview(args []string) int {
 		return a.runReviewStart(args[1:])
 	case "submit":
 		return a.runReviewSubmit(args[1:])
+	case "abort":
+		return a.runReviewAbort(args[1:])
 	case "-h", "--help", "help":
 		a.printReviewUsage()
 		return 0
@@ -1147,6 +1149,40 @@ func (a *App) runReviewSubmit(args []string) int {
 	return a.writeJSONResultForWorkdir(workdir, result)
 }
 
+func (a *App) runReviewAbort(args []string) int {
+	fs := flag.NewFlagSet("harness review abort", flag.ContinueOnError)
+	fs.SetOutput(a.Stderr)
+	roundID := fs.String("round", "", "Active unfinished review round ID.")
+	fs.Usage = func() {
+		fmt.Fprintln(a.Stderr, "Usage: harness review abort --round <round-id>")
+		fmt.Fprintln(a.Stderr)
+		fmt.Fprintln(a.Stderr, "Abort the active unfinished review round while preserving its artifacts.")
+	}
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 || strings.TrimSpace(*roundID) == "" {
+		fs.Usage()
+		return 2
+	}
+	workdir, err := a.Getwd()
+	if err != nil {
+		fmt.Fprintf(a.Stderr, "resolve working directory: %v\n", err)
+		return 1
+	}
+	recordedAt := a.Now().Format(time.RFC3339)
+	beforeStatus := readStatusSnapshot(workdir)
+	result := review.Service{
+		Workdir:    workdir,
+		Now:        a.Now,
+		AfterAbort: reviewAbortTimelineHook(workdir, beforeStatus, recordedAt, map[string]any{"round": strings.TrimSpace(*roundID)}),
+	}.Abort(*roundID)
+	return a.writeJSONResultForWorkdir(workdir, result)
+}
+
 func (a *App) runExecuteStart(args []string) int {
 	fs := flag.NewFlagSet("harness execute start", flag.ContinueOnError)
 	fs.SetOutput(a.Stderr)
@@ -1315,6 +1351,7 @@ func (a *App) printRootUsage() {
 	fmt.Fprintln(a.Stderr, "  evidence refresh Refresh CI and sync evidence from a recorded PR")
 	fmt.Fprintln(a.Stderr, "  review start    Create a deterministic review round")
 	fmt.Fprintln(a.Stderr, "  review submit   Record the integrated reviewer decision")
+	fmt.Fprintln(a.Stderr, "  review abort    Abort the active unfinished review round")
 	fmt.Fprintln(a.Stderr, "  land            Record merge confirmation and start required post-merge bookkeeping")
 	fmt.Fprintln(a.Stderr, "  land complete   Record required post-merge bookkeeping completion")
 	fmt.Fprintln(a.Stderr, "  archive         Freeze the current active plan")
@@ -1349,6 +1386,7 @@ func (a *App) printReviewUsage() {
 	fmt.Fprintln(a.Stderr, "Subcommands:")
 	fmt.Fprintln(a.Stderr, "  start      Create a deterministic review round")
 	fmt.Fprintln(a.Stderr, "  submit     Record the integrated reviewer decision")
+	fmt.Fprintln(a.Stderr, "  abort      Abort the active unfinished review round")
 }
 
 func (a *App) printExecuteUsage() {
@@ -1480,6 +1518,10 @@ func (a *App) writeJSONResult(value any) int {
 		if result.OK {
 			return 0
 		}
+	case review.AbortResult:
+		if result.OK {
+			return 0
+		}
 	case evidence.Result:
 		if result.OK {
 			return 0
@@ -1502,7 +1544,7 @@ func (a *App) writeJSONResult(value any) int {
 
 func watchlistTouchEnabled(value any) bool {
 	switch value.(type) {
-	case evidence.Result, evidence.RefreshResult, lifecycle.Result, review.StartResult, review.SubmitResult, status.Result:
+	case evidence.Result, evidence.RefreshResult, lifecycle.Result, review.StartResult, review.SubmitResult, review.AbortResult, status.Result:
 		return true
 	default:
 		return false

--- a/internal/cli/review_v3_test.go
+++ b/internal/cli/review_v3_test.go
@@ -75,6 +75,57 @@ func TestIntegratedReviewCLIStartAndSubmitCompleteRound(t *testing.T) {
 	}
 }
 
+func TestIntegratedReviewCLIAbortPreservesHistoryAndAllowsReplacement(t *testing.T) {
+	root := writeReviewV3CLIPlan(t)
+	stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)
+	app := cli.New(stdout, stderr)
+	app.Getwd = func() (string, error) { return root, nil }
+	app.UserHomeDir = func() (string, error) { return t.TempDir(), nil }
+
+	if code := app.Run([]string{"execute", "start"}); code != 0 {
+		t.Fatalf("execute start failed (%d): %s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := app.Run([]string{"review", "start"}); code != 0 {
+		t.Fatalf("review start failed (%d): %s", code, stderr.String())
+	}
+	var started struct {
+		Artifacts struct {
+			RoundID string `json:"round_id"`
+		} `json:"artifacts"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &started); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := app.Run([]string{"review", "abort", "--round", started.Artifacts.RoundID}); code != 0 {
+		t.Fatalf("review abort failed (%d): %s\n%s", code, stderr.String(), stdout.String())
+	}
+	var aborted struct {
+		OK      bool   `json:"ok"`
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &aborted); err != nil {
+		t.Fatal(err)
+	}
+	if !aborted.OK || aborted.Command != "review abort" {
+		t.Fatalf("unexpected abort result: %#v", aborted)
+	}
+	events := timeline.Service{Workdir: root}.Read()
+	if !events.OK || len(events.Events) == 0 || events.Events[len(events.Events)-1].Command != "review abort" {
+		t.Fatalf("expected abort timeline event: %#v", events)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := app.Run([]string{"review", "start"}); code != 0 {
+		t.Fatalf("replacement review start failed (%d): %s\n%s", code, stderr.String(), stdout.String())
+	}
+}
+
 func TestRemovedReviewOrchestrationCommandsAreRejected(t *testing.T) {
 	for _, args := range [][]string{{"review", "aggregate", "--round", "review-001-full"}, {"review", "dimensions", "list"}} {
 		stdout, stderr := new(bytes.Buffer), new(bytes.Buffer)

--- a/internal/cli/timeline_events.go
+++ b/internal/cli/timeline_events.go
@@ -100,6 +100,18 @@ func reviewSubmitTimelineHook(workdir string, before *status.Result, recordedAt 
 	}
 }
 
+func reviewAbortTimelineHook(workdir string, before *status.Result, recordedAt string, input any) func(reviewAbortResult) error {
+	return func(result reviewAbortResult) error {
+		return appendTimelineEvent(
+			workdir,
+			before,
+			readStatusSnapshot(workdir),
+			attachRawPayloads(timelineEventFromReviewAbort(result), input, result, result.Artifacts),
+			recordedAt,
+		)
+	}
+}
+
 func evidenceTimelineHook(workdir string, before *status.Result, recordedAt, kind string, input any) func(evidence.Result) error {
 	return func(result evidence.Result) error {
 		return appendTimelineEvent(
@@ -201,6 +213,23 @@ func timelineEventFromReviewSubmit(result reviewSubmitResult) timeline.Event {
 	return pruneTimelineEvent(event)
 }
 
+func timelineEventFromReviewAbort(result reviewAbortResult) timeline.Event {
+	event := timeline.Event{
+		Kind:    "review",
+		Command: result.Command,
+		Summary: result.Summary,
+	}
+	if result.Artifacts != nil {
+		event.PlanPath = result.Artifacts.PlanPath
+		event.ArtifactRefs = append(event.ArtifactRefs,
+			pathRef("plan_path", result.Artifacts.PlanPath),
+			valueRef("round_id", result.Artifacts.RoundID),
+			pathRef("ledger_path", result.Artifacts.LedgerPath),
+		)
+	}
+	return pruneTimelineEvent(event)
+}
+
 func timelineEventFromEvidence(result evidence.Result, kind string) timeline.Event {
 	event := timeline.Event{
 		Kind:    "evidence",
@@ -241,6 +270,7 @@ func timelineEventFromEvidenceRefresh(result evidence.RefreshResult) timeline.Ev
 
 type reviewStartResult = contracts.ReviewStartResult
 type reviewSubmitResult = contracts.ReviewSubmitResult
+type reviewAbortResult = contracts.ReviewAbortResult
 
 func pathRef(label, path string) timeline.ArtifactRef {
 	if strings.TrimSpace(path) == "" {

--- a/internal/contracts/registry.go
+++ b/internal/contracts/registry.go
@@ -101,6 +101,15 @@ func SchemaRegistry() []SchemaEntry {
 			Type:        reflect.TypeFor[ReviewSubmitResult](),
 		},
 		{
+			Key:         "commands.review.abort.result",
+			Group:       "command_results",
+			Path:        "schema/commands/review.abort.result.schema.json",
+			Title:       "Review abort command result",
+			Description: "JSON output for `harness review abort`.",
+			Shape:       "output",
+			Type:        reflect.TypeFor[ReviewAbortResult](),
+		},
+		{
 			Key:         "commands.evidence.submit.result",
 			Group:       "command_results",
 			Path:        "schema/commands/evidence.submit.result.schema.json",

--- a/internal/contracts/review.go
+++ b/internal/contracts/review.go
@@ -116,6 +116,10 @@ type ReviewLedgerAssignment struct {
 
 	// SubmittedAt is the submission timestamp when the slot has been submitted.
 	SubmittedAt string `json:"submitted_at,omitempty"`
+
+	// AbortedAt is the timestamp when the unfinished round was explicitly
+	// abandoned before submission.
+	AbortedAt string `json:"aborted_at,omitempty"`
 }
 
 // ReviewSubmissionInput is the JSON input consumed by `harness review submit`.
@@ -479,4 +483,41 @@ type ReviewSubmitArtifacts struct {
 
 	// SubmissionPath is the path to the created submission artifact.
 	SubmissionPath string `json:"submission_path"`
+}
+
+// ReviewAbortResult is the JSON result returned by `harness review abort`.
+type ReviewAbortResult struct {
+	// OK reports whether the command succeeded.
+	OK bool `json:"ok"`
+
+	// Command is the stable command identifier for the result payload.
+	Command string `json:"command"`
+
+	// Summary is the concise human-readable outcome description.
+	Summary string `json:"summary"`
+
+	// Artifacts identifies the preserved round and updated ledger.
+	Artifacts *ReviewAbortArtifacts `json:"artifacts,omitempty"`
+
+	// NextAction lists the most relevant follow-up steps in priority order.
+	NextAction []NextAction `json:"next_actions"`
+
+	// Errors lists hard failures that prevented the command from succeeding.
+	Errors []ErrorDetail `json:"errors,omitempty"`
+}
+
+// ReviewAbortArtifacts identifies the unfinished round preserved by abort.
+type ReviewAbortArtifacts struct {
+	// ProjectRoot is the repository root that anchors surfaced repo-facing
+	// paths.
+	ProjectRoot string `json:"project_root"`
+
+	// PlanPath is the current plan associated with the review round.
+	PlanPath string `json:"plan_path"`
+
+	// RoundID is the stable identifier of the aborted round.
+	RoundID string `json:"round_id"`
+
+	// LedgerPath is the updated round ledger that records aborted assignments.
+	LedgerPath string `json:"ledger_path"`
 }

--- a/internal/contracts/review_ui.go
+++ b/internal/contracts/review_ui.go
@@ -105,11 +105,15 @@ type ReviewReviewerView struct {
 	// Name is the reviewer-provided identity label when available.
 	Name string `json:"name,omitempty"`
 
-	// Status is pending or submitted.
+	// Status is pending, submitted, or aborted.
 	Status string `json:"status,omitempty"`
 
 	// SubmittedAt is the submission timestamp when known.
 	SubmittedAt string `json:"submitted_at,omitempty"`
+
+	// AbortedAt is the timestamp when the unfinished round was explicitly
+	// aborted.
+	AbortedAt string `json:"aborted_at,omitempty"`
 
 	// Summary is the reviewer's concise assessment.
 	Summary string `json:"summary,omitempty"`

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -153,6 +153,20 @@ func (s Service) Start(options StartOptions) StartResult {
 			Errors:  []CommandError{{Path: "review.candidate", Message: err.Error()}},
 		}
 	}
+	if spec.Kind == "delta" {
+		ancestor, err := reviewcoverage.IsAncestor(s.Workdir, spec.AnchorSHA, candidate.HeadSHA)
+		if err != nil {
+			return StartResult{
+				OK:      false,
+				Command: "review start",
+				Summary: "Unable to validate finalize review ancestry.",
+				Errors:  []CommandError{{Path: "review.coverage", Message: err.Error()}},
+			}
+		}
+		if !ancestor {
+			spec = inferredSpec{Kind: "full"}
+		}
+	}
 	if issues := validateRepairLink(s.Workdir, planStem, state, spec, revision); len(issues) > 0 {
 		return StartResult{
 			OK:      false,

--- a/internal/review/service.go
+++ b/internal/review/service.go
@@ -30,8 +30,10 @@ type Service struct {
 	Now                func() time.Time
 	AfterStart         func(StartResult) error
 	AfterSubmit        func(SubmitResult) error
+	AfterAbort         func(AbortResult) error
 	AfterStartSuccess  func(StartResult)
 	AfterSubmitSuccess func(SubmitResult)
+	AfterAbortSuccess  func(AbortResult)
 }
 
 type StartOptions = contracts.ReviewStartOptions
@@ -52,6 +54,8 @@ type StartResult = contracts.ReviewStartResult
 type StartArtifacts = contracts.ReviewStartArtifacts
 type SubmitResult = contracts.ReviewSubmitResult
 type SubmitArtifacts = contracts.ReviewSubmitArtifacts
+type AbortResult = contracts.ReviewAbortResult
+type AbortArtifacts = contracts.ReviewAbortArtifacts
 
 type inferredSpec struct {
 	Kind      string
@@ -164,6 +168,17 @@ func (s Service) Start(options StartOptions) StartResult {
 			}
 		}
 		if !ancestor {
+			if spec.Repair != nil && len(spec.Repair.FindingIDs) > 0 {
+				return StartResult{
+					OK:      false,
+					Command: "review start",
+					Summary: "Rewritten ancestry cannot automatically reset unresolved review findings.",
+					Errors: []CommandError{{
+						Path:    "review.coverage",
+						Message: "restore ancestry for a linked delta, or explicitly run harness review start --full when a whole-candidate review should replace the unresolved finding obligations",
+					}},
+				}
+			}
 			spec = inferredSpec{Kind: "full"}
 		}
 	}
@@ -521,6 +536,162 @@ func (s Service) Submit(roundID, reviewerName string, inputBytes []byte) SubmitR
 		issues := restoreJSONFileSnapshot(manifest.LedgerPath, previousLedger, previousLedgerExists, "ledger")
 		issues = append(issues, restoreJSONFileSnapshot(assignmentDef.SubmissionPath, previousSubmission, previousSubmissionExists, "submission")...)
 		issues = append(issues, restoreJSONFileSnapshot(manifest.Aggregate, previousAggregate, previousAggregateExists, "review.decision")...)
+		issues = append(issues, restoreStateSnapshot(s.Workdir, planStem, originalState, statePath)...)
+		return issues
+	})
+}
+
+func (s Service) Abort(roundID string) AbortResult {
+	locks, failure := s.acquireReviewAndStateMutationLocks()
+	if failure != nil {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: failure.Summary,
+			Errors:  []CommandError{failure.Issue},
+		}
+	}
+	defer locks.release()
+
+	roundID = strings.TrimSpace(roundID)
+	_, _, planStem, relPlanPath, state, statePath, errResult := s.loadCurrentExecutingPlan(locks.PlanPath)
+	if errResult != nil {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: errResult.Summary,
+			Errors:  errResult.Errors,
+		}
+	}
+	if state == nil || state.ActiveReviewRound == nil {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "No active review round can be aborted.",
+			Errors:  []CommandError{{Path: "state.active_review_round", Message: "start a review round before attempting to abort it"}},
+		}
+	}
+	active := state.ActiveReviewRound
+	if strings.TrimSpace(active.RoundID) != roundID {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "The requested review round is not active.",
+			Errors:  []CommandError{{Path: "round", Message: fmt.Sprintf("active review round is %s", active.RoundID)}},
+		}
+	}
+	if active.Aggregated {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Completed review rounds are immutable.",
+			Errors:  []CommandError{{Path: "round", Message: fmt.Sprintf("review round %s is complete and cannot be aborted", roundID)}},
+		}
+	}
+
+	roundDir := runstate.ReviewRoundDir(s.Workdir, planStem, roundID)
+	manifest, err := loadManifest(filepath.Join(roundDir, "manifest.json"))
+	if err != nil {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Unable to load active review round metadata.",
+			Errors:  []CommandError{{Path: "review.round", Message: sanitizedReadMessage("review round metadata", err)}},
+		}
+	}
+	if manifest.RoundID != roundID {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Active review round metadata is inconsistent.",
+			Errors:  []CommandError{{Path: "review.round", Message: fmt.Sprintf("manifest identifies round %s", manifest.RoundID)}},
+		}
+	}
+	if _, err := os.Stat(manifest.Aggregate); err == nil {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Completed review rounds are immutable.",
+			Errors:  []CommandError{{Path: "round", Message: fmt.Sprintf("review round %s already has a completed decision", roundID)}},
+		}
+	} else if !os.IsNotExist(err) {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Unable to inspect active review decision state.",
+			Errors:  []CommandError{{Path: "review.decision", Message: sanitizedReadMessage("the review decision", err)}},
+		}
+	}
+	ledger, err := loadLedger(manifest.LedgerPath)
+	if err != nil {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Unable to load active review assignment state.",
+			Errors:  []CommandError{{Path: "review.assignments", Message: sanitizedReadMessage("reviewer assignment state", err)}},
+		}
+	}
+	if ledger.RoundID != roundID {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Active review assignment state is inconsistent.",
+			Errors:  []CommandError{{Path: "review.assignments", Message: fmt.Sprintf("ledger identifies round %s", ledger.RoundID)}},
+		}
+	}
+
+	previousLedger, previousLedgerExists, err := readFileIfExists(manifest.LedgerPath)
+	if err != nil {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Unable to snapshot active review assignment state.",
+			Errors:  []CommandError{{Path: "review.assignments", Message: sanitizedReadMessage("reviewer assignment state", err)}},
+		}
+	}
+	originalState := cloneState(state)
+	abortedAt := s.now().Format(time.RFC3339)
+	for index := range ledger.Assignments {
+		ledger.Assignments[index].Status = "aborted"
+		ledger.Assignments[index].AbortedAt = abortedAt
+	}
+	ledger.UpdatedAt = abortedAt
+	if err := writeJSON(manifest.LedgerPath, ledger); err != nil {
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Unable to persist aborted review assignment state.",
+			Errors:  []CommandError{{Path: "review.assignments", Message: sanitizedWriteMessage("reviewer assignment state", err)}},
+		}
+	}
+	state.ActiveReviewRound = nil
+	statePath, err = saveState(s.Workdir, planStem, state)
+	if err != nil {
+		issues := restoreJSONFileSnapshot(manifest.LedgerPath, previousLedger, previousLedgerExists, "review.assignments")
+		return AbortResult{
+			OK:      false,
+			Command: "review abort",
+			Summary: "Unable to persist local harness state.",
+			Errors:  append([]CommandError{{Path: "state", Message: sanitizedWriteMessage("local harness state", err)}}, issues...),
+		}
+	}
+
+	return s.finalizeAbort(AbortResult{
+		OK:      true,
+		Command: "review abort",
+		Summary: fmt.Sprintf("Aborted unfinished review round %q.", roundID),
+		Artifacts: &AbortArtifacts{
+			ProjectRoot: s.Workdir,
+			PlanPath:    relPlanPath,
+			RoundID:     roundID,
+			LedgerPath:  repoFacingReviewPath(s.Workdir, manifest.LedgerPath),
+		},
+		NextAction: []NextAction{{
+			Command:     strPtr("harness review start"),
+			Description: "Start a replacement review; Harness will select a valid linked delta or full boundary without editing local state.",
+		}},
+	}, func() []CommandError {
+		issues := restoreJSONFileSnapshot(manifest.LedgerPath, previousLedger, previousLedgerExists, "review.assignments")
 		issues = append(issues, restoreStateSnapshot(s.Workdir, planStem, originalState, statePath)...)
 		return issues
 	})
@@ -1377,6 +1548,31 @@ func (s Service) finalizeSubmit(result SubmitResult, rollback func() []CommandEr
 	}
 	if s.AfterSubmitSuccess != nil {
 		s.AfterSubmitSuccess(result)
+	}
+	return result
+}
+
+func (s Service) finalizeAbort(result AbortResult, rollback func() []CommandError) AbortResult {
+	if !result.OK || s.AfterAbort == nil {
+		if result.OK && s.AfterAbortSuccess != nil {
+			s.AfterAbortSuccess(result)
+		}
+		return result
+	}
+	if err := s.AfterAbort(result); err != nil {
+		issues := []CommandError{{Path: "timeline", Message: "Unable to record the review timeline event."}}
+		if rollback != nil {
+			issues = append(issues, rollback()...)
+		}
+		return AbortResult{
+			OK:      false,
+			Command: result.Command,
+			Summary: "Unable to record the timeline event for the successful command result.",
+			Errors:  issues,
+		}
+	}
+	if s.AfterAbortSuccess != nil {
+		s.AfterAbortSuccess(result)
 	}
 	return result
 }

--- a/internal/review/service_internal_test.go
+++ b/internal/review/service_internal_test.go
@@ -34,6 +34,42 @@ func TestSubmitRollsBackSubmissionAndDecisionWhenStateSaveFails(t *testing.T) {
 	}
 }
 
+func TestAbortRollsBackLedgerWhenStateSaveFails(t *testing.T) {
+	root, stem := writeInternalExecutingPlan(t)
+	svc := Service{Workdir: root}
+	start := svc.Start(StartOptions{})
+	if !start.OK {
+		t.Fatalf("start failed: %#v", start)
+	}
+	manifest, err := loadManifest(filepath.Join(runstate.ReviewRoundDir(root, stem, start.Artifacts.RoundID), "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerBefore, err := os.ReadFile(manifest.LedgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalSaveState := saveState
+	saveState = func(string, string, *runstate.State) (string, error) { return "", errors.New("boom") }
+	t.Cleanup(func() { saveState = originalSaveState })
+	result := svc.Abort(start.Artifacts.RoundID)
+	if result.OK {
+		t.Fatalf("expected abort failure: %#v", result)
+	}
+	ledgerAfter, err := os.ReadFile(manifest.LedgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(ledgerAfter) != string(ledgerBefore) {
+		t.Fatal("state-save failure did not restore the review ledger")
+	}
+	state, _, err := runstate.LoadState(root, stem)
+	if err != nil || state == nil || state.ActiveReviewRound == nil || state.ActiveReviewRound.RoundID != start.Artifacts.RoundID {
+		t.Fatalf("state should remain pending: state=%#v err=%v", state, err)
+	}
+}
+
 func writeInternalExecutingPlan(t *testing.T) (string, string) {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -318,6 +318,43 @@ func TestForceFullResetsExistingCoverage(t *testing.T) {
 	}
 }
 
+func TestStartFallsBackToFullAfterRebaseRewritesReviewedAncestry(t *testing.T) {
+	root, stem := writeExecutingPlan(t, true)
+	appendCommit(t, root, "candidate under review")
+	svc := review.Service{Workdir: root, Now: fixedNow}
+	full := svc.Start(review.StartOptions{})
+	if !full.OK {
+		t.Fatalf("start full review: %#v", full)
+	}
+	if result := svc.Submit(full.Artifacts.RoundID, "reviewer-integrated", jsonBytes(t, review.SubmissionInput{Summary: "Pass."})); !result.OK {
+		t.Fatalf("submit full review: %#v", result)
+	}
+
+	reviewedHead := full.Artifacts.ReviewedHeadSHA
+	base := git(t, root, "rev-parse", reviewedHead+"^")
+	git(t, root, "branch", "candidate", reviewedHead)
+	git(t, root, "checkout", "-qb", "upstream", base)
+	if err := os.WriteFile(filepath.Join(root, "upstream.txt"), []byte("upstream\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "add", "upstream.txt")
+	git(t, root, "commit", "-qm", "advance upstream")
+	git(t, root, "checkout", "-q", "candidate")
+	git(t, root, "rebase", "upstream")
+	if ancestor := gitIsAncestor(t, root, reviewedHead, "HEAD"); ancestor {
+		t.Fatal("test setup expected rebase to rewrite reviewed ancestry")
+	}
+
+	replacement := svc.Start(review.StartOptions{})
+	if !replacement.OK || !strings.HasSuffix(replacement.Artifacts.RoundID, "-full") {
+		t.Fatalf("expected automatic full review after rewritten ancestry: %#v", replacement)
+	}
+	manifest := readManifest(t, root, stem, replacement.Artifacts.RoundID)
+	if manifest.Repair != nil || manifest.AnchorSHA != "" {
+		t.Fatalf("rewritten ancestry must establish a fresh full root: %#v", manifest)
+	}
+}
+
 func writeExecutingPlan(t *testing.T, done bool) (string, string) {
 	t.Helper()
 	root := t.TempDir()
@@ -429,6 +466,20 @@ func git(t *testing.T, root string, args ...string) string {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
 	}
 	return strings.TrimSpace(string(output))
+}
+
+func gitIsAncestor(t *testing.T, root, ancestor, descendant string) bool {
+	t.Helper()
+	command := exec.Command("git", "-C", root, "merge-base", "--is-ancestor", ancestor, descendant)
+	err := command.Run()
+	if err == nil {
+		return true
+	}
+	if exit, ok := err.(*exec.ExitError); ok && exit.ExitCode() == 1 {
+		return false
+	}
+	t.Fatalf("git merge-base --is-ancestor %s %s: %v", ancestor, descendant, err)
+	return false
 }
 
 func readManifest(t *testing.T, root, stem, roundID string) review.Manifest {

--- a/internal/review/service_test.go
+++ b/internal/review/service_test.go
@@ -3,6 +3,7 @@ package review_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -266,6 +267,107 @@ func TestSubmitRejectsMovedHeadAndLeavesRoundPending(t *testing.T) {
 	}
 }
 
+func TestAbortUnfinishedRoundPreservesCoverageAndAllowsReplacement(t *testing.T) {
+	root, stem := writeExecutingPlan(t, true)
+	svc := review.Service{Workdir: root, Now: fixedNow}
+	full := svc.Start(review.StartOptions{})
+	if result := svc.Submit(full.Artifacts.RoundID, "reviewer-integrated", jsonBytes(t, review.SubmissionInput{Summary: "Pass."})); !result.OK {
+		t.Fatalf("complete full review: %#v", result)
+	}
+	appendCommit(t, root, "follow-up candidate")
+	delta := svc.Start(review.StartOptions{})
+	if !delta.OK || !strings.HasSuffix(delta.Artifacts.RoundID, "-delta") {
+		t.Fatalf("start delta: %#v", delta)
+	}
+
+	aborted := svc.Abort(delta.Artifacts.RoundID)
+	if !aborted.OK || aborted.Artifacts == nil || aborted.Artifacts.RoundID != delta.Artifacts.RoundID {
+		t.Fatalf("abort unfinished round: %#v", aborted)
+	}
+	state, _, err := runstate.LoadState(root, stem)
+	if err != nil || state == nil || state.ActiveReviewRound != nil {
+		t.Fatalf("abort must clear only the active pointer: state=%#v err=%v", state, err)
+	}
+	if state.FinalizeCoverage == nil || state.FinalizeCoverage.TipRoundID != full.Artifacts.RoundID {
+		t.Fatalf("abort must preserve prior finalize coverage: %#v", state.FinalizeCoverage)
+	}
+	manifest := readManifest(t, root, stem, delta.Artifacts.RoundID)
+	ledger, err := os.ReadFile(manifest.LedgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored review.Ledger
+	if err := json.Unmarshal(ledger, &stored); err != nil {
+		t.Fatal(err)
+	}
+	if len(stored.Assignments) != 1 || stored.Assignments[0].Status != "aborted" || stored.Assignments[0].AbortedAt != fixedNow().Format(time.RFC3339) {
+		t.Fatalf("abort fact was not preserved in the ledger: %#v", stored)
+	}
+	if _, err := os.Stat(roundFile(root, stem, delta.Artifacts.RoundID, "manifest.json")); err != nil {
+		t.Fatalf("abort must preserve round artifacts: %v", err)
+	}
+
+	replacement := svc.Start(review.StartOptions{})
+	if !replacement.OK || !strings.HasSuffix(replacement.Artifacts.RoundID, "-delta") {
+		t.Fatalf("expected replacement review after abort: %#v", replacement)
+	}
+}
+
+func TestAbortRejectsNonActiveMismatchedAndCompletedRounds(t *testing.T) {
+	root, stem := writeExecutingPlan(t, true)
+	svc := review.Service{Workdir: root, Now: fixedNow}
+	if result := svc.Abort("review-001-full"); result.OK || result.Summary != "No active review round can be aborted." {
+		t.Fatalf("expected no-active rejection: %#v", result)
+	}
+	active := svc.Start(review.StartOptions{})
+	if result := svc.Abort("review-999-full"); result.OK || result.Summary != "The requested review round is not active." {
+		t.Fatalf("expected mismatched-round rejection: %#v", result)
+	}
+	stateBefore, _, _ := runstate.LoadState(root, stem)
+	if stateBefore == nil || stateBefore.ActiveReviewRound == nil || stateBefore.ActiveReviewRound.RoundID != active.Artifacts.RoundID {
+		t.Fatalf("mismatched abort changed active state: %#v", stateBefore)
+	}
+	if result := svc.Submit(active.Artifacts.RoundID, "reviewer-integrated", jsonBytes(t, review.SubmissionInput{Summary: "Pass."})); !result.OK {
+		t.Fatalf("complete review: %#v", result)
+	}
+	if result := svc.Abort(active.Artifacts.RoundID); result.OK || result.Summary != "Completed review rounds are immutable." {
+		t.Fatalf("expected completed-round rejection: %#v", result)
+	}
+	stateAfter, _, _ := runstate.LoadState(root, stem)
+	if stateAfter == nil || stateAfter.ActiveReviewRound == nil || !stateAfter.ActiveReviewRound.Aggregated || stateAfter.FinalizeCoverage == nil {
+		t.Fatalf("completed abort changed review state: %#v", stateAfter)
+	}
+}
+
+func TestAbortTimelineFailureRollsBackLedgerAndState(t *testing.T) {
+	root, stem := writeExecutingPlan(t, true)
+	svc := review.Service{Workdir: root, Now: fixedNow, AfterAbort: func(review.AbortResult) error {
+		return errors.New("timeline unavailable")
+	}}
+	active := svc.Start(review.StartOptions{})
+	manifest := readManifest(t, root, stem, active.Artifacts.RoundID)
+	ledgerBefore, err := os.ReadFile(manifest.LedgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := svc.Abort(active.Artifacts.RoundID)
+	if result.OK || len(result.Errors) == 0 || result.Errors[0].Path != "timeline" {
+		t.Fatalf("expected timeline rollback failure: %#v", result)
+	}
+	ledgerAfter, err := os.ReadFile(manifest.LedgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(ledgerAfter, ledgerBefore) {
+		t.Fatal("timeline failure did not restore the review ledger")
+	}
+	state, _, err := runstate.LoadState(root, stem)
+	if err != nil || state == nil || state.ActiveReviewRound == nil || state.ActiveReviewRound.RoundID != active.Artifacts.RoundID {
+		t.Fatalf("timeline failure did not restore active state: state=%#v err=%v", state, err)
+	}
+}
+
 func TestExistingCoverageInfersLinkedDeltaAndResolvesFinding(t *testing.T) {
 	root, stem := writeExecutingPlan(t, true)
 	svc := review.Service{Workdir: root, Now: fixedNow}
@@ -352,6 +454,48 @@ func TestStartFallsBackToFullAfterRebaseRewritesReviewedAncestry(t *testing.T) {
 	manifest := readManifest(t, root, stem, replacement.Artifacts.RoundID)
 	if manifest.Repair != nil || manifest.AnchorSHA != "" {
 		t.Fatalf("rewritten ancestry must establish a fresh full root: %#v", manifest)
+	}
+}
+
+func TestStartDoesNotSilentlyResetUnresolvedFindingsAfterRewrittenAncestry(t *testing.T) {
+	root, stem := writeExecutingPlan(t, true)
+	appendCommit(t, root, "candidate under review")
+	svc := review.Service{Workdir: root, Now: fixedNow}
+	full := svc.Start(review.StartOptions{})
+	blocked := svc.Submit(full.Artifacts.RoundID, "reviewer-integrated", jsonBytes(t, review.SubmissionInput{
+		Summary:  "One repair is required.",
+		Findings: []review.Finding{{Area: "correctness", Severity: "important", Title: "Repair required", Details: "The candidate misses an invariant."}},
+	}))
+	if !blocked.OK || blocked.Review == nil || len(blocked.Review.UnresolvedFindingIDs) != 1 {
+		t.Fatalf("expected unresolved finding: %#v", blocked)
+	}
+
+	reviewedHead := full.Artifacts.ReviewedHeadSHA
+	base := git(t, root, "rev-parse", reviewedHead+"^")
+	git(t, root, "branch", "candidate", reviewedHead)
+	git(t, root, "checkout", "-qb", "upstream", base)
+	if err := os.WriteFile(filepath.Join(root, "upstream.txt"), []byte("upstream\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, root, "add", "upstream.txt")
+	git(t, root, "commit", "-qm", "advance upstream")
+	git(t, root, "checkout", "-q", "candidate")
+	git(t, root, "rebase", "upstream")
+
+	replacement := svc.Start(review.StartOptions{})
+	if replacement.OK || !strings.Contains(replacement.Summary, "cannot automatically reset unresolved") {
+		t.Fatalf("expected safe pre-round failure: %#v", replacement)
+	}
+	roundEntries, err := os.ReadDir(filepath.Join(root, ".local", "harness", "plans", stem, "reviews"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roundEntries) != 1 {
+		t.Fatalf("failed inference created review artifacts: %#v", roundEntries)
+	}
+	explicit := svc.Start(review.StartOptions{ForceFull: true})
+	if !explicit.OK || !strings.HasSuffix(explicit.Artifacts.RoundID, "-full") {
+		t.Fatalf("expected explicit whole-candidate replacement to remain available: %#v", explicit)
 	}
 }
 

--- a/internal/reviewui/service.go
+++ b/internal/reviewui/service.go
@@ -40,6 +40,7 @@ type reviewerState struct {
 	Role        string
 	Status      string
 	SubmittedAt string
+	AbortedAt   string
 	Name        string
 	Summary     string
 	Warnings    []string
@@ -352,14 +353,18 @@ func (s Service) readRound(planStem, roundID, activeRoundID string) Round {
 	warnings = append(warnings, reviewerWarnings...)
 
 	pendingReviewers := 0
+	abortedReviewers := 0
 	for _, reviewer := range reviewers {
-		if normalizeSlotStatus(reviewer.Status) != "submitted" {
+		switch normalizeSlotStatus(reviewer.Status) {
+		case "pending":
 			pendingReviewers++
+		case "aborted":
+			abortedReviewers++
 		}
 	}
 	round.Reviewer = selectReviewer(reviewers)
 
-	status, summary := resolveRoundStatus(round, len(reviewers), pendingReviewers, manifestArtifact, ledgerArtifact, decisionArtifact)
+	status, summary := resolveRoundStatus(round, len(reviewers), pendingReviewers, abortedReviewers, manifestArtifact, ledgerArtifact, decisionArtifact)
 	round.Status = status
 	round.StatusSummary = summary
 	if manifestArtifact.Status == "invalid" || ledgerArtifact.Status == "invalid" || decisionArtifact.Status == "invalid" {
@@ -371,7 +376,7 @@ func (s Service) readRound(planStem, roundID, activeRoundID string) Round {
 	if ledgerArtifact.Status == "missing" && len(reviewers) > 0 {
 		appendWarning("Review progress is missing, so reviewer state is inferred conservatively.")
 	}
-	if decisionArtifact.Status == "missing" && pendingReviewers == 0 && len(reviewers) > 0 {
+	if decisionArtifact.Status == "missing" && pendingReviewers == 0 && abortedReviewers == 0 && len(reviewers) > 0 {
 		appendWarning("Reviewer results are present, but the review decision is still missing.")
 	}
 	round.Warnings = dedupeStrings(warnings)
@@ -455,6 +460,7 @@ func (s Service) readReviewers(roundDir string, manifest *Manifest, ledger *Ledg
 			}
 			reviewer.Status = item.Status
 			reviewer.SubmittedAt = item.SubmittedAt
+			reviewer.AbortedAt = item.AbortedAt
 			normalizedLedgerStatus, warning := canonicalSlotStatus(item.Status)
 			ledgerClaimedSubmitted = normalizedLedgerStatus == "submitted"
 			ledgerStatusWarning = warning
@@ -517,6 +523,7 @@ func selectReviewer(reviewers []reviewerState) *Reviewer {
 		Name:        selected.Name,
 		Status:      normalizeSlotStatus(selected.Status),
 		SubmittedAt: selected.SubmittedAt,
+		AbortedAt:   selected.AbortedAt,
 		Summary:     selected.Summary,
 		Warnings:    selected.Warnings,
 	}
@@ -553,12 +560,14 @@ func canonicalSlotStatus(status string) (string, string) {
 		return "pending", ""
 	case "submitted":
 		return "submitted", ""
+	case "aborted":
+		return "aborted", ""
 	default:
 		return "pending", fmt.Sprintf("Review progress reports unknown reviewer status %q, so the result is shown conservatively as pending.", strings.TrimSpace(status))
 	}
 }
 
-func resolveRoundStatus(round Round, reviewerCount, pendingReviewers int, manifestArtifact, ledgerArtifact, decisionArtifact artifact) (string, string) {
+func resolveRoundStatus(round Round, reviewerCount, pendingReviewers, abortedReviewers int, manifestArtifact, ledgerArtifact, decisionArtifact artifact) (string, string) {
 	if manifestArtifact.Status == "invalid" || ledgerArtifact.Status == "invalid" || decisionArtifact.Status == "invalid" {
 		return "degraded", "One or more artifacts are malformed; review state is shown conservatively."
 	}
@@ -570,6 +579,9 @@ func resolveRoundStatus(round Round, reviewerCount, pendingReviewers int, manife
 			return "in_progress", "Review is active, but the independent reviewer could not be recovered yet."
 		}
 		return "incomplete", "Review metadata is incomplete."
+	}
+	if abortedReviewers == reviewerCount {
+		return "aborted", "The unfinished review round was explicitly aborted."
 	}
 	if pendingReviewers > 0 {
 		return "waiting_for_review", "Waiting for independent review."

--- a/internal/reviewui/service_test.go
+++ b/internal/reviewui/service_test.go
@@ -77,6 +77,25 @@ func TestServiceReadKeepsOneReviewerPending(t *testing.T) {
 	}
 }
 
+func TestServiceReadSurfacesAbortedRoundHistory(t *testing.T) {
+	workdir := t.TempDir()
+	relPlanPath, planStem := seedActivePlan(t, workdir, "2026-07-13-review-aborted.md", "Aborted review")
+	saveReviewState(t, workdir, planStem, 1, "")
+	integrated := reviewAssignment(workdir, planStem, "review-001-full", "integrated", "integrated")
+	abortedAt := "2026-07-13T11:02:00Z"
+	assignment := ledgerAssignment(integrated, "aborted", "")
+	assignment.AbortedAt = abortedAt
+	writeReviewRound(t, workdir, planStem, reviewRoundFixture{
+		Manifest: contracts.ReviewManifest{RoundID: "review-001-full", Kind: "full", Revision: 1, PlanPath: relPlanPath, PlanStem: planStem, CreatedAt: "2026-07-13T11:00:00Z", Assignments: []contracts.ReviewAssignment{integrated}},
+		Ledger:   contracts.ReviewLedger{RoundID: "review-001-full", Kind: "full", UpdatedAt: abortedAt, Assignments: []contracts.ReviewLedgerAssignment{assignment}},
+	})
+
+	got := Service{Workdir: workdir}.Read().Rounds[0]
+	if got.Status != "aborted" || got.IsActive || got.Reviewer == nil || got.Reviewer.Status != "aborted" || got.Reviewer.AbortedAt != abortedAt {
+		t.Fatalf("expected preserved aborted review history, got %#v", got)
+	}
+}
+
 func TestServiceReadArchivedPlanVisibilityAndLandHiding(t *testing.T) {
 	t.Run("visible while waiting for merge", func(t *testing.T) {
 		workdir := t.TempDir()

--- a/internal/status/service.go
+++ b/internal/status/service.go
@@ -769,6 +769,7 @@ func buildNextActions(node string, facts *Facts, reviewCtx *reviewContext, block
 		if reviewCtx != nil && reviewCtx.InFlight {
 			return []NextAction{
 				{Command: reviewSubmitCommand(reviewCtx), Description: "Have the independent integrated reviewer submit its complete judgment for the active finalize round."},
+				{Command: strPtr(fmt.Sprintf("harness review abort --round %s", reviewCtx.RoundID)), Description: "Abort this unfinished round only when it cannot be completed, then start a replacement review without editing local state."},
 			}
 		}
 		if acceptanceIncomplete(facts) {

--- a/internal/status/service_test.go
+++ b/internal/status/service_test.go
@@ -329,6 +329,9 @@ func TestStatusFinalizeReviewInFlightIncludesReviewFacts(t *testing.T) {
 	if result.Facts == nil || result.Facts.ReviewKind != "full" || result.Facts.ReviewStatus != "in_progress" {
 		t.Fatalf("unexpected facts: %#v", result.Facts)
 	}
+	if len(result.NextAction) != 2 || result.NextAction[1].Command == nil || *result.NextAction[1].Command != "harness review abort --round review-004-full" {
+		t.Fatalf("expected supported abort recovery action, got %#v", result.NextAction)
+	}
 }
 
 func TestStatusFinalizeFixNodeAfterFailedFinalizeReview(t *testing.T) {

--- a/schema/artifacts/review-ledger.schema.json
+++ b/schema/artifacts/review-ledger.schema.json
@@ -62,6 +62,10 @@
         "submitted_at": {
           "type": "string",
           "description": "SubmittedAt is the submission timestamp when the slot has been submitted."
+        },
+        "aborted_at": {
+          "type": "string",
+          "description": "AbortedAt is the timestamp when the unfinished round was explicitly abandoned before submission."
         }
       },
       "additionalProperties": false,

--- a/schema/commands/review.abort.result.schema.json
+++ b/schema/commands/review.abort.result.schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/catu-ai/easyharness/tree/main/schema/commands/review.abort.result.schema.json",
+  "$ref": "#/$defs/ReviewAbortResult",
+  "$defs": {
+    "ErrorDetail": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path identifies the field, section, or artifact path associated with the error."
+        },
+        "message": {
+          "type": "string",
+          "description": "Message is the human-readable explanation of the problem."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path",
+        "message"
+      ],
+      "description": "ErrorDetail describes one machine-readable validation or execution problem in a command result."
+    },
+    "NextAction": {
+      "properties": {
+        "command": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Command is the suggested command line to run next when the next step is best expressed as a harness command."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Command is the suggested command line to run next when the next step is best expressed as a harness command."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description explains the suggested next step in plain language."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command",
+        "description"
+      ],
+      "description": "NextAction describes one concrete follow-up action that the caller should consider after reading a command result."
+    },
+    "ReviewAbortArtifacts": {
+      "properties": {
+        "project_root": {
+          "type": "string",
+          "description": "ProjectRoot is the repository root that anchors surfaced repo-facing paths."
+        },
+        "plan_path": {
+          "type": "string",
+          "description": "PlanPath is the current plan associated with the review round."
+        },
+        "round_id": {
+          "type": "string",
+          "description": "RoundID is the stable identifier of the aborted round."
+        },
+        "ledger_path": {
+          "type": "string",
+          "description": "LedgerPath is the updated round ledger that records aborted assignments."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "project_root",
+        "plan_path",
+        "round_id",
+        "ledger_path"
+      ],
+      "description": "ReviewAbortArtifacts identifies the unfinished round preserved by abort."
+    },
+    "ReviewAbortResult": {
+      "properties": {
+        "ok": {
+          "type": "boolean",
+          "description": "OK reports whether the command succeeded."
+        },
+        "command": {
+          "type": "string",
+          "description": "Command is the stable command identifier for the result payload."
+        },
+        "summary": {
+          "type": "string",
+          "description": "Summary is the concise human-readable outcome description."
+        },
+        "artifacts": {
+          "$ref": "#/$defs/ReviewAbortArtifacts",
+          "description": "Artifacts identifies the preserved round and updated ledger."
+        },
+        "next_actions": {
+          "oneOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/NextAction"
+              },
+              "type": "array",
+              "description": "NextAction lists the most relevant follow-up steps in priority order."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "NextAction lists the most relevant follow-up steps in priority order."
+        },
+        "errors": {
+          "items": {
+            "$ref": "#/$defs/ErrorDetail"
+          },
+          "type": "array",
+          "description": "Errors lists hard failures that prevented the command from succeeding."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ok",
+        "command",
+        "summary",
+        "next_actions"
+      ],
+      "description": "ReviewAbortResult is the JSON result returned by `harness review abort`."
+    }
+  },
+  "title": "Review abort command result",
+  "description": "JSON output for `harness review abort`."
+}

--- a/schema/index.json
+++ b/schema/index.json
@@ -153,6 +153,16 @@
       "go_type": "github.com/catu-ai/easyharness/internal/contracts.LifecycleResult"
     },
     {
+      "key": "commands.review.abort.result",
+      "group": "command_results",
+      "surface": "public",
+      "title": "Review abort command result",
+      "description": "JSON output for `harness review abort`.",
+      "path": "schema/commands/review.abort.result.schema.json",
+      "id": "https://github.com/catu-ai/easyharness/tree/main/schema/commands/review.abort.result.schema.json",
+      "go_type": "github.com/catu-ai/easyharness/internal/contracts.ReviewAbortResult"
+    },
+    {
       "key": "commands.review.start.result",
       "group": "command_results",
       "surface": "public",

--- a/schema/ui-resources/review.schema.json
+++ b/schema/ui-resources/review.schema.json
@@ -118,11 +118,15 @@
         },
         "status": {
           "type": "string",
-          "description": "Status is pending or submitted."
+          "description": "Status is pending, submitted, or aborted."
         },
         "submitted_at": {
           "type": "string",
           "description": "SubmittedAt is the submission timestamp when known."
+        },
+        "aborted_at": {
+          "type": "string",
+          "description": "AbortedAt is the timestamp when the unfinished round was explicitly aborted."
         },
         "summary": {
           "type": "string",

--- a/tests/e2e/coverage_test.go
+++ b/tests/e2e/coverage_test.go
@@ -29,6 +29,7 @@ var canonicalTransitionFamilies = []transitionFamily{
 	{ID: "step_implement_to_finalize_review", From: "execution/step-<n>/implement", To: "execution/finalize/review", Driver: "Plan edit", RequiredInputs: "Every step is complete. Formal review has not yet established clean coverage for the candidate."},
 	{ID: "finalize_review_to_finalize_fix", From: "execution/finalize/review", To: "execution/finalize/fix", Driver: "harness review submit", RequiredInputs: "The integrated reviewer reports blocking findings or a conservative failure."},
 	{ID: "finalize_review_to_finalize_archive", From: "execution/finalize/review", To: "execution/finalize/archive", Driver: "`harness review submit` or derived status", RequiredInputs: "A clean full root, optionally extended by clean linked deltas, covers current candidate HEAD."},
+	{ID: "finalize_review_abort_recovery", From: "execution/finalize/review", To: "execution/finalize/review", Driver: "harness review abort", RequiredInputs: "The exact active unfinished round is preserved as aborted history and its active pointer is cleared; completed coverage is unchanged."},
 	{ID: "finalize_fix_to_finalize_review", From: "execution/finalize/fix", To: "execution/finalize/review", Driver: "harness review start", RequiredInputs: "A committed repair starts an inferred linked delta, or `--full` explicitly resets materially invalidated coverage."},
 	{ID: "finalize_fix_to_new_step_implement", From: "execution/finalize/fix", To: "execution/step-<m>/implement", Driver: "Plan edit after `reopen --mode new-step`", RequiredInputs: "The first new unfinished step is added."},
 	{ID: "finalize_archive_to_publish", From: "execution/finalize/archive", To: "execution/finalize/publish", Driver: "harness archive", RequiredInputs: "Acceptance, steps, Closeout, and finalize coverage are complete."},
@@ -51,6 +52,11 @@ var currentScenarioCoverage = []scenarioCoverage{
 			"finalize_fix_to_finalize_review",
 			"finalize_review_to_finalize_archive",
 		},
+	},
+	{
+		ID:            "review_abort_recovery",
+		TestName:      "TestReviewAbortRecoveryWithBuiltBinary",
+		TransitionIDs: []string{"finalize_review_abort_recovery"},
 	},
 	{
 		ID:       "archive_reopen_finalize_fix",

--- a/tests/e2e/review_workflow_test.go
+++ b/tests/e2e/review_workflow_test.go
@@ -143,6 +143,55 @@ func TestReviewRewrittenAncestryFallsBackToFullWithBuiltBinary(t *testing.T) {
 	}
 }
 
+func TestReviewAbortRecoveryWithBuiltBinary(t *testing.T) {
+	workspace, _, planStem := prepareFinalizeReviewFixture(t)
+	active := startReviewRound(t, workspace, false)
+
+	abortCommand := support.Run(t, workspace.Root, "review", "abort", "--round", active.Artifacts.RoundID)
+	support.RequireSuccess(t, abortCommand)
+	support.RequireNoStderr(t, abortCommand)
+	var aborted struct {
+		OK        bool   `json:"ok"`
+		Command   string `json:"command"`
+		Artifacts struct {
+			RoundID string `json:"round_id"`
+		} `json:"artifacts"`
+	}
+	aborted = support.RequireJSONResult[struct {
+		OK        bool   `json:"ok"`
+		Command   string `json:"command"`
+		Artifacts struct {
+			RoundID string `json:"round_id"`
+		} `json:"artifacts"`
+	}](t, abortCommand)
+	if !aborted.OK || aborted.Command != "review abort" || aborted.Artifacts.RoundID != active.Artifacts.RoundID {
+		t.Fatalf("unexpected abort result: %#v", aborted)
+	}
+
+	ledger := support.ReadJSONFile[struct {
+		Assignments []struct {
+			Status    string `json:"status"`
+			AbortedAt string `json:"aborted_at"`
+		} `json:"assignments"`
+	}](t, reviewRoundArtifactPath(workspace.Root, planStem, active.Artifacts.RoundID, "ledger.json"))
+	if len(ledger.Assignments) != 1 || ledger.Assignments[0].Status != "aborted" || ledger.Assignments[0].AbortedAt == "" {
+		t.Fatalf("expected preserved aborted assignment history, got %#v", ledger)
+	}
+
+	status := runStatus(t, workspace.Root)
+	assertNode(t, status, "execution/finalize/review")
+	if status.Facts.ReviewStatus != "" {
+		t.Fatalf("aborted round must not remain active, got %#v", status.Facts)
+	}
+	replacement := startReviewRound(t, workspace, false)
+	if replacement.Artifacts.RoundID == active.Artifacts.RoundID || !strings.HasSuffix(replacement.Artifacts.RoundID, "-full") {
+		t.Fatalf("expected a new full replacement round, got %#v", replacement)
+	}
+
+	completedAbort := support.Run(t, workspace.Root, "review", "abort", "--round", active.Artifacts.RoundID)
+	support.RequireExitCode(t, completedAbort, 1)
+}
+
 func runReviewGit(t *testing.T, root string, args ...string) string {
 	t.Helper()
 	command := exec.Command("git", append([]string{"-C", root}, args...)...)

--- a/tests/e2e/review_workflow_test.go
+++ b/tests/e2e/review_workflow_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -106,6 +107,64 @@ func TestReviewFullResetAndCandidateBoundaryWithBuiltBinary(t *testing.T) {
 		"summary": "This stale judgment must not persist.", "findings": []map[string]any{},
 	}))
 	support.RequireExitCode(t, changed, 1)
+}
+
+func TestReviewRewrittenAncestryFallsBackToFullWithBuiltBinary(t *testing.T) {
+	workspace, _, planStem := prepareFinalizeReviewFixture(t)
+	workspace.CommitAll(t, "base fixture")
+	workspace.WriteFile(t, "candidate/product.txt", []byte("candidate\n"))
+	workspace.CommitAll(t, "candidate under review")
+
+	full := startReviewRound(t, workspace, false)
+	passing := submitReview(t, workspace, full.Artifacts.RoundID, "integrated-reviewer", "The candidate passes.", nil, nil)
+	if passing.Review.Decision != "pass" {
+		t.Fatalf("expected initial full review to pass, got %#v", passing)
+	}
+	reviewedHead := full.Artifacts.ReviewedHeadSHA
+	base := runReviewGit(t, workspace.Root, "rev-parse", reviewedHead+"^")
+	runReviewGit(t, workspace.Root, "branch", "candidate", reviewedHead)
+	runReviewGit(t, workspace.Root, "checkout", "-qb", "upstream", base)
+	workspace.WriteFile(t, "upstream.txt", []byte("upstream\n"))
+	runReviewGit(t, workspace.Root, "add", "upstream.txt")
+	runReviewGit(t, workspace.Root, "commit", "-qm", "advance upstream")
+	runReviewGit(t, workspace.Root, "checkout", "-q", "candidate")
+	runReviewGit(t, workspace.Root, "rebase", "upstream")
+	if runReviewGitExitCode(t, workspace.Root, "merge-base", "--is-ancestor", reviewedHead, "HEAD") == 0 {
+		t.Fatal("test setup expected rebase to rewrite reviewed ancestry")
+	}
+
+	replacement := startReviewRound(t, workspace, false)
+	if !strings.HasSuffix(replacement.Artifacts.RoundID, "-full") {
+		t.Fatalf("expected rewritten ancestry to establish a full root, got %#v", replacement)
+	}
+	manifest := support.ReadJSONFile[reviewManifest](t, reviewRoundArtifactPath(workspace.Root, planStem, replacement.Artifacts.RoundID, "manifest.json"))
+	if manifest.Kind != "full" || manifest.AnchorSHA != "" {
+		t.Fatalf("unexpected replacement review manifest: %#v", manifest)
+	}
+}
+
+func runReviewGit(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-C", root}, args...)...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func runReviewGitExitCode(t *testing.T, root string, args ...string) int {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-C", root}, args...)...)
+	err := command.Run()
+	if err == nil {
+		return 0
+	}
+	exit, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("git %s: %v", strings.Join(args, " "), err)
+	}
+	return exit.ExitCode()
 }
 
 func prepareFinalizeReviewFixture(t *testing.T) (*support.Workspace, string, string) {

--- a/web/src/helpers.ts
+++ b/web/src/helpers.ts
@@ -432,6 +432,8 @@ export function reviewRoundCompactStatusLabel(round: ReviewRound): string {
       return "DONE";
     case "incomplete":
       return "PART";
+    case "aborted":
+      return "ABORT";
     default:
       return reviewRoundStatusLabel(round).toUpperCase();
   }
@@ -493,6 +495,8 @@ export function reviewRoundStatusLabel(round: ReviewRound): string {
       return "Complete";
     case "incomplete":
       return "Incomplete";
+    case "aborted":
+      return "Aborted";
     default:
       return humanizeLabel(status);
   }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -210,6 +210,7 @@ export type ReviewReviewer = {
   name?: string;
   status?: string;
   submitted_at?: string;
+  aborted_at?: string;
   summary?: string;
   warnings?: string[] | null;
 };


### PR DESCRIPTION
## Summary

- choose a valid full review boundary before creating artifacts when clean reviewed ancestry was rewritten
- fail safely when rewritten ancestry still carries unresolved findings
- add atomic `harness review abort --round <id>` recovery that preserves history and existing coverage
- surface abort recovery through status, help, schemas, managed skills, UI history, and built-binary E2E

## Root cause

Review kind inference selected a linked delta before checking Git ancestry. The ancestry failure was discovered only after reviewer submission, while the active unfinished round prevented starting a replacement full review and no supported abort command existed.

## Validation

- `scripts/validate-release`
- complete Go and built-binary E2E suites
- installer and release smoke tests
- UI production build
- bootstrap and contract schema synchronization checks
- independent finalize review: pass, no findings
