### PR TITLE
Fix lightweight land review coverage

### DIFF
--- a/docs/plans/active/2026-07-20-fix-lightweight-land-review-coverage.md
+++ b/docs/plans/active/2026-07-20-fix-lightweight-land-review-coverage.md
@@ -56,17 +56,17 @@ lightweight archive snapshot to exist in a Git tree.
 
 ## Acceptance Criteria
 
-- [ ] A valid lightweight candidate with commit-bearing publish evidence can
+- [x] A valid lightweight candidate with commit-bearing publish evidence can
       enter and complete land without looking for its `.local` archive path in
       the published Git tree.
-- [ ] Lightweight land still rejects a published candidate that retains the
+- [x] Lightweight land still rejects a published candidate that retains the
       reviewed active plan, changes reviewed plan or supplement content
       outside allowed archive mechanics, or introduces an unreviewed product
       delta.
-- [ ] Base-aware validation accepts an equivalent rewritten lightweight
+- [x] Base-aware validation accepts an equivalent rewritten lightweight
       candidate and rejects candidate-owned drift.
-- [ ] Standard published-candidate and land behavior remains unchanged.
-- [ ] Automated coverage includes a full lightweight lifecycle through
+- [x] Standard published-candidate and land behavior remains unchanged.
+- [x] Automated coverage includes a full lightweight lifecycle through
       `land complete` with an immutable published commit.
 
 ## Review Focus
@@ -97,7 +97,7 @@ lightweight archive snapshot to exist in a Git tree.
 
 ### Step 2: Close the lifecycle regression gap
 
-- Done: [ ]
+- Done: [x]
 - Outcome: The built CLI proves a commit-bearing lightweight candidate can
   progress from archive through completed land bookkeeping.
 - Covers: Acceptance criterion 5.

--- a/docs/plans/active/2026-07-20-fix-lightweight-land-review-coverage.md
+++ b/docs/plans/active/2026-07-20-fix-lightweight-land-review-coverage.md
@@ -1,0 +1,122 @@
+---
+template_version: 0.3.0
+created_at: "2026-07-20T21:49:42+08:00"
+approved_at: "2026-07-20T21:51:14+08:00"
+source_type: direct_request
+source_refs:
+    - user request
+size: S
+---
+
+# Fix lightweight land review coverage
+
+<!-- If this plan uses supplements/<plan-stem>/, keep the markdown concise,
+absorb repository-facing normative content into formal tracked locations before
+archive, and record supplement absorption in Closeout. Lightweight plans should
+normally avoid supplements. -->
+
+## Goal
+
+Make `harness land` complete successfully for a correctly archived lightweight
+candidate whose publish or fresh sync evidence records an immutable commit.
+Preserve review-coverage guarantees without requiring the ignored local
+lightweight archive snapshot to exist in a Git tree.
+
+### Decisions and Constraints
+
+- Lightweight archive snapshots remain command-owned local runtime state and
+  must not become tracked repository artifacts.
+- Published-candidate validation must remain fail-closed for unreviewed product
+  changes, rewritten candidate drift, missing active-plan deletion, and
+  supplement drift.
+- Standard workflow validation keeps its existing tracked archive semantics.
+- This repair does not add compatibility shims, evidence fallbacks, or manual
+  state-recovery behavior.
+
+## Scope
+
+### In Scope
+
+- Distinguish standard and lightweight archive mechanics when validating an
+  immutable published candidate during merge handoff.
+- Validate the local lightweight archive snapshot against the reviewed plan
+  while validating only repository-visible lightweight transitions in Git.
+- Cover ordinary and base-aware published candidate validation, including
+  lightweight plan supplements.
+- Exercise the lightweight workflow through successful land entry and land
+  completion with commit-bearing evidence.
+
+### Out of Scope
+
+- Changing where lightweight plans are archived.
+- Tracking lightweight archive snapshots or adding a second tracked archive.
+- Changing publish, CI, or sync evidence schemas.
+- Migrating or rewriting existing standard archived plans.
+- Automating recovery of already hand-edited command-owned runtime state.
+
+## Acceptance Criteria
+
+- [ ] A valid lightweight candidate with commit-bearing publish evidence can
+      enter and complete land without looking for its `.local` archive path in
+      the published Git tree.
+- [ ] Lightweight land still rejects a published candidate that retains the
+      reviewed active plan, changes reviewed plan or supplement content
+      outside allowed archive mechanics, or introduces an unreviewed product
+      delta.
+- [ ] Base-aware validation accepts an equivalent rewritten lightweight
+      candidate and rejects candidate-owned drift.
+- [ ] Standard published-candidate and land behavior remains unchanged.
+- [ ] Automated coverage includes a full lightweight lifecycle through
+      `land complete` with an immutable published commit.
+
+## Review Focus
+
+- Challenge the split between local snapshot integrity and immutable Git-tree
+  validation: no ignored `.local` path may be required from a commit, and no
+  repository-visible transition may escape review coverage.
+- Verify lightweight supplements obey the same local-target/tracked-source
+  boundary as the plan itself.
+- Check both ancestry-preserving and base-aware rewritten-candidate paths for
+  accidental weakening of standard validation.
+
+## Deferred Items
+
+- None.
+
+## Work Breakdown
+
+### Step 1: Make published coverage profile-aware
+
+- Done: [x]
+- Outcome: Published review coverage models lightweight archive mechanics as a
+  local snapshot plus repository-visible source removal, while retaining the
+  existing tracked target model for standard plans.
+- Covers: Acceptance criteria 1, 2, 3, and 4.
+- Check: Focused review-coverage and lifecycle tests exercise valid and invalid
+  standard and lightweight candidates.
+
+### Step 2: Close the lifecycle regression gap
+
+- Done: [ ]
+- Outcome: The built CLI proves a commit-bearing lightweight candidate can
+  progress from archive through completed land bookkeeping.
+- Covers: Acceptance criterion 5.
+- Check: The lightweight E2E and the relevant package suites pass from a clean
+  candidate.
+
+## Validation Strategy
+
+- Run focused unit tests for review coverage and lifecycle land readiness,
+  including standard, lightweight, supplements, ancestry-preserving, and
+  base-aware cases.
+- Run the built-binary lightweight E2E through `land complete` with populated
+  publish commit evidence.
+- Run the full Go test suite and plan lint before finalize review.
+
+## Closeout
+
+- Validation: PENDING_UNTIL_ARCHIVE
+- Review: PENDING_UNTIL_ARCHIVE
+- Delivered: PENDING_UNTIL_ARCHIVE
+- Not Delivered: PENDING_UNTIL_ARCHIVE
+- Follow-Up Issues: NONE

--- a/docs/plans/archived/2026-07-20-fix-lightweight-land-review-coverage.md
+++ b/docs/plans/archived/2026-07-20-fix-lightweight-land-review-coverage.md
@@ -115,8 +115,19 @@ lightweight archive snapshot to exist in a Git tree.
 
 ## Closeout
 
-- Validation: PENDING_UNTIL_ARCHIVE
-- Review: PENDING_UNTIL_ARCHIVE
-- Delivered: PENDING_UNTIL_ARCHIVE
-- Not Delivered: PENDING_UNTIL_ARCHIVE
+- Archived At: 2026-07-20T22:13:14+08:00
+- Revision: 1
+- Validation: `go test ./... -count=1`, focused review-coverage and lifecycle
+  suites, the commit-bearing lightweight `land complete` E2E, and
+  `git diff --check` passed.
+- Review: Integrated full review requested one fail-closed repair for archive
+  targets already present in a reviewed or base tree; linked delta
+  `review-002-delta` verified the repair, resolved the finding, and passed with
+  no new findings.
+- Delivered: Profile-aware published coverage now validates lightweight local
+  plan and supplement snapshots separately from Git-visible source removals,
+  rejects tracked `.local` archive targets directly, preserves standard and
+  base-aware validation, and exercises the complete lightweight land lifecycle.
+- Not Delivered: No archive-storage, evidence-schema, migration, or manual
+  runtime-state recovery changes.
 - Follow-Up Issues: NONE

--- a/internal/lifecycle/service.go
+++ b/internal/lifecycle/service.go
@@ -1154,7 +1154,13 @@ func evaluateArchivedReviewCoverage(workdir, planStem string, doc *plan.Document
 	}
 	var validationErr error
 	if publishedRevision != "" {
-		if publishedBaseRevision != "" {
+		if doc.WorkflowProfile() == plan.WorkflowProfileLightweight {
+			if publishedBaseRevision != "" {
+				validationErr = reviewcoverage.ValidatePublishedLightweightCandidateAgainstBase(workdir, doc.Path, chain, publishedRevision, publishedBaseRevision)
+			} else {
+				validationErr = reviewcoverage.ValidatePublishedLightweightCandidate(workdir, doc.Path, chain, publishedRevision)
+			}
+		} else if publishedBaseRevision != "" {
 			validationErr = reviewcoverage.ValidatePublishedCandidateAgainstBase(workdir, doc.Path, chain, publishedRevision, publishedBaseRevision)
 		} else {
 			validationErr = reviewcoverage.ValidatePublishedCandidate(workdir, doc.Path, chain, publishedRevision)

--- a/internal/reviewcoverage/closeout.go
+++ b/internal/reviewcoverage/closeout.go
@@ -196,6 +196,23 @@ func ValidatePublishedCandidate(workdir, archivedPlanPath string, chain *Chain, 
 	if err != nil {
 		return err
 	}
+	return validatePublishedCandidateAncestry(workdir, chain, publishedHead, allowed)
+}
+
+// ValidatePublishedLightweightCandidate validates a published lightweight
+// candidate without requiring its command-owned local archive snapshot to
+// exist in Git. The local snapshot still has to match the reviewed plan and
+// supplements, while the published tree must contain only the corresponding
+// tracked source removals plus the reviewed candidate delta.
+func ValidatePublishedLightweightCandidate(workdir, archivedPlanPath string, chain *Chain, publishedRevision string) error {
+	publishedHead, allowed, err := validatePublishedLightweightCandidateStructure(workdir, archivedPlanPath, chain, publishedRevision)
+	if err != nil {
+		return err
+	}
+	return validatePublishedCandidateAncestry(workdir, chain, publishedHead, allowed)
+}
+
+func validatePublishedCandidateAncestry(workdir string, chain *Chain, publishedHead string, allowed map[string]bool) error {
 	ancestor, err := IsAncestor(workdir, chain.CoveredHeadSHA, publishedHead)
 	if err != nil {
 		return fmt.Errorf("validate published candidate ancestry: %w", err)
@@ -224,6 +241,21 @@ func ValidatePublishedCandidateAgainstBase(workdir, archivedPlanPath string, cha
 	if err != nil {
 		return err
 	}
+	return validatePublishedCandidateAgainstBase(workdir, chain, publishedHead, allowed, baseRevision)
+}
+
+// ValidatePublishedLightweightCandidateAgainstBase is the base-aware variant
+// of ValidatePublishedLightweightCandidate for an otherwise equivalent
+// candidate whose commits were rewritten during synchronization.
+func ValidatePublishedLightweightCandidateAgainstBase(workdir, archivedPlanPath string, chain *Chain, publishedRevision, baseRevision string) error {
+	publishedHead, allowed, err := validatePublishedLightweightCandidateStructure(workdir, archivedPlanPath, chain, publishedRevision)
+	if err != nil {
+		return err
+	}
+	return validatePublishedCandidateAgainstBase(workdir, chain, publishedHead, allowed, baseRevision)
+}
+
+func validatePublishedCandidateAgainstBase(workdir string, chain *Chain, publishedHead string, allowed map[string]bool, baseRevision string) error {
 	currentBase, err := ResolveCommit(workdir, baseRevision)
 	if err != nil {
 		return fmt.Errorf("resolve published candidate base %q: %w", baseRevision, err)
@@ -330,52 +362,35 @@ func validatePublishedCandidateStructure(workdir, archivedPlanPath string, chain
 	return publishedHead, allowed, nil
 }
 
-func validateArchivedCandidateStructure(workdir, archivedPlanPath string, chain *Chain) (string, string, map[string]bool, error) {
-	if chain == nil || strings.TrimSpace(chain.CoveredHeadSHA) == "" {
-		return "", "", nil, fmt.Errorf("archived candidate has no reviewed head coverage")
-	}
-	reviewedPlan, err := repoRelativePath(workdir, chain.ReviewedPlanPath)
+func validatePublishedLightweightCandidateStructure(workdir, archivedPlanPath string, chain *Chain, publishedRevision string) (string, map[string]bool, error) {
+	reviewedPlan, archivedPlan, err := validateLocalArchivedPlanSnapshot(workdir, archivedPlanPath, chain)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("resolve reviewed plan path: %w", err)
+		return "", nil, err
 	}
-	archivedPlan, err := repoRelativePath(workdir, archivedPlanPath)
+	publishedHead, err := ResolveCommit(workdir, publishedRevision)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("resolve archived plan path: %w", err)
+		return "", nil, fmt.Errorf("resolve published candidate %q: %w", publishedRevision, err)
 	}
-	if reviewedPlan == archivedPlan {
-		return "", "", nil, fmt.Errorf("archived plan path still equals reviewed active plan path")
+	if entry, err := treeEntry(workdir, publishedHead, reviewedPlan); err != nil {
+		return "", nil, err
+	} else if entry != "" {
+		return "", nil, fmt.Errorf("reviewed active plan path still exists in published candidate: %s", reviewedPlan)
 	}
 
-	baseline, err := gitBytes(workdir, "show", chain.CoveredHeadSHA+":"+reviewedPlan)
+	// Only tracked source removals are archive mechanics for lightweight work.
+	// The ignored local targets must remain outside this allowlist so a
+	// force-added .local artifact is rejected as an unreviewed product change.
+	allowed := map[string]bool{reviewedPlan: true}
+	if err := validatePublishedLightweightSupplements(workdir, chain.CoveredHeadSHA, publishedHead, reviewedPlan, archivedPlan, allowed); err != nil {
+		return "", nil, err
+	}
+	return publishedHead, allowed, nil
+}
+
+func validateArchivedCandidateStructure(workdir, archivedPlanPath string, chain *Chain) (string, string, map[string]bool, error) {
+	reviewedPlan, archivedPlan, err := validateLocalArchivedPlanSnapshot(workdir, archivedPlanPath, chain)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("read reviewed plan content: %w", err)
-	}
-	archivedPlanFSPath := filepath.Join(workdir, filepath.FromSlash(archivedPlan))
-	currentMode, current, err := readGitWorktreeFile(archivedPlanFSPath)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("read archived plan content: %w", err)
-	}
-	if currentMode != "100644" {
-		return "", "", nil, fmt.Errorf("archived plan has git mode %s, expected command-rendered regular file mode 100644", currentMode)
-	}
-	expected, err := commandRenderedArchivePlan(baseline)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("prepare reviewed plan for archive comparison: %w", err)
-	}
-	expectedComparable, err := planWithMaskedCloseoutBody(expected)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("read command-rendered plan structure: %w", err)
-	}
-	reviewedComparable, err := planWithMaskedCloseoutBody(baseline)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("read reviewed plan structure: %w", err)
-	}
-	currentComparable, err := planWithMaskedCloseoutBody(current)
-	if err != nil {
-		return "", "", nil, fmt.Errorf("read archived plan structure: %w", err)
-	}
-	if !bytes.Equal(expectedComparable, currentComparable) && !bytes.Equal(reviewedComparable, currentComparable) {
-		return "", "", nil, fmt.Errorf("archived plan differs from the command-rendered reviewed plan outside the allowed Closeout body near %s", firstComparableDifference(expectedComparable, currentComparable))
+		return "", "", nil, err
 	}
 	if _, err := os.Lstat(filepath.Join(workdir, filepath.FromSlash(reviewedPlan))); !os.IsNotExist(err) {
 		if err != nil {
@@ -389,6 +404,56 @@ func validateArchivedCandidateStructure(workdir, archivedPlanPath string, chain 
 		return "", "", nil, err
 	}
 	return reviewedPlan, archivedPlan, allowed, nil
+}
+
+func validateLocalArchivedPlanSnapshot(workdir, archivedPlanPath string, chain *Chain) (string, string, error) {
+	if chain == nil || strings.TrimSpace(chain.CoveredHeadSHA) == "" {
+		return "", "", fmt.Errorf("archived candidate has no reviewed head coverage")
+	}
+	reviewedPlan, err := repoRelativePath(workdir, chain.ReviewedPlanPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve reviewed plan path: %w", err)
+	}
+	archivedPlan, err := repoRelativePath(workdir, archivedPlanPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve archived plan path: %w", err)
+	}
+	if reviewedPlan == archivedPlan {
+		return "", "", fmt.Errorf("archived plan path still equals reviewed active plan path")
+	}
+
+	baseline, err := gitBytes(workdir, "show", chain.CoveredHeadSHA+":"+reviewedPlan)
+	if err != nil {
+		return "", "", fmt.Errorf("read reviewed plan content: %w", err)
+	}
+	archivedPlanFSPath := filepath.Join(workdir, filepath.FromSlash(archivedPlan))
+	currentMode, current, err := readGitWorktreeFile(archivedPlanFSPath)
+	if err != nil {
+		return "", "", fmt.Errorf("read archived plan content: %w", err)
+	}
+	if currentMode != "100644" {
+		return "", "", fmt.Errorf("archived plan has git mode %s, expected command-rendered regular file mode 100644", currentMode)
+	}
+	expected, err := commandRenderedArchivePlan(baseline)
+	if err != nil {
+		return "", "", fmt.Errorf("prepare reviewed plan for archive comparison: %w", err)
+	}
+	expectedComparable, err := planWithMaskedCloseoutBody(expected)
+	if err != nil {
+		return "", "", fmt.Errorf("read command-rendered plan structure: %w", err)
+	}
+	reviewedComparable, err := planWithMaskedCloseoutBody(baseline)
+	if err != nil {
+		return "", "", fmt.Errorf("read reviewed plan structure: %w", err)
+	}
+	currentComparable, err := planWithMaskedCloseoutBody(current)
+	if err != nil {
+		return "", "", fmt.Errorf("read archived plan structure: %w", err)
+	}
+	if !bytes.Equal(expectedComparable, currentComparable) && !bytes.Equal(reviewedComparable, currentComparable) {
+		return "", "", fmt.Errorf("archived plan differs from the command-rendered reviewed plan outside the allowed Closeout body near %s", firstComparableDifference(expectedComparable, currentComparable))
+	}
+	return reviewedPlan, archivedPlan, nil
 }
 
 func commandRenderedArchivePlan(content []byte) ([]byte, error) {
@@ -571,6 +636,93 @@ func validatePublishedSupplements(workdir, coveredHead, publishedHead, reviewedP
 		allowed[target] = true
 	}
 	return nil
+}
+
+func validatePublishedLightweightSupplements(workdir, coveredHead, publishedHead, reviewedPlan, archivedPlan string, allowed map[string]bool) error {
+	reviewedDir := repoSlashPath(plan.SupplementsDirForPlanPath(filepath.FromSlash(reviewedPlan)))
+	archivedDir := repoSlashPath(plan.SupplementsDirForPlanPath(filepath.FromSlash(archivedPlan)))
+	data, err := gitBytes(workdir, "ls-tree", "-r", "-z", coveredHead, "--", reviewedDir)
+	if err != nil {
+		return fmt.Errorf("inspect reviewed plan supplements: %w", err)
+	}
+	expectedTargets := make(map[string]bool)
+	for _, raw := range bytes.Split(data, []byte{0}) {
+		entry := string(raw)
+		if entry == "" {
+			continue
+		}
+		metadata, source, ok := strings.Cut(entry, "\t")
+		fields := strings.Fields(metadata)
+		if !ok || len(fields) < 1 || source == "" {
+			return fmt.Errorf("parse reviewed supplement tree entry %q", entry)
+		}
+		expectedMode := fields[0]
+		source = filepath.ToSlash(source)
+		rel, err := filepath.Rel(filepath.FromSlash(reviewedDir), filepath.FromSlash(source))
+		if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+			return fmt.Errorf("reviewed supplement escaped its expected directory: %s", source)
+		}
+		target := filepath.ToSlash(filepath.Join(filepath.FromSlash(archivedDir), rel))
+		baseline, err := gitBytes(workdir, "show", coveredHead+":"+source)
+		if err != nil {
+			return fmt.Errorf("read reviewed supplement %s: %w", source, err)
+		}
+		currentMode, current, err := readGitWorktreeFile(filepath.Join(workdir, filepath.FromSlash(target)))
+		if err != nil {
+			return fmt.Errorf("read archived supplement %s: %w", target, err)
+		}
+		if currentMode != expectedMode {
+			return fmt.Errorf("archived supplement git mode differs from reviewed content: %s (%s -> %s)", target, expectedMode, currentMode)
+		}
+		if !bytes.Equal(baseline, current) {
+			return fmt.Errorf("archived supplement differs from reviewed content: %s", target)
+		}
+		if sourceEntry, err := treeEntry(workdir, publishedHead, source); err != nil {
+			return err
+		} else if sourceEntry != "" {
+			return fmt.Errorf("reviewed supplement still exists in published candidate: %s", source)
+		}
+		allowed[source] = true
+		expectedTargets[target] = true
+	}
+
+	actualTargets, err := localArchiveEntries(workdir, archivedDir)
+	if err != nil {
+		return fmt.Errorf("inspect archived lightweight supplements: %w", err)
+	}
+	for _, target := range actualTargets {
+		if !expectedTargets[target] {
+			return fmt.Errorf("unexpected archived lightweight supplement: %s", target)
+		}
+	}
+	return nil
+}
+
+func localArchiveEntries(workdir, archivedDir string) ([]string, error) {
+	root := filepath.Join(workdir, filepath.FromSlash(archivedDir))
+	entries := make([]string, 0)
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == root || entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(workdir, path)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, filepath.ToSlash(rel))
+		return nil
+	})
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(entries)
+	return entries, nil
 }
 
 func readGitRevisionFile(workdir, revision, path string) (string, []byte, error) {

--- a/internal/reviewcoverage/closeout.go
+++ b/internal/reviewcoverage/closeout.go
@@ -371,6 +371,11 @@ func validatePublishedLightweightCandidateStructure(workdir, archivedPlanPath st
 	if err != nil {
 		return "", nil, fmt.Errorf("resolve published candidate %q: %w", publishedRevision, err)
 	}
+	if entry, err := treeEntry(workdir, publishedHead, archivedPlan); err != nil {
+		return "", nil, err
+	} else if entry != "" {
+		return "", nil, fmt.Errorf("lightweight archived plan is tracked in published candidate: %s", archivedPlan)
+	}
 	if entry, err := treeEntry(workdir, publishedHead, reviewedPlan); err != nil {
 		return "", nil, err
 	} else if entry != "" {
@@ -641,6 +646,21 @@ func validatePublishedSupplements(workdir, coveredHead, publishedHead, reviewedP
 func validatePublishedLightweightSupplements(workdir, coveredHead, publishedHead, reviewedPlan, archivedPlan string, allowed map[string]bool) error {
 	reviewedDir := repoSlashPath(plan.SupplementsDirForPlanPath(filepath.FromSlash(reviewedPlan)))
 	archivedDir := repoSlashPath(plan.SupplementsDirForPlanPath(filepath.FromSlash(archivedPlan)))
+	trackedTargets, err := gitBytes(workdir, "ls-tree", "-r", "-z", publishedHead, "--", archivedDir)
+	if err != nil {
+		return fmt.Errorf("inspect published lightweight archive supplements: %w", err)
+	}
+	for _, raw := range bytes.Split(trackedTargets, []byte{0}) {
+		entry := string(raw)
+		if entry == "" {
+			continue
+		}
+		_, target, ok := strings.Cut(entry, "\t")
+		if !ok || target == "" {
+			return fmt.Errorf("parse published lightweight supplement tree entry %q", entry)
+		}
+		return fmt.Errorf("lightweight archived supplement is tracked in published candidate: %s", filepath.ToSlash(target))
+	}
 	data, err := gitBytes(workdir, "ls-tree", "-r", "-z", coveredHead, "--", reviewedDir)
 	if err != nil {
 		return fmt.Errorf("inspect reviewed plan supplements: %w", err)

--- a/internal/reviewcoverage/closeout_test.go
+++ b/internal/reviewcoverage/closeout_test.go
@@ -426,6 +426,26 @@ func TestValidatePublishedLightweightCandidateRejectsUnexpectedLocalSupplement(t
 	}
 }
 
+func TestValidatePublishedLightweightCandidateRejectsLocalPlanDrift(t *testing.T) {
+	root, archivedPlan, chain, published := lightweightPublishedCandidate(t, false)
+	writeFile(t, root, archivedPlan, strings.Replace(reviewedPlan, "Ship the candidate.", "Changed local goal.", 1))
+
+	err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published)
+	if err == nil || !strings.Contains(err.Error(), "outside the allowed Closeout body") {
+		t.Fatalf("expected local lightweight plan drift rejection, got %v", err)
+	}
+}
+
+func TestValidatePublishedLightweightCandidateRejectsLocalSupplementDrift(t *testing.T) {
+	root, archivedPlan, chain, published := lightweightPublishedCandidate(t, true)
+	writeFile(t, root, ".local/harness/plans/archived/supplements/2026-07-13-test/notes.md", "changed supplement\n")
+
+	err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published)
+	if err == nil || !strings.Contains(err.Error(), "archived supplement differs") {
+		t.Fatalf("expected local lightweight supplement drift rejection, got %v", err)
+	}
+}
+
 func TestValidatePublishedLightweightCandidateAgainstBaseAllowsEquivalentRebase(t *testing.T) {
 	root, archivedPlan, chain, upstream := baseAwareLightweightPublishedCandidate(t)
 	git(t, root, "checkout", "candidate")

--- a/internal/reviewcoverage/closeout_test.go
+++ b/internal/reviewcoverage/closeout_test.go
@@ -356,6 +356,177 @@ func TestValidatePublishedCandidateRejectsUnreviewedPublishedChange(t *testing.T
 	}
 }
 
+func TestValidatePublishedLightweightCandidateAllowsLocalArchiveSnapshot(t *testing.T) {
+	root, archivedPlan, chain, published := lightweightPublishedCandidate(t, true)
+
+	if err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published); err != nil {
+		t.Fatalf("expected local lightweight archive snapshot to preserve published coverage: %v", err)
+	}
+}
+
+func TestValidatePublishedLightweightCandidateRejectsRetainedTrackedSource(t *testing.T) {
+	root, archivedPlan, chain, _ := lightweightPublishedCandidate(t, true)
+	published := chain.CoveredHeadSHA
+
+	err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published)
+	if err == nil || !strings.Contains(err.Error(), "reviewed active plan path still exists") {
+		t.Fatalf("expected retained active plan rejection, got %v", err)
+	}
+}
+
+func TestValidatePublishedLightweightCandidateRejectsRetainedTrackedSupplement(t *testing.T) {
+	root, archivedPlan, chain, _ := lightweightPublishedCandidate(t, true)
+	activeSupplement := "docs/plans/active/supplements/2026-07-13-test/notes.md"
+	writeFile(t, root, activeSupplement, "reviewed supplement\n")
+	git(t, root, "add", activeSupplement)
+	git(t, root, "commit", "-m", "restore tracked supplement")
+	published := git(t, root, "rev-parse", "HEAD")
+	if err := os.Remove(filepath.Join(root, filepath.FromSlash(activeSupplement))); err != nil {
+		t.Fatalf("remove restored active supplement from worktree: %v", err)
+	}
+
+	err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published)
+	if err == nil || !strings.Contains(err.Error(), "reviewed supplement still exists") {
+		t.Fatalf("expected retained active supplement rejection, got %v", err)
+	}
+}
+
+func TestValidatePublishedLightweightCandidateRejectsUnreviewedProductChange(t *testing.T) {
+	root, archivedPlan, chain, _ := lightweightPublishedCandidate(t, false)
+	writeFile(t, root, "product.go", "package product\n\nconst Candidate = 2\n")
+	git(t, root, "add", "product.go")
+	git(t, root, "commit", "-m", "unreviewed product change")
+	published := git(t, root, "rev-parse", "HEAD")
+
+	err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published)
+	if err == nil || !strings.Contains(err.Error(), "unreviewed product change") || !strings.Contains(err.Error(), "product.go") {
+		t.Fatalf("expected unreviewed lightweight product change rejection, got %v", err)
+	}
+}
+
+func TestValidatePublishedLightweightCandidateRejectsForceTrackedLocalArchive(t *testing.T) {
+	root, archivedPlan, chain, _ := lightweightPublishedCandidate(t, false)
+	git(t, root, "add", "-f", archivedPlan)
+	git(t, root, "commit", "-m", "force track local archive")
+	published := git(t, root, "rev-parse", "HEAD")
+
+	err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published)
+	if err == nil || !strings.Contains(err.Error(), "unreviewed product change") || !strings.Contains(err.Error(), archivedPlan) {
+		t.Fatalf("expected force-tracked local archive rejection, got %v", err)
+	}
+}
+
+func TestValidatePublishedLightweightCandidateRejectsUnexpectedLocalSupplement(t *testing.T) {
+	root, archivedPlan, chain, published := lightweightPublishedCandidate(t, false)
+	writeFile(t, root, ".local/harness/plans/archived/supplements/2026-07-13-test/extra.md", "unexpected\n")
+
+	err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published)
+	if err == nil || !strings.Contains(err.Error(), "unexpected archived lightweight supplement") {
+		t.Fatalf("expected unexpected local supplement rejection, got %v", err)
+	}
+}
+
+func TestValidatePublishedLightweightCandidateAgainstBaseAllowsEquivalentRebase(t *testing.T) {
+	root, archivedPlan, chain, upstream := baseAwareLightweightPublishedCandidate(t)
+	git(t, root, "checkout", "candidate")
+	git(t, root, "rebase", "upstream")
+	published := git(t, root, "rev-parse", "HEAD")
+
+	if err := ValidatePublishedLightweightCandidateAgainstBase(root, archivedPlan, chain, published, upstream); err != nil {
+		t.Fatalf("expected equivalent rebased lightweight candidate to preserve coverage: %v", err)
+	}
+}
+
+func TestValidatePublishedLightweightCandidateAgainstBaseRejectsCandidateDrift(t *testing.T) {
+	root, archivedPlan, chain, upstream := baseAwareLightweightPublishedCandidate(t)
+	git(t, root, "checkout", "candidate")
+	git(t, root, "rebase", "upstream")
+	writeFile(t, root, "product.go", "package product\n\nconst Candidate = 2\n")
+	git(t, root, "add", "product.go")
+	git(t, root, "commit", "-m", "candidate drift")
+	published := git(t, root, "rev-parse", "HEAD")
+
+	err := ValidatePublishedLightweightCandidateAgainstBase(root, archivedPlan, chain, published, upstream)
+	if err == nil || !strings.Contains(err.Error(), "candidate-owned delta changed") || !strings.Contains(err.Error(), "product.go") {
+		t.Fatalf("expected rebased lightweight candidate drift rejection, got %v", err)
+	}
+}
+
+func lightweightPublishedCandidate(t *testing.T, withSupplement bool) (string, string, *Chain, string) {
+	t.Helper()
+	root := t.TempDir()
+	initGit(t, root)
+	activePlan := "docs/plans/active/2026-07-13-test.md"
+	archivedPlan := ".local/harness/plans/archived/2026-07-13-test.md"
+	activeSupplement := "docs/plans/active/supplements/2026-07-13-test/notes.md"
+	archivedSupplement := ".local/harness/plans/archived/supplements/2026-07-13-test/notes.md"
+	writeFile(t, root, activePlan, reviewedPlan)
+	writeFile(t, root, "product.go", "package product\n\nconst Candidate = 1\n")
+	if withSupplement {
+		writeFile(t, root, activeSupplement, "reviewed supplement\n")
+	}
+	git(t, root, "add", ".")
+	git(t, root, "commit", "-m", "reviewed")
+	covered := git(t, root, "rev-parse", "HEAD")
+
+	commandRendered, err := commandRenderedArchivePlan([]byte(reviewedPlan))
+	if err != nil {
+		t.Fatalf("render command-owned archive baseline: %v", err)
+	}
+	writeFile(t, root, archivedPlan, string(commandRendered))
+	if err := os.Remove(filepath.Join(root, filepath.FromSlash(activePlan))); err != nil {
+		t.Fatalf("remove active plan: %v", err)
+	}
+	if withSupplement {
+		writeFile(t, root, archivedSupplement, "reviewed supplement\n")
+		if err := os.Remove(filepath.Join(root, filepath.FromSlash(activeSupplement))); err != nil {
+			t.Fatalf("remove active supplement: %v", err)
+		}
+	}
+	git(t, root, "add", "-u")
+	git(t, root, "commit", "-m", "archive lightweight plan")
+	published := git(t, root, "rev-parse", "HEAD")
+
+	return root, archivedPlan, &Chain{CoveredHeadSHA: covered, ReviewedPlanPath: activePlan}, published
+}
+
+func baseAwareLightweightPublishedCandidate(t *testing.T) (string, string, *Chain, string) {
+	t.Helper()
+	root := t.TempDir()
+	initGit(t, root)
+	activePlan := "docs/plans/active/2026-07-13-test.md"
+	archivedPlan := ".local/harness/plans/archived/2026-07-13-test.md"
+	writeFile(t, root, activePlan, reviewedPlan)
+	writeFile(t, root, "product.go", "package product\n\nconst Candidate = 0\n")
+	git(t, root, "add", ".")
+	git(t, root, "commit", "-m", "base")
+	base := git(t, root, "rev-parse", "HEAD")
+
+	git(t, root, "checkout", "-b", "candidate")
+	writeFile(t, root, "product.go", "package product\n\nconst Candidate = 1\n")
+	git(t, root, "add", "product.go")
+	git(t, root, "commit", "-m", "reviewed candidate")
+	reviewed := git(t, root, "rev-parse", "HEAD")
+	commandRendered, err := commandRenderedArchivePlan([]byte(reviewedPlan))
+	if err != nil {
+		t.Fatalf("render command-owned archive baseline: %v", err)
+	}
+	writeFile(t, root, archivedPlan, string(commandRendered))
+	if err := os.Remove(filepath.Join(root, filepath.FromSlash(activePlan))); err != nil {
+		t.Fatalf("remove active plan: %v", err)
+	}
+	git(t, root, "add", "-u")
+	git(t, root, "commit", "-m", "archive lightweight plan")
+
+	git(t, root, "checkout", "-b", "upstream", base)
+	writeFile(t, root, "upstream.txt", "unrelated upstream work\n")
+	git(t, root, "add", "upstream.txt")
+	git(t, root, "commit", "-m", "upstream advance")
+	upstream := git(t, root, "rev-parse", "HEAD")
+
+	return root, archivedPlan, &Chain{CoveredHeadSHA: reviewed, ReviewedPlanPath: activePlan}, upstream
+}
+
 func baseAwareArchivedCandidate(t *testing.T, overlap bool) (string, string, *Chain, string) {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/reviewcoverage/closeout_test.go
+++ b/internal/reviewcoverage/closeout_test.go
@@ -411,8 +411,21 @@ func TestValidatePublishedLightweightCandidateRejectsForceTrackedLocalArchive(t 
 	published := git(t, root, "rev-parse", "HEAD")
 
 	err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published)
-	if err == nil || !strings.Contains(err.Error(), "unreviewed product change") || !strings.Contains(err.Error(), archivedPlan) {
+	if err == nil || !strings.Contains(err.Error(), "lightweight archived plan is tracked") || !strings.Contains(err.Error(), archivedPlan) {
 		t.Fatalf("expected force-tracked local archive rejection, got %v", err)
+	}
+}
+
+func TestValidatePublishedLightweightCandidateRejectsPreReviewedTrackedTargets(t *testing.T) {
+	for _, targetKind := range []string{"plan", "supplement"} {
+		t.Run(targetKind, func(t *testing.T) {
+			root, archivedPlan, chain, published := pretrackedLightweightTargetCandidate(t, targetKind)
+
+			err := ValidatePublishedLightweightCandidate(root, archivedPlan, chain, published)
+			if err == nil || !strings.Contains(err.Error(), "is tracked in published candidate") {
+				t.Fatalf("expected pre-reviewed tracked lightweight %s rejection, got %v", targetKind, err)
+			}
+		})
 	}
 }
 
@@ -472,6 +485,26 @@ func TestValidatePublishedLightweightCandidateAgainstBaseRejectsCandidateDrift(t
 	}
 }
 
+func TestValidatePublishedLightweightCandidateAgainstBaseRejectsBaseOwnedArchiveTarget(t *testing.T) {
+	root, archivedPlan, chain, _ := baseAwareLightweightPublishedCandidate(t)
+	git(t, root, "add", "-f", archivedPlan)
+	git(t, root, "commit", "-m", "base owns local archive target")
+	upstream := git(t, root, "rev-parse", "HEAD")
+	git(t, root, "checkout", "candidate")
+	git(t, root, "rebase", "upstream")
+	published := git(t, root, "rev-parse", "HEAD")
+	commandRendered, err := commandRenderedArchivePlan([]byte(reviewedPlan))
+	if err != nil {
+		t.Fatalf("render local archive snapshot: %v", err)
+	}
+	writeFile(t, root, archivedPlan, string(commandRendered))
+
+	err = ValidatePublishedLightweightCandidateAgainstBase(root, archivedPlan, chain, published, upstream)
+	if err == nil || !strings.Contains(err.Error(), "lightweight archived plan is tracked") {
+		t.Fatalf("expected base-owned lightweight archive target rejection, got %v", err)
+	}
+}
+
 func lightweightPublishedCandidate(t *testing.T, withSupplement bool) (string, string, *Chain, string) {
 	t.Helper()
 	root := t.TempDir()
@@ -502,6 +535,45 @@ func lightweightPublishedCandidate(t *testing.T, withSupplement bool) (string, s
 		if err := os.Remove(filepath.Join(root, filepath.FromSlash(activeSupplement))); err != nil {
 			t.Fatalf("remove active supplement: %v", err)
 		}
+	}
+	git(t, root, "add", "-u")
+	git(t, root, "commit", "-m", "archive lightweight plan")
+	published := git(t, root, "rev-parse", "HEAD")
+
+	return root, archivedPlan, &Chain{CoveredHeadSHA: covered, ReviewedPlanPath: activePlan}, published
+}
+
+func pretrackedLightweightTargetCandidate(t *testing.T, targetKind string) (string, string, *Chain, string) {
+	t.Helper()
+	root := t.TempDir()
+	initGit(t, root)
+	activePlan := "docs/plans/active/2026-07-13-test.md"
+	archivedPlan := ".local/harness/plans/archived/2026-07-13-test.md"
+	activeSupplement := "docs/plans/active/supplements/2026-07-13-test/notes.md"
+	archivedSupplement := ".local/harness/plans/archived/supplements/2026-07-13-test/notes.md"
+	writeFile(t, root, ".gitignore", ".local/\n")
+	writeFile(t, root, activePlan, reviewedPlan)
+	writeFile(t, root, activeSupplement, "reviewed supplement\n")
+	commandRendered, err := commandRenderedArchivePlan([]byte(reviewedPlan))
+	if err != nil {
+		t.Fatalf("render command-owned archive baseline: %v", err)
+	}
+	writeFile(t, root, archivedPlan, string(commandRendered))
+	writeFile(t, root, archivedSupplement, "reviewed supplement\n")
+	git(t, root, "add", ".")
+	if targetKind == "plan" {
+		git(t, root, "add", "-f", archivedPlan)
+	} else {
+		git(t, root, "add", "-f", archivedSupplement)
+	}
+	git(t, root, "commit", "-m", "reviewed with pretracked local target")
+	covered := git(t, root, "rev-parse", "HEAD")
+
+	if err := os.Remove(filepath.Join(root, filepath.FromSlash(activePlan))); err != nil {
+		t.Fatalf("remove active plan: %v", err)
+	}
+	if err := os.Remove(filepath.Join(root, filepath.FromSlash(activeSupplement))); err != nil {
+		t.Fatalf("remove active supplement: %v", err)
 	}
 	git(t, root, "add", "-u")
 	git(t, root, "commit", "-m", "archive lightweight plan")

--- a/tests/e2e/lightweight_workflow_test.go
+++ b/tests/e2e/lightweight_workflow_test.go
@@ -88,12 +88,14 @@ func TestLightweightWorkflowWithBuiltBinary(t *testing.T) {
 	if len(postArchiveStatus.NextAction) == 0 || !strings.Contains(postArchiveStatus.NextAction[0].Description, "repo-visible breadcrumb") {
 		t.Fatalf("expected breadcrumb guidance after lightweight archive, got %#v", postArchiveStatus.NextAction)
 	}
+	publishedHead := workspace.CommitAll(t, "commit lightweight active plan removal")
 
 	submitEvidence(t, workspace, "publish", "tmp/lightweight-publish.json", map[string]any{
 		"status": "recorded",
 		"pr_url": "https://github.com/catu-ai/easyharness/pull/109",
 		"branch": "codex/e2e-lightweight-workflow",
 		"base":   "main",
+		"commit": publishedHead,
 	})
 	submitEvidence(t, workspace, "ci", "tmp/lightweight-ci.json", map[string]any{
 		"status":   "not_applied",
@@ -112,6 +114,34 @@ func TestLightweightWorkflowWithBuiltBinary(t *testing.T) {
 	}
 	if len(awaitMergeStatus.NextAction) == 0 || !strings.Contains(awaitMergeStatus.NextAction[0].Description, "repo-visible breadcrumb") {
 		t.Fatalf("expected await-merge breadcrumb guidance, got %#v", awaitMergeStatus.NextAction)
+	}
+
+	land := support.Run(t, workspace.Root, "land", "--pr", "https://github.com/catu-ai/easyharness/pull/109", "--commit", publishedHead)
+	support.RequireSuccess(t, land)
+	support.RequireNoStderr(t, land)
+	landPayload := requireLifecycleResult(t, land)
+	if !landPayload.OK || landPayload.Command != "land" {
+		t.Fatalf("unexpected lightweight land payload: %#v", landPayload)
+	}
+	assertLifecycleEnvelope(t, landPayload, "land", 1)
+
+	landComplete := support.Run(t, workspace.Root, "land", "complete")
+	support.RequireSuccess(t, landComplete)
+	support.RequireNoStderr(t, landComplete)
+	landCompletePayload := requireLifecycleResult(t, landComplete)
+	if !landCompletePayload.OK || landCompletePayload.Command != "land complete" {
+		t.Fatalf("unexpected lightweight land-complete payload: %#v", landCompletePayload)
+	}
+	assertLifecycleEnvelope(t, landCompletePayload, "idle", 1)
+
+	current = support.ReadJSONFile[currentPlan](t, workspace.Path(".local/harness/current-plan.json"))
+	if current.PlanPath != "" || current.LastLandedPlanPath != archivedRelPath || current.LastLandedAt == "" {
+		t.Fatalf("expected lightweight idle marker with last-landed context, got %#v", current)
+	}
+	postLandStatus := runStatus(t, workspace.Root)
+	assertNode(t, postLandStatus, "idle")
+	if postLandStatus.Artifacts.PlanPath != archivedRelPath {
+		t.Fatalf("expected lightweight last-landed path in idle status, got %#v", postLandStatus)
 	}
 }
 


### PR DESCRIPTION
## What Changed

Fixes the v0.6.0 lightweight workflow dead-end where `harness land` tried to
read the ignored `.local` archive snapshot from the published Git commit.

Published coverage is now profile-aware: standard candidates retain tracked
archive validation, while lightweight candidates validate the local snapshot
separately and require only the reviewed tracked source plan and supplements to
be removed from Git. The validator also fails closed when any lightweight
archive target is tracked, including targets already present before review or
introduced by the recorded base.

## Confidence

- Added ancestry-preserving and base-aware coverage for lightweight
  candidates, supplements, source retention, product drift, and tracked
  `.local` targets.
- Extended the built-binary lightweight E2E through commit-bearing publish
  evidence, `land`, `land complete`, and idle state.
- `go test ./... -count=1` and focused lightweight E2E passed.
- Independent integrated review passed after a linked repair delta resolved
  its only finding.
